### PR TITLE
Godbolt Boost detection: search for static libs if shared not found

### DIFF
--- a/cmake/HPX_SetupBoost.cmake
+++ b/cmake/HPX_SetupBoost.cmake
@@ -45,14 +45,33 @@ if(NOT TARGET hpx_dependencies_boost)
     if(NOT Boost_FOUND)
       # Search using MODULE mode
       find_package(
+        Boost ${Boost_MINIMUM_VERSION} MODULE QUIET NO_POLICY_SCOPE
+        COMPONENTS ${__boost_libraries}
+      )
+    endif()
+
+    if(NOT Boost_FOUND AND NOT Boost_USE_STATIC_LIBS)
+      hpx_info(
+        "Shared Boost not found, attempting to find static Boost libraries."
+      )
+      set(Boost_USE_STATIC_LIBS ON)
+      find_package(
         Boost ${Boost_MINIMUM_VERSION} MODULE REQUIRED NO_POLICY_SCOPE
         COMPONENTS ${__boost_libraries}
       )
     endif()
 
+    if(NOT Boost_FOUND)
+      hpx_error("Could not find Boost. Please check your configuration.")
+    endif()
+
     add_library(hpx_dependencies_boost INTERFACE IMPORTED)
 
-    target_link_libraries(hpx_dependencies_boost INTERFACE Boost::boost)
+    if(TARGET Boost::boost)
+      target_link_libraries(hpx_dependencies_boost INTERFACE Boost::boost)
+    else()
+      target_link_libraries(hpx_dependencies_boost INTERFACE Boost::headers)
+    endif()
 
     foreach(__boost_library ${__boost_libraries})
       target_link_libraries(

--- a/cmake/HPX_SetupBoostFilesystem.cmake
+++ b/cmake/HPX_SetupBoostFilesystem.cmake
@@ -9,9 +9,15 @@ if(HPX_FILESYSTEM_WITH_BOOST_FILESYSTEM_COMPATIBILITY)
   if(NOT TARGET Boost::filesystem)
 
     find_package(
-      Boost ${Boost_MINIMUM_VERSION} NO_POLICY_SCOPE MODULE
+      Boost ${Boost_MINIMUM_VERSION} NO_POLICY_SCOPE CONFIG QUIET
       COMPONENTS filesystem
     )
+    if(NOT Boost_FOUND)
+      find_package(
+        Boost ${Boost_MINIMUM_VERSION} NO_POLICY_SCOPE MODULE
+        COMPONENTS filesystem
+      )
+    endif()
 
     if(NOT Boost_FILESYSTEM_FOUND)
       hpx_error(

--- a/cmake/HPX_SetupBoostRegex.cmake
+++ b/cmake/HPX_SetupBoostRegex.cmake
@@ -7,8 +7,14 @@
 if(NOT TARGET Boost::regex)
 
   find_package(
-    Boost ${Boost_MINIMUM_VERSION} NO_POLICY_SCOPE MODULE COMPONENTS regex
+    Boost ${Boost_MINIMUM_VERSION} NO_POLICY_SCOPE CONFIG QUIET
+    COMPONENTS regex
   )
+  if(NOT Boost_FOUND)
+    find_package(
+      Boost ${Boost_MINIMUM_VERSION} NO_POLICY_SCOPE MODULE COMPONENTS regex
+    )
+  endif()
 
   if(Boost_REGEX_FOUND)
     hpx_info("  regex")


### PR DESCRIPTION
Fixes #6541

## Proposed Changes

- added automatic fallback to search for static Boost libraries if shared libraries are not found during detection. 
- updated boost module detection (Filesystem, Regex, etc.) to prioritize CONFIG mode before falling back to MODULE mode for better compatibility with modern pre-installed versions.
- added fallback link to Boost::headers if primary Boost::boost target is unavailable, ensuring header-only usage still works smoothly. consolidated and cleaned up boost setup logic to remove redundant external module files.

## Any background context you want to provide?

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [x] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
