### PR TITLE
Fix threads hanging indefinitely by acquiring the state mutex before checking for an exclusive lock

### DIFF
--- a/libs/core/synchronization/include/hpx/synchronization/shared_mutex.hpp
+++ b/libs/core/synchronization/include/hpx/synchronization/shared_mutex.hpp
@@ -101,14 +101,11 @@ namespace hpx::detail {
         {
             while (true)
             {
+                std::unique_lock<mutex_type> lk(state_change);
                 auto s = state.load(std::memory_order_acquire);
                 while (s.data.exclusive || s.data.exclusive_waiting_blocked)
                 {
-                    {
-                        std::unique_lock<mutex_type> lk(state_change);
-                        shared_cond.wait(lk);
-                    }
-
+                    shared_cond.wait(lk);
                     s = state.load(std::memory_order_acquire);
                 }
 


### PR DESCRIPTION
Fixes #6854 

## Proposed Changes

- Fixed a race condition in `shared_mutex::lock_shared()` where threads could hang indefinitely
- The mutex protecting the condition variable is now acquired before checking the wait condition


## Any background context you want to provide?

**Note:** The same issue might exist in other lock functions.

## Checklist

- [ ] I have added a new feature and have added tests to go along with it.
- [x] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.