### PR TITLE
Add semantic tests for extrema algorithms with repeated values

### DIFF
--- a/libs/core/algorithms/tests/unit/algorithms/max_element.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/max_element.cpp
@@ -7,6 +7,7 @@
 #include <hpx/algorithm.hpp>
 #include <hpx/init.hpp>
 #include <hpx/modules/testing.hpp>
+#include <hpx/parallel/algorithms/minmax.hpp>
 
 #include <cstddef>
 #include <ctime>
@@ -125,6 +126,8 @@ void max_element_test()
 {
     test_max_element<std::random_access_iterator_tag>();
     test_max_element<std::forward_iterator_tag>();
+    test_max_element_semantics<std::random_access_iterator_tag>();
+    test_max_element_semantics<std::forward_iterator_tag>();
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/core/algorithms/tests/unit/algorithms/min_element.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/min_element.cpp
@@ -7,6 +7,7 @@
 #include <hpx/algorithm.hpp>
 #include <hpx/init.hpp>
 #include <hpx/modules/testing.hpp>
+#include <hpx/parallel/algorithms/minmax.hpp>
 
 #include <cstddef>
 #include <ctime>
@@ -126,6 +127,8 @@ void min_element_test()
 {
     test_min_element<std::random_access_iterator_tag>();
     test_min_element<std::forward_iterator_tag>();
+    test_min_element_semantics<std::random_access_iterator_tag>();
+    test_min_element_semantics<std::forward_iterator_tag>();
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/core/algorithms/tests/unit/algorithms/minmax_element.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/minmax_element.cpp
@@ -7,6 +7,7 @@
 #include <hpx/algorithm.hpp>
 #include <hpx/init.hpp>
 #include <hpx/modules/testing.hpp>
+#include <hpx/parallel/algorithms/minmax.hpp>
 
 #include <cstddef>
 #include <ctime>
@@ -139,6 +140,8 @@ void minmax_element_test()
 {
     test_minmax_element<std::random_access_iterator_tag>();
     test_minmax_element<std::forward_iterator_tag>();
+    test_minmax_element_semantics<std::random_access_iterator_tag>();
+    test_minmax_element_semantics<std::forward_iterator_tag>();
 }
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fixes #6627 

## Proposed Changes

- Added semantic tests for extrema algorithms (min_element, max_element, minmax_element) to verify behavior with repeated values
- Tests ensure that:
  - min_element returns the first occurrence of the minimum value
  - max_element returns the first occurrence of the maximum value
  - minmax_element returns the first occurrence of the minimum value and the last occurrence of the maximum value
- Added tests for all execution policies (seq, par, par_unseq) and custom comparison functions

## Any background context you want to provide?

The existing tests for extrema algorithms did not cover the important semantic behavior when dealing with repeated values. These new tests ensure that the algorithms maintain their expected behavior across different execution policies and comparison functions.

## Checklist

- [x] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.