### PR TITLE
Fix linker error for print_dec<unsigned long> on ARM64

### DIFF
--- a/libs/core/debugging/include/hpx/debugging/print.hpp
+++ b/libs/core/debugging/include/hpx/debugging/print.hpp
@@ -78,6 +78,12 @@ namespace hpx::debug {
             std::ostream&, std::int64_t const&, int);
         extern template HPX_CORE_EXPORT void print_dec(
             std::ostream&, std::uint64_t const&, int);
+#if defined(__APPLE__)
+        extern template HPX_CORE_EXPORT void print_dec(
+            std::ostream&, long const&, int);
+        extern template HPX_CORE_EXPORT void print_dec(
+            std::ostream&, unsigned long const&, int);
+#endif
 
         extern template HPX_CORE_EXPORT void print_dec(
             std::ostream&, std::atomic<int> const&, int);

--- a/libs/core/debugging/src/print.cpp
+++ b/libs/core/debugging/src/print.cpp
@@ -61,6 +61,10 @@ namespace hpx::debug {
         template void print_dec(std::ostream&, std::uint32_t const&, int);
         template void print_dec(std::ostream&, std::int64_t const&, int);
         template void print_dec(std::ostream&, std::uint64_t const&, int);
+#if defined(__APPLE__)
+        template void print_dec(std::ostream&, long const&, int);
+        template void print_dec(std::ostream&, unsigned long const&, int);
+#endif
 
         template void print_dec(std::ostream&, std::atomic<int> const&, int);
         template void print_dec(


### PR DESCRIPTION
Add explicit template instantiations for `long` and `unsigned long` to resolve undefined symbol errors when using debug output with `unsigned long` values on ARM64 macOS.

On ARM64, `unsigned long` is distinct from `std::uint64_t`, requiring separate template instantiations. This matches the existing pattern for other integer types and is safe on all platforms.

## Fixes bug during linking `numa_allocator_test` on ARM64 macOS

The build on macOS ARM64 (Apple Silicon) failed during the linking phase of the `numa_allocator_test`.

**Evidence:**
The linker explicitly reported an `Undefined symbol` error for a specific template specialization of `print_dec`:

```
Undefined symbols for architecture arm64:
  "void hpx::debug::detail::print_dec<unsigned long>(std::__1::basic_ostream<char, ...>&, unsigned long const&, int)", referenced from:
      void hpx::debug::detail::display<...> in numa_allocator.cpp.o
ld: symbol(s) not found for architecture arm64
```

This is undesirable because:
*   It breaks the build completely on a supported and increasingly common architecture (ARM64).
*   It indicates that the debugging infrastructure (`hpx::debug::dec`) was incomplete, as it could not handle standard C++ fundamental types like `unsigned long` and `long` directly, forcing users to cast variables to `uint64_t` manually to avoid linker errors.

#### Analysis
The `print.cpp` source file previously only contained explicit instantiations for fixed-width types (`std::uint64_t`, `std::int64_t`, etc.):

```cpp
// Existing code
template void print_dec(std::ostream&, std::uint64_t const&, int);On **ARM64 macOS**:
```

1.  `std::uint64_t` is typically a typedef for `unsigned long long`.
2.  `std::size_t` is typically a typedef for `unsigned long`.
3.  In C++, `unsigned long` and `unsigned long long` are **distinct types** for the purpose of template instantiation and function overloading, even if they have the same size (64 bits).

Because the library only instantiated the template for `std::uint64_t` (aka `unsigned long long`), the compiler generated a symbol for that specific type. When `numa_allocator.cpp` invoked `print_dec` with an `unsigned long` (likely via `std::size_t`), the linker looked for the `unsigned long` symbol, which did not exist.

#### Why the fix is correct
We added explicit instantiations for the missing types, guarded by `__APPLE__` to avoid conflicts on other platforms:

```cpp
// Added code
#if defined(__APPLE__)
template void print_dec(std::ostream&, long const&, int);
template void print_dec(std::ostream&, unsigned long const&, int);
#endif
```

**Proof of Correctness:**
1.  **Symbol Availability:** By explicitly instantiating `unsigned long` on macOS, we force the compiler to generate the exact symbol (`__Z...m...` for `unsigned long` vs `__Z...y...` for `unsigned long long`) that the linker was previously complaining was missing.
2.  **Platform Safety:**
    *   **On macOS (ARM64/x86_64):** `unsigned long` is distinct from `std::uint64_t`. The guard enables the instantiation, providing the missing symbol and fixing the linker error.
    *   **On Linux (x86_64):** `std::uint64_t` is often defined as `unsigned long`. If we blindly instantiated both, it would result in a "duplicate explicit instantiation" error. The `#if defined(__APPLE__)` guard ensures we only add the instantiation on platforms where it is strictly required and safe.
3.  **Pattern Consistency:** This change aligns `print_dec` with how standard libraries handle integer overloads, ensuring support for all fundamental integer types.

## Proposed Changes

  - Add `extern template` declarations for `long` and `unsigned long` specializations of `print_dec` in `libs/core/debugging/include/hpx/debugging/print.hpp` (guarded by `__APPLE__`).
  - Add explicit template instantiations for `long` and `unsigned long` specializations of `print_dec` in `libs/core/debugging/src/print.cpp` (guarded by `__APPLE__`).
  - This enables `hpx::debug::dec<N>(val)` to work correctly when `val` is of type `unsigned long` or `long`, fixing build failures on platforms where these are distinct from fixed-width integer types.

## Any background context you want to provide?
The build was failing on ARM64 macOS with an undefined symbol error: `void hpx::debug::detail::print_dec<unsigned long>(...)`. This function is used by `numa_allocator_test`. While `std::uint64_t` was instantiated, `unsigned long` was not. Since `unsigned long` is a distinct type from `uint64_t` on this platform (even if they have the same size), the linker could not find the symbol.

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [x] I have fixed a bug and have added a regression test. (The existing `numa_allocator_test` serves as the regression test).
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.