### PR TITLE
modified existing extrema algo tests

### DIFF
--- a/libs/core/algorithms/tests/unit/algorithms/max_element.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/max_element.cpp
@@ -23,7 +23,7 @@ void test_max_element(IteratorTag)
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    std::vector<std::size_t> c = test::random_iota(10007);
+    std::vector<std::size_t> c = test::random_repeat(10007);
 
     iterator end(std::end(c));
     base_iterator ref_end(std::end(c));
@@ -54,7 +54,7 @@ void test_max_element(ExPolicy policy, IteratorTag)
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    std::vector<std::size_t> c = test::random_iota(10007);
+    std::vector<std::size_t> c = test::random_repeat(10007);
 
     iterator end(std::end(c));
     base_iterator ref_end(std::end(c));
@@ -83,7 +83,7 @@ void test_max_element_async(ExPolicy p, IteratorTag)
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    std::vector<std::size_t> c = test::random_iota(10007);
+    std::vector<std::size_t> c = test::random_repeat(10007);
 
     iterator end(std::end(c));
     base_iterator ref_end(std::end(c));
@@ -135,7 +135,7 @@ void test_max_element_exception(IteratorTag)
     typedef test::decorated_iterator<base_iterator, IteratorTag>
         decorated_iterator;
 
-    std::vector<std::size_t> c = test::random_iota(10007);
+    std::vector<std::size_t> c = test::random_repeat(10007);
 
     {
         bool caught_exception = false;
@@ -194,7 +194,7 @@ void test_max_element_exception(ExPolicy policy, IteratorTag)
     typedef test::decorated_iterator<base_iterator, IteratorTag>
         decorated_iterator;
 
-    std::vector<std::size_t> c = test::random_iota(10007);
+    std::vector<std::size_t> c = test::random_repeat(10007);
 
     {
         bool caught_exception = false;
@@ -250,7 +250,7 @@ void test_max_element_exception_async(ExPolicy p, IteratorTag)
     typedef test::decorated_iterator<base_iterator, IteratorTag>
         decorated_iterator;
 
-    std::vector<std::size_t> c = test::random_iota(10007);
+    std::vector<std::size_t> c = test::random_repeat(10007);
 
     {
         bool returned_from_algorithm = false;
@@ -345,7 +345,7 @@ void test_max_element_bad_alloc(IteratorTag)
     typedef test::decorated_iterator<base_iterator, IteratorTag>
         decorated_iterator;
 
-    std::vector<std::size_t> c = test::random_iota(10007);
+    std::vector<std::size_t> c = test::random_repeat(10007);
 
     {
         bool caught_exception = false;
@@ -400,7 +400,7 @@ void test_max_element_bad_alloc(ExPolicy policy, IteratorTag)
     typedef test::decorated_iterator<base_iterator, IteratorTag>
         decorated_iterator;
 
-    std::vector<std::size_t> c = test::random_iota(10007);
+    std::vector<std::size_t> c = test::random_repeat(10007);
 
     {
         bool caught_exception = false;
@@ -454,7 +454,7 @@ void test_max_element_bad_alloc_async(ExPolicy p, IteratorTag)
     typedef test::decorated_iterator<base_iterator, IteratorTag>
         decorated_iterator;
 
-    std::vector<std::size_t> c = test::random_iota(10007);
+    std::vector<std::size_t> c = test::random_repeat(10007);
 
     {
         bool returned_from_algorithm = false;

--- a/libs/core/algorithms/tests/unit/algorithms/min_element.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/min_element.cpp
@@ -24,7 +24,7 @@ void test_min_element(IteratorTag)
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    std::vector<std::size_t> c = test::random_iota(10007);
+    std::vector<std::size_t> c = test::random_repeat(10007);
 
     iterator end(std::end(c));
     base_iterator ref_end(std::end(c));
@@ -55,7 +55,7 @@ void test_min_element(ExPolicy policy, IteratorTag)
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    std::vector<std::size_t> c = test::random_iota(10007);
+    std::vector<std::size_t> c = test::random_repeat(10007);
 
     iterator end(std::end(c));
     base_iterator ref_end(std::end(c));
@@ -84,7 +84,7 @@ void test_min_element_async(ExPolicy p, IteratorTag)
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    std::vector<std::size_t> c = test::random_iota(10007);
+    std::vector<std::size_t> c = test::random_repeat(10007);
 
     iterator end(std::end(c));
     base_iterator ref_end(std::end(c));
@@ -136,7 +136,7 @@ void test_min_element_exception(IteratorTag)
     typedef test::decorated_iterator<base_iterator, IteratorTag>
         decorated_iterator;
 
-    std::vector<std::size_t> c = test::random_iota(10007);
+    std::vector<std::size_t> c = test::random_repeat(10007);
 
     {
         bool caught_exception = false;
@@ -195,7 +195,7 @@ void test_min_element_exception(ExPolicy policy, IteratorTag)
     typedef test::decorated_iterator<base_iterator, IteratorTag>
         decorated_iterator;
 
-    std::vector<std::size_t> c = test::random_iota(10007);
+    std::vector<std::size_t> c = test::random_repeat(10007);
 
     {
         bool caught_exception = false;
@@ -251,7 +251,7 @@ void test_min_element_exception_async(ExPolicy p, IteratorTag)
     typedef test::decorated_iterator<base_iterator, IteratorTag>
         decorated_iterator;
 
-    std::vector<std::size_t> c = test::random_iota(10007);
+    std::vector<std::size_t> c = test::random_repeat(10007);
 
     {
         bool returned_from_algorithm = false;
@@ -346,7 +346,7 @@ void test_min_element_bad_alloc(IteratorTag)
     typedef test::decorated_iterator<base_iterator, IteratorTag>
         decorated_iterator;
 
-    std::vector<std::size_t> c = test::random_iota(10007);
+    std::vector<std::size_t> c = test::random_repeat(10007);
 
     {
         bool caught_exception = false;
@@ -401,7 +401,7 @@ void test_min_element_bad_alloc(ExPolicy policy, IteratorTag)
     typedef test::decorated_iterator<base_iterator, IteratorTag>
         decorated_iterator;
 
-    std::vector<std::size_t> c = test::random_iota(10007);
+    std::vector<std::size_t> c = test::random_repeat(10007);
 
     {
         bool caught_exception = false;
@@ -455,7 +455,7 @@ void test_min_element_bad_alloc_async(ExPolicy p, IteratorTag)
     typedef test::decorated_iterator<base_iterator, IteratorTag>
         decorated_iterator;
 
-    std::vector<std::size_t> c = test::random_iota(10007);
+    std::vector<std::size_t> c = test::random_repeat(10007);
 
     {
         bool returned_from_algorithm = false;

--- a/libs/core/algorithms/tests/unit/algorithms/minmax_element.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/minmax_element.cpp
@@ -25,7 +25,7 @@ void test_minmax_element(IteratorTag)
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    std::vector<std::size_t> c = test::random_iota(10007);
+    std::vector<std::size_t> c = test::random_repeat(10007);
 
     iterator end(std::end(c));
     base_iterator ref_end(std::end(c));
@@ -60,7 +60,7 @@ void test_minmax_element(ExPolicy policy, IteratorTag)
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    std::vector<std::size_t> c = test::random_iota(10007);
+    std::vector<std::size_t> c = test::random_repeat(10007);
 
     iterator end(std::end(c));
     base_iterator ref_end(std::end(c));
@@ -93,7 +93,7 @@ void test_minmax_element_async(ExPolicy p, IteratorTag)
     typedef std::vector<std::size_t>::iterator base_iterator;
     typedef test::test_iterator<base_iterator, IteratorTag> iterator;
 
-    std::vector<std::size_t> c = test::random_iota(10007);
+    std::vector<std::size_t> c = test::random_repeat(10007);
 
     iterator end(std::end(c));
     base_iterator ref_end(std::end(c));
@@ -149,7 +149,7 @@ void test_minmax_element_exception(IteratorTag)
     typedef test::decorated_iterator<base_iterator, IteratorTag>
         decorated_iterator;
 
-    std::vector<std::size_t> c = test::random_iota(10007);
+    std::vector<std::size_t> c = test::random_repeat(10007);
 
     {
         bool caught_exception = false;
@@ -208,7 +208,7 @@ void test_minmax_element_exception(ExPolicy policy, IteratorTag)
     typedef test::decorated_iterator<base_iterator, IteratorTag>
         decorated_iterator;
 
-    std::vector<std::size_t> c = test::random_iota(10007);
+    std::vector<std::size_t> c = test::random_repeat(10007);
 
     {
         bool caught_exception = false;
@@ -264,7 +264,7 @@ void test_minmax_element_exception_async(ExPolicy p, IteratorTag)
     typedef test::decorated_iterator<base_iterator, IteratorTag>
         decorated_iterator;
 
-    std::vector<std::size_t> c = test::random_iota(10007);
+    std::vector<std::size_t> c = test::random_repeat(10007);
 
     {
         bool returned_from_algorithm = false;
@@ -359,7 +359,7 @@ void test_minmax_element_bad_alloc(IteratorTag)
     typedef test::decorated_iterator<base_iterator, IteratorTag>
         decorated_iterator;
 
-    std::vector<std::size_t> c = test::random_iota(10007);
+    std::vector<std::size_t> c = test::random_repeat(10007);
 
     {
         bool caught_exception = false;
@@ -414,7 +414,7 @@ void test_minmax_element_bad_alloc(ExPolicy policy, IteratorTag)
     typedef test::decorated_iterator<base_iterator, IteratorTag>
         decorated_iterator;
 
-    std::vector<std::size_t> c = test::random_iota(10007);
+    std::vector<std::size_t> c = test::random_repeat(10007);
 
     {
         bool caught_exception = false;
@@ -468,7 +468,7 @@ void test_minmax_element_bad_alloc_async(ExPolicy p, IteratorTag)
     typedef test::decorated_iterator<base_iterator, IteratorTag>
         decorated_iterator;
 
-    std::vector<std::size_t> c = test::random_iota(10007);
+    std::vector<std::size_t> c = test::random_repeat(10007);
 
     {
         bool returned_from_algorithm = false;

--- a/libs/core/algorithms/tests/unit/algorithms/test_utils.hpp
+++ b/libs/core/algorithms/tests/unit/algorithms/test_utils.hpp
@@ -198,6 +198,17 @@ namespace test {
         return c;
     }
 
+    inline std::vector<std::size_t> random_repeat(std::size_t size)
+    {
+        std::vector<std::size_t> c(size);
+        std::random_device rd;
+        std::mt19937 g(rd());
+        std::uniform_int_distribution<std::size_t> uni(0, (size - 1) / 2);
+        for (auto& x : c)
+            x = uni(g);
+        return c;
+    }
+
     template <typename T>
     inline std::vector<T> random_iota(std::size_t size)
     {


### PR DESCRIPTION
Fixes #6627 

## Proposed Changes

  - Added a new test utility `random_repeat` to generate vectors having repeated values.
  - This utility is used to test the extrema algorithms, and I've verified that the existing implementations work properly.

## Any background context you want to provide?
Used `uniform_int_distribution` to generate random numbers. 
Tests for container_algorithms can also be modified, but the tests need to be modified to not use `sentinel` (as we have duplicate values in our vector). I can update the tests if usage of `sentinel` can be removed in these tests. 

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [x] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
