### PR TITLE
Resolves the redundant use of `resolver_client` in `agas/agas_fwd.hpp`

### DIFF
--- a/libs/full/agas/include/hpx/agas/agas_fwd.hpp
+++ b/libs/full/agas/include/hpx/agas/agas_fwd.hpp
@@ -18,9 +18,6 @@ namespace hpx {
 
     namespace naming {
 
-        // FIXME: obsolete name, replace with agas::addressing_serve
-        using resolver_client = agas::addressing_service;
-
         HPX_EXPORT agas::addressing_service& get_agas_client();
         HPX_EXPORT agas::addressing_service* get_agas_client_ptr();
     }    // namespace naming

--- a/libs/full/agas/src/detail/interface.cpp
+++ b/libs/full/agas/src/detail/interface.cpp
@@ -172,13 +172,13 @@ namespace hpx::agas::detail::impl {
     bool resolve_local(
         naming::gid_type const& gid, naming::address& addr, error_code& ec)
     {
-        naming::resolver_client* agas_ = naming::get_agas_client_ptr();
+        agas::addressing_service* agas_ = naming::get_agas_client_ptr();
         return (agas_ != nullptr) ? agas_->resolve_local(gid, addr, ec) : false;
     }
 
     bool resolve_cached(naming::gid_type const& gid, naming::address& addr)
     {
-        naming::resolver_client* agas_ = naming::get_agas_client_ptr();
+        agas::addressing_service* agas_ = naming::get_agas_client_ptr();
         return (agas_ != nullptr) ? agas_->resolve_cached(gid, addr) : false;
     }
 
@@ -224,7 +224,7 @@ namespace hpx::agas::detail::impl {
 
     ///////////////////////////////////////////////////////////////////////////
     // helper functions allowing to bind and unbind a GID to a given address
-    // without having to directly refer to the resolver_client
+    // without having to directly refer to the agas::addressing_service
     bool bind_gid_local(naming::gid_type const& gid_,
         naming::address const& addr, error_code& ec)
     {
@@ -406,7 +406,7 @@ namespace hpx::agas::detail::impl {
     {
         HPX_ASSERT(!naming::detail::is_locked(gid));
 
-        naming::resolver_client& resolver = naming::get_agas_client();
+        agas::addressing_service& resolver = naming::get_agas_client();
         if (keep_alive_)
             return resolver.incref_async(gid, credits, keep_alive_);
 

--- a/libs/full/components_base/include/hpx/components_base/get_lva.hpp
+++ b/libs/full/components_base/include/hpx/components_base/get_lva.hpp
@@ -19,7 +19,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     /// The \a get_lva template is a helper structure allowing to convert a
     /// local virtual address as stored in a local address (returned from
-    /// the function \a resolver_client#resolve) to the address of the
+    /// the function \a agas::addressing_service#resolve) to the address of the
     /// component implementing the action.
     ///
     /// The default implementation uses the template argument \a Component

--- a/libs/full/init_runtime/src/pre_main.cpp
+++ b/libs/full/init_runtime/src/pre_main.cpp
@@ -102,7 +102,7 @@ namespace hpx { namespace detail {
 
         using components::stubs::runtime_support;
 
-        naming::resolver_client& agas_client = naming::get_agas_client();
+        agas::addressing_service& agas_client = naming::get_agas_client();
         runtime& rt = get_runtime();
 
         int exit_code = 0;

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed.hpp
@@ -236,7 +236,7 @@ namespace hpx {
         ///////////////////////////////////////////////////////////////////////
         /// \brief Allow access to the AGAS client instance used by the HPX
         ///        runtime.
-        naming::resolver_client& get_agas_client();
+        agas::addressing_service& get_agas_client();
 
 #if defined(HPX_HAVE_NETWORKING)
         /// \brief Allow access to the parcel handler instance used by the HPX
@@ -404,7 +404,7 @@ namespace hpx {
         notification_policy_type parcel_handler_notifier_;
         parcelset::parcelhandler parcel_handler_;
 #endif
-        naming::resolver_client agas_client_;
+        agas::addressing_service agas_client_;
         applier::applier applier_;
 
         // locality basename -> used cores

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/server/runtime_support.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/server/runtime_support.hpp
@@ -271,7 +271,7 @@ namespace hpx::components::server {
     protected:
         // Load all components from the ini files found in the configuration
         int load_components(util::section& ini, naming::gid_type const& prefix,
-            naming::resolver_client& agas_client,
+            agas::addressing_service& agas_client,
             hpx::program_options::options_description& options,
             std::set<std::string>& startup_handled);
 
@@ -279,13 +279,13 @@ namespace hpx::components::server {
         bool load_component(hpx::util::plugin::dll& d, util::section& ini,
             std::string const& instance, std::string const& component,
             filesystem::path const& lib, naming::gid_type const& prefix,
-            naming::resolver_client& agas_client, bool isdefault,
+            agas::addressing_service& agas_client, bool isdefault,
             bool isenabled, hpx::program_options::options_description& options,
             std::set<std::string>& startup_handled);
         bool load_component_dynamic(util::section& ini,
             std::string const& instance, std::string const& component,
             filesystem::path lib, naming::gid_type const& prefix,
-            naming::resolver_client& agas_client, bool isdefault,
+            agas::addressing_service& agas_client, bool isdefault,
             bool isenabled, hpx::program_options::options_description& options,
             std::set<std::string>& startup_handled);
 
@@ -298,7 +298,7 @@ namespace hpx::components::server {
         bool load_component_static(util::section& ini,
             std::string const& instance, std::string const& component,
             filesystem::path const& lib, naming::gid_type const& prefix,
-            naming::resolver_client& agas_client, bool isdefault,
+            agas::addressing_service& agas_client, bool isdefault,
             bool isenabled, hpx::program_options::options_description& options,
             std::set<std::string>& startup_handled);
         bool load_startup_shutdown_functions_static(

--- a/libs/full/runtime_distributed/src/applier.cpp
+++ b/libs/full/runtime_distributed/src/applier.cpp
@@ -61,7 +61,7 @@ namespace hpx { namespace applier {
 
     void applier::initialize(std::uint64_t rts)
     {
-        naming::resolver_client& agas_client = naming::get_agas_client();
+        agas::addressing_service& agas_client = naming::get_agas_client();
         runtime_support_id_ =
             hpx::id_type(agas_client.get_local_locality().get_msb(), rts,
                 hpx::id_type::management_type::unmanaged);

--- a/libs/full/runtime_distributed/src/big_boot_barrier.cpp
+++ b/libs/full/runtime_distributed/src/big_boot_barrier.cpp
@@ -452,7 +452,7 @@ namespace hpx::agas {
         // its dtor calls big_boot_barrier::notify().
         big_boot_barrier::scoped_lock lock(get_big_boot_barrier());
 
-        naming::resolver_client& agas_client = naming::get_agas_client();
+        agas::addressing_service& agas_client = naming::get_agas_client();
 
         if (HPX_UNLIKELY(agas_client.is_connecting()))
         {
@@ -570,7 +570,7 @@ namespace hpx::agas {
         header.ids.register_ids_on_worker_loc();
 
         runtime_distributed& rt = get_runtime_distributed();
-        naming::resolver_client& agas_client = naming::get_agas_client();
+        agas::addressing_service& agas_client = naming::get_agas_client();
 
         if (HPX_UNLIKELY(agas_client.get_status() != hpx::state::starting))
         {
@@ -652,7 +652,7 @@ namespace hpx::agas {
         // pre-cache all known locality endpoints in local AGAS on locality 0 as well
         if (service_mode::bootstrap == service_type)
         {
-            naming::resolver_client& agas_client = naming::get_agas_client();
+            agas::addressing_service& agas_client = naming::get_agas_client();
             agas_client.pre_cache_endpoints(localities);
         }
     }
@@ -774,7 +774,7 @@ namespace hpx::agas {
 #endif
     void big_boot_barrier::notify()
     {
-        naming::resolver_client& agas_client = naming::get_agas_client();
+        agas::addressing_service& agas_client = naming::get_agas_client();
 
         bool notify = false;
         {

--- a/libs/full/runtime_distributed/src/runtime_distributed.cpp
+++ b/libs/full/runtime_distributed/src/runtime_distributed.cpp
@@ -889,7 +889,7 @@ namespace hpx {
             active_counters_->stop_evaluating_counters(terminate);
     }
 
-    naming::resolver_client& runtime_distributed::get_agas_client()
+    agas::addressing_service& runtime_distributed::get_agas_client()
     {
         return agas_client_;
     }
@@ -1881,13 +1881,13 @@ namespace hpx {
 namespace hpx::naming {
 
     // shortcut for get_runtime().get_agas_client()
-    resolver_client& get_agas_client()
+    agas::addressing_service& get_agas_client()
     {
         return get_runtime_distributed().get_agas_client();
     }
 
     // shortcut for get_runtime_ptr()->get_agas_client()
-    resolver_client* get_agas_client_ptr()
+    agas::addressing_service* get_agas_client_ptr()
     {
         auto* rtd = get_runtime_distributed_ptr();
         return rtd ? &rtd->get_agas_client() : nullptr;

--- a/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
+++ b/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
@@ -289,7 +289,7 @@ namespace hpx { namespace components { namespace server {
         bool dijkstra_token)
     {
         applier::applier& appl = hpx::applier::get_applier();
-        naming::resolver_client& agas_client = naming::get_agas_client();
+        agas::addressing_service& agas_client = naming::get_agas_client();
 
         agas_client.start_shutdown();
 
@@ -428,7 +428,7 @@ namespace hpx { namespace components { namespace server {
             "runtime_support::shutdown_all: initializing application shutdown");
 
         applier::applier& appl = hpx::applier::get_applier();
-        naming::resolver_client& agas_client = naming::get_agas_client();
+        agas::addressing_service& agas_client = naming::get_agas_client();
 
         agas_client.start_shutdown();
 
@@ -615,7 +615,7 @@ namespace hpx { namespace components { namespace server {
 
             applier::applier& appl = hpx::applier::get_applier();
             threads::threadmanager& tm = appl.get_thread_manager();
-            naming::resolver_client& agas_client = naming::get_agas_client();
+            agas::addressing_service& agas_client = naming::get_agas_client();
 
             error_code ec(throwmode::lightweight);
 
@@ -781,7 +781,7 @@ namespace hpx { namespace components { namespace server {
         options.add(get_runtime().get_app_options());
 
         // then dynamic ones
-        naming::resolver_client& client = naming::get_agas_client();
+        agas::addressing_service& client = naming::get_agas_client();
         int result = load_components(
             ini, client.get_local_locality(), client, options, startup_handled);
         if (result != 0)
@@ -1125,7 +1125,7 @@ namespace hpx { namespace components { namespace server {
     bool runtime_support::load_component_static(util::section& ini,
         std::string const& instance, std::string const& component,
         filesystem::path const& lib, naming::gid_type const& /* prefix */,
-        naming::resolver_client& /* agas_client */, bool /* isdefault */,
+        agas::addressing_service& /* agas_client */, bool /* isdefault */,
         bool /* isenabled */,
         hpx::program_options::options_description& options,
         std::set<std::string>& startup_handled)
@@ -1190,7 +1190,7 @@ namespace hpx { namespace components { namespace server {
     ///////////////////////////////////////////////////////////////////////////
     // Load all components from the ini files found in the configuration
     int runtime_support::load_components(util::section& ini,
-        naming::gid_type const& prefix, naming::resolver_client& agas_client,
+        naming::gid_type const& prefix, agas::addressing_service& agas_client,
         hpx::program_options::options_description& options,
         std::set<std::string>& startup_handled)
     {
@@ -1473,7 +1473,7 @@ namespace hpx { namespace components { namespace server {
     bool runtime_support::load_component_dynamic(util::section& ini,
         std::string const& instance, std::string const& component,
         filesystem::path lib, naming::gid_type const& prefix,
-        naming::resolver_client& agas_client, bool isdefault, bool isenabled,
+        agas::addressing_service& agas_client, bool isdefault, bool isenabled,
         hpx::program_options::options_description& options,
         std::set<std::string>& startup_handled)
     {
@@ -1623,7 +1623,7 @@ namespace hpx { namespace components { namespace server {
         util::section& ini, std::string const& instance,
         std::string const& /* component */, filesystem::path const& lib,
         naming::gid_type const& /* prefix */,
-        naming::resolver_client& /* agas_client */, bool /* isdefault */,
+        agas::addressing_service& /* agas_client */, bool /* isdefault */,
         bool /* isenabled */,
         hpx::program_options::options_description& options,
         std::set<std::string>& startup_handled)


### PR DESCRIPTION
Resolves [FIXME on L21 of agas_fwd.hpp](https://github.com/STEllAR-GROUP/hpx/blob/916b982fa04031f201fda358d31259a445139aa9/libs/full/agas/include/hpx/agas/agas_fwd.hpp#L21)

## Proposed Changes

  - replacing all usages of the alias `resolver_client` with the actual type `agas::addressing_service` everywhere it is used as mentioned in the FIXME
  - Updated corresponding comments and Doxygen documentation to reflect the new naming.
  - This is a mechanical refactoring only — no functionality was changed.
