### PR TITLE
Extend inspect checks to cover .ixx module interface files

### DIFF
--- a/tools/inspect/apple_macro_check.cpp
+++ b/tools/inspect/apple_macro_check.cpp
@@ -55,6 +55,7 @@ namespace boost { namespace inspect {
         register_signature(".hpp");
         register_signature(".hxx");
         register_signature(".ipp");
+        register_signature(".ixx");
     }
 
     void apple_macro_check::inspect(const string& library_name,

--- a/tools/inspect/ascii_check.cpp
+++ b/tools/inspect/ascii_check.cpp
@@ -94,6 +94,7 @@ namespace boost { namespace inspect {
         register_signature(".hpp");
         register_signature(".hxx");
         register_signature(".ipp");
+        register_signature(".ixx");
     }
 
     void ascii_check::inspect(const string& library_name,

--- a/tools/inspect/assert_macro_check.cpp
+++ b/tools/inspect/assert_macro_check.cpp
@@ -55,6 +55,7 @@ namespace boost { namespace inspect {
         register_signature(".hpp");
         register_signature(".hxx");
         register_signature(".ipp");
+        register_signature(".ixx");
     }
 
     void assert_macro_check::inspect(const string& library_name,

--- a/tools/inspect/deprecated_include_check.cpp
+++ b/tools/inspect/deprecated_include_check.cpp
@@ -72,6 +72,7 @@ namespace boost { namespace inspect {
         register_signature(".hxx");
         register_signature(".inc");
         register_signature(".ipp");
+        register_signature(".ixx");
 
         for (deprecated_includes const* includes_it = &names[0];
              includes_it->include_regex != nullptr; ++includes_it)

--- a/tools/inspect/deprecated_macro_check.cpp
+++ b/tools/inspect/deprecated_macro_check.cpp
@@ -66,6 +66,7 @@ namespace boost { namespace inspect {
         register_signature(".hpp");
         register_signature(".hxx");
         register_signature(".ipp");
+        register_signature(".ixx");
     }
 
     void deprecated_macro_check::inspect(const string& library_name,

--- a/tools/inspect/deprecated_name_check.cpp
+++ b/tools/inspect/deprecated_name_check.cpp
@@ -120,6 +120,7 @@ namespace boost { namespace inspect {
         register_signature(".hxx");
         register_signature(".inc");
         register_signature(".ipp");
+        register_signature(".ixx");
 
         for (deprecated_names const* names_it = &names[0];
              names_it->name_regex != nullptr; ++names_it)

--- a/tools/inspect/end_check.cpp
+++ b/tools/inspect/end_check.cpp
@@ -30,6 +30,7 @@ namespace boost { namespace inspect {
         register_signature(".hpp");
         register_signature(".hxx");
         register_signature(".ipp");
+        register_signature(".ixx");
     }
 
     void end_check::inspect(const string& library_name,

--- a/tools/inspect/endline_whitespace_check.cpp
+++ b/tools/inspect/endline_whitespace_check.cpp
@@ -37,6 +37,7 @@ namespace boost { namespace inspect {
         register_signature(".inc");
         register_signature(".ipp");
         register_signature(".txt");
+        register_signature(".ixx");
     }
 
     void whitespace_check::inspect(const string& library_name,

--- a/tools/inspect/include_check.cpp
+++ b/tools/inspect/include_check.cpp
@@ -301,6 +301,7 @@ namespace boost { namespace inspect {
         register_signature(".hxx");
         register_signature(".inc");
         register_signature(".ipp");
+        register_signature(".ixx");
 
         for (names_includes const* names_it = &names[0];
             names_it->name_regex != nullptr; ++names_it)

--- a/tools/inspect/inspect.cpp
+++ b/tools/inspect/inspect.cpp
@@ -728,6 +728,7 @@ namespace boost { namespace inspect {
         register_signature(".hxx.in");
         register_signature(".inc.in");
         register_signature(".ipp.in");
+        register_signature(".ixx");
     }
 
     source_inspector::source_inspector()

--- a/tools/inspect/length_check.cpp
+++ b/tools/inspect/length_check.cpp
@@ -40,6 +40,7 @@ namespace boost { namespace inspect {
         register_signature(".inc");
         register_signature(".ipp");
         register_signature(".txt");
+        register_signature(".ixx");
     }
 
     struct pattern

--- a/tools/inspect/minmax_check.cpp
+++ b/tools/inspect/minmax_check.cpp
@@ -57,6 +57,7 @@ namespace boost { namespace inspect {
         register_signature(".hxx");
         register_signature(".inc");
         register_signature(".ipp");
+        register_signature(".ixx");
     }
 
     //  inspect ( C++ source files )  ---------------------------------------//

--- a/tools/inspect/tab_check.cpp
+++ b/tools/inspect/tab_check.cpp
@@ -28,6 +28,7 @@ namespace boost { namespace inspect {
         register_signature(".ipp");
         register_signature("Jamfile");
         register_signature(".py");
+        register_signature(".ixx");
     }
 
     void tab_check::inspect(const string& library_name,

--- a/tools/inspect/unnamed_namespace_check.cpp
+++ b/tools/inspect/unnamed_namespace_check.cpp
@@ -34,6 +34,7 @@ namespace boost { namespace inspect {
         register_signature(".inc");
         register_signature(".ipp");
         register_signature(".inl");
+        register_signature(".ixx");
     }
 
     void unnamed_namespace_check::inspect(const string& library_name,

--- a/tools/inspect/windows_macro_check.cpp
+++ b/tools/inspect/windows_macro_check.cpp
@@ -51,6 +51,7 @@ namespace boost { namespace inspect {
         register_signature(".hpp");
         register_signature(".hxx");
         register_signature(".ipp");
+        register_signature(".ixx"); 
     }
 
     void windows_macro_check::inspect(const string& library_name,


### PR DESCRIPTION
## Proposed Changes

  - Added `.ixx` to registered file extensions in relevant inspect checks
  (apple_macro_check, ascii_check, assert_macro_check,
  deprecated_*_check, end_check, endline_whitespace_check,
  include_check, length_check, minmax_check, tab_check,
  unnamed_namespace_check, windows_macro_check).
- Updated header_inspector in `inspect.cpp` to treat `.ixx` as header-like.


## Any background context you want to provide?
This change is necessary as HPX is adapting C++20 modules by introducing a new file type with .ixx extension. 

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
