### PR TITLE
update relocation definitions to track p2786r13 standard

### DIFF
--- a/libs/core/type_support/CMakeLists.txt
+++ b/libs/core/type_support/CMakeLists.txt
@@ -20,6 +20,7 @@ set(type_support_headers
     hpx/type_support/extra_data.hpp
     hpx/type_support/identity.hpp
     hpx/type_support/is_relocatable.hpp
+    hpx/type_support/is_replaceable.hpp
     hpx/type_support/is_trivially_relocatable.hpp
     hpx/type_support/is_contiguous_iterator.hpp
     hpx/type_support/lazy_conditional.hpp

--- a/libs/core/type_support/include/hpx/type_support/is_replaceable.hpp
+++ b/libs/core/type_support/include/hpx/type_support/is_replaceable.hpp
@@ -10,13 +10,14 @@
 
 #include <type_traits>
 
+#include <hpx/type_support/is_trivially_relocatable.hpp>
+
 namespace hpx::experimental {
 
     HPX_CXX_EXPORT template <typename T>
     struct is_replaceable
-      : std::bool_constant<std::is_object_v<T> &&
-            std::is_move_constructible_v<T> && std::is_move_assignable_v<T> &&
-            std::is_destructible_v<T> && !std::is_volatile_v<T>>
+      : std::bool_constant<std::is_move_constructible_v<T> &&
+            std::is_move_assignable_v<T> && is_trivially_relocatable_v<T>>
     {
     };
 

--- a/libs/core/type_support/include/hpx/type_support/is_replaceable.hpp
+++ b/libs/core/type_support/include/hpx/type_support/is_replaceable.hpp
@@ -1,0 +1,26 @@
+//  Copyright (c) 2025 Isidoros Tsaousis-Seiras
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#include <type_traits>
+
+namespace hpx::experimental {
+
+    HPX_CXX_EXPORT template <typename T>
+    struct is_replaceable
+      : std::bool_constant<std::is_object_v<T> &&
+            std::is_move_constructible_v<T> && std::is_move_assignable_v<T> &&
+            std::is_destructible_v<T> && !std::is_volatile_v<T>>
+    {
+    };
+
+    HPX_CXX_EXPORT template <typename T>
+    inline constexpr bool is_replaceable_v = is_replaceable<T>::value;
+
+}    // namespace hpx::experimental

--- a/libs/core/type_support/include/hpx/type_support/is_replaceable.hpp
+++ b/libs/core/type_support/include/hpx/type_support/is_replaceable.hpp
@@ -15,6 +15,11 @@
 
 namespace hpx::experimental {
 
+// P2786R13 defines a single feature-test macro __cpp_trivial_relocatability
+// that covers both the core-language keyword and the associated library traits
+// (std::is_trivially_relocatable, std::is_replaceable, std::relocate_at).
+// The language and library features are bundled in one proposal, so guarding on
+// this macro is sufficient to confirm that std::is_replaceable is available.
 #if defined(__cpp_trivial_relocatability)
     HPX_CXX_CORE_EXPORT template <typename T>
     struct is_replaceable : std::is_replaceable<T>

--- a/libs/core/type_support/include/hpx/type_support/is_replaceable.hpp
+++ b/libs/core/type_support/include/hpx/type_support/is_replaceable.hpp
@@ -11,16 +11,14 @@
 #include <cstddef>
 #include <type_traits>
 
-#include <hpx/type_support/is_trivially_relocatable.hpp>
-
 namespace hpx::experimental {
 
-// P2786R13 defines a single feature-test macro __cpp_trivial_relocatability
-// that covers both the core-language keyword and the associated library traits
-// (std::is_trivially_relocatable, std::is_replaceable, std::relocate_at).
-// The language and library features are bundled in one proposal, so guarding on
-// this macro is sufficient to confirm that std::is_replaceable is available.
-#if defined(__cpp_trivial_relocatability)
+// std::is_replaceable is a library trait introduced by P2786R13.
+// Guard its use on the library feature-test macro __cpp_lib_trivially_relocatable
+// rather than the core-language macro __cpp_trivial_relocatability, since the
+// standard library may not ship the trait even when the language keyword is
+// available (or vice versa).
+#if defined(__cpp_lib_trivially_relocatable)
     HPX_CXX_CORE_EXPORT template <typename T>
     struct is_replaceable : std::is_replaceable<T>
     {

--- a/libs/core/type_support/include/hpx/type_support/is_replaceable.hpp
+++ b/libs/core/type_support/include/hpx/type_support/is_replaceable.hpp
@@ -15,7 +15,7 @@
 
 namespace hpx::experimental {
 
-#if defined(__cpp_lib_is_replaceable)
+#if defined(__cpp_lib_trivially_relocatable)
     HPX_CXX_CORE_EXPORT template <typename T>
     struct is_replaceable : std::is_replaceable<T>
     {

--- a/libs/core/type_support/include/hpx/type_support/is_replaceable.hpp
+++ b/libs/core/type_support/include/hpx/type_support/is_replaceable.hpp
@@ -15,7 +15,7 @@
 
 namespace hpx::experimental {
 
-#if defined(__cpp_lib_trivially_relocatable)
+#if defined(__cpp_trivial_relocatability)
     HPX_CXX_CORE_EXPORT template <typename T>
     struct is_replaceable : std::is_replaceable<T>
     {

--- a/libs/core/type_support/include/hpx/type_support/is_replaceable.hpp
+++ b/libs/core/type_support/include/hpx/type_support/is_replaceable.hpp
@@ -8,13 +8,14 @@
 
 #include <hpx/config.hpp>
 
+#include <cstddef>
 #include <type_traits>
 
 #include <hpx/type_support/is_trivially_relocatable.hpp>
 
 namespace hpx::experimental {
 
-#if defined(__cpp_lib_trivially_relocatable)
+#if defined(__cpp_lib_is_replaceable)
     HPX_CXX_CORE_EXPORT template <typename T>
     struct is_replaceable : std::is_replaceable<T>
     {

--- a/libs/core/type_support/include/hpx/type_support/is_replaceable.hpp
+++ b/libs/core/type_support/include/hpx/type_support/is_replaceable.hpp
@@ -13,12 +13,11 @@
 
 namespace hpx::experimental {
 
-// std::is_replaceable is a library trait introduced by P2786R13.
-// Guard its use on the library feature-test macro __cpp_lib_trivially_relocatable
-// rather than the core-language macro __cpp_trivial_relocatability, since the
-// standard library may not ship the trait even when the language keyword is
-// available (or vice versa).
-#if defined(__cpp_lib_trivially_relocatable)
+// P2786R13 specifies a single feature-test macro __cpp_trivial_relocatability
+// that signals availability of both the language facilities and the library
+// trait std::is_replaceable, see
+// https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2786r13.html#language-feature-test-macros
+#if defined(__cpp_trivial_relocatability)
     HPX_CXX_CORE_EXPORT template <typename T>
     struct is_replaceable : std::is_replaceable<T>
     {

--- a/libs/core/type_support/include/hpx/type_support/is_trivially_relocatable.hpp
+++ b/libs/core/type_support/include/hpx/type_support/is_trivially_relocatable.hpp
@@ -12,6 +12,13 @@
 
 namespace hpx::experimental {
 
+#if defined(__cpp_lib_trivially_relocatable)
+    template <typename T>
+    struct is_trivially_relocatable : std::is_trivially_relocatable<T>
+    {
+    };
+#else
+
     // All trivially copyable types are trivially relocatable
     // Other types should default to false.
     HPX_CXX_CORE_EXPORT template <typename T>
@@ -73,6 +80,8 @@ namespace hpx::experimental {
       : is_trivially_relocatable<T>
     {
     };
+
+#endif
 
     HPX_CXX_CORE_EXPORT template <typename T>
     inline constexpr bool is_trivially_relocatable_v =

--- a/libs/core/type_support/include/hpx/type_support/is_trivially_relocatable.hpp
+++ b/libs/core/type_support/include/hpx/type_support/is_trivially_relocatable.hpp
@@ -12,13 +12,12 @@
 
 namespace hpx::experimental {
 
-// P2786R13 defines a single feature-test macro __cpp_trivial_relocatability
-// that covers both the core-language keyword and the associated library traits
-// (std::is_trivially_relocatable, std::is_replaceable, std::relocate_at).
-// The language and library features are bundled in one proposal, so guarding on
-// this macro is sufficient to confirm that std::is_trivially_relocatable is
-// available.
-#if defined(__cpp_trivial_relocatability)
+// std::is_trivially_relocatable is a library trait introduced by P2786R13.
+// Guard its use on the library feature-test macro __cpp_lib_trivially_relocatable
+// rather than the core-language macro __cpp_trivial_relocatability, since the
+// standard library may not ship the trait even when the language keyword is
+// available (or vice versa).
+#if defined(__cpp_lib_trivially_relocatable)
     template <typename T>
     struct is_trivially_relocatable : std::is_trivially_relocatable<T>
     {

--- a/libs/core/type_support/include/hpx/type_support/is_trivially_relocatable.hpp
+++ b/libs/core/type_support/include/hpx/type_support/is_trivially_relocatable.hpp
@@ -12,6 +12,12 @@
 
 namespace hpx::experimental {
 
+// P2786R13 defines a single feature-test macro __cpp_trivial_relocatability
+// that covers both the core-language keyword and the associated library traits
+// (std::is_trivially_relocatable, std::is_replaceable, std::relocate_at).
+// The language and library features are bundled in one proposal, so guarding on
+// this macro is sufficient to confirm that std::is_trivially_relocatable is
+// available.
 #if defined(__cpp_trivial_relocatability)
     template <typename T>
     struct is_trivially_relocatable : std::is_trivially_relocatable<T>

--- a/libs/core/type_support/include/hpx/type_support/is_trivially_relocatable.hpp
+++ b/libs/core/type_support/include/hpx/type_support/is_trivially_relocatable.hpp
@@ -12,7 +12,7 @@
 
 namespace hpx::experimental {
 
-#if defined(__cpp_lib_trivially_relocatable)
+#if defined(__cpp_trivial_relocatability)
     template <typename T>
     struct is_trivially_relocatable : std::is_trivially_relocatable<T>
     {

--- a/libs/core/type_support/include/hpx/type_support/is_trivially_relocatable.hpp
+++ b/libs/core/type_support/include/hpx/type_support/is_trivially_relocatable.hpp
@@ -12,12 +12,11 @@
 
 namespace hpx::experimental {
 
-// std::is_trivially_relocatable is a library trait introduced by P2786R13.
-// Guard its use on the library feature-test macro __cpp_lib_trivially_relocatable
-// rather than the core-language macro __cpp_trivial_relocatability, since the
-// standard library may not ship the trait even when the language keyword is
-// available (or vice versa).
-#if defined(__cpp_lib_trivially_relocatable)
+// P2786R13 specifies a single feature-test macro __cpp_trivial_relocatability
+// that signals availability of both the language facilities and the library
+// trait std::is_trivially_relocatable, see
+// https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2025/p2786r13.html#language-feature-test-macros
+#if defined(__cpp_trivial_relocatability)
     template <typename T>
     struct is_trivially_relocatable : std::is_trivially_relocatable<T>
     {

--- a/libs/core/type_support/include/hpx/type_support/relocate_at.hpp
+++ b/libs/core/type_support/include/hpx/type_support/relocate_at.hpp
@@ -15,7 +15,8 @@
 #include <cstring>
 #include <type_traits>
 
-#if defined(HPX_HAVE_P1144_STD_RELOCATE_AT)
+#if defined(HPX_HAVE_P1144_STD_RELOCATE_AT) ||                                 \
+    defined(__cpp_lib_trivially_relocatable)
 #include <memory>
 #endif
 
@@ -118,10 +119,14 @@ namespace hpx::experimental {
         // noexcept if the memmove path is taken or if the move path is noexcept
         noexcept(detail::relocate_at_helper(src, dst)))
     {
+#if defined(__cpp_lib_trivially_relocatable)
+        return std::relocate_at(src, dst);
+#else
         static_assert(is_relocatable_v<T>,
             "new (dst) T(std::move(*src)) must be well-formed");
 
         return detail::relocate_at_helper(src, dst);
+#endif
     }
 
     HPX_CXX_CORE_EXPORT template <typename T>

--- a/libs/core/type_support/include/hpx/type_support/relocate_at.hpp
+++ b/libs/core/type_support/include/hpx/type_support/relocate_at.hpp
@@ -119,14 +119,10 @@ namespace hpx::experimental {
         // noexcept if the memmove path is taken or if the move path is noexcept
         noexcept(detail::relocate_at_helper(src, dst)))
     {
-#if defined(__cpp_lib_trivially_relocatable)
-        return std::relocate_at(src, dst);
-#else
-        static_assert(is_relocatable_v<T>,
-            "new (dst) T(std::move(*src)) must be well-formed");
+        static_assert(
+            is_relocatable_v<T>, "T(std::move(*src)) must be well-formed");
 
         return detail::relocate_at_helper(src, dst);
-#endif
     }
 
     HPX_CXX_CORE_EXPORT template <typename T>

--- a/libs/core/type_support/include/hpx/type_support/relocate_at.hpp
+++ b/libs/core/type_support/include/hpx/type_support/relocate_at.hpp
@@ -15,11 +15,6 @@
 #include <cstring>
 #include <type_traits>
 
-#if defined(HPX_HAVE_P1144_STD_RELOCATE_AT) ||                                 \
-    defined(__cpp_trivial_relocatability)
-#include <memory>
-#endif
-
 namespace hpx::detail {
 
     // since c++20 std::destroy_at can be used on array types, destructing each

--- a/libs/core/type_support/include/hpx/type_support/relocate_at.hpp
+++ b/libs/core/type_support/include/hpx/type_support/relocate_at.hpp
@@ -16,7 +16,7 @@
 #include <type_traits>
 
 #if defined(HPX_HAVE_P1144_STD_RELOCATE_AT) ||                                 \
-    defined(__cpp_lib_trivially_relocatable)
+    defined(__cpp_trivial_relocatability)
 #include <memory>
 #endif
 

--- a/libs/core/type_support/include/hpx/type_support/relocate_at.hpp
+++ b/libs/core/type_support/include/hpx/type_support/relocate_at.hpp
@@ -13,6 +13,7 @@
 
 #include <concepts>
 #include <cstring>
+#include <memory>
 #include <type_traits>
 
 namespace hpx::detail {

--- a/libs/core/type_support/include/hpx/type_support/uninitialized_relocation_primitives.hpp
+++ b/libs/core/type_support/include/hpx/type_support/uninitialized_relocation_primitives.hpp
@@ -505,6 +505,6 @@ namespace hpx::experimental::util {
             first, last, dst_last, iterators_are_contiguous_default_t{});
     }
 
-#endif    // defined(__cpp_lib_trivially_relocatable)
+#endif    // defined(HPX_HAVE_P1144_RELOCATE_AT)
 
 }    // namespace hpx::experimental::util

--- a/libs/core/type_support/tests/unit/CMakeLists.txt
+++ b/libs/core/type_support/tests/unit/CMakeLists.txt
@@ -32,7 +32,7 @@ endforeach()
 
 if(HPX_WITH_COMPILE_ONLY_TESTS)
   # add compile time tests
-  set(compile_tests is_contiguous_iterator is_relocatable
+  set(compile_tests is_contiguous_iterator is_relocatable is_replaceable
                     is_trivially_relocatable
   )
 

--- a/libs/core/type_support/tests/unit/is_replaceable.cpp
+++ b/libs/core/type_support/tests/unit/is_replaceable.cpp
@@ -1,0 +1,71 @@
+//  Copyright (c) 2025 Isidoros Tsaousis-Seiras
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/type_support/is_replaceable.hpp>
+
+#include <cassert>
+#include <memory>
+#include <mutex>
+#include <type_traits>
+
+using hpx::experimental::is_replaceable_v;
+
+// Integral types are replaceable
+static_assert(is_replaceable_v<int>);
+// Const types are not assignable
+static_assert(!is_replaceable_v<int const>);
+
+// Pointer types are replaceable
+static_assert(is_replaceable_v<int*>);
+static_assert(is_replaceable_v<int const*>);
+
+// Function pointers are replaceable
+static_assert(is_replaceable_v<int (*)()>);
+
+// Arrays are not assignable
+static_assert(!is_replaceable_v<int[]>);
+static_assert(!is_replaceable_v<int[4]>);
+
+// References are not objects
+static_assert(!is_replaceable_v<int&>);
+static_assert(!is_replaceable_v<int&&>);
+
+// Void types
+static_assert(!is_replaceable_v<void>);
+
+// std::mutex is not move assignable
+static_assert(!is_replaceable_v<std::mutex>);
+
+struct not_destructible
+{
+    not_destructible(not_destructible const&);
+    not_destructible(not_destructible&&);
+    ~not_destructible() = delete;
+};
+static_assert(!is_replaceable_v<not_destructible>);
+
+struct not_move_assignable
+{
+    not_move_assignable& operator=(not_move_assignable&&) = delete;
+};
+static_assert(!is_replaceable_v<not_move_assignable>);
+
+struct not_move_constructible
+{
+    not_move_constructible(not_move_constructible&&) = delete;
+    not_move_constructible& operator=(not_move_constructible&&);
+};
+static_assert(!is_replaceable_v<not_move_constructible>);
+
+struct move_assignable
+{
+    move_assignable(move_assignable&&);
+    move_assignable& operator=(move_assignable&&);
+    ~move_assignable();
+};
+static_assert(is_replaceable_v<move_assignable>);
+
+int main() {}

--- a/libs/core/type_support/tests/unit/is_replaceable.cpp
+++ b/libs/core/type_support/tests/unit/is_replaceable.cpp
@@ -42,9 +42,14 @@ static_assert(!is_replaceable_v<void>);
 // std::mutex is not move assignable, nor trivially relocatable
 static_assert(!is_replaceable_v<std::mutex>);
 
+struct trivial_class
+{
+    int x;
+};
+static_assert(is_replaceable_v<trivial_class>);
+
 struct not_destructible
 {
-    not_destructible(not_destructible const&);
     not_destructible(not_destructible&&);
     ~not_destructible() = delete;
 };
@@ -63,15 +68,16 @@ struct not_move_constructible
 };
 static_assert(!is_replaceable_v<not_move_constructible>);
 
-struct move_assignable_but_not_trivially_relocatable
+struct move_assignable_but_not_implicitly_replaceable
 {
     std::unique_ptr<int> p;
-    move_assignable_but_not_trivially_relocatable(
-        move_assignable_but_not_trivially_relocatable&&) = default;
-    move_assignable_but_not_trivially_relocatable& operator=(
-        move_assignable_but_not_trivially_relocatable&&) = default;
+    move_assignable_but_not_implicitly_replaceable(
+        move_assignable_but_not_implicitly_replaceable&&) = default;
+    move_assignable_but_not_implicitly_replaceable& operator=(
+        move_assignable_but_not_implicitly_replaceable&&) = default;
 };
-static_assert(!is_replaceable_v<move_assignable_but_not_trivially_relocatable>);
+static_assert(
+    !is_replaceable_v<move_assignable_but_not_implicitly_replaceable>);
 
 // Opt-in example
 struct opt_in_replaceable

--- a/libs/core/type_support/tests/unit/is_replaceable.cpp
+++ b/libs/core/type_support/tests/unit/is_replaceable.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2025 Pratyksh Gupta
+//  Copyright (c) 2026 Pratyksh Gupta
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -19,11 +19,14 @@ static_assert(is_replaceable_v<int>);
 // Const types are not assignable (thus not replaceable)
 static_assert(!is_replaceable_v<int const>);
 
-// Pointer types are replaceable
+// Pointer types are replaceable if they are not const-qualified themselves.
 static_assert(is_replaceable_v<int*>);
-static_assert(is_replaceable_v<int const*>);    // pointer itself is mutable
-static_assert(
-    !is_replaceable_v<int* const>);    // const pointer is not replaceable
+static_assert(is_replaceable_v<int const*>);
+
+// Pointers follow the same rules as other objects. A pointer is replaceable only
+// if it is not const-qualified itself, as replacement requires assignment.
+// P2786R13 Section 3.2: "const-qualified objects are never replaceable."
+static_assert(!is_replaceable_v<int* const>);
 
 // Function pointers are replaceable
 static_assert(is_replaceable_v<int (*)()>);
@@ -48,6 +51,10 @@ struct trivial_class
 };
 static_assert(is_replaceable_v<trivial_class>);
 
+// Replaceability implies a type can be destroyed and reconstructed.
+// Consequently, a type must be destructible to be replaceable.
+// Per P2786R13, implicit replaceability also requires trivial relocatability,
+// which in turn requires trivial destructibility.
 struct not_destructible
 {
     not_destructible(not_destructible&&);

--- a/libs/core/type_support/tests/unit/is_replaceable.cpp
+++ b/libs/core/type_support/tests/unit/is_replaceable.cpp
@@ -104,4 +104,25 @@ namespace hpx::experimental {
 
 static_assert(is_replaceable_v<opt_in_replaceable>);
 
+// volatile types are not replaceable because their state is unstable and
+// bitwise move-assignment (replacement) cannot guarantee preservation of
+// their specific access semantics.
+static_assert(!is_replaceable_v<int volatile>);
+static_assert(is_replaceable_v<int volatile*>);     // pointer to volatile is OK
+static_assert(!is_replaceable_v<int* volatile>);    // volatile pointer is not
+
+struct has_const_member
+{
+    int const x;
+};
+// move assignment is deleted for classes with const members
+static_assert(!is_replaceable_v<has_const_member>);
+
+struct has_volatile_member
+{
+    int volatile x;
+};
+// volatile members do not necessarily make move assignment non-trivial
+static_assert(is_replaceable_v<has_volatile_member>);
+
 int main() {}

--- a/libs/core/type_support/tests/unit/is_replaceable.cpp
+++ b/libs/core/type_support/tests/unit/is_replaceable.cpp
@@ -4,7 +4,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/type_support/is_replaceable.hpp>
+#include <hpx/modules/type_support.hpp>
 
 #include <cassert>
 #include <memory>


### PR DESCRIPTION
Fixes #6625

## Proposed Changes

  - added is_replaceable trait to align with p2786r13
  - updated is_trivially_relocatable to use the standard version if the c++26 feature macro is present
  - wired up relocate_at to call std::relocate_at when available
 
## Any background context you want to provide?

## Checklist

Not all points below apply to all pull requests.

- [x] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
