### PR TITLE
Switch to executing a parallel algorithm to synchronous execution

### DIFF
--- a/cmake/templates/std_headers.hpp.in
+++ b/cmake/templates/std_headers.hpp.in
@@ -96,6 +96,15 @@
 # include "lct.h"
 #endif
 
+#if defined(HPX_HAVE_MODULE_ASYNC_CUDA)
+# if defined(HPX_HAVE_CUDA) && defined(HPX_HAVE_GPUBLAS)
+#  include <cublas_api.h>
+#  include <cublas_v2.h>
+# elif defined(HPX_HAVE_HIP) && defined(HPX_HAVE_GPUBLAS)
+#  include <hipblas.h>
+# endif
+#endif
+
 #if defined(HPX_HAVE_MODULE_THRUST)
 # include <hpx/thrust/thrust_headers.hpp>
 #endif

--- a/libs/core/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
@@ -129,18 +129,18 @@ namespace hpx::parallel::util::detail {
         typename Stride = std::size_t>
     hpx::util::iterator_range<chunk_size_iterator<IterOrR>>
     get_bulk_iteration_shape(ExPolicy& policy, IterOrR& it_or_r,
-        std::size_t& count, Stride s = Stride(1))
+        std::size_t& count, std::size_t& cores, Stride s = Stride(1))
     {
         if (count == 0)
         {
+            cores = 1;
             auto it = chunk_size_iterator(it_or_r, 1);
             return hpx::util::iterator_range(it, it);
         }
 
-        std::size_t const cores =
-            hpx::execution::experimental::processing_units_count(
-                policy.parameters(), policy.executor(),
-                hpx::chrono::null_duration, count);
+        cores = hpx::execution::experimental::processing_units_count(
+            policy.parameters(), policy.executor(), hpx::chrono::null_duration,
+            count);
 
         std::size_t max_chunks =
             hpx::execution::experimental::maximal_number_of_chunks(
@@ -183,10 +183,12 @@ namespace hpx::parallel::util::detail {
         typename IterOrR, typename Stride = std::size_t>
     hpx::util::iterator_range<chunk_size_iterator<IterOrR>>
     get_bulk_iteration_shape(ExPolicy& policy, std::vector<Future>& workitems,
-        F1&& f1, IterOrR& it_or_r, std::size_t& count, Stride s = Stride(1))
+        F1&& f1, IterOrR& it_or_r, std::size_t& count, std::size_t& cores,
+        Stride s = Stride(1))
     {
         if (count == 0)
         {
+            cores = 1;
             auto it = chunk_size_iterator(it_or_r, 1);
             return hpx::util::iterator_range(it, it);
         }
@@ -219,10 +221,8 @@ namespace hpx::parallel::util::detail {
             hpx::execution::experimental::measure_iteration(
                 policy.parameters(), policy.executor(), test_function, count);
 
-        std::size_t const cores =
-            hpx::execution::experimental::processing_units_count(
-                policy.parameters(), policy.executor(), iteration_duration,
-                count);
+        cores = hpx::execution::experimental::processing_units_count(
+            policy.parameters(), policy.executor(), iteration_duration, count);
 
         std::size_t max_chunks =
             hpx::execution::experimental::maximal_number_of_chunks(
@@ -264,20 +264,20 @@ namespace hpx::parallel::util::detail {
         typename Stride = std::size_t>
     std::vector<hpx::tuple<IterOrR, std::size_t>>
     get_bulk_iteration_shape_variable(ExPolicy& policy, IterOrR& it_or_r,
-        std::size_t& count, Stride s = Stride(1))
+        std::size_t& count, std::size_t& cores, Stride s = Stride(1))
     {
         using tuple_type = hpx::tuple<IterOrR, std::size_t>;
         std::vector<tuple_type> shape;
 
         if (count == 0)
         {
+            cores = 1;
             return shape;
         }
 
-        std::size_t const cores =
-            hpx::execution::experimental::processing_units_count(
-                policy.parameters(), policy.executor(),
-                hpx::chrono::null_duration, count);
+        cores = hpx::execution::experimental::processing_units_count(
+            policy.parameters(), policy.executor(), hpx::chrono::null_duration,
+            count);
 
         std::size_t max_chunks =
             hpx::execution::experimental::maximal_number_of_chunks(
@@ -338,20 +338,20 @@ namespace hpx::parallel::util::detail {
         typename FwdIter, typename Stride = std::size_t>
     decltype(auto) get_bulk_iteration_shape(std::false_type, ExPolicy& policy,
         std::vector<Future>& workitems, F1&& f1, FwdIter& begin,
-        std::size_t& count, Stride s = Stride(1))
+        std::size_t& count, std::size_t& cores, Stride s = Stride(1))
     {
         return get_bulk_iteration_shape(
-            policy, workitems, HPX_FORWARD(F1, f1), begin, count, s);
+            policy, workitems, HPX_FORWARD(F1, f1), begin, count, cores, s);
     }
 
     HPX_CXX_EXPORT template <typename ExPolicy, typename Future, typename F1,
         typename FwdIter, typename Stride = std::size_t>
     decltype(auto) get_bulk_iteration_shape(std::true_type, ExPolicy& policy,
         std::vector<Future>& workitems, F1&& f1, FwdIter& begin,
-        std::size_t& count, Stride s = Stride(1))
+        std::size_t& count, std::size_t& cores, Stride s = Stride(1))
     {
         return get_bulk_iteration_shape_variable(
-            policy, workitems, HPX_FORWARD(F1, f1), begin, count, s);
+            policy, workitems, HPX_FORWARD(F1, f1), begin, count, cores, s);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -384,21 +384,21 @@ namespace hpx::parallel::util::detail {
     hpx::util::iterator_range<
         parallel::util::detail::chunk_size_idx_iterator<FwdIter>>
     get_bulk_iteration_shape_idx(ExPolicy& policy, FwdIter begin,
-        std::size_t count, Stride s = Stride(1))
+        std::size_t count, std::size_t& cores, Stride s = Stride(1))
     {
         using iterator =
             parallel::util::detail::chunk_size_idx_iterator<FwdIter>;
 
         if (count == 0)
         {
+            cores = 1;
             auto it = iterator(begin, 1);
             return hpx::util::iterator_range(it, it);
         }
 
-        std::size_t const cores =
-            hpx::execution::experimental::processing_units_count(
-                policy.parameters(), policy.executor(),
-                hpx::chrono::null_duration, count);
+        cores = hpx::execution::experimental::processing_units_count(
+            policy.parameters(), policy.executor(), hpx::chrono::null_duration,
+            count);
 
         std::size_t max_chunks =
             hpx::execution::experimental::maximal_number_of_chunks(
@@ -447,13 +447,14 @@ namespace hpx::parallel::util::detail {
         parallel::util::detail::chunk_size_idx_iterator<FwdIter>>
     get_bulk_iteration_shape_idx(ExPolicy& policy,
         std::vector<Future>& workitems, F1&& f1, FwdIter begin,
-        std::size_t count, Stride s = Stride(1))
+        std::size_t count, std::size_t& cores, Stride s = Stride(1))
     {
         using iterator =
             parallel::util::detail::chunk_size_idx_iterator<FwdIter>;
 
         if (count == 0)
         {
+            cores = 1;
             auto it = iterator(begin, 1);
             return hpx::util::iterator_range(it, it);
         }
@@ -488,10 +489,8 @@ namespace hpx::parallel::util::detail {
             hpx::execution::experimental::measure_iteration(
                 policy.parameters(), policy.executor(), test_function, count);
 
-        std::size_t const cores =
-            hpx::execution::experimental::processing_units_count(
-                policy.parameters(), policy.executor(), iteration_duration,
-                count);
+        cores = hpx::execution::experimental::processing_units_count(
+            policy.parameters(), policy.executor(), iteration_duration, count);
 
         std::size_t max_chunks =
             hpx::execution::experimental::maximal_number_of_chunks(
@@ -536,20 +535,20 @@ namespace hpx::parallel::util::detail {
         typename Stride = std::size_t>
     std::vector<hpx::tuple<FwdIter, std::size_t, std::size_t>>
     get_bulk_iteration_shape_idx_variable(ExPolicy& policy, FwdIter first,
-        std::size_t count, Stride s = Stride(1))
+        std::size_t count, std::size_t& cores, Stride s = Stride(1))
     {
         using tuple_type = hpx::tuple<FwdIter, std::size_t, std::size_t>;
         std::vector<tuple_type> shape;
 
         if (count == 0)
         {
+            cores = 1;
             return shape;
         }
 
-        std::size_t const cores =
-            hpx::execution::experimental::processing_units_count(
-                policy.parameters(), policy.executor(),
-                hpx::chrono::null_duration, count);
+        cores = hpx::execution::experimental::processing_units_count(
+            policy.parameters(), policy.executor(), hpx::chrono::null_duration,
+            count);
 
         std::size_t max_chunks =
             hpx::execution::experimental::maximal_number_of_chunks(

--- a/libs/core/algorithms/include/hpx/parallel/util/detail/partitioner_iteration.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/detail/partitioner_iteration.hpp
@@ -48,9 +48,7 @@ namespace hpx::parallel::util::detail {
         template <typename Archive>
         void serialize(Archive& ar, unsigned)
         {
-            // clang-format off
             ar & f_;
-            // clang-format on
         }
     };
 }    // namespace hpx::parallel::util::detail

--- a/libs/core/algorithms/include/hpx/parallel/util/partitioner.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/partitioner.hpp
@@ -50,6 +50,7 @@ namespace hpx::parallel::util::detail {
             hpx::execution::experimental::extract_invokes_testing_function_v<
                 parameters_type>;
 
+        std::size_t cores = 1;
         if constexpr (has_variable_chunk_size)
         {
             static_assert(!invokes_testing_function,
@@ -57,7 +58,7 @@ namespace hpx::parallel::util::detail {
                 "has_variable_chunk_size and invokes_testing_function");
 
             auto&& shape = detail::get_bulk_iteration_shape_variable(
-                policy, it_or_r, count);
+                policy, it_or_r, count, cores);
 
             return execution::bulk_async_execute(policy.executor(),
                 partitioner_iteration<Result, F>{HPX_FORWARD(F, f)},
@@ -66,7 +67,7 @@ namespace hpx::parallel::util::detail {
         else if constexpr (!invokes_testing_function)
         {
             auto&& shape =
-                detail::get_bulk_iteration_shape(policy, it_or_r, count);
+                detail::get_bulk_iteration_shape(policy, it_or_r, count, cores);
 
             return execution::bulk_async_execute(policy.executor(),
                 partitioner_iteration<Result, F>{HPX_FORWARD(F, f)},
@@ -76,7 +77,7 @@ namespace hpx::parallel::util::detail {
         {
             std::vector<hpx::future<Result>> inititems;
             auto&& shape = detail::get_bulk_iteration_shape(
-                policy, inititems, f, it_or_r, count);
+                policy, inititems, f, it_or_r, count, cores);
 
             auto&& workitems = execution::bulk_async_execute(policy.executor(),
                 partitioner_iteration<Result, F>{HPX_FORWARD(F, f)},
@@ -102,6 +103,7 @@ namespace hpx::parallel::util::detail {
             hpx::execution::experimental::extract_invokes_testing_function_v<
                 parameters_type>;
 
+        std::size_t cores = 1;
         if constexpr (has_variable_chunk_size)
         {
             static_assert(!invokes_testing_function,
@@ -109,7 +111,7 @@ namespace hpx::parallel::util::detail {
                 "has_variable_chunk_size and invokes_testing_function");
 
             auto&& shape = detail::get_bulk_iteration_shape_idx_variable(
-                policy, first, count, stride);
+                policy, first, count, cores, stride);
 
             return execution::bulk_async_execute(policy.executor(),
                 partitioner_iteration<Result, F>{HPX_FORWARD(F, f)},
@@ -118,7 +120,7 @@ namespace hpx::parallel::util::detail {
         else if constexpr (!invokes_testing_function)
         {
             auto&& shape = detail::get_bulk_iteration_shape_idx(
-                policy, first, count, stride);
+                policy, first, count, cores, stride);
 
             return execution::bulk_async_execute(policy.executor(),
                 partitioner_iteration<Result, F>{HPX_FORWARD(F, f)},
@@ -128,7 +130,7 @@ namespace hpx::parallel::util::detail {
         {
             std::vector<hpx::future<Result>> inititems;
             auto&& shape = detail::get_bulk_iteration_shape_idx(
-                policy, inititems, f, first, count, stride);
+                policy, inititems, f, first, count, cores, stride);
 
             auto&& workitems = execution::bulk_async_execute(policy.executor(),
                 partitioner_iteration<Result, F>{HPX_FORWARD(F, f)},

--- a/libs/core/algorithms/include/hpx/parallel/util/scan_partitioner.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/scan_partitioner.hpp
@@ -89,9 +89,10 @@ namespace hpx::parallel::util {
                         experimental::extract_has_variable_chunk_size<
                             parameters_type>::type;
 
+                    std::size_t cores = 1;
                     auto shape = detail::get_bulk_iteration_shape(
                         has_variable_chunk_size(), policy, workitems, f1, first,
-                        count, 1);
+                        count, cores, 1);
 
                     // schedule every chunk on a separate thread
                     std::size_t size = hpx::util::size(shape);

--- a/libs/core/async_cuda/include/hpx/async_cuda/custom_blas_api.hpp
+++ b/libs/core/async_cuda/include/hpx/async_cuda/custom_blas_api.hpp
@@ -35,6 +35,7 @@
 
 #elif defined(HPX_HAVE_CUDA) && defined(HPX_HAVE_GPUBLAS)
 
+#include <cublas_api.h>
 #include <cublas_v2.h>
 
 #endif

--- a/libs/core/execution/include/hpx/execution/algorithms/let_value.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/let_value.hpp
@@ -47,15 +47,15 @@ namespace hpx::execution::experimental {
             template <typename Env = empty_env>
             struct generate_completion_signatures
             {
-                template <typename Pack, typename Enable = void>
+                template <typename Func, typename Pack, typename Enable = void>
                 struct successor_sender_types_helper;
 
-                template <typename... Ts>
-                struct successor_sender_types_helper<meta::pack<Ts...>,
-                    std::enable_if_t<hpx::is_invocable_v<F,
+                template <typename Func, typename... Ts>
+                struct successor_sender_types_helper<Func, meta::pack<Ts...>,
+                    std::enable_if_t<std::is_invocable_v<Func,
                         std::add_lvalue_reference_t<std::decay_t<Ts>>...>>>
                 {
-                    using type = hpx::util::invoke_result_t<F,
+                    using type = std::invoke_result_t<Func,
                         std::add_lvalue_reference_t<std::decay_t<Ts>>...>;
 
                     static_assert(is_sender_v<type>,
@@ -65,7 +65,7 @@ namespace hpx::execution::experimental {
 
                 template <typename... Ts>
                 using successor_sender_types = meta::type<
-                    successor_sender_types_helper<meta::pack<Ts...>>>;
+                    successor_sender_types_helper<F, meta::pack<Ts...>>>;
 
                 // Type of the potential values returned from the predecessor
                 // sender

--- a/libs/core/executors/include/hpx/executors/parallel_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/parallel_executor.hpp
@@ -705,6 +705,12 @@ namespace hpx::execution::experimental {
     };
 
     HPX_CXX_EXPORT template <typename Policy>
+    struct is_bulk_one_way_executor<
+        hpx::execution::parallel_policy_executor<Policy>> : std::true_type
+    {
+    };
+
+    HPX_CXX_EXPORT template <typename Policy>
     struct is_bulk_two_way_executor<
         hpx::execution::parallel_policy_executor<Policy>> : std::true_type
     {

--- a/libs/core/executors/include/hpx/executors/restricted_thread_pool_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/restricted_thread_pool_executor.hpp
@@ -277,13 +277,6 @@ namespace hpx::execution::experimental {
     };
 
     HPX_CXX_EXPORT template <typename Policy>
-    struct is_bulk_one_way_executor<restricted_policy_executor<Policy>>
-      : is_bulk_one_way_executor<
-            hpx::execution::parallel_policy_executor<Policy>>
-    {
-    };
-
-    HPX_CXX_EXPORT template <typename Policy>
     struct is_two_way_executor<restricted_policy_executor<Policy>>
       : is_two_way_executor<hpx::execution::parallel_policy_executor<Policy>>
     {

--- a/libs/core/executors/include/hpx/executors/scheduler_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/scheduler_executor.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2021-2024 Hartmut Kaiser
+//  Copyright (c) 2021-2025 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/concepts.hpp>
 #include <hpx/modules/datastructures.hpp>
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/execution_base.hpp>
@@ -17,6 +16,7 @@
 #include <hpx/modules/tag_invoke.hpp>
 #include <hpx/modules/timing.hpp>
 #include <hpx/modules/topology.hpp>
+#include <hpx/modules/type_support.hpp>
 
 #include <cstddef>
 #include <exception>
@@ -114,12 +114,8 @@ namespace hpx::execution::experimental {
         using future_type = hpx::future<T>;
 
     private:
-        // clang-format off
-        template <typename Parameters,
-            HPX_CONCEPT_REQUIRES_(
-                hpx::traits::is_executor_parameters_v<Parameters>
-            )>
-        // clang-format on
+        template <typename Parameters>
+            requires(hpx::traits::is_executor_parameters_v<Parameters>)
         friend auto tag_invoke(
             hpx::execution::experimental::processing_units_count_t tag,
             Parameters&& params, scheduler_executor const& exec,
@@ -150,11 +146,15 @@ namespace hpx::execution::experimental {
         friend auto tag_invoke(hpx::parallel::execution::sync_execute_t,
             scheduler_executor const& exec, F&& f, Ts&&... ts)
         {
-            // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-            return *hpx::this_thread::experimental::sync_wait(
-                then(schedule(exec.sched_),
-                    hpx::util::deferred_call(
-                        HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...)));
+            using result_type =
+                hpx::util::detail::invoke_deferred_result_t<F, Ts...>;
+
+            return hpx::util::void_guard<result_type>(),
+                   // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+                   *hpx::this_thread::experimental::sync_wait(
+                       then(schedule(exec.sched_),
+                           hpx::util::deferred_call(
+                               HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...)));
         }
 
         // TwoWayExecutor interface
@@ -182,12 +182,8 @@ namespace hpx::execution::experimental {
         }
 
         // BulkTwoWayExecutor interface
-        // clang-format off
-        template <typename F, typename S, typename... Ts,
-            HPX_CONCEPT_REQUIRES_(
-                !std::is_integral_v<S>
-            )>
-        // clang-format on
+        template <typename F, typename S, typename... Ts>
+            requires(!std::is_integral_v<S>)
         friend auto tag_invoke(hpx::parallel::execution::bulk_async_execute_t,
             scheduler_executor const& exec, F&& f, S const& shape, Ts&&... ts)
         {
@@ -243,27 +239,26 @@ namespace hpx::execution::experimental {
             }
         }
 
-        // clang-format off
-        template <typename F, typename S, typename... Ts,
-            HPX_CONCEPT_REQUIRES_(
-                !std::is_integral_v<S>
-            )>
-        // clang-format on
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::bulk_sync_execute_t,
+        template <typename F, typename S, typename... Ts>
+            requires(!std::is_integral_v<S>)
+        friend auto tag_invoke(hpx::parallel::execution::bulk_sync_execute_t,
             scheduler_executor const& exec, F&& f, S const& shape, Ts&&... ts)
         {
-            hpx::this_thread::experimental::sync_wait(
-                bulk(schedule(exec.sched_), shape,
-                    hpx::bind_back(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...)));
+            using shape_element =
+                typename hpx::traits::range_traits<S>::value_type;
+            using result_type = hpx::util::detail::invoke_deferred_result_t<F,
+                shape_element, Ts...>;
+
+            return hpx::util::void_guard<result_type>(),
+                   // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+                   *hpx::this_thread::experimental::sync_wait(
+                       bulk(schedule(exec.sched_), shape,
+                           hpx::bind_back(
+                               HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...)));
         }
 
-        // clang-format off
-        template <typename F, typename S, typename Future, typename... Ts,
-            HPX_CONCEPT_REQUIRES_(
-                !std::is_integral_v<S>
-            )>
-        // clang-format on
+        template <typename F, typename S, typename Future, typename... Ts>
+            requires(!std::is_integral_v<S>)
         friend decltype(auto) tag_invoke(
             hpx::parallel::execution::bulk_then_execute_t,
             scheduler_executor const& exec, F&& f, S const& shape,
@@ -314,13 +309,9 @@ namespace hpx::execution::experimental {
         -> scheduler_executor<std::decay_t<BaseScheduler>>;
 
     // support all properties exposed by the wrapped scheduler
-    // clang-format off
     HPX_CXX_EXPORT template <typename Tag, typename BaseScheduler,
-        typename Property,
-        HPX_CONCEPT_REQUIRES_(
-            hpx::execution::experimental::is_scheduling_property_v<Tag>
-        )>
-    // clang-format on
+        typename Property>
+        requires(hpx::execution::experimental::is_scheduling_property_v<Tag>)
     auto tag_invoke(
         Tag tag, scheduler_executor<BaseScheduler> const& exec, Property&& prop)
         -> decltype(scheduler_executor<BaseScheduler>(std::declval<Tag>()(
@@ -330,12 +321,8 @@ namespace hpx::execution::experimental {
             tag(exec.sched(), HPX_FORWARD(Property, prop)));
     }
 
-    // clang-format off
-    HPX_CXX_EXPORT template <typename Tag, typename BaseScheduler,
-        HPX_CONCEPT_REQUIRES_(
-            hpx::execution::experimental::is_scheduling_property_v<Tag>
-        )>
-    // clang-format on
+    HPX_CXX_EXPORT template <typename Tag, typename BaseScheduler>
+        requires(hpx::execution::experimental::is_scheduling_property_v<Tag>)
     auto tag_invoke(Tag tag, scheduler_executor<BaseScheduler> const& exec)
         -> decltype(std::declval<Tag>()(std::declval<BaseScheduler>()))
     {

--- a/libs/core/executors/include/hpx/executors/thread_pool_scheduler_bulk.hpp
+++ b/libs/core/executors/include/hpx/executors/thread_pool_scheduler_bulk.hpp
@@ -46,7 +46,7 @@ namespace hpx::execution::experimental::detail {
     // Compute a chunk size given a number of worker threads and a total number
     // of items n. Returns a power-of-2 chunk size that produces at most 8 and
     // at least 4 chunks per worker thread.
-    static constexpr std::uint32_t get_bulk_scheduler_chunk_size(
+    constexpr std::uint32_t get_bulk_scheduler_chunk_size(
         std::uint32_t const num_threads, std::size_t const n) noexcept
     {
         std::uint64_t chunk_size = 1;


### PR DESCRIPTION
... if instructed to run on one core using one chunk

- flyby: added missing trait specialization to parallel_executor
- flyby: removed superfluous trait specialization for restricted_policy_executor
- flyby: making return values from sync_execute and bulk_sync_execute consistent for scheduler_executor
