### PR TITLE
Expose an explicit CMake target HPX::init to be used by non-executables

### DIFF
--- a/docs/sphinx/manual/creating_hpx_projects.rst
+++ b/docs/sphinx/manual/creating_hpx_projects.rst
@@ -263,6 +263,18 @@ executables if you are using the macros described below
 (:ref:`using_hpx_cmake_macros`). See :ref:`minimal` for more information on
 implicitly using ``main()`` as the entry point.
 
+If you want to use the facilities exposed by ``hpx::runtime_manager`` in binaries
+that were not linked as executables (e.g., in shared libraries), you will need
+make your cmake target explicitly depend on the ``HPX::init`` target:
+
+.. code-block:: cmake
+
+   add_library(hello_world_component SHARED hello_world_component.cpp)
+   target_link_libraries(hello_world_component PRIVATE HPX::init)
+
+Otherwise you may see compilation errors complaining about the header file
+``hpx/runtime_manager.hpp`` not being found.
+
 Creating a component requires setting two additional compile definitions:
 
 .. code-block:: cmake

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -149,6 +149,7 @@ set(_is_executable "$<STREQUAL:$<TARGET_PROPERTY:TYPE>,EXECUTABLE>")
 set(_is_library "$<IN_LIST:$<TARGET_PROPERTY:TYPE>,${_library_types}>")
 
 add_library(hpx INTERFACE)
+add_library(init INTERFACE)
 add_library(wrap_main INTERFACE)
 
 target_link_libraries(hpx INTERFACE hpx_full)
@@ -183,6 +184,7 @@ target_link_libraries(
 )
 
 target_link_libraries(wrap_main INTERFACE hpx_interface_wrap_main)
+target_link_libraries(init INTERFACE HPXInternal::hpx_init)
 target_link_libraries(hpx INTERFACE hpx_interface)
 
 # HPX::component is to be linked privately to all HPX components NOTE: The
@@ -209,7 +211,7 @@ target_compile_definitions(
     "$<${_is_library}:HPX_PLUGIN_NAME_DEFAULT=hpx_$<TARGET_PROPERTY:NAME>>"
 )
 
-set(hpx_targets hpx wrap_main plugin component)
+set(hpx_targets hpx wrap_main init plugin component)
 set(hpx_internal_targets hpx_full hpx_interface hpx_interface_wrap_main)
 
 # cmake-format: off


### PR DESCRIPTION
- This is necessary to successfully use hpx::runtime_manager in shared libraries and similar

@SAtacker Would you mind verifying if this solves the issue you reported?