### PR TITLE
Expose format module using C++20 modules

### DIFF
--- a/libs/core/config/include/hpx/config/export_definitions.hpp
+++ b/libs/core/config/include/hpx/config/export_definitions.hpp
@@ -51,20 +51,6 @@
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
-// C++20 module export definitions
-#if defined(HPX_BUILD_MODULE)
-# undef HPX_CORE_EXPORT
-# define HPX_CORE_EXPORT         /* empty */
-# define HPX_MODULE_EXPORT       export
-# define HPX_MODULE_EXTERN_CORE  export extern "C++"
-# define HPX_NODISCARD_CORE      HPX_MODULE_EXTERN_CORE [[nodiscard]]
-#else
-# define HPX_MODULE_EXPORT       /* empty */
-# define HPX_MODULE_EXTERN_CORE  HPX_CORE_EXPORT
-# define HPX_NODISCARD_CORE      [[nodiscard]] HPX_CORE_EXPORT
-#endif
-
-///////////////////////////////////////////////////////////////////////////////
 #if defined(HPX_EXPORTS) || defined(HPX_FULL_EXPORTS)
 # define  HPX_EXPORT             HPX_SYMBOL_EXPORT
 #else
@@ -101,4 +87,21 @@
 # define HPX_ALWAYS_IMPORT       HPX_SYMBOL_IMPORT
 #endif
 #endif
+
+///////////////////////////////////////////////////////////////////////////////
+// C++20 module export definitions
+#if defined(HPX_BUILD_MODULE)
+# undef HPX_CORE_EXPORT
+# undef HPX_ALWAYS_EXPORT
+# define HPX_CORE_EXPORT         /* empty */
+# define HPX_ALWAYS_EXPORT       /* empty */
+# define HPX_MODULE_EXPORT       export
+# define HPX_MODULE_EXTERN_CORE  export extern "C++"
+# define HPX_NODISCARD_CORE      HPX_MODULE_EXTERN_CORE [[nodiscard]]
+#else
+# define HPX_MODULE_EXPORT       /* empty */
+# define HPX_MODULE_EXTERN_CORE  HPX_CORE_EXPORT
+# define HPX_NODISCARD_CORE      [[nodiscard]] HPX_CORE_EXPORT
+#endif
+
 // clang-format on

--- a/libs/core/format/CMakeLists.txt
+++ b/libs/core/format/CMakeLists.txt
@@ -26,6 +26,7 @@ include(HPX_AddModule)
 add_hpx_module(
   core format
   GLOBAL_HEADER_GEN OFF
+  GLOBAL_HEADER_MODULE_GEN ON
   SOURCES ${format_sources}
   HEADERS ${format_headers}
   COMPAT_HEADERS ${format_compat_headers}

--- a/libs/core/format/include/hpx/modules/format.hpp
+++ b/libs/core/format/include/hpx/modules/format.hpp
@@ -9,6 +9,12 @@
 
 #include <hpx/config.hpp>
 
+#if !defined(HPX_HAVE_CXX_MODULES) ||                                          \
+    defined(HPX_APPLICATION_DOESNT_USE_CXX_MODULES) ||                         \
+    (defined(HPX_CORE_EXPORTS) || defined(HPX_FULL_EXPORTS) ||                 \
+        defined(HPX_LIBRARY_EXPORTS) || defined(HPX_COMPONENT_EXPORTS) ||      \
+        defined(HPX_BUILD_MODULE))
+
 #include <cctype>
 #include <cstddef>
 #include <cstdio>
@@ -272,18 +278,18 @@ namespace hpx::util {
         };
 
         ///////////////////////////////////////////////////////////////////////
-        HPX_CORE_EXPORT void format_to(std::ostream& os,
+        HPX_MODULE_EXTERN_CORE void format_to(std::ostream& os,
             std::string_view format_str, format_arg const* args,
             std::size_t count);
 
-        HPX_CORE_EXPORT std::string format(std::string_view format_str,
+        HPX_MODULE_EXTERN_CORE std::string format(std::string_view format_str,
             format_arg const* args, std::size_t count);
     }    // namespace detail
 
     // enable using format in variadic contexts
-    HPX_CORE_EXPORT std::string const& format();
+    HPX_MODULE_EXTERN_CORE std::string const& format();
 
-    template <typename... Args>
+    HPX_MODULE_EXPORT template <typename... Args>
     std::string format(std::string_view format_str, Args const&... args)
     {
         detail::format_arg const format_args[] = {
@@ -291,7 +297,7 @@ namespace hpx::util {
         return detail::format(format_str, format_args, sizeof...(Args));
     }
 
-    template <typename... Args>
+    HPX_MODULE_EXPORT template <typename... Args>
     std::ostream& format_to(
         std::ostream& os, std::string_view format_str, Args const&... args)
     {
@@ -331,10 +337,16 @@ namespace hpx::util {
         };
     }    // namespace detail
 
-    template <typename Range>
+    HPX_MODULE_EXPORT template <typename Range>
     detail::format_join<Range> format_join(
         Range const& range, std::string_view delimiter) noexcept
     {
         return {range, delimiter};
     }
 }    // namespace hpx::util
+
+#else
+
+import HPX.Core;
+
+#endif

--- a/libs/core/format/include/hpx/util/bad_lexical_cast.hpp
+++ b/libs/core/format/include/hpx/util/bad_lexical_cast.hpp
@@ -14,7 +14,7 @@
 
 namespace hpx::util {
 
-    class HPX_ALWAYS_EXPORT bad_lexical_cast : public std::bad_cast
+    HPX_MODULE_EXPORT class HPX_ALWAYS_EXPORT bad_lexical_cast : public std::bad_cast
     {
     public:
         bad_lexical_cast() noexcept

--- a/libs/core/format/include/hpx/util/from_string.hpp
+++ b/libs/core/format/include/hpx/util/from_string.hpp
@@ -168,7 +168,7 @@ namespace hpx::util {
         };
     }    // namespace detail
 
-    template <typename T, typename Char>
+    HPX_MODULE_EXPORT template <typename T, typename Char>
     [[nodiscard]] T from_string(std::basic_string<Char> const& v)
     {
         try
@@ -183,7 +183,7 @@ namespace hpx::util {
         }
     }
 
-    template <typename T, typename U, typename Char>
+    HPX_MODULE_EXPORT template <typename T, typename U, typename Char>
     [[nodiscard]] T from_string(
         std::basic_string<Char> const& v, U&& default_value)
     {
@@ -199,7 +199,7 @@ namespace hpx::util {
         }
     }
 
-    template <typename T>
+    HPX_MODULE_EXPORT template <typename T>
     [[nodiscard]] T from_string(std::string const& v)
     {
         try
@@ -214,7 +214,7 @@ namespace hpx::util {
         }
     }
 
-    template <typename T, typename U>
+    HPX_MODULE_EXPORT template <typename T, typename U>
     [[nodiscard]] T from_string(std::string const& v, U&& default_value)
     {
         try

--- a/libs/core/format/include/hpx/util/to_string.hpp
+++ b/libs/core/format/include/hpx/util/to_string.hpp
@@ -37,7 +37,7 @@ namespace hpx::util {
         };
     }    // namespace detail
 
-    template <typename T>
+    HPX_MODULE_EXPORT template <typename T>
     [[nodiscard]] std::string to_string(T const& v)
     {
         try

--- a/libs/core/hpx_core.ixx
+++ b/libs/core/hpx_core.ixx
@@ -38,6 +38,7 @@ export module HPX.Core;
 
 // include all HPX module files here that have been converted to C++ modules
 #include <hpx/modules/version.hpp>
+#include <hpx/modules/format.hpp>
 
 #if defined(HPX_CLANG_VERSION)
 #pragma clang diagnostic pop


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - Adapted header files to use appropriate export macros
  - Updated format module `CMakeLists.txt` to enable module generation
  - Modified `hpx_core.ixx` to include format module headers (will be reverted once #6770  is merged)

## Any background context you want to provide?
This is part of the ongoing GSoC project to expose HPX using C++20 modules. This PR will serve as a foundation of how template functions should be exported using C++20 modules.

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
