### PR TITLE
tests: add proxy-iterator regression test for find

### DIFF
--- a/libs/core/algorithms/tests/regressions/CMakeLists.txt
+++ b/libs/core/algorithms/tests/regressions/CMakeLists.txt
@@ -8,6 +8,7 @@ set(tests
     count_3646
     fill_executor_5016
     findfirstof_more_searched_for
+    find_proxy_support
     for_each_annotated_function
     for_each_on_main_thread
     for_loop_2281

--- a/libs/core/algorithms/tests/regressions/find_proxy_support.cpp
+++ b/libs/core/algorithms/tests/regressions/find_proxy_support.cpp
@@ -1,0 +1,56 @@
+//  Copyright (c) 2025 Arivoli Ramamoorthy
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0.
+//  (See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+//  Regression test for Issue #6719
+//  Ensures that the find-family algorithms correctly handle proxy-reference
+
+#include <hpx/algorithm.hpp>
+#include <hpx/executors/execution_policy.hpp>
+#include <hpx/init.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <vector>
+
+void find_proxy_reference_test()
+{
+    std::vector<bool> v = {false, true, false, true};
+
+    // Sequential policy
+    auto it_seq = hpx::find(hpx::execution::seq, v.begin(), v.end(), true);
+    HPX_TEST(it_seq != v.end());
+    HPX_TEST_EQ(std::distance(v.begin(), it_seq), 1);
+
+    // Parallel policy
+    auto it_par = hpx::find(hpx::execution::par, v.begin(), v.end(), false);
+    HPX_TEST(it_par != v.end());
+    HPX_TEST_EQ(std::distance(v.begin(), it_par), 0);
+
+    // find_if
+    auto it_if = hpx::find_if(
+        hpx::execution::seq, v.begin(), v.end(), [](bool x) { return x; });
+    HPX_TEST(it_if != v.end());
+    HPX_TEST_EQ(std::distance(v.begin(), it_if), 1);
+
+    // find_if_not
+    auto it_not = hpx::find_if_not(
+        hpx::execution::par, v.begin(), v.end(), [](bool x) { return x; });
+    HPX_TEST(it_not != v.end());
+    HPX_TEST_EQ(std::distance(v.begin(), it_not), 0);
+}
+
+int hpx_main()
+{
+    find_proxy_reference_test();
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
Fixes #6719

## Proposed Changes

- Added a regression test for proxy-reference iterator support in the `find` family of algorithms (`find`, `find_if`, `find_if_not`).
- The test uses `std::vector<bool>` to verify that these algorithms correctly handle proxy references (previously causing compile errors before PR #6753).