### PR TITLE
Add base template template param to execution_policy

### DIFF
--- a/libs/core/compute_local/include/hpx/compute_local/host/block_allocator.hpp
+++ b/libs/core/compute_local/include/hpx/compute_local/host/block_allocator.hpp
@@ -261,15 +261,15 @@ namespace hpx::compute::host {
     struct block_allocator
       : public detail::policy_allocator<T,
             hpx::execution::detail::parallel_policy_shim<
-                block_executor<Executor>,
+                hpx::execution::detail::empty_base, block_executor<Executor>,
                 typename block_executor<Executor>::executor_parameters_type>>
     {
         using executor_type = block_executor<Executor>;
         using executor_parameters_type =
             typename executor_type::executor_parameters_type;
-        using policy_type =
-            hpx::execution::detail::parallel_policy_shim<executor_type,
-                executor_parameters_type>;
+        using policy_type = hpx::execution::detail::parallel_policy_shim<
+            hpx::execution::detail::empty_base, executor_type,
+            executor_parameters_type>;
         using base_type = detail::policy_allocator<T, policy_type>;
         using target_type = std::vector<host::target>;
 

--- a/libs/core/executors/include/hpx/executors/datapar/execution_policy.hpp
+++ b/libs/core/executors/include/hpx/executors/datapar/execution_policy.hpp
@@ -38,14 +38,15 @@ namespace hpx::execution {
         //
         // The algorithm returns a future representing the result of the
         // corresponding algorithm when invoked with the sequenced_policy.
-        template <typename Executor, typename Parameters>
+        template <template <class> typename Base, typename Executor,
+            typename Parameters>
         struct simd_task_policy_shim
-          : execution_policy<simd_task_policy_shim, Executor, Parameters,
+          : execution_policy<simd_task_policy_shim, Base, Executor, Parameters,
                 unsequenced_execution_tag>
         {
         private:
-            using base_type = execution_policy<simd_task_policy_shim, Executor,
-                Parameters, unsequenced_execution_tag>;
+            using base_type = execution_policy<simd_task_policy_shim, Base,
+                Executor, Parameters, unsequenced_execution_tag>;
 
         public:
             /// \cond NOINTERNAL
@@ -62,12 +63,12 @@ namespace hpx::execution {
             template <typename Executor_, typename Parameters_,
                 typename = std::enable_if_t<
                     !std::is_same_v<
-                        simd_task_policy_shim<Executor_, Parameters_>,
+                        simd_task_policy_shim<Base, Executor_, Parameters_>,
                         simd_task_policy_shim> &&
                     std::is_convertible_v<Executor_, Executor> &&
                     std::is_convertible_v<Parameters_, Parameters>>>
             explicit constexpr simd_task_policy_shim(
-                simd_task_policy_shim<Executor_, Parameters_> const& rhs)
+                simd_task_policy_shim<Base, Executor_, Parameters_> const& rhs)
               : base_type(
                     simd_task_policy_shim(rhs.executor(), rhs.parameters()))
             {
@@ -78,7 +79,7 @@ namespace hpx::execution {
                     std::is_convertible_v<Executor_, Executor> &&
                     std::is_convertible_v<Parameters_, Parameters>>>
             simd_task_policy_shim& operator=(
-                simd_task_policy_shim<Executor_, Parameters_> const& rhs)
+                simd_task_policy_shim<Base, Executor_, Parameters_> const& rhs)
             {
                 base_type::operator=(
                     simd_task_policy_shim(rhs.executor(), rhs.parameters()));
@@ -96,21 +97,26 @@ namespace hpx::execution {
     ///
     /// The algorithm returns a future representing the result of the
     /// corresponding algorithm when invoked with the sequenced_policy.
-    using simd_task_policy = detail::simd_task_policy_shim<sequenced_executor,
-        hpx::traits::executor_parameters_type_t<sequenced_executor>>;
+    template <template <class> typename Base = detail::empty_base>
+    using basic_simd_task_policy =
+        detail::simd_task_policy_shim<Base, sequenced_executor,
+            hpx::traits::executor_parameters_type_t<sequenced_executor>>;
+
+    using simd_task_policy = basic_simd_task_policy<>;
 
     namespace detail {
 
         // The class simd_policy is an execution policy type used as a unique
         // type to disambiguate parallel algorithm overloading and require that
         // a parallel algorithm's execution may not be parallelized.
-        template <typename Executor, typename Parameters>
+        template <template <class> typename Base, typename Executor,
+            typename Parameters>
         struct simd_policy_shim
-          : execution_policy<simd_policy_shim, Executor, Parameters,
+          : execution_policy<simd_policy_shim, Base, Executor, Parameters,
                 unsequenced_execution_tag>
         {
         private:
-            using base_type = execution_policy<simd_policy_shim, Executor,
+            using base_type = execution_policy<simd_policy_shim, Base, Executor,
                 Parameters, unsequenced_execution_tag>;
 
         public:
@@ -126,12 +132,13 @@ namespace hpx::execution {
 
             template <typename Executor_, typename Parameters_,
                 typename = std::enable_if_t<
-                    !std::is_same_v<simd_policy_shim<Executor_, Parameters_>,
+                    !std::is_same_v<
+                        simd_policy_shim<Base, Executor_, Parameters_>,
                         simd_policy_shim> &&
                     std::is_convertible_v<Executor_, Executor> &&
                     std::is_convertible_v<Parameters_, Parameters>>>
             explicit constexpr simd_policy_shim(
-                simd_policy_shim<Executor_, Parameters_> const& rhs)
+                simd_policy_shim<Base, Executor_, Parameters_> const& rhs)
               : base_type(simd_policy_shim(rhs.executor(), rhs.parameters()))
             {
             }
@@ -141,7 +148,7 @@ namespace hpx::execution {
                     std::is_convertible_v<Executor_, Executor> &&
                     std::is_convertible_v<Parameters_, Parameters>>>
             simd_policy_shim& operator=(
-                simd_policy_shim<Executor_, Parameters_> const& rhs)
+                simd_policy_shim<Base, Executor_, Parameters_> const& rhs)
             {
                 base_type::operator=(
                     simd_policy_shim(rhs.executor(), rhs.parameters()));
@@ -155,8 +162,11 @@ namespace hpx::execution {
     /// The class simd_policy is an execution policy type used as a unique type
     /// to disambiguate parallel algorithm overloading and require that a
     /// parallel algorithm's execution may not be parallelized.
-    using simd_policy = detail::simd_policy_shim<sequenced_executor,
+    template <template <class> typename Base = detail::empty_base>
+    using basic_simd_policy = detail::simd_policy_shim<Base, sequenced_executor,
         hpx::traits::executor_parameters_type_t<sequenced_executor>>;
+
+    using simd_policy = basic_simd_policy<>;
 
     /// Default sequential execution policy object.
     inline constexpr simd_policy simd{};
@@ -167,13 +177,14 @@ namespace hpx::execution {
         // The class par_simd_policy is an execution policy type used as a
         // unique type to disambiguate parallel algorithm overloading and
         // indicate that a parallel algorithm's execution may be parallelized.
-        template <typename Executor, typename Parameters>
+        template <template <class> typename Base, typename Executor,
+            typename Parameters>
         struct par_simd_task_policy_shim
-          : execution_policy<par_simd_task_policy_shim, Executor, Parameters,
-                unsequenced_execution_tag>
+          : execution_policy<par_simd_task_policy_shim, Base, Executor,
+                Parameters, unsequenced_execution_tag>
         {
         private:
-            using base_type = execution_policy<par_simd_task_policy_shim,
+            using base_type = execution_policy<par_simd_task_policy_shim, Base,
                 Executor, Parameters, unsequenced_execution_tag>;
 
         public:
@@ -191,12 +202,13 @@ namespace hpx::execution {
             template <typename Executor_, typename Parameters_,
                 typename = std::enable_if_t<
                     !std::is_same_v<
-                        par_simd_task_policy_shim<Executor_, Parameters_>,
+                        par_simd_task_policy_shim<Base, Executor_, Parameters_>,
                         par_simd_task_policy_shim> &&
                     std::is_convertible_v<Executor_, Executor> &&
                     std::is_convertible_v<Parameters_, Parameters>>>
             explicit constexpr par_simd_task_policy_shim(
-                par_simd_task_policy_shim<Executor_, Parameters_> const& rhs)
+                par_simd_task_policy_shim<Base, Executor_, Parameters_> const&
+                    rhs)
               : base_type(
                     par_simd_task_policy_shim(rhs.executor(), rhs.parameters()))
             {
@@ -207,7 +219,8 @@ namespace hpx::execution {
                     std::is_convertible_v<Executor_, Executor> &&
                     std::is_convertible_v<Parameters_, Parameters>>>
             par_simd_task_policy_shim& operator=(
-                par_simd_task_policy_shim<Executor_, Parameters_> const& rhs)
+                par_simd_task_policy_shim<Base, Executor_, Parameters_> const&
+                    rhs)
             {
                 base_type::operator=(par_simd_task_policy_shim(
                     rhs.executor(), rhs.parameters()));
@@ -224,23 +237,27 @@ namespace hpx::execution {
     ///
     /// The algorithm returns a future representing the result of the
     /// corresponding algorithm when invoked with the parallel_policy.
-    using par_simd_task_policy =
-        detail::par_simd_task_policy_shim<parallel_executor,
+    template <template <class> typename Base = detail::empty_base>
+    using basic_par_simd_task_policy =
+        detail::par_simd_task_policy_shim<Base, parallel_executor,
             hpx::traits::executor_parameters_type_t<parallel_executor>>;
+
+    using par_simd_task_policy = basic_par_simd_task_policy<>;
 
     namespace detail {
 
         // The class par_simd_policy_shim is an execution policy type used as a
         // unique type to disambiguate parallel algorithm overloading and
         // indicate that a parallel algorithm's execution may be parallelized.
-        template <typename Executor, typename Parameters>
+        template <template <class> typename Base, typename Executor,
+            typename Parameters>
         struct par_simd_policy_shim
-          : execution_policy<par_simd_policy_shim, Executor, Parameters,
+          : execution_policy<par_simd_policy_shim, Base, Executor, Parameters,
                 unsequenced_execution_tag>
         {
         private:
-            using base_type = execution_policy<par_simd_policy_shim, Executor,
-                Parameters, unsequenced_execution_tag>;
+            using base_type = execution_policy<par_simd_policy_shim, Base,
+                Executor, Parameters, unsequenced_execution_tag>;
 
         public:
             /// \cond NOINTERNAL
@@ -257,12 +274,12 @@ namespace hpx::execution {
             template <typename Executor_, typename Parameters_,
                 typename = std::enable_if_t<
                     !std::is_same_v<
-                        par_simd_policy_shim<Executor_, Parameters_>,
+                        par_simd_policy_shim<Base, Executor_, Parameters_>,
                         par_simd_policy_shim> &&
                     std::is_convertible_v<Executor_, Executor> &&
                     std::is_convertible_v<Parameters_, Parameters>>>
             explicit constexpr par_simd_policy_shim(
-                par_simd_policy_shim<Executor_, Parameters_> const& rhs)
+                par_simd_policy_shim<Base, Executor_, Parameters_> const& rhs)
               : base_type(
                     par_simd_policy_shim(rhs.executor(), rhs.parameters()))
             {
@@ -273,7 +290,7 @@ namespace hpx::execution {
                     std::is_convertible_v<Executor_, Executor> &&
                     std::is_convertible_v<Parameters_, Parameters>>>
             par_simd_policy_shim& operator=(
-                par_simd_policy_shim<Executor_, Parameters_> const& rhs)
+                par_simd_policy_shim<Base, Executor_, Parameters_> const& rhs)
             {
                 base_type::operator=(
                     par_simd_policy_shim(rhs.executor(), rhs.parameters()));
@@ -290,48 +307,56 @@ namespace hpx::execution {
     ///
     /// The algorithm returns a future representing the result of the
     /// corresponding algorithm when invoked with the parallel_policy.
-    using par_simd_policy = detail::par_simd_policy_shim<parallel_executor,
-        hpx::traits::executor_parameters_type_t<parallel_executor>>;
+    template <template <class> typename Base = detail::empty_base>
+    using basic_par_simd_policy =
+        detail::par_simd_policy_shim<Base, parallel_executor,
+            hpx::traits::executor_parameters_type_t<parallel_executor>>;
+
+    using par_simd_policy = basic_par_simd_policy<>;
 
     /// Default data-parallel execution policy object.
     inline constexpr par_simd_policy par_simd{};
 
     namespace detail {
         /// \cond NOINTERN
-        template <typename Executor, typename Parameters>
+        template <template <class> typename Base, typename Executor,
+            typename Parameters>
         constexpr decltype(auto) tag_invoke(
             hpx::execution::experimental::to_task_t tag,
-            simd_policy_shim<Executor, Parameters> const& policy)
+            simd_policy_shim<Base, Executor, Parameters> const& policy)
         {
             return simd_task_policy()
                 .on(hpx::experimental::prefer(tag, policy.executor()))
                 .with(policy.parameters());
         }
 
-        template <typename Executor, typename Parameters>
+        template <template <class> typename Base, typename Executor,
+            typename Parameters>
         constexpr decltype(auto) tag_invoke(
             hpx::execution::experimental::to_par_t tag,
-            simd_policy_shim<Executor, Parameters> const& policy)
+            simd_policy_shim<Base, Executor, Parameters> const& policy)
         {
             return par_simd_policy()
                 .on(hpx::experimental::prefer(tag, policy.executor()))
                 .with(policy.parameters());
         }
 
-        template <typename Executor, typename Parameters>
+        template <template <class> typename Base, typename Executor,
+            typename Parameters>
         constexpr decltype(auto) tag_invoke(
             hpx::execution::experimental::to_non_simd_t tag,
-            simd_policy_shim<Executor, Parameters> const& policy)
+            simd_policy_shim<Base, Executor, Parameters> const& policy)
         {
             return sequenced_policy()
                 .on(hpx::experimental::prefer(tag, policy.executor()))
                 .with(policy.parameters());
         }
 
-        template <typename Executor, typename Parameters>
+        template <template <class> typename Base, typename Executor,
+            typename Parameters>
         constexpr decltype(auto) tag_invoke(
             hpx::execution::experimental::to_simd_t tag,
-            sequenced_policy_shim<Executor, Parameters> const& policy)
+            sequenced_policy_shim<Base, Executor, Parameters> const& policy)
         {
             return simd_policy()
                 .on(hpx::experimental::prefer(tag, policy.executor()))
@@ -339,40 +364,45 @@ namespace hpx::execution {
         }
 
         ///////////////////////////////////////////////////////////////////////
-        template <typename Executor, typename Parameters>
+        template <template <class> typename Base, typename Executor,
+            typename Parameters>
         constexpr decltype(auto) tag_invoke(
             hpx::execution::experimental::to_non_task_t tag,
-            simd_task_policy_shim<Executor, Parameters> const& policy)
+            simd_task_policy_shim<Base, Executor, Parameters> const& policy)
         {
             return simd_policy()
                 .on(hpx::experimental::prefer(tag, policy.executor()))
                 .with(policy.parameters());
         }
 
-        template <typename Executor, typename Parameters>
+        template <template <class> typename Base, typename Executor,
+            typename Parameters>
         constexpr decltype(auto) tag_invoke(
             hpx::execution::experimental::to_par_t tag,
-            simd_task_policy_shim<Executor, Parameters> const& policy)
+            simd_task_policy_shim<Base, Executor, Parameters> const& policy)
         {
             return par_simd_task_policy()
                 .on(hpx::experimental::prefer(tag, policy.executor()))
                 .with(policy.parameters());
         }
 
-        template <typename Executor, typename Parameters>
+        template <template <class> typename Base, typename Executor,
+            typename Parameters>
         constexpr decltype(auto) tag_invoke(
             hpx::execution::experimental::to_non_simd_t tag,
-            simd_task_policy_shim<Executor, Parameters> const& policy)
+            simd_task_policy_shim<Base, Executor, Parameters> const& policy)
         {
             return sequenced_task_policy()
                 .on(hpx::experimental::prefer(tag, policy.executor()))
                 .with(policy.parameters());
         }
 
-        template <typename Executor, typename Parameters>
+        template <template <class> typename Base, typename Executor,
+            typename Parameters>
         constexpr decltype(auto) tag_invoke(
             hpx::execution::experimental::to_simd_t tag,
-            sequenced_task_policy_shim<Executor, Parameters> const& policy)
+            sequenced_task_policy_shim<Base, Executor, Parameters> const&
+                policy)
         {
             return simd_task_policy()
                 .on(hpx::experimental::prefer(tag, policy.executor()))
@@ -380,40 +410,44 @@ namespace hpx::execution {
         }
 
         ///////////////////////////////////////////////////////////////////////
-        template <typename Executor, typename Parameters>
+        template <template <class> typename Base, typename Executor,
+            typename Parameters>
         constexpr decltype(auto) tag_invoke(
             hpx::execution::experimental::to_task_t tag,
-            par_simd_policy_shim<Executor, Parameters> const& policy)
+            par_simd_policy_shim<Base, Executor, Parameters> const& policy)
         {
             return par_simd_task_policy()
                 .on(hpx::experimental::prefer(tag, policy.executor()))
                 .with(policy.parameters());
         }
 
-        template <typename Executor, typename Parameters>
+        template <template <class> typename Base, typename Executor,
+            typename Parameters>
         constexpr decltype(auto) tag_invoke(
             hpx::execution::experimental::to_non_par_t tag,
-            par_simd_policy_shim<Executor, Parameters> const& policy)
+            par_simd_policy_shim<Base, Executor, Parameters> const& policy)
         {
             return simd_policy()
                 .on(hpx::experimental::prefer(tag, policy.executor()))
                 .with(policy.parameters());
         }
 
-        template <typename Executor, typename Parameters>
+        template <template <class> typename Base, typename Executor,
+            typename Parameters>
         constexpr decltype(auto) tag_invoke(
             hpx::execution::experimental::to_non_simd_t tag,
-            par_simd_policy_shim<Executor, Parameters> const& policy)
+            par_simd_policy_shim<Base, Executor, Parameters> const& policy)
         {
             return parallel_policy()
                 .on(hpx::experimental::prefer(tag, policy.executor()))
                 .with(policy.parameters());
         }
 
-        template <typename Executor, typename Parameters>
+        template <template <class> typename Base, typename Executor,
+            typename Parameters>
         constexpr decltype(auto) tag_invoke(
             hpx::execution::experimental::to_simd_t tag,
-            parallel_policy_shim<Executor, Parameters> const& policy)
+            parallel_policy_shim<Base, Executor, Parameters> const& policy)
         {
             return par_simd_policy()
                 .on(hpx::experimental::prefer(tag, policy.executor()))
@@ -421,40 +455,44 @@ namespace hpx::execution {
         }
 
         ///////////////////////////////////////////////////////////////////////
-        template <typename Executor, typename Parameters>
+        template <template <class> typename Base, typename Executor,
+            typename Parameters>
         constexpr decltype(auto) tag_invoke(
             hpx::execution::experimental::to_non_task_t tag,
-            par_simd_task_policy_shim<Executor, Parameters> const& policy)
+            par_simd_task_policy_shim<Base, Executor, Parameters> const& policy)
         {
             return par_simd_policy()
                 .on(hpx::experimental::prefer(tag, policy.executor()))
                 .with(policy.parameters());
         }
 
-        template <typename Executor, typename Parameters>
+        template <template <class> typename Base, typename Executor,
+            typename Parameters>
         constexpr decltype(auto) tag_invoke(
             hpx::execution::experimental::to_non_par_t tag,
-            par_simd_task_policy_shim<Executor, Parameters> const& policy)
+            par_simd_task_policy_shim<Base, Executor, Parameters> const& policy)
         {
             return simd_task_policy()
                 .on(hpx::experimental::prefer(tag, policy.executor()))
                 .with(policy.parameters());
         }
 
-        template <typename Executor, typename Parameters>
+        template <template <class> typename Base, typename Executor,
+            typename Parameters>
         constexpr decltype(auto) tag_invoke(
             hpx::execution::experimental::to_non_simd_t tag,
-            par_simd_task_policy_shim<Executor, Parameters> const& policy)
+            par_simd_task_policy_shim<Base, Executor, Parameters> const& policy)
         {
             return parallel_task_policy()
                 .on(hpx::experimental::prefer(tag, policy.executor()))
                 .with(policy.parameters());
         }
 
-        template <typename Executor, typename Parameters>
+        template <template <class> typename Base, typename Executor,
+            typename Parameters>
         constexpr decltype(auto) tag_invoke(
             hpx::execution::experimental::to_simd_t tag,
-            parallel_task_policy_shim<Executor, Parameters> const& policy)
+            parallel_task_policy_shim<Base, Executor, Parameters> const& policy)
         {
             return par_simd_task_policy()
                 .on(hpx::experimental::prefer(tag, policy.executor()))
@@ -470,30 +508,32 @@ namespace hpx::detail {
     // extensions
 
     /// \cond NOINTERNAL
-    template <typename Executor, typename Parameters>
+    template <template <class> typename Base, typename Executor,
+        typename Parameters>
     struct is_execution_policy<
-        hpx::execution::detail::simd_policy_shim<Executor, Parameters>>
+        hpx::execution::detail::simd_policy_shim<Base, Executor, Parameters>>
       : std::true_type
     {
     };
 
-    template <typename Executor, typename Parameters>
-    struct is_execution_policy<
-        hpx::execution::detail::simd_task_policy_shim<Executor, Parameters>>
-      : std::true_type
+    template <template <class> typename Base, typename Executor,
+        typename Parameters>
+    struct is_execution_policy<hpx::execution::detail::simd_task_policy_shim<
+        Base, Executor, Parameters>> : std::true_type
     {
     };
 
-    template <typename Executor, typename Parameters>
-    struct is_execution_policy<
-        hpx::execution::detail::par_simd_policy_shim<Executor, Parameters>>
-      : std::true_type
+    template <template <class> typename Base, typename Executor,
+        typename Parameters>
+    struct is_execution_policy<hpx::execution::detail::par_simd_policy_shim<
+        Base, Executor, Parameters>> : std::true_type
     {
     };
 
-    template <typename Executor, typename Parameters>
-    struct is_execution_policy<
-        hpx::execution::detail::par_simd_task_policy_shim<Executor, Parameters>>
+    template <template <class> typename Base, typename Executor,
+        typename Parameters>
+    struct is_execution_policy<hpx::execution::detail::
+            par_simd_task_policy_shim<Base, Executor, Parameters>>
       : std::true_type
     {
     };
@@ -501,16 +541,35 @@ namespace hpx::detail {
 
     ///////////////////////////////////////////////////////////////////////////
     /// \cond NOINTERNAL
-    template <typename Executor, typename Parameters>
+    template <template <class> typename Base, typename Executor,
+        typename Parameters>
     struct is_sequenced_execution_policy<
-        hpx::execution::detail::simd_policy_shim<Executor, Parameters>>
+        hpx::execution::detail::simd_policy_shim<Base, Executor, Parameters>>
       : std::true_type
     {
     };
 
-    template <typename Executor, typename Parameters>
-    struct is_sequenced_execution_policy<
-        hpx::execution::detail::simd_task_policy_shim<Executor, Parameters>>
+    template <template <class> typename Base, typename Executor,
+        typename Parameters>
+    struct is_sequenced_execution_policy<hpx::execution::detail::
+            simd_task_policy_shim<Base, Executor, Parameters>> : std::true_type
+    {
+    };
+    /// \endcond
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// \cond NOINTERNAL
+    template <template <class> typename Base, typename Executor,
+        typename Parameters>
+    struct is_async_execution_policy<hpx::execution::detail::
+            simd_task_policy_shim<Base, Executor, Parameters>> : std::true_type
+    {
+    };
+
+    template <template <class> typename Base, typename Executor,
+        typename Parameters>
+    struct is_async_execution_policy<hpx::execution::detail::
+            par_simd_task_policy_shim<Base, Executor, Parameters>>
       : std::true_type
     {
     };
@@ -518,33 +577,17 @@ namespace hpx::detail {
 
     ///////////////////////////////////////////////////////////////////////////
     /// \cond NOINTERNAL
-    template <typename Executor, typename Parameters>
-    struct is_async_execution_policy<
-        hpx::execution::detail::simd_task_policy_shim<Executor, Parameters>>
-      : std::true_type
+    template <template <class> typename Base, typename Executor,
+        typename Parameters>
+    struct is_parallel_execution_policy<hpx::execution::detail::
+            par_simd_policy_shim<Base, Executor, Parameters>> : std::true_type
     {
     };
 
-    template <typename Executor, typename Parameters>
-    struct is_async_execution_policy<
-        hpx::execution::detail::par_simd_task_policy_shim<Executor, Parameters>>
-      : std::true_type
-    {
-    };
-    /// \endcond
-
-    ///////////////////////////////////////////////////////////////////////////
-    /// \cond NOINTERNAL
-    template <typename Executor, typename Parameters>
-    struct is_parallel_execution_policy<
-        hpx::execution::detail::par_simd_policy_shim<Executor, Parameters>>
-      : std::true_type
-    {
-    };
-
-    template <typename Executor, typename Parameters>
-    struct is_parallel_execution_policy<
-        hpx::execution::detail::par_simd_task_policy_shim<Executor, Parameters>>
+    template <template <class> typename Base, typename Executor,
+        typename Parameters>
+    struct is_parallel_execution_policy<hpx::execution::detail::
+            par_simd_task_policy_shim<Base, Executor, Parameters>>
       : std::true_type
     {
     };
@@ -552,30 +595,32 @@ namespace hpx::detail {
 
     ///////////////////////////////////////////////////////////////////////////
     /// \cond NOINTERNAL
-    template <typename Executor, typename Parameters>
+    template <template <class> typename Base, typename Executor,
+        typename Parameters>
     struct is_vectorpack_execution_policy<
-        hpx::execution::detail::simd_policy_shim<Executor, Parameters>>
+        hpx::execution::detail::simd_policy_shim<Base, Executor, Parameters>>
       : std::true_type
     {
     };
 
-    template <typename Executor, typename Parameters>
-    struct is_vectorpack_execution_policy<
-        hpx::execution::detail::simd_task_policy_shim<Executor, Parameters>>
-      : std::true_type
+    template <template <class> typename Base, typename Executor,
+        typename Parameters>
+    struct is_vectorpack_execution_policy<hpx::execution::detail::
+            simd_task_policy_shim<Base, Executor, Parameters>> : std::true_type
     {
     };
 
-    template <typename Executor, typename Parameters>
-    struct is_vectorpack_execution_policy<
-        hpx::execution::detail::par_simd_policy_shim<Executor, Parameters>>
-      : std::true_type
+    template <template <class> typename Base, typename Executor,
+        typename Parameters>
+    struct is_vectorpack_execution_policy<hpx::execution::detail::
+            par_simd_policy_shim<Base, Executor, Parameters>> : std::true_type
     {
     };
 
-    template <typename Executor, typename Parameters>
-    struct is_vectorpack_execution_policy<
-        hpx::execution::detail::par_simd_task_policy_shim<Executor, Parameters>>
+    template <template <class> typename Base, typename Executor,
+        typename Parameters>
+    struct is_vectorpack_execution_policy<hpx::execution::detail::
+            par_simd_task_policy_shim<Base, Executor, Parameters>>
       : std::true_type
     {
     };

--- a/libs/core/executors/include/hpx/executors/datapar/execution_policy_fwd.hpp
+++ b/libs/core/executors/include/hpx/executors/datapar/execution_policy_fwd.hpp
@@ -15,16 +15,20 @@
 namespace hpx::execution::detail {
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Executor, typename Parameters>
+    template <template <class> typename Base, typename Executor,
+        typename Parameters>
     struct simd_policy_shim;
 
-    template <typename Executor, typename Parameters>
+    template <template <class> typename Base, typename Executor,
+        typename Parameters>
     struct simd_task_policy_shim;
 
-    template <typename Executor, typename Parameters>
+    template <template <class> typename Base, typename Executor,
+        typename Parameters>
     struct par_simd_policy_shim;
 
-    template <typename Executor, typename Parameters>
+    template <template <class> typename Base, typename Executor,
+        typename Parameters>
     struct par_simd_task_policy_shim;
 }    // namespace hpx::execution::detail
 

--- a/libs/core/executors/include/hpx/executors/execution_policy_fwd.hpp
+++ b/libs/core/executors/include/hpx/executors/execution_policy_fwd.hpp
@@ -11,27 +11,35 @@
 namespace hpx::execution::detail {
 
     // forward declarations, see execution_policy.hpp
-    template <typename Executor, typename Parameters>
+    template <template <class> typename Base, typename Executor,
+        typename Parameters>
     struct sequenced_policy_shim;
 
-    template <typename Executor, typename Parameters>
+    template <template <class> typename Base, typename Executor,
+        typename Parameters>
     struct sequenced_task_policy_shim;
 
-    template <typename Executor, typename Parameters>
+    template <template <class> typename Base, typename Executor,
+        typename Parameters>
     struct parallel_policy_shim;
 
-    template <typename Executor, typename Parameters>
+    template <template <class> typename Base, typename Executor,
+        typename Parameters>
     struct parallel_task_policy_shim;
 
-    template <typename Executor, typename Parameters>
+    template <template <class> typename Base, typename Executor,
+        typename Parameters>
     struct unsequenced_task_policy_shim;
 
-    template <typename Executor, typename Parameters>
+    template <template <class> typename Base, typename Executor,
+        typename Parameters>
     struct unsequenced_policy_shim;
 
-    template <typename Executor, typename Parameters>
+    template <template <class> typename Base, typename Executor,
+        typename Parameters>
     struct parallel_unsequenced_task_policy_shim;
 
-    template <typename Executor, typename Parameters>
+    template <template <class> typename Base, typename Executor,
+        typename Parameters>
     struct parallel_unsequenced_policy_shim;
 }    // namespace hpx::execution::detail

--- a/libs/core/executors/tests/unit/CMakeLists.txt
+++ b/libs/core/executors/tests/unit/CMakeLists.txt
@@ -8,6 +8,7 @@ set(tests
     annotating_executor
     annotation_property
     created_executor
+    execution_policy_base
     execution_policy_mappings
     explicit_scheduler_executor
     fork_join_executor

--- a/libs/core/executors/tests/unit/execution_policy_base.cpp
+++ b/libs/core/executors/tests/unit/execution_policy_base.cpp
@@ -1,0 +1,67 @@
+//  Copyright (c) 2025 Agustin Berge
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/datapar.hpp>
+#include <hpx/execution.hpp>
+#include <hpx/init.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/program_options.hpp>
+
+#include <type_traits>
+
+template <typename Derived>
+struct custom_base
+{
+};
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename ExPolicy>
+void test_base(ExPolicy&& policy)
+{
+    using policy_t = std::decay_t<ExPolicy>;
+
+    static_assert(std::is_base_of_v<custom_base<policy_t>, policy_t>,
+        "must have custom_base<policy_t> as base class");
+
+    (void) policy;
+}
+
+void test_base()
+{
+    using namespace hpx::execution;
+
+    test_base(basic_sequenced_policy<custom_base>{});
+    test_base(basic_parallel_policy<custom_base>{});
+    test_base(basic_unsequenced_policy<custom_base>{});
+    test_base(basic_parallel_unsequenced_policy<custom_base>{});
+    test_base(basic_sequenced_task_policy<custom_base>{});
+    test_base(basic_parallel_task_policy<custom_base>{});
+    test_base(basic_unsequenced_task_policy<custom_base>{});
+    test_base(basic_parallel_unsequenced_task_policy<custom_base>{});
+#if defined(HPX_HAVE_DATAPAR)
+    test_base(basic_simd_task_policy<custom_base>{});
+    test_base(basic_par_simd_task_policy<custom_base>{});
+    test_base(basic_simd_task_policy<custom_base>{});
+    test_base(basic_par_simd_task_policy<custom_base>{});
+#endif
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(hpx::program_options::variables_map&)
+{
+    test_base();
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // Initialize and run HPX
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
## Proposed Changes

Add a template template param to `execution_policy` to specify a base class to inherit from in a way that's compatible with policy rebinding.

## Any background context you want to provide?

This is required to inject a `thrust::execution_policy` base into HPX execution policies.

## Checklist

Not all points below apply to all pull requests.

- [x] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
