### PR TITLE
Transition SR tag_invoke to member functions

### DIFF
--- a/libs/core/execution/include/hpx/execution/algorithms/as_sender.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/as_sender.hpp
@@ -25,7 +25,7 @@
 #include <utility>
 
 namespace hpx::execution::experimental {
-
+    namespace hpxexp = hpx::execution::experimental;
     namespace detail {
 
         ///////////////////////////////////////////////////////////////////////////
@@ -54,8 +54,8 @@ namespace hpx::execution::experimental {
             as_sender_operation_state& operator=(
                 as_sender_operation_state const&) = delete;
 
-            friend void tag_invoke(hpx::execution::experimental::start_t,
-                as_sender_operation_state& os) noexcept
+            friend void tag_invoke(
+                hpxexp::start_t, as_sender_operation_state& os) noexcept
             {
                 os.start_helper();
             }
@@ -79,19 +79,17 @@ namespace hpx::execution::experimental {
                             {
                                 if constexpr (std::is_void_v<result_type>)
                                 {
-                                    hpx::execution::experimental::set_value(
-                                        HPX_MOVE(receiver_));
+                                    hpxexp::set_value(HPX_MOVE(receiver_));
                                 }
                                 else
                                 {
-                                    hpx::execution::experimental::set_value(
+                                    hpxexp::set_value(
                                         HPX_MOVE(receiver_), future_.get());
                                 }
                             }
                             else if (future_.has_exception())
                             {
-                                hpx::execution::experimental::set_error(
-                                    HPX_MOVE(receiver_),
+                                hpxexp::set_error(HPX_MOVE(receiver_),
                                     future_.get_exception_ptr());
                             }
                         };
@@ -120,8 +118,7 @@ namespace hpx::execution::experimental {
                         }
                     },
                     [&](std::exception_ptr ep) {
-                        hpx::execution::experimental::set_error(
-                            HPX_MOVE(receiver_), HPX_MOVE(ep));
+                        hpxexp::set_error(HPX_MOVE(receiver_), HPX_MOVE(ep));
                     });
             }
 
@@ -140,22 +137,19 @@ namespace hpx::execution::experimental {
             template <bool IsVoid, typename _result_type>
             struct set_value_void_checked
             {
-                using type = hpx::execution::experimental::set_value_t(
-                    _result_type);
+                using type = hpxexp::set_value_t(_result_type);
             };
 
             template <typename _result_type>
             struct set_value_void_checked<true, _result_type>
             {
-                using type = hpx::execution::experimental::set_value_t();
+                using type = hpxexp::set_value_t();
             };
 
-            using completion_signatures =
-                hpx::execution::experimental::completion_signatures<
-                    typename set_value_void_checked<std::is_void_v<result_type>,
-                        result_type>::type,
-                    hpx::execution::experimental::set_error_t(
-                        std::exception_ptr)>;
+            using completion_signatures = hpxexp::completion_signatures<
+                typename set_value_void_checked<std::is_void_v<result_type>,
+                    result_type>::type,
+                hpxexp::set_error_t(std::exception_ptr)>;
 #else
             // Sender compatibility
             template <typename, typename T>

--- a/libs/core/execution/include/hpx/execution/algorithms/bulk.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/bulk.hpp
@@ -34,6 +34,7 @@
 #include <utility>
 
 namespace hpx::execution::experimental {
+    namespace hpxexp = hpx::execution::experimental;
 
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
@@ -46,37 +47,33 @@ namespace hpx::execution::experimental {
             HPX_NO_UNIQUE_ADDRESS std::decay_t<F> f;
 
 #if defined(HPX_HAVE_STDEXEC)
-            using sender_concept = hpx::execution::experimental::sender_t;
+            using sender_concept = hpxexp::sender_t;
 
             template <typename... Args>
             using default_set_value =
-                hpx::execution::experimental::completion_signatures<
-                    hpx::execution::experimental::set_value_t(Args...)>;
+                hpxexp::completion_signatures<hpxexp::set_value_t(Args...)>;
 
             template <typename Arg>
             using default_set_error =
-                hpx::execution::experimental::completion_signatures<
-                    hpx::execution::experimental::set_error_t(Arg)>;
+                hpxexp::completion_signatures<hpxexp::set_error_t(Arg)>;
 
-            using disable_set_stopped =
-                hpx::execution::experimental::completion_signatures<>;
+            using disable_set_stopped = hpxexp::completion_signatures<>;
 
             // clang-format off
             template <typename Env>
             friend auto tag_invoke(get_completion_signatures_t,
                 bulk_sender const&, Env) noexcept -> hpx::execution::
                 experimental::transform_completion_signatures_of<Sender, Env,
-                    hpx::execution::experimental::completion_signatures<
-                        hpx::execution::experimental::set_error_t(
+                    hpxexp::completion_signatures<
+                        hpxexp::set_error_t(
                             std::exception_ptr)>,
                     default_set_value, default_set_error, disable_set_stopped>;
             // clang-format on
 
             friend constexpr auto tag_invoke(
-                hpx::execution::experimental::get_env_t,
-                bulk_sender const& s) noexcept
+                hpxexp::get_env_t, bulk_sender const& s) noexcept
             {
-                return hpx::execution::experimental::get_env(s.sender);
+                return hpxexp::get_env(s.sender);
             }
 #else
             using is_sender = void;
@@ -107,14 +104,13 @@ namespace hpx::execution::experimental {
             // clang-format off
             template <typename CPO,
                 HPX_CONCEPT_REQUIRES_(
-                    hpx::execution::experimental::detail::is_receiver_cpo_v<CPO> &&
-                    hpx::execution::experimental::detail::has_completion_scheduler_v<
+                    hpxexp::detail::is_receiver_cpo_v<CPO> &&
+                    hpxexp::detail::has_completion_scheduler_v<
                         CPO, std::decay_t<Sender>>
                 )>
             // clang-format on
             friend constexpr auto tag_invoke(
-                hpx::execution::experimental::get_completion_scheduler_t<CPO>
-                    tag,
+                hpxexp::get_completion_scheduler_t<CPO> tag,
                 bulk_sender const& s)
             {
                 return tag(s.sender);
@@ -124,8 +120,7 @@ namespace hpx::execution::experimental {
             struct bulk_receiver
             {
 #if defined(HPX_HAVE_STDEXEC)
-                using receiver_concept =
-                    hpx::execution::experimental::receiver_t;
+                using receiver_concept = hpxexp::receiver_t;
 #endif
                 HPX_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
                 HPX_NO_UNIQUE_ADDRESS std::decay_t<Shape> shape;
@@ -143,15 +138,14 @@ namespace hpx::execution::experimental {
                 friend void tag_invoke(
                     set_error_t, bulk_receiver&& r, Error&& error) noexcept
                 {
-                    hpx::execution::experimental::set_error(
+                    hpxexp::set_error(
                         HPX_MOVE(r.receiver), HPX_FORWARD(Error, error));
                 }
 
                 friend void tag_invoke(
                     set_stopped_t, bulk_receiver&& r) noexcept
                 {
-                    hpx::execution::experimental::set_stopped(
-                        HPX_MOVE(r.receiver));
+                    hpxexp::set_stopped(HPX_MOVE(r.receiver));
                 }
 
                 template <typename... Ts>
@@ -167,19 +161,18 @@ namespace hpx::execution::experimental {
                             {
                                 HPX_INVOKE(f, s, ts...);
                             }
-                            hpx::execution::experimental::set_value(
+                            hpxexp::set_value(
                                 HPX_MOVE(receiver), HPX_FORWARD(Ts, ts)...);
                         },
                         [&](std::exception_ptr ep) {
-                            hpx::execution::experimental::set_error(
-                                HPX_MOVE(receiver), HPX_MOVE(ep));
+                            hpxexp::set_error(HPX_MOVE(receiver), HPX_MOVE(ep));
                         });
                 }
 
                 template <typename... Ts>
                 friend auto tag_invoke(
                     set_value_t, bulk_receiver&& r, Ts&&... ts) noexcept
-                    -> decltype(hpx::execution::experimental::set_value(
+                    -> decltype(hpxexp::set_value(
                                     std::declval<std::decay_t<Receiver>&&>(),
                                     HPX_FORWARD(Ts, ts)...),
                         void())
@@ -196,7 +189,7 @@ namespace hpx::execution::experimental {
             friend auto tag_invoke(
                 connect_t, bulk_sender&& s, Receiver&& receiver)
             {
-                return hpx::execution::experimental::connect(HPX_MOVE(s.sender),
+                return hpxexp::connect(HPX_MOVE(s.sender),
                     bulk_receiver<Receiver>(HPX_FORWARD(Receiver, receiver),
                         HPX_MOVE(s.shape), HPX_MOVE(s.f)));
             }
@@ -205,7 +198,7 @@ namespace hpx::execution::experimental {
             friend auto tag_invoke(
                 connect_t, bulk_sender& s, Receiver&& receiver)
             {
-                return hpx::execution::experimental::connect(s.sender,
+                return hpxexp::connect(s.sender,
                     bulk_receiver<Receiver>(
                         HPX_FORWARD(Receiver, receiver), s.shape, s.f));
             }
@@ -247,7 +240,7 @@ namespace hpx::execution::experimental {
             HPX_CONCEPT_REQUIRES_(
                 is_sender_v<Sender> &&
                 experimental::detail::is_completion_scheduler_tag_invocable_v<
-                    hpx::execution::experimental::set_value_t, Sender,
+                    hpxexp::set_value_t, Sender,
                     bulk_t, Shape, F
                 >
             )>
@@ -256,10 +249,9 @@ namespace hpx::execution::experimental {
             bulk_t, Sender&& sender, Shape const& shape, F&& f)
         {
             auto scheduler =
-                hpx::execution::experimental::get_completion_scheduler<
-                    hpx::execution::experimental::set_value_t>(
+                hpxexp::get_completion_scheduler<hpxexp::set_value_t>(
 #if defined(HPX_HAVE_STDEXEC)
-                    hpx::execution::experimental::get_env(sender)
+                    hpxexp::get_env(sender)
 #else
                     sender
 #endif

--- a/libs/core/execution/include/hpx/execution/algorithms/keep_future.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/keep_future.hpp
@@ -23,6 +23,7 @@
 #include <utility>
 
 namespace hpx::execution::experimental {
+    namespace hpxexp = hpx::execution::experimental;
 
     namespace detail {
 
@@ -51,13 +52,12 @@ namespace hpx::execution::experimental {
                         // to move receiver and future into the on_completed
                         // callback.
                         state->set_on_completed([&os]() mutable {
-                            hpx::execution::experimental::set_value(
+                            hpxexp::set_value(
                                 HPX_MOVE(os.receiver), HPX_MOVE(os.future));
                         });
                     },
                     [&](std::exception_ptr ep) {
-                        hpx::execution::experimental::set_error(
-                            HPX_MOVE(os.receiver), HPX_MOVE(ep));
+                        hpxexp::set_error(HPX_MOVE(os.receiver), HPX_MOVE(ep));
                     });
             }
         };
@@ -68,11 +68,9 @@ namespace hpx::execution::experimental {
             std::decay_t<Future> future;
 #if defined(HPX_HAVE_STDEXEC)
             using completion_signatures =
-                hpx::execution::experimental::completion_signatures<
-                    hpx::execution::experimental::set_value_t(
-                        std::decay_t<Future>),
-                    hpx::execution::experimental::set_error_t(
-                        std::exception_ptr)>;
+                hpxexp::completion_signatures<hpxexp::set_value_t(
+                                                  std::decay_t<Future>),
+                    hpxexp::set_error_t(std::exception_ptr)>;
 #else
             struct completion_signatures
             {

--- a/libs/core/execution/include/hpx/execution/algorithms/make_future.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/make_future.hpp
@@ -34,6 +34,7 @@
 
 namespace hpx::execution::experimental {
 
+    namespace hpxexp = hpx::execution::experimental;
     // enforce proper formatting
     namespace detail {
 
@@ -133,11 +134,10 @@ namespace hpx::execution::experimental {
             future_data(init_no_addref no_addref, other_allocator const& alloc,
                 Sender&& sender)
               : base_type(no_addref, alloc)
-              , op_state(hpx::execution::experimental::connect(
-                    HPX_FORWARD(Sender, sender),
+              , op_state(hpxexp::connect(HPX_FORWARD(Sender, sender),
                     detail::future_receiver<T>{{this}}))
             {
-                hpx::execution::experimental::start(op_state);
+                hpxexp::start(op_state);
             }
         };
 
@@ -146,7 +146,7 @@ namespace hpx::execution::experimental {
           : future_data<T, Allocator, OperationState,
                 future_data_with_run_loop<T, Allocator, OperationState>>
         {
-            hpx::execution::experimental::run_loop& loop;
+            hpxexp::run_loop& loop;
 
             using base_type = future_data<T, Allocator, OperationState,
                 future_data_with_run_loop>;
@@ -157,10 +157,10 @@ namespace hpx::execution::experimental {
             future_data_with_run_loop(init_no_addref no_addref,
                 other_allocator const& alloc,
 #if defined(HPX_HAVE_STDEXEC)
-                decltype(std::declval<hpx::execution::experimental::run_loop>()
-                             .get_scheduler()) const& sched,
+                decltype(std::declval<hpxexp::run_loop>().get_scheduler())
+                    const& sched,
 #else
-                hpx::execution::experimental::run_loop_scheduler const& sched,
+                hpxexp::run_loop_scheduler const& sched,
 #endif
                 Sender&& sender)
               : base_type(no_addref, alloc, HPX_FORWARD(Sender, sender))
@@ -168,8 +168,7 @@ namespace hpx::execution::experimental {
               //TODO: Keep an eye on this, it is based on the internal impl of
               // stdexec, so it is subect to change. This is currently relying
               // on the env struct to expose __loop_ as a public member.
-              , loop(*hpx::execution::experimental::get_env(schedule(sched))
-                          .__loop_)
+              , loop(*hpxexp::get_env(schedule(sched)).__loop_)
 #else
               , loop(sched.get_run_loop())
 #endif
@@ -196,15 +195,14 @@ namespace hpx::execution::experimental {
         {
             using allocator_type = Allocator;
 
-            using value_types = hpx::execution::experimental::value_types_of_t<
-                std::decay_t<Sender>, hpx::execution::experimental::empty_env,
-                meta::pack, meta::pack>;
+            using value_types = hpxexp::value_types_of_t<std::decay_t<Sender>,
+                hpxexp::empty_env, meta::pack, meta::pack>;
 
             using result_type =
                 std::decay_t<detail::single_result_t<value_types>>;
-            using operation_state_type = hpx::util::invoke_result_t<
-                hpx::execution::experimental::connect_t, Sender,
-                detail::future_receiver<result_type>>;
+            using operation_state_type =
+                hpx::util::invoke_result_t<hpxexp::connect_t, Sender,
+                    detail::future_receiver<result_type>>;
 
             using shared_state =
                 future_data<result_type, allocator_type, operation_state_type>;
@@ -233,24 +231,23 @@ namespace hpx::execution::experimental {
         template <typename Sender, typename Allocator>
         auto make_future_with_run_loop(
 #if defined(HPX_HAVE_STDEXEC)
-            decltype(std::declval<hpx::execution::experimental::run_loop>()
-                         .get_scheduler()) const& sched,
+            decltype(std::declval<hpxexp::run_loop>().get_scheduler())
+                const& sched,
 #else
-            hpx::execution::experimental::run_loop_scheduler const& sched,
+            hpxexp::run_loop_scheduler const& sched,
 #endif
             Sender&& sender, Allocator const& allocator)
         {
             using allocator_type = Allocator;
 
-            using value_types = hpx::execution::experimental::value_types_of_t<
-                std::decay_t<Sender>, hpx::execution::experimental::empty_env,
-                meta::pack, meta::pack>;
+            using value_types = hpxexp::value_types_of_t<std::decay_t<Sender>,
+                hpxexp::empty_env, meta::pack, meta::pack>;
 
             using result_type =
                 std::decay_t<detail::single_result_t<value_types>>;
-            using operation_state_type = hpx::util::invoke_result_t<
-                hpx::execution::experimental::connect_t, Sender,
-                detail::future_receiver<result_type>>;
+            using operation_state_type =
+                hpx::util::invoke_result_t<hpxexp::connect_t, Sender,
+                    detail::future_receiver<result_type>>;
 
             using shared_state = future_data_with_run_loop<result_type,
                 allocator_type, operation_state_type>;
@@ -276,26 +273,24 @@ namespace hpx::execution::experimental {
 
 namespace hpx::traits::detail {
 
+    namespace hpxexp = hpx::execution::experimental;
     template <typename T, typename Allocator, typename OperationState,
         typename NewAllocator>
-    struct shared_state_allocator<hpx::execution::experimental::detail::
-                                      future_data<T, Allocator, OperationState>,
-        NewAllocator>
+    struct shared_state_allocator<
+        hpxexp::detail::future_data<T, Allocator, OperationState>, NewAllocator>
     {
-        using type = hpx::execution::experimental::detail::future_data<T,
-            NewAllocator, OperationState>;
+        using type =
+            hpxexp::detail::future_data<T, NewAllocator, OperationState>;
     };
 
     template <typename T, typename Allocator, typename OperationState,
         typename NewAllocator>
     struct shared_state_allocator<
-        hpx::execution::experimental::detail::future_data_with_run_loop<T,
-            Allocator, OperationState>,
+        hpxexp::detail::future_data_with_run_loop<T, Allocator, OperationState>,
         NewAllocator>
     {
-        using type =
-            hpx::execution::experimental::detail::future_data_with_run_loop<T,
-                NewAllocator, OperationState>;
+        using type = hpxexp::detail::future_data_with_run_loop<T, NewAllocator,
+            OperationState>;
     };
 }    // namespace hpx::traits::detail
 
@@ -330,7 +325,7 @@ namespace hpx::execution::experimental {
                 is_sender_v<Sender> &&
                 hpx::traits::is_allocator_v<Allocator> &&
                 experimental::detail::is_completion_scheduler_tag_invocable_v<
-                    hpx::execution::experimental::set_value_t,
+                    hpxexp::set_value_t,
                     Sender, make_future_t, Allocator
                 >
             )>
@@ -340,13 +335,11 @@ namespace hpx::execution::experimental {
         {
 #if defined(HPX_HAVE_STDEXEC)
             auto scheduler =
-                hpx::execution::experimental::get_completion_scheduler<
-                    hpx::execution::experimental::set_value_t>(
-                    hpx::execution::experimental::get_env(sender));
+                hpxexp::get_completion_scheduler<hpxexp::set_value_t>(
+                    hpxexp::get_env(sender));
 #else
             auto scheduler =
-                hpx::execution::experimental::get_completion_scheduler<
-                    hpx::execution::experimental::set_value_t>(sender);
+                hpxexp::get_completion_scheduler<hpxexp::set_value_t>(sender);
 #endif
 
             return hpx::functional::tag_invoke(make_future_t{},
@@ -357,15 +350,15 @@ namespace hpx::execution::experimental {
         template <typename Sender,
             typename Allocator = hpx::util::internal_allocator<>,
             HPX_CONCEPT_REQUIRES_(
-                hpx::execution::experimental::is_sender_v<Sender>
+                hpxexp::is_sender_v<Sender>
             )>
         // clang-format on
         friend auto tag_invoke(make_future_t,
 #if defined(HPX_HAVE_STDEXEC)
-            decltype(std::declval<hpx::execution::experimental::run_loop>()
-                         .get_scheduler()) const& sched,
+            decltype(std::declval<hpxexp::run_loop>().get_scheduler())
+                const& sched,
 #else
-            hpx::execution::experimental::run_loop_scheduler const& sched,
+            hpxexp::run_loop_scheduler const& sched,
 #endif
             Sender&& sender, Allocator const& allocator = Allocator{})
         {
@@ -391,16 +384,15 @@ namespace hpx::execution::experimental {
         template <typename Scheduler,
             typename Allocator = hpx::util::internal_allocator<>,
             HPX_CONCEPT_REQUIRES_(
-                hpx::execution::experimental::is_scheduler_v<Scheduler> &&
+                hpxexp::is_scheduler_v<Scheduler> &&
                 hpx::traits::is_allocator_v<Allocator>
             )>
         // clang-format on
         friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(make_future_t,
             Scheduler&& scheduler, Allocator const& allocator = Allocator{})
         {
-            return hpx::execution::experimental::detail::inject_scheduler<
-                make_future_t, Scheduler, Allocator>{
-                HPX_FORWARD(Scheduler, scheduler), allocator};
+            return hpxexp::detail::inject_scheduler<make_future_t, Scheduler,
+                Allocator>{HPX_FORWARD(Scheduler, scheduler), allocator};
         }
 
         // clang-format off

--- a/libs/core/execution/include/hpx/execution/algorithms/when_all.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/when_all.hpp
@@ -14,31 +14,30 @@
 #include <hpx/execution_base/stdexec_forward.hpp>
 
 namespace hpx::execution::experimental {
+
+    namespace hpxexp = hpx::execution::experimental;
+
     template <typename F, typename Sender, typename... Senders>
     constexpr HPX_FORCEINLINE auto tag_invoke(
         hpx::detail::dataflow_t, F&& f, Sender&& sender, Senders&&... senders)
-        -> decltype(hpx::execution::experimental::then(
-            hpx::execution::experimental::when_all(
-                HPX_FORWARD(Sender, sender), HPX_FORWARD(Senders, senders)...),
+        -> decltype(hpxexp::then(hpxexp::when_all(HPX_FORWARD(Sender, sender),
+                                     HPX_FORWARD(Senders, senders)...),
             HPX_FORWARD(F, f)))
     {
-        return hpx::execution::experimental::then(
-            hpx::execution::experimental::when_all(
-                HPX_FORWARD(Sender, sender), HPX_FORWARD(Senders, senders)...),
+        return hpxexp::then(hpxexp::when_all(HPX_FORWARD(Sender, sender),
+                                HPX_FORWARD(Senders, senders)...),
             HPX_FORWARD(F, f));
     }
 
     template <typename F, typename Sender, typename... Senders>
     constexpr HPX_FORCEINLINE auto tag_invoke(hpx::detail::dataflow_t,
         hpx::launch, F&& f, Sender&& sender, Senders&&... senders)
-        -> decltype(hpx::execution::experimental::then(
-            hpx::execution::experimental::when_all(
-                HPX_FORWARD(Sender, sender), HPX_FORWARD(Senders, senders)...),
+        -> decltype(hpxexp::then(hpxexp::when_all(HPX_FORWARD(Sender, sender),
+                                     HPX_FORWARD(Senders, senders)...),
             HPX_FORWARD(F, f)))
     {
-        return hpx::execution::experimental::then(
-            hpx::execution::experimental::when_all(
-                HPX_FORWARD(Sender, sender), HPX_FORWARD(Senders, senders)...),
+        return hpxexp::then(hpxexp::when_all(HPX_FORWARD(Sender, sender),
+                                HPX_FORWARD(Senders, senders)...),
             HPX_FORWARD(F, f));
     }
 }    // namespace hpx::execution::experimental

--- a/libs/core/execution/include/hpx/execution/algorithms/when_all_vector.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/when_all_vector.hpp
@@ -41,6 +41,7 @@
 #include <vector>
 
 namespace hpx::when_all_vector_detail {
+    namespace hpxexp = hpx::execution::experimental;
 
     // callback object to request cancellation
     struct on_stop_requested
@@ -85,11 +86,9 @@ namespace hpx::when_all_vector_detail {
 
         // We expect a single value type or nothing from the predecessor
         // sender type
-        using element_value_type =
-            std::decay_t<hpx::execution::experimental::detail::single_result_t<
-                hpx::execution::experimental::value_types_of_t<Sender,
-                    hpx::execution::experimental::empty_env, meta::pack,
-                    meta::pack>>>;
+        using element_value_type = std::decay_t<
+            hpxexp::detail::single_result_t<hpxexp::value_types_of_t<Sender,
+                hpxexp::empty_env, meta::pack, meta::pack>>>;
 
         static constexpr bool is_void_value_type =
             std::is_void_v<element_value_type>;
@@ -107,14 +106,13 @@ namespace hpx::when_all_vector_detail {
         template <typename T, typename Dummy = void>
         struct set_value_completion_helper
         {
-            using type = hpx::execution::experimental::set_value_t(
-                std::vector<T>);
+            using type = hpxexp::set_value_t(std::vector<T>);
         };
 
         template <typename Dummy>
         struct set_value_completion_helper<void, Dummy>
         {
-            using type = hpx::execution::experimental::set_value_t();
+            using type = hpxexp::set_value_t();
         };
 
         using set_value_transform_to_vector =
@@ -122,23 +120,19 @@ namespace hpx::when_all_vector_detail {
 
         template <typename...>
         using transformed_comp_sigs_identity =
-            hpx::execution::experimental::completion_signatures<
-                set_value_transform_to_vector>;
+            hpxexp::completion_signatures<set_value_transform_to_vector>;
 
         template <typename Err>
         using decay_set_error =
-            hpx::execution::experimental::completion_signatures<
-                hpx::execution::experimental::set_error_t(std::decay_t<Err>)>;
+            hpxexp::completion_signatures<hpxexp::set_error_t(
+                std::decay_t<Err>)>;
 
         template <typename Env>
-        friend auto tag_invoke(
-            hpx::execution::experimental::get_completion_signatures_t,
+        friend auto tag_invoke(hpxexp::get_completion_signatures_t,
             when_all_vector_sender_type const&, Env const&) noexcept
-            -> hpx::execution::experimental::transform_completion_signatures_of<
-                Sender, Env,
-                hpx::execution::experimental::completion_signatures<
-                    hpx::execution::experimental::set_error_t(
-                        std::exception_ptr)>,
+            -> hpxexp::transform_completion_signatures_of<Sender, Env,
+                hpxexp::completion_signatures<hpxexp::set_error_t(
+                    std::exception_ptr)>,
                 transformed_comp_sigs_identity, decay_set_error>;
 #else
         // This sender sends a single vector of the type sent by the
@@ -157,9 +151,7 @@ namespace hpx::when_all_vector_detail {
             template <template <typename...> class Variant>
             using error_types = hpx::util::detail::unique_concat_t<
                 hpx::util::detail::transform_t<
-                    hpx::execution::experimental::error_types_of_t<Sender, Env,
-                        Variant>,
-                    std::decay>,
+                    hpxexp::error_types_of_t<Sender, Env, Variant>, std::decay>,
                 Variant<std::exception_ptr>>;
 
             static constexpr bool sends_stopped = true;
@@ -168,7 +160,7 @@ namespace hpx::when_all_vector_detail {
         // clang-format off
         template <typename Env>
         friend auto tag_invoke(
-            hpx::execution::experimental::get_completion_signatures_t,
+            hpxexp::get_completion_signatures_t,
             when_all_vector_sender_type const&,
             Env) noexcept -> generate_completion_signatures<Env>;
         // clang-format on
@@ -186,15 +178,13 @@ namespace hpx::when_all_vector_detail {
             struct when_all_vector_receiver
             {
 #if defined(HPX_HAVE_STDEXEC)
-                using receiver_concept =
-                    hpx::execution::experimental::receiver_t;
+                using receiver_concept = hpxexp::receiver_t;
 #endif
                 operation_state& op_state;
                 std::size_t const i;
 
                 template <typename Error>
-                friend void tag_invoke(
-                    hpx::execution::experimental::set_error_t,
+                friend void tag_invoke(hpxexp::set_error_t,
                     when_all_vector_receiver&& r, Error&& error) noexcept
                 {
                     if (!r.op_state.set_stopped_error_called.exchange(true))
@@ -214,8 +204,7 @@ namespace hpx::when_all_vector_detail {
                     r.op_state.finish();
                 }
 
-                friend void tag_invoke(
-                    hpx::execution::experimental::set_stopped_t,
+                friend void tag_invoke(hpxexp::set_stopped_t,
                     when_all_vector_receiver&& r) noexcept
                 {
                     // request stop only if we're not in error state
@@ -227,8 +216,7 @@ namespace hpx::when_all_vector_detail {
                 };
 
                 template <typename... Ts>
-                friend void tag_invoke(
-                    hpx::execution::experimental::set_value_t,
+                friend void tag_invoke(hpxexp::set_value_t,
                     when_all_vector_receiver&& r, Ts&&... ts) noexcept
                 {
                     if (!r.op_state.set_stopped_error_called)
@@ -261,14 +249,14 @@ namespace hpx::when_all_vector_detail {
 
                 // clang-format off
                 // TODO: Make this a method
-                friend auto tag_invoke(hpx::execution::experimental::get_env_t,
+                friend auto tag_invoke(hpxexp::get_env_t,
                     when_all_vector_receiver const& r)
 #if defined(HPX_HAVE_STDEXEC)
                     noexcept
-                    -> hpx::execution::experimental::env<
-                        hpx::execution::experimental::env_of_t<receiver_type>,
-                        hpx::execution::experimental::prop<
-                            hpx::execution::experimental::get_stop_token_t,
+                    -> hpxexp::env<
+                        hpxexp::env_of_t<receiver_type>,
+                        hpxexp::prop<
+                            hpxexp::get_stop_token_t,
                             hpx::experimental::in_place_stop_token>>
                 {
                     /* The new calling convention is:
@@ -278,26 +266,26 @@ namespace hpx::when_all_vector_detail {
                     // returning an env constructed directly with the
                     // temporaries returned by the functions causes wrong
                     // behaviour.
-                    auto e = hpx::execution::experimental::get_env(
+                    auto e = hpxexp::get_env(
                         r.op_state.receiver);
-                    auto p = hpx::execution::experimental::prop(
-                        hpx::execution::experimental::get_stop_token,
+                    auto p = hpxexp::prop(
+                        hpxexp::get_stop_token,
                         r.op_state.stop_source_.get_token());
-                    return hpx::execution::experimental::env(
+                    return hpxexp::env(
                         std::move(e), std::move(p));
                 }
 #else
-                    -> hpx::execution::experimental::make_env_t<
-                        hpx::execution::experimental::get_stop_token_t,
+                    -> hpxexp::make_env_t<
+                        hpxexp::get_stop_token_t,
                         hpx::experimental::in_place_stop_token,
-                        hpx::execution::experimental::env_of_t<receiver_type>>
+                        hpxexp::env_of_t<receiver_type>>
                 {
                     /* The old calling convention is:
                      * make_env<tag>(val, old_env) */
-                    return hpx::execution::experimental::make_env<
-                        hpx::execution::experimental::get_stop_token_t>(
+                    return hpxexp::make_env<
+                        hpxexp::get_stop_token_t>(
                         r.op_state.stop_source_.get_token(),
-                        hpx::execution::experimental::get_env(
+                        hpxexp::get_env(
                             r.op_state.receiver));
                 }
 #endif
@@ -309,8 +297,8 @@ namespace hpx::when_all_vector_detail {
 
             hpx::experimental::in_place_stop_source stop_source_{};
 
-            using stop_token_t = hpx::execution::experimental::stop_token_of_t<
-                hpx::execution::experimental::env_of_t<receiver_type>&>;
+            using stop_token_t =
+                hpxexp::stop_token_of_t<hpxexp::env_of_t<receiver_type>&>;
             hpx::optional<typename stop_token_t::template callback_type<
                 on_stop_requested>>
                 on_stop_{};
@@ -330,15 +318,13 @@ namespace hpx::when_all_vector_detail {
             // The first error sent by any predecessor sender is stored in a
             // optional of a variant of the error_types
 #if defined(HPX_HAVE_STDEXEC)
-            using error_types =
-                typename hpx::execution::experimental::error_types_of_t<
-                    when_all_vector_sender_impl<
-                        Sender>::when_all_vector_sender_type,
-                    hpx::execution::experimental::empty_env, hpx::variant>;
+            using error_types = typename hpxexp::error_types_of_t<
+                when_all_vector_sender_impl<
+                    Sender>::when_all_vector_sender_type,
+                hpxexp::empty_env, hpx::variant>;
 #else
             using error_types = typename generate_completion_signatures<
-                hpx::execution::experimental::empty_env>::
-                template error_types<hpx::variant>;
+                hpxexp::empty_env>::template error_types<hpx::variant>;
 #endif
             std::optional<error_types> error;
 
@@ -349,8 +335,7 @@ namespace hpx::when_all_vector_detail {
             // the operation states to handle the non-movability and
             // non-copyability of them
             using operation_state_type =
-                hpx::execution::experimental::connect_result_t<Sender,
-                    when_all_vector_receiver>;
+                hpxexp::connect_result_t<Sender, when_all_vector_receiver>;
             using operation_states_storage_type =
                 std::unique_ptr<std::optional<operation_state_type>[]>;
             operation_states_storage_type op_states = nullptr;
@@ -370,15 +355,13 @@ namespace hpx::when_all_vector_detail {
 #if defined(__NVCC__)
                     op_states[i].emplace(
                         hpx::util::detail::with_result_of([&]() {
-                            return hpx::execution::experimental::connect(
-                                std::move(sender),
+                            return hpxexp::connect(std::move(sender),
                                 when_all_vector_receiver{*this, i});
                         }));
 #else
                     op_states[i].emplace(
                         hpx::util::detail::with_result_of([&]() {
-                            return hpx::execution::experimental::connect(
-                                HPX_MOVE(sender),
+                            return hpxexp::connect(HPX_MOVE(sender),
                                 when_all_vector_receiver{*this, i});
                         }));
 #endif
@@ -386,7 +369,7 @@ namespace hpx::when_all_vector_detail {
                     // MSVC doesn't get copy elision quite right, the operation
                     // state must be constructed explicitly directly in place
                     op_states[i].template emplace_f<operation_state_type>(
-                        hpx::execution::experimental::connect, HPX_MOVE(sender),
+                        hpxexp::connect, HPX_MOVE(sender),
                         when_all_vector_receiver{*this, i});
 #endif
                     ++i;
@@ -411,8 +394,7 @@ namespace hpx::when_all_vector_detail {
                     {
                         if constexpr (is_void_value_type)
                         {
-                            hpx::execution::experimental::set_value(
-                                HPX_MOVE(receiver));
+                            hpxexp::set_value(HPX_MOVE(receiver));
                         }
                         else
                         {
@@ -426,7 +408,7 @@ namespace hpx::when_all_vector_detail {
                                 values.push_back(HPX_MOVE(t.value()));
 #endif
                             }
-                            hpx::execution::experimental::set_value(
+                            hpxexp::set_value(
                                 HPX_MOVE(receiver), HPX_MOVE(values));
                         }
                     }
@@ -434,8 +416,7 @@ namespace hpx::when_all_vector_detail {
                     {
                         hpx::visit(
                             [this](auto&& error) {
-                                hpx::execution::experimental::set_error(
-                                    HPX_MOVE(receiver),
+                                hpxexp::set_error(HPX_MOVE(receiver),
                                     HPX_FORWARD(decltype(error), error));
                             },
                             HPX_MOVE(error.value()));
@@ -443,12 +424,10 @@ namespace hpx::when_all_vector_detail {
                     else
                     {
 #if defined(HPX_HAVE_STDEXEC)
-                        if constexpr (hpx::execution::experimental::
-                                          sends_stopped<Sender>)
+                        if constexpr (hpxexp::sends_stopped<Sender>)
                         {
 #endif
-                            hpx::execution::experimental::set_stopped(
-                                HPX_MOVE(receiver));
+                            hpxexp::set_stopped(HPX_MOVE(receiver));
 #if defined(HPX_HAVE_STDEXEC)
                         }
                         else
@@ -460,21 +439,19 @@ namespace hpx::when_all_vector_detail {
                 }
             }
 
-            friend void tag_invoke(hpx::execution::experimental::start_t,
-                operation_state& os) noexcept
+            friend void tag_invoke(
+                hpxexp::start_t, operation_state& os) noexcept
             {
                 // register stop callback
                 os.on_stop_.emplace(
-                    hpx::execution::experimental::get_stop_token(
-                        hpx::execution::experimental::get_env(os.receiver)),
+                    hpxexp::get_stop_token(hpxexp::get_env(os.receiver)),
                     on_stop_requested{os.stop_source_});
 
                 // If a stop has already been requested. Don't bother starting
                 // the child operations.
                 if (os.stop_source_.stop_requested())
                 {
-                    hpx::execution::experimental::set_stopped(
-                        HPX_FORWARD(Receiver, os.receiver));
+                    hpxexp::set_stopped(HPX_FORWARD(Receiver, os.receiver));
                     return;
                 }
 
@@ -486,15 +463,13 @@ namespace hpx::when_all_vector_detail {
                     // send nothing to the continuation.
                     if constexpr (is_void_value_type)
                     {
-                        hpx::execution::experimental::set_value(
-                            HPX_MOVE(os.receiver));
+                        hpxexp::set_value(HPX_MOVE(os.receiver));
                     }
                     // If the predecessor sender type sends something we
                     // send an empty vector of that type to the continuation.
                     else
                     {
-                        hpx::execution::experimental::set_value(
-                            HPX_MOVE(os.receiver),
+                        hpxexp::set_value(HPX_MOVE(os.receiver),
                             std::vector<element_value_type>{});
                     }
                 }
@@ -504,15 +479,14 @@ namespace hpx::when_all_vector_detail {
                 {
                     for (std::size_t i = 0; i < os.num_predecessors; ++i)
                     {
-                        hpx::execution::experimental::start(
-                            os.op_states.get()[i].value());
+                        hpxexp::start(os.op_states.get()[i].value());
                     }
                 }
             }
         };
 
         template <typename Receiver>
-        friend auto tag_invoke(hpx::execution::experimental::connect_t,
+        friend auto tag_invoke(hpxexp::connect_t,
             when_all_vector_sender_type&& s, Receiver&& receiver)
         {
             return operation_state<Receiver>(
@@ -520,7 +494,7 @@ namespace hpx::when_all_vector_detail {
         }
 
         template <typename Receiver>
-        friend auto tag_invoke(hpx::execution::experimental::connect_t,
+        friend auto tag_invoke(hpxexp::connect_t,
             when_all_vector_sender_type& s, Receiver&& receiver)
         {
             return operation_state<Receiver>(receiver, s.senders);
@@ -530,6 +504,7 @@ namespace hpx::when_all_vector_detail {
 
 namespace hpx::execution::experimental {
 
+    namespace hpxexp = hpx::execution::experimental;
     // execution::when_all_vector is an extension over P2300 (wg21.link/p2300)
     //
     // execution::when_all_vector is used to join an arbitrary number of sender
@@ -557,7 +532,7 @@ namespace hpx::execution::experimental {
         // clang-format off
         template <typename Sender,
             HPX_CONCEPT_REQUIRES_(
-                is_sender_v<Sender>
+                hpxexp::is_sender_v<Sender>
             )>
         // clang-format on
         friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(
@@ -570,7 +545,7 @@ namespace hpx::execution::experimental {
         // clang-format off
         template <typename Sender,
             HPX_CONCEPT_REQUIRES_(
-                is_sender_v<Sender>
+                hpxexp::is_sender_v<Sender>
             )>
         // clang-format on
         friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(

--- a/libs/core/execution/include/hpx/execution/algorithms/when_all_vector.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/when_all_vector.hpp
@@ -1,5 +1,6 @@
 //  Copyright (c) 2020 ETH Zurich
 //  Copyright (c) 2022 Hartmut Kaiser
+//  Copyright (c) 2025 Isidoros Tsaousis-Seiras
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -65,6 +66,9 @@ namespace hpx::when_all_vector_detail {
     struct when_all_vector_sender_impl<Sender>::when_all_vector_sender_type
     {
         using is_sender = void;
+#if defined(HPX_HAVE_STDEXEC)
+        using sender_concept = hpx::execution::experimental::sender_t;
+#endif
         using senders_type = std::vector<Sender>;
         senders_type senders;
 
@@ -174,6 +178,10 @@ namespace hpx::when_all_vector_detail {
         struct operation_state
         {
             using receiver_type = std::decay_t<Receiver>;
+#if defined(HPX_HAVE_STDEXEC)
+            using operation_state_concept =
+                hpx::execution::experimental::operation_state_t;
+#endif
 
             struct when_all_vector_receiver
             {

--- a/libs/core/execution_base/include/hpx/execution_base/any_sender.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/any_sender.hpp
@@ -326,6 +326,8 @@ struct hpx::detail::empty_vtable_type<
 
 namespace hpx::execution::experimental::detail {
 
+    namespace hpxexp = hpx::execution::experimental;
+
     template <typename Sender, typename Receiver>
     struct any_operation_state_impl final : any_operation_state_base
     {
@@ -333,14 +335,14 @@ namespace hpx::execution::experimental::detail {
 
         template <typename Sender_, typename Receiver_>
         any_operation_state_impl(Sender_&& sender, Receiver_&& receiver)
-          : operation_state(hpx::execution::experimental::connect(
+          : operation_state(hpxexp::connect(
                 HPX_FORWARD(Sender_, sender), HPX_FORWARD(Receiver_, receiver)))
         {
         }
 
         void start() & noexcept override
         {
-            hpx::execution::experimental::start(operation_state);
+            hpxexp::start(operation_state);
         }
     };
 
@@ -378,8 +380,7 @@ namespace hpx::execution::experimental::detail {
         any_operation_state& operator=(any_operation_state const&) = delete;
 
         HPX_CORE_EXPORT friend void tag_invoke(
-            hpx::execution::experimental::start_t,
-            any_operation_state& os) noexcept;
+            hpxexp::start_t, any_operation_state& os) noexcept;
     };
 
     template <typename... Ts>
@@ -441,6 +442,7 @@ struct hpx::detail::empty_vtable_type<
 
 namespace hpx::execution::experimental::detail {
 
+    namespace hpxexp = hpx::execution::experimental;
     template <typename Receiver, typename... Ts>
     struct any_receiver_impl final : any_receiver_base<Ts...>
     {
@@ -462,19 +464,17 @@ namespace hpx::execution::experimental::detail {
 
         void set_value(Ts... ts) && override
         {
-            hpx::execution::experimental::set_value(
-                HPX_MOVE(receiver), HPX_MOVE(ts)...);
+            hpxexp::set_value(HPX_MOVE(receiver), HPX_MOVE(ts)...);
         }
 
         void set_error(std::exception_ptr ep) && noexcept override
         {
-            hpx::execution::experimental::set_error(
-                HPX_MOVE(receiver), HPX_MOVE(ep));
+            hpxexp::set_error(HPX_MOVE(receiver), HPX_MOVE(ep));
         }
 
         void set_stopped() && noexcept override
         {
-            hpx::execution::experimental::set_stopped(HPX_MOVE(receiver));
+            hpxexp::set_stopped(HPX_MOVE(receiver));
         }
     };
 
@@ -518,8 +518,8 @@ namespace hpx::execution::experimental::detail {
         any_receiver& operator=(any_receiver&&) = default;
         any_receiver& operator=(any_receiver const&) = delete;
 
-        friend void tag_invoke(hpx::execution::experimental::set_value_t,
-            any_receiver&& r, Ts&&... ts) noexcept
+        friend void tag_invoke(
+            hpxexp::set_value_t, any_receiver&& r, Ts&&... ts) noexcept
         {
             // We first move the storage to a temporary variable so that this
             // any_receiver is empty after this set_value. Doing
@@ -539,8 +539,8 @@ namespace hpx::execution::experimental::detail {
             }
         }
 
-        friend void tag_invoke(hpx::execution::experimental::set_error_t,
-            any_receiver&& r, std::exception_ptr ep) noexcept
+        friend void tag_invoke(hpxexp::set_error_t, any_receiver&& r,
+            std::exception_ptr ep) noexcept
         {
             // We first move the storage to a temporary variable so that this
             // any_receiver is empty after this set_error. Doing
@@ -550,8 +550,7 @@ namespace hpx::execution::experimental::detail {
             HPX_MOVE(moved_storage.get()).set_error(HPX_MOVE(ep));
         }
 
-        friend void tag_invoke(hpx::execution::experimental::set_stopped_t,
-            any_receiver&& r) noexcept
+        friend void tag_invoke(hpxexp::set_stopped_t, any_receiver&& r) noexcept
         {
             // We first move the storage to a temporary variable so that this
             // any_receiver is empty after this set_stopped. Doing
@@ -711,6 +710,7 @@ namespace hpx::execution::experimental::detail {
 
 namespace hpx::execution::experimental {
 
+    namespace hpxexp = hpx::execution::experimental;
 #if defined(HPX_MSVC) || !defined(HPX_HAVE_CXX20_TRIVIAL_VIRTUAL_DESTRUCTOR)
     namespace detail {
         // This helper only exists to make it possible to use
@@ -786,8 +786,8 @@ namespace hpx::execution::experimental {
 #if defined(HPX_HAVE_STDEXEC)
         // TODO: Remove this
         using completion_signatures =
-            hpx::execution::experimental::completion_signatures<
-                set_value_t(Ts...), set_error_t(std::exception_ptr)>;
+            hpxexp::completion_signatures<set_value_t(Ts...),
+                set_error_t(std::exception_ptr)>;
 #else
         // clang-format off
         template <typename Env>
@@ -800,8 +800,7 @@ namespace hpx::execution::experimental {
 
         template <typename R>
         friend detail::any_operation_state tag_invoke(
-            hpx::execution::experimental::connect_t, unique_any_sender&& s,
-            R&& r)
+            hpxexp::connect_t, unique_any_sender&& s, R&& r)
         {
             // We first move the storage to a temporary variable so that this
             // any_sender is empty after this connect. Doing
@@ -873,8 +872,8 @@ namespace hpx::execution::experimental {
 #if defined(HPX_HAVE_STDEXEC)
         // TODO: Remove this
         using completion_signatures =
-            hpx::execution::experimental::completion_signatures<
-                set_value_t(Ts...), set_error_t(std::exception_ptr)>;
+            hpxexp::completion_signatures<set_value_t(Ts...),
+                set_error_t(std::exception_ptr)>;
 #else
         // clang-format off
         template <typename Env>
@@ -886,7 +885,7 @@ namespace hpx::execution::experimental {
 
         template <typename R>
         friend detail::any_operation_state tag_invoke(
-            hpx::execution::experimental::connect_t, any_sender& s, R&& r)
+            hpxexp::connect_t, any_sender& s, R&& r)
         {
             return s.storage.get().connect(
                 detail::any_receiver<Ts...>{HPX_FORWARD(R, r)});
@@ -894,7 +893,7 @@ namespace hpx::execution::experimental {
 
         template <typename R>
         friend detail::any_operation_state tag_invoke(
-            hpx::execution::experimental::connect_t, any_sender&& s, R&& r)
+            hpxexp::connect_t, any_sender&& s, R&& r)
         {
             // We first move the storage to a temporary variable so that this
             // any_sender is empty after this connect. Doing
@@ -909,21 +908,18 @@ namespace hpx::execution::experimental {
 
 namespace hpx::detail {
 
+    namespace hpxexp = hpx::execution::experimental;
+
     template <typename... Ts>
-    struct empty_vtable_type<
-        hpx::execution::experimental::detail::unique_any_sender_base<Ts...>>
+    struct empty_vtable_type<hpxexp::detail::unique_any_sender_base<Ts...>>
     {
-        using type =
-            hpx::execution::experimental::detail::empty_unique_any_sender<
-                Ts...>;
+        using type = hpxexp::detail::empty_unique_any_sender<Ts...>;
     };
 
     template <typename... Ts>
-    struct empty_vtable_type<
-        hpx::execution::experimental::detail::any_sender_base<Ts...>>
+    struct empty_vtable_type<hpxexp::detail::any_sender_base<Ts...>>
     {
-        using type =
-            hpx::execution::experimental::detail::empty_any_sender<Ts...>;
+        using type = hpxexp::detail::empty_any_sender<Ts...>;
     };
 }    // namespace hpx::detail
 

--- a/libs/core/execution_base/include/hpx/execution_base/completion_scheduler.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/completion_scheduler.hpp
@@ -15,13 +15,14 @@
 #include <utility>
 
 namespace hpx::execution::experimental { namespace detail {
+    namespace hpxexp = hpx::execution::experimental;
     // clang-format off
     template <typename CPO, typename Sender>
     concept has_completion_scheduler_v = requires(Sender&& s) {
         {
-            hpx::execution::experimental::get_completion_scheduler<CPO>(
-                hpx::execution::experimental::get_env(std::forward<Sender>(s)))
-        } -> hpx::execution::experimental::scheduler;
+            hpxexp::get_completion_scheduler<CPO>(
+                hpxexp::get_env(std::forward<Sender>(s)))
+        } -> hpxexp::scheduler;
     };
 
     template <typename ReceiverCPO, typename Sender, typename AlgorithmCPO,
@@ -29,8 +30,8 @@ namespace hpx::execution::experimental { namespace detail {
     concept is_completion_scheduler_tag_invocable_v = requires(
         AlgorithmCPO alg, Sender&& snd, Ts&&... ts) {
         tag_invoke(alg,
-            hpx::execution::experimental::get_completion_scheduler<ReceiverCPO>(
-                hpx::execution::experimental::get_env(snd)),
+            hpxexp::get_completion_scheduler<ReceiverCPO>(
+                hpxexp::get_env(snd)),
             std::forward<Sender>(snd), std::forward<Ts>(ts)...);
     };
     // clang-format on

--- a/libs/core/execution_base/include/hpx/execution_base/completion_signatures.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/completion_signatures.hpp
@@ -37,6 +37,8 @@
 
 namespace hpx::execution::experimental {
 
+    namespace hpxexp = hpx::execution::experimental;
+
     // empty_variant will be returned by execution::value_types_of_t and
     // execution::error_types_of_t if no signatures are provided.
     struct empty_variant
@@ -476,9 +478,7 @@ namespace hpx::execution::experimental {
     // operations.
 #if defined(HPX_HAVE_STDEXEC)
     template <typename Sender, typename... Env>
-    struct is_sender_in
-      : std::bool_constant<
-            hpx::execution::experimental::sender_in<Sender, Env...>>
+    struct is_sender_in : std::bool_constant<hpxexp::sender_in<Sender, Env...>>
     {
     };
 
@@ -486,8 +486,7 @@ namespace hpx::execution::experimental {
     inline constexpr bool is_sender_in_v = is_sender_in<Sender, Env...>::value;
 
     template <typename Sender>
-    struct is_sender
-      : std::bool_constant<hpx::execution::experimental::sender<Sender>>
+    struct is_sender : std::bool_constant<hpxexp::sender<Sender>>
     {
     };
 
@@ -497,8 +496,7 @@ namespace hpx::execution::experimental {
     // \see is_sender
     template <typename Sender, typename Receiver>
     struct is_sender_to
-      : std::bool_constant<
-            hpx::execution::experimental::sender_to<Sender, Receiver>>
+      : std::bool_constant<hpxexp::sender_to<Sender, Receiver>>
     {
     };
 
@@ -509,15 +507,14 @@ namespace hpx::execution::experimental {
     // The sender_of concept defines the requirements for a sender type that on
     // successful completion sends the specified set of value types.
     template <typename Sender, typename Signal,
-        typename Env = hpx::execution::experimental::empty_env>
+        typename Env = hpxexp::empty_env>
     struct is_sender_of
-      : std::bool_constant<
-            hpx::execution::experimental::sender_of<Sender, Signal, Env>>
+      : std::bool_constant<hpxexp::sender_of<Sender, Signal, Env>>
     {
     };
 
     template <typename Sender, typename Signal,
-        typename Env = hpx::execution::experimental::empty_env>
+        typename Env = hpxexp::empty_env>
     inline constexpr bool is_sender_of_v =
         is_sender_of<Sender, Signal, Env>::value;
 
@@ -533,11 +530,9 @@ namespace hpx::execution::experimental {
     // single-sender-value-type<S, E> is an alias for type void.
     // 3. Otherwise, single-sender-value-type<S, E> is ill-formed.
     //
-    template <typename Sender,
-        typename Env = hpx::execution::experimental::empty_env>
+    template <typename Sender, typename Env = hpxexp::empty_env>
     using single_sender_value_t =
-        hpx::execution::experimental::stdexec_internal::__single_sender_value_t<
-            Sender, Env>;
+        hpxexp::stdexec_internal::__single_sender_value_t<Sender, Env>;
 
     template <typename A, typename B>
     inline constexpr bool is_derived_from_v = std::derived_from<A, B>;
@@ -548,23 +543,22 @@ namespace hpx::execution::experimental {
     //    hpx::execution::experimental::with_awaitable_senders<Promise>;
 
     template <typename ReceiverID>
-    using operation = hpx::execution::experimental::stdexec_internal::
-        __connect_awaitable_::__operation<ReceiverID>;
+    using operation =
+        hpxexp::stdexec_internal::__connect_awaitable_::__operation<ReceiverID>;
 
     template <typename ReceiverID>
-    using promise = hpx::execution::experimental::stdexec_internal::
-        __connect_awaitable_::__promise<ReceiverID>;
+    using promise =
+        hpxexp::stdexec_internal::__connect_awaitable_::__promise<ReceiverID>;
 
     template <typename Rec>
-    using promise_t = hpx::execution::experimental::stdexec_internal::
-        __connect_awaitable_::__promise_t<Rec>;
+    using promise_t =
+        hpxexp::stdexec_internal::__connect_awaitable_::__promise_t<Rec>;
 
     template <typename Rec>
-    using operation_t = hpx::execution::experimental::stdexec_internal::
-        __connect_awaitable_::__operation_t<Rec>;
+    using operation_t =
+        hpxexp::stdexec_internal::__connect_awaitable_::__operation_t<Rec>;
 
-    using connect_awaitable_t =
-        hpx::execution::experimental::stdexec_internal::__connect_awaitable_t;
+    using connect_awaitable_t = hpxexp::stdexec_internal::__connect_awaitable_t;
     inline constexpr connect_awaitable_t connect_awaitable{};
 #else
     template <typename Sender, typename Env = no_env>
@@ -1606,7 +1600,7 @@ namespace hpx::execution::experimental {
     template <typename Sender, typename Receiver>
     struct has_nothrow_connect
       : std::integral_constant<bool,
-            noexcept(hpx::execution::experimental::connect(
+            noexcept(hpxexp::connect(
                 std::declval<Sender>(), std::declval<Receiver>()))>
     {
     };
@@ -1644,8 +1638,8 @@ namespace hpx::execution::experimental {
                 connect_result_t<sender_type, receiver> op_state_;
             };
         };
-    }     // namespace detail
-#endif    // HPX_HAVE_CXX20_COROUTINES
+    }    // namespace detail
+#endif     // HPX_HAVE_CXX20_COROUTINES
 
     /// End definitions from coroutine_utils and sender
 

--- a/libs/core/execution_base/include/hpx/execution_base/stdexec_forward.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/stdexec_forward.hpp
@@ -98,6 +98,9 @@ namespace hpx::execution::experimental {
     using stdexec::get_completion_signatures;
     using stdexec::get_completion_signatures_t;
 
+    // Operation State
+    using stdexec::operation_state_t;
+
     // Sender
     using stdexec::connect;
     using stdexec::connect_result_t;


### PR DESCRIPTION
P2300 has moved away from the tag_invoke design pattern, following the guidance in [P2855](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p2855r1.html). This PR removes tag_invoke support from the P2300 CPOs used by our senders. However, sender-adapter CPOs can remain tag_invoke-friendly since they provide an operator() that internally calls tag_invoke. For example, when_all_vector must drop support for tag_invoke(set_value_t...), but the when_all_vector algorithm itself can still be implemented as a CPO using operator() that calls tag_invoke(when_all_vector_t) under the hood.

At present, the non-stdexec implementation of senders will not be updated to work without tag_invoke.