### PR TITLE
Fix unreachable code warning in wait_all

### DIFF
--- a/libs/core/async_combinators/include/hpx/async_combinators/wait_all.hpp
+++ b/libs/core/async_combinators/include/hpx/async_combinators/wait_all.hpp
@@ -548,7 +548,10 @@ namespace hpx {
                     new frame_type(values), false);
                 return frame->wait_all();
             }
-            return false;
+            else
+            {
+                return false;
+            }
         }
 
         template <typename T>


### PR DESCRIPTION
Fixes unreachable code warning

```
hpx\async_combinators\wait_all.hpp(551,1): warning C4702: unreachable code
```