### PR TITLE
Fix oneapi overloads

### DIFF
--- a/libs/core/async_sycl/include/hpx/async_sycl/sycl_executor.hpp
+++ b/libs/core/async_sycl/include/hpx/async_sycl/sycl_executor.hpp
@@ -25,6 +25,7 @@
 #include <memory>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 namespace hpx::sycl::experimental {
     namespace detail {
@@ -377,8 +378,6 @@ namespace hpx {
                 f),
             HPX_FORWARD(Ts, ts)...);
     }
-
-    // TODO(daissgr) Maybe make the next two specialized for the submit method (mostly by requiring a different function point?
 
     template <typename Executor, typename... Ts, typename T,
         std::enable_if_t<(std::conjunction_v<sycl::experimental::detail::

--- a/libs/core/async_sycl/include/hpx/async_sycl/sycl_executor.hpp
+++ b/libs/core/async_sycl/include/hpx/async_sycl/sycl_executor.hpp
@@ -133,41 +133,41 @@ namespace hpx::sycl::experimental {
         // using a default argument (code_location::current())
 
         /// sycl::queue::member_function type with code_location parameter
-        template <typename Param>
+        template <typename... Params>
         using queue_function_code_loc_ptr_t = cl::sycl::event (
-            cl::sycl::queue::*)(Param, cl::sycl::detail::code_location const&);
+            cl::sycl::queue::*)(Params..., cl::sycl::detail::code_location const&);
         /// Invoke member function given queue and parameters. Default
         /// code_location argument added automatically.
-        template <typename Param>
-        void post(queue_function_code_loc_ptr_t<Param>&& queue_member_function,
-            Param&& args)
+        template <typename... Params>
+        void post(queue_function_code_loc_ptr_t<Params...>&& queue_member_function,
+            Params&&... args)
         {
             // for the intel version we need to actually pass the code
             // location.  Within the intel sycl api this is usually a default
             // argument, but for invoke we need to pass it manually
             cl::sycl::event e =
-                HPX_INVOKE(HPX_FORWARD(queue_function_code_loc_ptr_t<Param>,
+                HPX_INVOKE(HPX_FORWARD(queue_function_code_loc_ptr_t<Params...>,
                                queue_member_function),
-                    command_queue, HPX_FORWARD(Param, args),
+                    command_queue, HPX_FORWARD(Params, args)...,
                     cl::sycl::detail::code_location::current());
         }
         /// Invoke queue member function given queue and parameters. Default
         /// code_location argument added automatically.  / Returns hpx::future
         /// tied to the sycl event returned by the asynchronous queue member
         /// function call (two way)
-        template <typename Param>
+        template <typename... Params>
         hpx::future<void> async_execute(
-            queue_function_code_loc_ptr_t<Param>&& queue_member_function,
-            Param&& args)
+            queue_function_code_loc_ptr_t<Params...>&& queue_member_function,
+            Params&&... args)
         {
             // launching a sycl member function may throw -- if it does put it
             // into the future
             return hpx::detail::try_catch_exception_ptr(
                 [&]() {
                     cl::sycl::event e = HPX_INVOKE(
-                        HPX_FORWARD(queue_function_code_loc_ptr_t<Param>,
+                        HPX_FORWARD(queue_function_code_loc_ptr_t<Params...>,
                             queue_member_function),
-                        command_queue, HPX_FORWARD(Param, args),
+                        command_queue, HPX_FORWARD(Params, args)...,
                         cl::sycl::detail::code_location::current());
                     return get_future(e);
                 },
@@ -247,7 +247,7 @@ namespace hpx {
 
     /// hpx::async overload for launching sycl queue member functions with an
     /// sycl executor
-    template <typename Executor, typename... Ts>
+    template <typename Executor, typename... Ts, std::enable_if_t<!(std::conjunction_v<std::is_scalar<Ts>...>), bool> guard=true>
     HPX_FORCEINLINE decltype(auto) async(Executor&& exec,
         hpx::sycl::experimental::sycl_executor::queue_function_ptr_t<Ts...>&& f,
         Ts&&... ts)
@@ -268,7 +268,7 @@ namespace hpx {
 
     /// hpx::apply overload for launching sycl queue member functions with an
     /// sycl executor
-    template <typename Executor, typename... Ts>
+    template <typename Executor, typename... Ts, std::enable_if_t<!(std::conjunction_v<std::is_scalar<Ts>...>), bool> guard=true>
     HPX_FORCEINLINE bool apply(Executor&& exec,
         hpx::sycl::experimental::sycl_executor::queue_function_ptr_t<Ts...>&& f,
         Ts&&... ts)
@@ -290,11 +290,11 @@ namespace hpx {
     (defined(__clang__) && defined(SYCL_IMPLEMENTATION_ONEAPI))
     /// hpx::async overload for launching sycl queue member functions with an
     /// sycl executor and code location ptrs
-    template <typename Executor, typename Ts>
+    template <typename Executor, typename... Ts, std::enable_if_t<(std::conjunction_v<std::is_scalar<Ts>...>), bool> guard=true>
     HPX_FORCEINLINE decltype(auto) async(Executor&& exec,
         hpx::sycl::experimental::sycl_executor::queue_function_code_loc_ptr_t<
-            Ts>&& f,
-        Ts&& ts)
+            Ts...>&& f,
+        Ts&&... ts)
     {
         // Make sure we only use this for sycl executors
         static_assert(std::is_same<std::decay_t<Executor>,
@@ -304,18 +304,18 @@ namespace hpx {
             typename std::decay<Executor>::type>::call(HPX_FORWARD(Executor,
                                                            exec),
             HPX_FORWARD(hpx::sycl::experimental::sycl_executor::
-                            queue_function_code_loc_ptr_t<Ts>,
+                            queue_function_code_loc_ptr_t<Ts...>,
                 f),
-            HPX_FORWARD(Ts, ts));
+            HPX_FORWARD(Ts, ts)...);
     }
 
     /// hpx::apply overload for launching sycl queue member functions with an
     /// sycl executor and code location ptrs
-    template <typename Executor, typename Ts>
+    template <typename Executor, typename... Ts, std::enable_if_t<(std::conjunction_v<std::is_scalar<Ts>...>), bool> guard=true>
     HPX_FORCEINLINE bool apply(Executor&& exec,
         hpx::sycl::experimental::sycl_executor::queue_function_code_loc_ptr_t<
-            Ts>&& f,
-        Ts&& ts)
+            Ts...>&& f,
+        Ts&&... ts)
     {
         // Make sure we only use this for sycl executors
         static_assert(std::is_same_v<std::decay_t<Executor>,
@@ -324,9 +324,50 @@ namespace hpx {
         return detail::post_dispatch<typename std::decay<Executor>::type>::call(
             HPX_FORWARD(Executor, exec),
             HPX_FORWARD(hpx::sycl::experimental::sycl_executor::
-                            queue_function_code_loc_ptr_t<Ts>,
+                            queue_function_code_loc_ptr_t<Ts...>,
                 f),
-            HPX_FORWARD(Ts, ts));
+            HPX_FORWARD(Ts, ts)...);
+    }
+
+    // TODO(daissgr) Maybe make the next two specialized for the submit method (mostly by requiring a different function point?
+
+    template <typename Executor, typename T>
+    HPX_FORCEINLINE decltype(auto) async(Executor&& exec,
+        hpx::sycl::experimental::sycl_executor::queue_function_code_loc_ptr_t<
+            T>&& f,
+        T&& t)
+    {
+        // Make sure we only use this for sycl executors
+        static_assert(std::is_same<std::decay_t<Executor>,
+            hpx::sycl::experimental::sycl_executor>::value);
+        // Use the same async_dispatch than the normal async otherwise
+        return detail::async_dispatch<
+            typename std::decay<Executor>::type>::call(HPX_FORWARD(Executor,
+                                                           exec),
+            HPX_FORWARD(hpx::sycl::experimental::sycl_executor::
+                            queue_function_code_loc_ptr_t<T>,
+                f),
+            HPX_FORWARD(T, t));
+    }
+
+    /// hpx::apply overload for launching sycl queue member functions with an
+    /// sycl executor and code location ptrs
+    template <typename Executor, typename T>
+    HPX_FORCEINLINE bool apply(Executor&& exec,
+        hpx::sycl::experimental::sycl_executor::queue_function_code_loc_ptr_t<
+            T>&& f,
+        T&& t)
+    {
+        // Make sure we only use this for sycl executors
+        static_assert(std::is_same_v<std::decay_t<Executor>,
+            hpx::sycl::experimental::sycl_executor>);
+        // Use the same apply_dispatch than the normal apply otherwise
+        return detail::post_dispatch<typename std::decay<Executor>::type>::call(
+            HPX_FORWARD(Executor, exec),
+            HPX_FORWARD(hpx::sycl::experimental::sycl_executor::
+                            queue_function_code_loc_ptr_t<T>,
+                f),
+            HPX_FORWARD(T, t));
     }
 #endif
 }    // namespace hpx

--- a/libs/core/async_sycl/include/hpx/async_sycl/sycl_executor.hpp
+++ b/libs/core/async_sycl/include/hpx/async_sycl/sycl_executor.hpp
@@ -28,7 +28,7 @@
 
 namespace hpx::sycl::experimental {
     namespace detail {
-        /// type trait to identify basic sycl queue args (as in: no sycl indices / callable kernels) 
+        /// type trait to identify basic sycl queue args (as in: no sycl indices / callable kernels)
         /// Required for correct overloading later on
         template <class T>
         struct is_basic_queue_arg
@@ -36,7 +36,8 @@ namespace hpx::sycl::experimental {
                 std::is_scalar<T>::value ||
                     std::is_same<T, cl::sycl::event>::value ||
                     std::is_same<T, const std::vector<cl::sycl::event>&>::value>
-        {};
+        {
+        };
     }    // namespace detail
 
     struct sycl_executor
@@ -146,14 +147,17 @@ namespace hpx::sycl::experimental {
         /// sycl::queue::member_function type with code_location parameter
         template <typename... Params>
         using queue_function_code_loc_ptr_t = cl::sycl::event (
-            cl::sycl::queue::*)(std::conditional_t<
+            cl::sycl::queue::*)(
+            std::conditional_t<
                 std::is_trivial_v<std::remove_reference_t<Params>>,
-                std::decay_t<Params>, Params>..., cl::sycl::detail::code_location const&);
+                std::decay_t<Params>, Params>...,
+            cl::sycl::detail::code_location const&);
 
         /// Invoke member function given queue and parameters. Default
         /// code_location argument added automatically.
         template <typename... Params>
-        void post(queue_function_code_loc_ptr_t<Params...>&& queue_member_function,
+        void post(
+            queue_function_code_loc_ptr_t<Params...>&& queue_member_function,
             Params&&... args)
         {
             // for the intel version we need to actually pass the code
@@ -224,11 +228,10 @@ namespace hpx::sycl::experimental {
             return command_queue.get_context();
         }
         /// Return the underlying queue for direct access
-        HPX_FORCEINLINE cl::sycl::queue& get_queue() 
+        HPX_FORCEINLINE cl::sycl::queue& get_queue()
         {
             return command_queue;
         }
-
 
         // TODO Future work: Check if we want to expose any other (non-event)
         // queue methods
@@ -395,9 +398,8 @@ namespace hpx {
             typename std::decay<Executor>::type>::call(HPX_FORWARD(Executor,
                                                            exec),
             std::forward<hpx::sycl::experimental::sycl_executor::
-                            queue_function_code_loc_ptr_t<Ts..., T>>(f),
-                std::forward<Ts>(ts)...,
-            std::forward<T>(t));
+                    queue_function_code_loc_ptr_t<Ts..., T>>(f),
+            std::forward<Ts>(ts)..., std::forward<T>(t));
     }
 
     /// hpx::apply overload for launching sycl queue member functions with an
@@ -420,9 +422,8 @@ namespace hpx {
         return detail::post_dispatch<typename std::decay<Executor>::type>::call(
             HPX_FORWARD(Executor, exec),
             std::forward<hpx::sycl::experimental::sycl_executor::
-                            queue_function_code_loc_ptr_t<Ts..., T>>(f),
-                std::forward<Ts>(ts)...,
-            std::forward<T>(t));
+                    queue_function_code_loc_ptr_t<Ts..., T>>(f),
+            std::forward<Ts>(ts)..., std::forward<T>(t));
     }
 #endif
 }    // namespace hpx

--- a/libs/core/async_sycl/include/hpx/async_sycl/sycl_executor.hpp
+++ b/libs/core/async_sycl/include/hpx/async_sycl/sycl_executor.hpp
@@ -269,7 +269,11 @@ namespace hpx {
     /// sycl executor
 #if defined(__INTEL_LLVM_COMPILER) ||                                          \
     (defined(__clang__) && defined(SYCL_IMPLEMENTATION_ONEAPI))
-    template <typename Executor, typename... Ts, std::enable_if_t<!(std::conjunction_v<sycl::experimental::detail::is_basic_queue_arg<Ts>...>), bool> guard=true>
+    template <typename Executor, typename... Ts,
+        std::enable_if_t<!(std::conjunction_v<sycl::experimental::detail::
+                                 is_basic_queue_arg<Ts>...>),
+            bool>
+            guard = true>
 #else
     template <typename Executor, typename... Ts>
 #endif
@@ -295,7 +299,11 @@ namespace hpx {
     /// sycl executor
 #if defined(__INTEL_LLVM_COMPILER) ||                                          \
     (defined(__clang__) && defined(SYCL_IMPLEMENTATION_ONEAPI))
-    template <typename Executor, typename... Ts, std::enable_if_t<!(std::conjunction_v<sycl::experimental::detail::is_basic_queue_arg<Ts>...>), bool> guard=true>
+    template <typename Executor, typename... Ts,
+        std::enable_if_t<!(std::conjunction_v<sycl::experimental::detail::
+                                 is_basic_queue_arg<Ts>...>),
+            bool>
+            guard = true>
 #else
     template <typename Executor, typename... Ts>
 #endif
@@ -320,7 +328,11 @@ namespace hpx {
     (defined(__clang__) && defined(SYCL_IMPLEMENTATION_ONEAPI))
     /// hpx::async overload for launching sycl queue member functions with an
     /// sycl executor and code location ptrs
-    template <typename Executor, typename... Ts, std::enable_if_t<(std::conjunction_v<sycl::experimental::detail::is_basic_queue_arg<Ts>...>), bool> guard=true>
+    template <typename Executor, typename... Ts,
+        std::enable_if_t<(std::conjunction_v<sycl::experimental::detail::
+                                 is_basic_queue_arg<Ts>...>),
+            bool>
+            guard = true>
     HPX_FORCEINLINE decltype(auto) async(Executor&& exec,
         hpx::sycl::experimental::sycl_executor::queue_function_code_loc_ptr_t<
             Ts...>&& f,
@@ -341,7 +353,11 @@ namespace hpx {
 
     /// hpx::apply overload for launching sycl queue member functions with an
     /// sycl executor and code location ptrs
-    template <typename Executor, typename... Ts, std::enable_if_t<(std::conjunction_v<sycl::experimental::detail::is_basic_queue_arg<Ts>...>), bool> guard=true>
+    template <typename Executor, typename... Ts,
+        std::enable_if_t<(std::conjunction_v<sycl::experimental::detail::
+                                 is_basic_queue_arg<Ts>...>),
+            bool>
+            guard = true>
     HPX_FORCEINLINE bool apply(Executor&& exec,
         hpx::sycl::experimental::sycl_executor::queue_function_code_loc_ptr_t<
             Ts...>&& f,
@@ -361,11 +377,15 @@ namespace hpx {
 
     // TODO(daissgr) Maybe make the next two specialized for the submit method (mostly by requiring a different function point?
 
-    template <typename Executor, typename... Ts, typename T, std::enable_if_t<(std::conjunction_v<sycl::experimental::detail::is_basic_queue_arg<Ts>...>), bool> guard=true>
+    template <typename Executor, typename... Ts, typename T,
+        std::enable_if_t<(std::conjunction_v<sycl::experimental::detail::
+                                 is_basic_queue_arg<Ts>...>),
+            bool>
+            guard = true>
     HPX_FORCEINLINE decltype(auto) async(Executor&& exec,
         hpx::sycl::experimental::sycl_executor::queue_function_code_loc_ptr_t<
-            Ts..., T>&& f, Ts&&... ts,
-        T&& t)
+            Ts..., T>&& f,
+        Ts&&... ts, T&& t)
     {
         // Make sure we only use this for sycl executors
         static_assert(std::is_same<std::decay_t<Executor>,
@@ -383,11 +403,15 @@ namespace hpx {
     /// hpx::apply overload for launching sycl queue member functions with an
     /// sycl executor and code location ptrs
     /* template <typename Executor, typename T> */
-    template <typename Executor, typename... Ts, typename T, std::enable_if_t<(std::conjunction_v<sycl::experimental::detail::is_basic_queue_arg<Ts>...>), bool> guard=true>
+    template <typename Executor, typename... Ts, typename T,
+        std::enable_if_t<(std::conjunction_v<sycl::experimental::detail::
+                                 is_basic_queue_arg<Ts>...>),
+            bool>
+            guard = true>
     HPX_FORCEINLINE bool apply(Executor&& exec,
         hpx::sycl::experimental::sycl_executor::queue_function_code_loc_ptr_t<
-            Ts..., T>&& f, Ts&&... ts,
-        T&& t)
+            Ts..., T>&& f,
+        Ts&&... ts, T&& t)
     {
         // Make sure we only use this for sycl executors
         static_assert(std::is_same_v<std::decay_t<Executor>,

--- a/libs/core/async_sycl/tests/unit/sycl_stream.cpp
+++ b/libs/core/async_sycl/tests/unit/sycl_stream.cpp
@@ -70,6 +70,10 @@ int hpx_main(int, char*[])
     hpx::apply(exec, &cl::sycl::queue::parallel_for,
         cl::sycl::range<1>{vectorsize}, reset_input_method);
 
+    // Note: shortcut function like cl::sycl::queue::parallel_for (which bypass
+    // the usual queue.submit pattern) require a reference to a kernel function
+    // (hence we cannot pass a temporary. Instead we define our kernel lambdas
+    // here...
     const auto copy_step = [=](cl::sycl::id<1> i) { c[i] = a[i]; };
     const auto scale_step = [=](cl::sycl::id<1> i) { b[i] = scalar * c[i]; };
     const auto add_step = [=](cl::sycl::id<1> i) { c[i] = a[i] + b[i]; };
@@ -77,6 +81,7 @@ int hpx_main(int, char*[])
         a[i] = b[i] + scalar * c[i];
     };
 
+    // ... and call them here
     hpx::apply(exec, &cl::sycl::queue::parallel_for,
         cl::sycl::range<1>{vectorsize}, copy_step);
     hpx::apply(exec, &cl::sycl::queue::parallel_for,
@@ -133,8 +138,31 @@ int hpx_main(int, char*[])
     }
     std::cerr << "Validation passed!" << std::endl;
 
+    // Test running single_tasks with executor (to test single_task overloads are working)
+    const auto single_task_test1 = [=]() {
+        a[42] = 137.0f;
+    };
+    const auto single_task_test2 = [=]() {
+        a[137] = 42.0f;
+    };
+    hpx::apply(exec, &cl::sycl::queue::single_task, single_task_test1);
+    hpx::apply(exec, &cl::sycl::queue::single_task, single_task_test2);
+
+    auto fut_single_task_test = hpx::async(exec, &cl::sycl::queue::copy,
+        static_cast<const float*>(a), static_cast<float*>(a_host), static_cast<size_t>(vectorsize));
+    fut_single_task_test.get();
+
+    if (std::abs(a_host[42] - 137.0f) > epsilon || std::abs(a_host[137] - 42.0f) > epsilon)
+    {
+        std::cerr << "Validation error! Wrong results in array a after "
+                     "single_task test!"
+                  << std::endl;
+        std::terminate();
+    }
+    std::cerr << "Single_task validation passed!" << std::endl;
+
     // Cleanup
-    std::cout << "\nDisabling SYCL future polling.\n";
+    std::cout << "\nAll done! Disabling SYCL future polling now...\n";
     hpx::sycl::experimental::detail::unregister_polling(
         hpx::resource::get_thread_pool(0));
     return hpx::finalize();

--- a/libs/core/async_sycl/tests/unit/sycl_stream.cpp
+++ b/libs/core/async_sycl/tests/unit/sycl_stream.cpp
@@ -50,8 +50,8 @@ int hpx_main(int, char*[])
     // Note: Parameter types needs to match exactly, otherwise the correct
     // function won't be found -- in this case we need to cast from float* to void*
     // otherwise the correct memset overload won't be found
-    hpx::apply(
-        exec, &cl::sycl::queue::memset, static_cast<void*>(c), 0, static_cast<size_t>(num_bytes));
+    hpx::apply(exec, &cl::sycl::queue::memset, static_cast<void*>(c), 0,
+        static_cast<size_t>(num_bytes));
     hpx::apply(exec, &cl::sycl::queue::memset, static_cast<void*>(a_host), 0,
         static_cast<size_t>(num_bytes));
     hpx::apply(exec, &cl::sycl::queue::memset, static_cast<void*>(b_host), 0,
@@ -98,8 +98,9 @@ int hpx_main(int, char*[])
         static_cast<float*>(c_host), static_cast<size_t>(vectorsize));
     hpx::apply(exec, &cl::sycl::queue::copy, static_cast<const float*>(b),
         static_cast<float*>(b_host), static_cast<size_t>(vectorsize));
-    auto fut = hpx::async(exec, &cl::sycl::queue::copy,
-        static_cast<const float*>(a), static_cast<float*>(a_host), static_cast<size_t>(vectorsize));
+    auto fut =
+        hpx::async(exec, &cl::sycl::queue::copy, static_cast<const float*>(a),
+            static_cast<float*>(a_host), static_cast<size_t>(vectorsize));
 
     fut.get();
 
@@ -139,20 +140,18 @@ int hpx_main(int, char*[])
     std::cerr << "Validation passed!" << std::endl;
 
     // Test running single_tasks with executor (to test single_task overloads are working)
-    const auto single_task_test1 = [=]() {
-        a[42] = 137.0f;
-    };
-    const auto single_task_test2 = [=]() {
-        a[137] = 42.0f;
-    };
+    const auto single_task_test1 = [=]() { a[42] = 137.0f; };
+    const auto single_task_test2 = [=]() { a[137] = 42.0f; };
     hpx::apply(exec, &cl::sycl::queue::single_task, single_task_test1);
     hpx::apply(exec, &cl::sycl::queue::single_task, single_task_test2);
 
-    auto fut_single_task_test = hpx::async(exec, &cl::sycl::queue::copy,
-        static_cast<const float*>(a), static_cast<float*>(a_host), static_cast<size_t>(vectorsize));
+    auto fut_single_task_test =
+        hpx::async(exec, &cl::sycl::queue::copy, static_cast<const float*>(a),
+            static_cast<float*>(a_host), static_cast<size_t>(vectorsize));
     fut_single_task_test.get();
 
-    if (std::abs(a_host[42] - 137.0f) > epsilon || std::abs(a_host[137] - 42.0f) > epsilon)
+    if (std::abs(a_host[42] - 137.0f) > epsilon ||
+        std::abs(a_host[137] - 42.0f) > epsilon)
     {
         std::cerr << "Validation error! Wrong results in array a after "
                      "single_task test!"

--- a/libs/core/async_sycl/tests/unit/sycl_stream.cpp
+++ b/libs/core/async_sycl/tests/unit/sycl_stream.cpp
@@ -51,13 +51,13 @@ int hpx_main(int, char*[])
     // function won't be found -- in this case we need to cast from float* to void*
     // otherwise the correct memset overload won't be found
     hpx::apply(
-        exec, &cl::sycl::queue::memset, static_cast<void*>(c), 0, num_bytes);
+        exec, &cl::sycl::queue::memset, static_cast<void*>(c), 0, static_cast<size_t>(num_bytes));
     hpx::apply(exec, &cl::sycl::queue::memset, static_cast<void*>(a_host), 0,
-        num_bytes);
+        static_cast<size_t>(num_bytes));
     hpx::apply(exec, &cl::sycl::queue::memset, static_cast<void*>(b_host), 0,
-        num_bytes);
+        static_cast<size_t>(num_bytes));
     hpx::apply(exec, &cl::sycl::queue::memset, static_cast<void*>(c_host), 0,
-        num_bytes);
+        static_cast<size_t>(num_bytes));
 
     float aj = 1.0;
     float bj = 2.0;
@@ -90,11 +90,11 @@ int hpx_main(int, char*[])
     // function won't be found -- in this case we need to cast from float* to const float*
     // otherwise the correct copy overload won't be found
     hpx::apply(exec, &cl::sycl::queue::copy, static_cast<const float*>(c),
-        c_host, vectorsize);
+        static_cast<float*>(c_host), static_cast<size_t>(vectorsize));
     hpx::apply(exec, &cl::sycl::queue::copy, static_cast<const float*>(b),
-        b_host, vectorsize);
+        static_cast<float*>(b_host), static_cast<size_t>(vectorsize));
     auto fut = hpx::async(exec, &cl::sycl::queue::copy,
-        static_cast<const float*>(a), a_host, vectorsize);
+        static_cast<const float*>(a), static_cast<float*>(a_host), static_cast<size_t>(vectorsize));
 
     fut.get();
 


### PR DESCRIPTION
### Background
Our HPX-SYCL was originally written to support both hipSYCL and oneAPI. It allows passing a SYCL executor (containing a SYCL queue), a SYCL queue member function, and its parameters to hpx::async. The correct overload of the queue member function would be determined based on the passed parameters, the member function would then be launched asynchronously on the executor queue, and we would get an HPX future back.

However, oneAPI is using an additional (afaik non-standard) ```code_location``` parameter for many of its SYCL queue member functions. Usually, a SYCL user/developer would not notice this because the ```code_location``` has a default value. In our case, however, it is problematic as it messes with choosing the correct  function overloads when passing the calls to ```hpx::apply``` or ```hpx::async```.

The [original SYCL PR](https://github.com/STEllAR-GROUP/hpx/pull/6085) that added SYCL to HPX addressed this with additional overloads for ```hpx::async``` and ```hpx::apply``` when using oneAPI. These added the code location parameter automatically to find the correct overload.

### The actual issue
However, since then, something about the code location parameter appears to have changed: When compiling the sycl_stream.cpp example with HPX, I now encounter a few errors, such as:
```
/home/devel/hpx/libs/core/async_sycl/tests/unit/sycl_stream.cpp:53:5: error: no matching function for call to 'apply'
   53 |     hpx::apply(
```
or, alternatively, for other lines, errors about ambiguous calls. I am not quite sure when this started breaking, but at least with icpx 2025.0.0 I encountered this issue.

### Fix and next steps
This PR fixes all these overload issues by modifying the overloads of hpx::apply/async for SYCL executors. Depending on the type of the passed arguments I am determining whether to use the overload that adds the code location parameter or not.

With this, passing queue methods works again with oneAPI, at the very least for the most important ones that I tried in the tests (submit, parallel_for, memset, copy, single_task, ...). Optional parameters such as SYCL event dependencies should also work.

In the future, I would like to expand the test suite for this, actually. There aren't this many SYCL queue member functions left, so we might just have a test for each of them. If we add the SYCL tests to the CI this would also warn us with something regarding the overloads breaks again.
However, all of that would require some extra work. Hence, I would put this on the roadmap for after the HPX 1.11.0 release (would be nice for 2.0.0 though). For now, I would be glad to just get this current version of the bugfix in before adding more stuff!

### Additional comments:
- This is PR 1 / 3 for the SYCL changes I want to add before 1.11.0. I split them up as they address separate issues.
- At one point I had to use std::forward instead of HPX_FORWARD as HPX_FORWARD somehow gave me compilation problems for this part: 
```cpp
std::forward<hpx::sycl::experimental::sycl_executor::
                            queue_function_code_loc_ptr_t<Ts..., T>>(f),
                std::forward<Ts>(ts)...,
```
