### PR TITLE
implement serialization for partition_data in 1d_stencil_5

### DIFF
--- a/examples/1d_stencil/1d_stencil_5.cpp
+++ b/examples/1d_stencil/1d_stencil_5.cpp
@@ -20,6 +20,7 @@
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
+#include <hpx/serialization.hpp>
 
 #include <memory>
 
@@ -98,9 +99,21 @@ private:
     friend class hpx::serialization::access;
 
     template <typename Archive>
-    void serialize(Archive&, unsigned int const) const
+    void save(Archive& ar, unsigned int const) const
     {
+        ar & size_;
+        ar& hpx::serialization::make_array(data_.get(), size_);
     }
+
+    template <typename Archive>
+    void load(Archive& ar, unsigned int const)
+    {
+        ar & size_;
+        data_.reset(new double[size_]);
+        ar& hpx::serialization::make_array(data_.get(), size_);
+    }
+
+    HPX_SERIALIZATION_SPLIT_MEMBER()
 
 private:
     buffer_type data_;


### PR DESCRIPTION
Fixes #6874

## Proposed Changes

  - i fixed 1d_stencil_5 crash by implementing the missing serialization logic for partition_data,which was previously empty and this ensures the data is correctly packed and transmitted during HPX actions, preventing the system from crashing on invalid empty objects.

## Any background context you want to provide?

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [x] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
