### PR TITLE
Update modules.rst

### DIFF
--- a/docs/sphinx/contributing/modules.rst
+++ b/docs/sphinx/contributing/modules.rst
@@ -14,7 +14,7 @@ Module structure
 This section explains the structure of an |hpx| module.
 
 The tool `create_library_skeleton.py
-<https://github.com/STEllAR-GROUP/hpx/blob/master/libs/create_library_skeleton.py>`_
+<https://github.com/STEllAR-GROUP/hpx/blob/master/libs/create_module_skeleton.py>`_
 can be used to generate a basic skeleton. To create a library skeleton, run the
 tool in the ``libs`` subdirectory with the module name as an argument:
 


### PR DESCRIPTION
changed the link to ```https://github.com/STEllAR-GROUP/hpx/blob/master/libs/create_module_skeleton.py```

Fixes #6671

## Proposed Changes
Updated the broken hyperlink in docs/sphinx/contributing/modules.rst.

## Any background context you want to provide?
