### PR TITLE
implement thread affinity api similar to pthread_setaffinity_np

### DIFF
--- a/.circleci/tests.unit5.targets
+++ b/.circleci/tests.unit5.targets
@@ -15,4 +15,5 @@ tests.unit.modules.synchronization
 tests.unit.modules.tag_invoke
 tests.unit.modules.testing
 tests.unit.modules.threading
+tests.unit.modules.threading_base
 tests.unit.modules.timed_execution

--- a/libs/core/executors/include/hpx/executors/fork_join_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/fork_join_executor.hpp
@@ -345,14 +345,8 @@ namespace hpx::execution::experimental {
                 // Make sure the main thread runs with the required priority
                 // as well. Yield with the intent to be resumed with the
                 // required settings.
-                threads::detail::set_thread_state(threads::get_self_id(),
-                    threads::thread_schedule_state::pending,
-                    threads::thread_restart_state::signaled, priority,
-                    threads::thread_schedule_hint(
-                        static_cast<std::int16_t>(main_thread_)),
-                    true);
-                hpx::this_thread::suspend(
-                    threads::thread_schedule_state::suspended);
+                hpx::this_thread::set_affinity(
+                    static_cast<std::int16_t>(main_thread_), priority);
             }
 
             void init_threads()

--- a/libs/core/threading_base/CMakeLists.txt
+++ b/libs/core/threading_base/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2023 The STE||AR-Group
+# Copyright (c) 2019-2026 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -25,6 +25,7 @@ set(threading_base_headers
     hpx/threading_base/scheduler_mode.hpp
     hpx/threading_base/scheduler_state.hpp
     hpx/threading_base/scoped_annotation.hpp
+    hpx/threading_base/set_thread_affinity.hpp
     hpx/threading_base/set_thread_state.hpp
     hpx/threading_base/set_thread_state_timed.hpp
     hpx/threading_base/thread_data.hpp
@@ -81,6 +82,7 @@ set(threading_base_sources
     print.cpp
     register_thread.cpp
     scheduler_base.cpp
+    set_thread_affinity.cpp
     set_thread_state.cpp
     set_thread_state_timed.cpp
     thread_data.cpp

--- a/libs/core/threading_base/include/hpx/threading_base/set_thread_affinity.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/set_thread_affinity.hpp
@@ -1,0 +1,34 @@
+//  Copyright (c) 2024-2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/modules/errors.hpp>
+#include <hpx/threading_base/threading_base_fwd.hpp>
+
+#include <cstdint>
+
+#include <hpx/config/warnings_prefix.hpp>
+
+namespace hpx::threads {
+
+    HPX_CXX_EXPORT HPX_CORE_EXPORT thread_state set_thread_affinity(
+        thread_id_type const& id, std::int16_t target_pu,
+        thread_priority priority = thread_priority::bound,
+        error_code& ec = throws);
+
+}    // namespace hpx::threads
+
+namespace hpx::this_thread {
+
+    HPX_CXX_EXPORT HPX_CORE_EXPORT void set_affinity(std::int16_t target_pu,
+        threads::thread_priority priority = threads::thread_priority::bound,
+        error_code& ec = throws);
+
+}    // namespace hpx::this_thread
+
+#include <hpx/config/warnings_suffix.hpp>

--- a/libs/core/threading_base/src/set_thread_affinity.cpp
+++ b/libs/core/threading_base/src/set_thread_affinity.cpp
@@ -1,0 +1,68 @@
+//  Copyright (c) 2024-2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#include <hpx/assert.hpp>
+#include <hpx/modules/errors.hpp>
+#include <hpx/modules/format.hpp>
+#include <hpx/threading_base/set_thread_affinity.hpp>
+#include <hpx/threading_base/set_thread_state.hpp>
+#include <hpx/threading_base/thread_helpers.hpp>
+#include <hpx/threading_base/threading_base_fwd.hpp>
+#include <hpx/topology/cpu_mask.hpp>
+
+#include <cstdint>
+
+namespace hpx::threads {
+
+    thread_state set_thread_affinity(thread_id_type const& id,
+        std::int16_t target_pu, thread_priority priority, error_code& ec)
+    {
+        if (HPX_UNLIKELY(id == invalid_thread_id))
+        {
+            HPX_THROWS_IF(ec, hpx::error::null_thread_id,
+                "threads::set_thread_affinity", "null thread id encountered");
+            return thread_state{
+                thread_schedule_state::unknown, thread_restart_state::unknown};
+        }
+
+        if (target_pu < 0 ||
+            target_pu >=
+                static_cast<std::int16_t>(hpx::threads::hardware_concurrency()))
+        {
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "threads::set_thread_affinity", "invalid target pu number: {}",
+                target_pu);
+            return thread_state{
+                thread_schedule_state::unknown, thread_restart_state::unknown};
+        }
+
+        thread_schedule_hint schedulehint(target_pu);
+
+        thread_state previous_state = detail::set_thread_state(id,
+            thread_schedule_state::pending, thread_restart_state::signaled,
+            priority, schedulehint, true, ec);
+
+        return previous_state;
+    }
+
+}    // namespace hpx::threads
+
+namespace hpx::this_thread {
+
+    void set_affinity(std::int16_t target_pu, threads::thread_priority priority,
+        error_code& ec)
+    {
+        hpx::threads::set_thread_affinity(
+            threads::get_self_id(), target_pu, priority, ec);
+        if (ec)
+            return;
+
+        hpx::this_thread::suspend(
+            hpx::threads::thread_schedule_state::suspended);
+    }
+
+}    // namespace hpx::this_thread

--- a/libs/core/threading_base/tests/unit/CMakeLists.txt
+++ b/libs/core/threading_base/tests/unit/CMakeLists.txt
@@ -4,7 +4,10 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(tests)
+set(tests set_thread_affinity)
+set(set_thread_affinity_LIBRARIES hpx_threading_base hpx_async_base hpx_futures
+                                  hpx_init hpx_testing
+)
 
 foreach(test ${tests})
   set(sources ${test}.cpp)
@@ -13,7 +16,8 @@ foreach(test ${tests})
 
   add_hpx_executable(
     ${test}_test INTERNAL_FLAGS
-    SOURCES ${sources} ${${test}_FLAGS} ${${test}_LIBRARIES}
+    SOURCES ${sources} ${${test}_FLAGS}
+    DEPENDENCIES ${${test}_LIBRARIES}
     EXCLUDE_FROM_ALL
     HPX_PREFIX ${HPX_BUILD_PREFIX}
     FOLDER "Tests/Unit/Modules/Core/ThreadingBase"

--- a/libs/core/threading_base/tests/unit/set_thread_affinity.cpp
+++ b/libs/core/threading_base/tests/unit/set_thread_affinity.cpp
@@ -1,0 +1,105 @@
+//  Copyright (c) 2024-2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+#include <hpx/async.hpp>
+#include <hpx/future.hpp>
+#include <hpx/init.hpp>
+#include <hpx/modules/runtime_local.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/threading_base/set_thread_affinity.hpp>
+#include <hpx/threading_base/thread_data.hpp>
+#include <hpx/threading_base/thread_helpers.hpp>
+#include <hpx/threading_base/thread_num_tss.hpp>
+#include <iostream>
+
+#include <cstddef>
+#include <cstdint>
+#include <stdexcept>
+#include <vector>
+
+void test_set_affinity_current_thread()
+{
+    hpx::async([]() {
+        hpx::this_thread::set_affinity(0, hpx::threads::thread_priority::bound);
+
+        auto id = hpx::threads::get_self_id();
+        auto* data = hpx::threads::get_thread_id_data(id);
+        HPX_TEST_EQ(data->get_last_worker_thread_num(), std::size_t(0));
+    }).get();
+}
+
+void test_set_affinity_other_thread()
+{
+    hpx::thread t([]() { hpx::this_thread::suspend(); });
+
+    hpx::threads::thread_id_type id = t.native_handle();
+
+    hpx::threads::set_thread_affinity(id, 0);
+
+    hpx::threads::set_thread_state(
+        id, hpx::threads::thread_schedule_state::pending);
+
+    t.join();
+    HPX_TEST(true);
+}
+
+void test_set_affinity_all_cores()
+{
+    hpx::async([]() {
+        std::size_t num_pus = hpx::threads::hardware_concurrency();
+        for (std::size_t i = 0; i < num_pus; ++i)
+        {
+            hpx::this_thread::set_affinity(static_cast<std::int16_t>(i),
+                hpx::threads::thread_priority::bound);
+            auto id = hpx::threads::get_self_id();
+            auto* data = hpx::threads::get_thread_id_data(id);
+            HPX_TEST_EQ(data->get_last_worker_thread_num(), i);
+        }
+    }).get();
+}
+
+void test_concurrent_affinity()
+{
+    std::vector<hpx::future<void>> futures;
+    std::size_t num_threads = 20;
+
+    for (std::size_t i = 0; i < num_threads; ++i)
+    {
+        futures.push_back(hpx::async([i]() {
+            hpx::this_thread::set_affinity(static_cast<std::int16_t>(
+                i % hpx::threads::hardware_concurrency()));
+        }));
+    }
+    hpx::wait_all(futures);
+    HPX_TEST(true);
+}
+
+void test_invalid_pu()
+{
+    hpx::error_code ec(hpx::throwmode::lightweight);
+    hpx::this_thread::set_affinity(
+        10000, hpx::threads::thread_priority::bound, ec);
+    HPX_TEST(ec);
+}
+
+int hpx_main()
+{
+    test_set_affinity_current_thread();
+    test_set_affinity_other_thread();
+    test_set_affinity_all_cores();
+    test_concurrent_affinity();
+    test_invalid_pu();
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    hpx::local::init(hpx_main, argc, argv);
+    return hpx::util::report_errors();
+}
+#endif


### PR DESCRIPTION
Fixes #6506

## Proposed Changes

  - implemented hpx::threads::set_thread_affinity to allow setting cpu affinity for any HPX thread.
  - added hpx::this_thread::set_affinity convenience function for binding current thread.
  - added test(set_thread_affinity_test)

## Any background context you want to provide?

## Checklist

Not all points below apply to all pull requests.

- [x] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
