### PR TITLE
fix(stdexec): added adaption to ensure successful build with stdexec

### DIFF
--- a/libs/core/execution_base/include/hpx/execution_base/stdexec_forward.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/stdexec_forward.hpp
@@ -162,7 +162,6 @@ namespace hpx::execution::experimental {
 
     // Domain
     HPX_CXX_EXPORT using stdexec::default_domain;
-    HPX_CXX_EXPORT using stdexec::dependent_domain;
 
     // Execute
     HPX_CXX_EXPORT using stdexec::execute;
@@ -237,12 +236,10 @@ namespace hpx::execution::experimental {
     HPX_CXX_EXPORT using stdexec::sends_stopped;
     HPX_CXX_EXPORT using stdexec::value_types_of_t;
 
-    HPX_CXX_EXPORT using stdexec::make_completion_signatures;
     HPX_CXX_EXPORT using stdexec::transform_completion_signatures;
     HPX_CXX_EXPORT using stdexec::transform_completion_signatures_of;
 
     // Transform sender
-    HPX_CXX_EXPORT using stdexec::transform_env;
     HPX_CXX_EXPORT using stdexec::transform_sender;
     HPX_CXX_EXPORT using stdexec::transform_sender_result_t;
     HPX_CXX_EXPORT using stdexec::transform_sender_t;

--- a/libs/core/executors/include/hpx/executors/thread_pool_scheduler.hpp
+++ b/libs/core/executors/include/hpx/executors/thread_pool_scheduler.hpp
@@ -298,6 +298,20 @@ namespace hpx::execution::experimental {
                 {
                     return e.sched;
                 }
+
+                // clang-format off
+                template <typename CPO,
+                    HPX_CONCEPT_REQUIRES_(
+                        meta::value<meta::one_of<
+                            CPO, set_value_t, set_stopped_t>>
+                    )>
+                // clang-format on
+                constexpr auto query(
+                    hpx::execution::experimental::get_completion_scheduler_t<
+                        CPO>) const noexcept
+                {
+                    return sched;
+                }
             };
 
             friend constexpr env tag_invoke(
@@ -353,6 +367,11 @@ namespace hpx::execution::experimental {
             thread_pool_policy_scheduler const& sched)
         {
             return {sched};
+        }
+
+        constexpr sender<thread_pool_policy_scheduler> schedule() const
+        {
+            return {*this};
         }
 
         void policy(Policy policy) noexcept


### PR DESCRIPTION
Fixes #6842

## Proposed Changes

  - Removed `stdexec::dependent_domain` since it has been deleted in the upstream repo
  - Changed `stdexec::make_completion_signatures` to `exec::make_completion_signatures` to ensure consistency
  - Removed `stdexec::transform_env` since it has been deleted in the upstream repo
  - Added `query()` and `schedule()` functions to `thread_pool_policy_scheduler` to meet the requirement

## Any background context you want to provide?
[upstream repo](https://github.com/NVIDIA/stdexec)

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
