### PR TITLE
Fix: FindTBB.cmake cannot find correct TBB library. #6504

### DIFF
--- a/cmake/FindTBB.cmake
+++ b/cmake/FindTBB.cmake
@@ -18,8 +18,10 @@ find_package(PkgConfig QUIET)
 pkg_check_modules(PC_Tbb QUIET libtbb)
 
 find_path(
-  Tbb_INCLUDE_DIR tbb/tbb.h
+  Tbb_INCLUDE_DIR
+  NAMES tbb/tbb.h
   HINTS ${Tbb_ROOT} ENV TBB_ROOT ${PC_Tbb_INCLUDEDIR} ${PC_Tbb_INCLUDE_DIRS}
+  PATHS /usr/include
   PATH_SUFFIXES include
 )
 
@@ -32,18 +34,17 @@ if(Tbb_PLATFORM STREQUAL "mic-knl")
 endif()
 
 find_library(
-  Tbb_PROXY_LIBRARY
+  TBB_LIBRARY
   NAMES tbb libtbb
   HINTS ${Tbb_ROOT} ENV TBB_ROOT ${PC_Tbb_LIBDIR} ${PC_Tbb_LIBRARY_DIRS}
+  PATHS /usr/lib /usr/lib/x86_64-linux-gnu
   PATH_SUFFIXES ${Tbb_PATH_SUFFIX} lib lib64
 )
 
 set(Tbb_LIBRARIES ${Tbb_LIBRARY} ${Tbb_PROXY_LIBRARY})
 set(Tbb_INCLUDE_DIRS ${Tbb_INCLUDE_DIR})
 
-find_package_handle_standard_args(
-  TBB DEFAULT_MSG TBB_LIBRARY TBB_INCLUDE_DIR
-)
+find_package_handle_standard_args(TBB DEFAULT_MSG TBB_LIBRARY TBB_INCLUDE_DIR)
 
 foreach(v Tbb_ROOT Tbb_PLATFORM)
   get_property(
@@ -60,7 +61,3 @@ foreach(v Tbb_ROOT Tbb_PLATFORM)
 endforeach()
 
 mark_as_advanced(Tbb_ROOT Tbb_LIBRARY Tbb_PROXY_LIBRARY Tbb_INCLUDE_DIR)
-
-
-find_path(Tbb_INCLUDE_DIR tbb/tbb.h PATHS /usr/include)
-find_library(TBB_LIBRARY NAMES tbb PATHS /usr/lib /usr/lib/x86_64-linux-gnu)

--- a/cmake/FindTBB.cmake
+++ b/cmake/FindTBB.cmake
@@ -42,7 +42,7 @@ set(Tbb_LIBRARIES ${Tbb_LIBRARY} ${Tbb_PROXY_LIBRARY})
 set(Tbb_INCLUDE_DIRS ${Tbb_INCLUDE_DIR})
 
 find_package_handle_standard_args(
-  TBBmalloc DEFAULT_MSG Tbb_LIBRARY Tbb_PROXY_LIBRARY Tbb_INCLUDE_DIR
+  TBB DEFAULT_MSG TBB_LIBRARY TBB_INCLUDE_DIR
 )
 
 foreach(v Tbb_ROOT Tbb_PLATFORM)
@@ -60,3 +60,7 @@ foreach(v Tbb_ROOT Tbb_PLATFORM)
 endforeach()
 
 mark_as_advanced(Tbb_ROOT Tbb_LIBRARY Tbb_PROXY_LIBRARY Tbb_INCLUDE_DIR)
+
+
+find_path(Tbb_INCLUDE_DIR tbb/tbb.h PATHS /usr/include)
+find_library(TBB_LIBRARY NAMES tbb PATHS /usr/lib /usr/lib/x86_64-linux-gnu)


### PR DESCRIPTION
Fixes#

## Proposed Changes

- This PR fixes issue #6504 related to TBB detection during CMake configuration.
- Fixed `FindTBB.cmake` parsing issue that prevented CMake from locating the correct TBB library.
- Ensured proper detection of `TBB_LIBRARY` and `TBB_INCLUDE_DIR`.
- Verified successful configuration and build with TBB examples enabled.

## Any background context you want to provide?

This PR resolves issue #6504. While attempting to build HPX with TBB support (`HPX_WITH_EXAMPLES_TBB=ON`), CMake was failing to properly detect the TBB library due to a malformed or incorrect script in `FindTBB.cmake`. This caused users to be unable to compile with TBB-related examples or modules.

After fixing the CMake script, HPX now configures and compiles successfully with TBB enabled.

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test. *(optional — if no test needed, leave unchecked)*
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
