### PR TITLE
Changed reduce implementation and added tests

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
@@ -456,7 +456,7 @@ namespace hpx::parallel { namespace detail {
             std::next(part_begin, 2), part_size - 2, HPX_MOVE(init), r);
     }
 
-    HPX_CXX_EXPORT template <typename T>
+    HPX_CXX_CORE_EXPORT template <typename T>
     struct reduce : public algorithm<reduce<T>, T>
     {
         constexpr reduce() noexcept

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
@@ -400,7 +400,7 @@ namespace hpx::parallel {
                 if (chunk_size < 2)
                 {
                     chunk_size = (num_elements + num_cores - 1) / num_cores;
-                    chunk_size = (std::max)(chunk_size, std::size_t(2));
+                    chunk_size = (std::max) (chunk_size, std::size_t(2));
                 }
 
                 // chunk_size_iterator gives the last partition num_elements % chunk_size

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
@@ -356,6 +356,7 @@ namespace hpx {
 #else    // DOXYGEN
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/concepts.hpp>
 #include <hpx/modules/executors.hpp>
 #include <hpx/modules/iterator_support.hpp>

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
@@ -433,8 +433,7 @@ namespace hpx::execution::experimental {
     };
 }    // namespace hpx::execution::experimental
 
-namespace hpx::parallel {
-    namespace detail {
+namespace hpx::parallel { namespace detail {
 
     // Helper function to reduce a partition without requiring an init value.
     // Assumes partition size is always >= 2 (enforced by reduce_executor_parameters).
@@ -470,9 +469,8 @@ namespace hpx::parallel {
         static constexpr T sequential(ExPolicy&& policy, InIterB first,
             InIterE last, T_&& init, Reduce&& r)
         {
-            return sequential_reduce<ExPolicy>(
-                HPX_FORWARD(ExPolicy, policy), first, last,
-                HPX_FORWARD(T_, init), HPX_FORWARD(Reduce, r));
+            return sequential_reduce<ExPolicy>(HPX_FORWARD(ExPolicy, policy),
+                first, last, HPX_FORWARD(T_, init), HPX_FORWARD(Reduce, r));
         }
 
         template <typename ExPolicy, typename FwdIterB, typename FwdIterE,
@@ -495,7 +493,7 @@ namespace hpx::parallel {
 
             // Handle single-element case: can't partition into size >= 2
             // This must be checked for all execution policies
-            auto const count = distance(first, last);
+            auto const count = hpx::parallel::detail::distance(first, last);
             if (count == 1)
             {
                 T result = HPX_INVOKE(r, HPX_FORWARD(T_, init), *first);
@@ -515,13 +513,12 @@ namespace hpx::parallel {
                     part_begin, part_size, r);
             };
 
-            auto reduce_policy =
-                policy.with(reduce_executor_parameters{});
+            auto reduce_policy = policy.with(reduce_executor_parameters{});
             using reduce_policy_type = std::decay_t<decltype(reduce_policy)>;
 
             return util::partitioner<reduce_policy_type, T>::call(
-                HPX_MOVE(reduce_policy), first, distance(first, last),
-                HPX_MOVE(f1),
+                HPX_MOVE(reduce_policy), first,
+                hpx::parallel::detail::distance(first, last), HPX_MOVE(f1),
                 hpx::unwrapping(
                     [init = HPX_FORWARD(T_, init), r = HPX_FORWARD(Reduce, r)](
                         auto&& results) -> T {
@@ -532,8 +529,7 @@ namespace hpx::parallel {
         }
     };
     /// \endcond
-    }    // namespace detail
-}    // namespace hpx::parallel
+}}    // namespace hpx::parallel::detail
 
 namespace hpx {
 

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
@@ -63,7 +63,7 @@ namespace hpx {
     /// with an execution policy object of type \a sequenced_policy
     /// execute in sequential order in the calling thread.
     ///
-    /// The reduce operations in the parallel \a copy_if algorithm invoked
+    /// The reduce operations in the parallel \a reduce algorithm invoked
     /// with an execution policy object of type \a parallel_policy
     /// or \a parallel_task_policy are permitted to execute in an unordered
     /// fashion in unspecified threads, and indeterminately sequenced
@@ -418,9 +418,8 @@ namespace hpx::parallel {
                 }
 
                 auto f1 = [r](FwdIterB part_begin, std::size_t part_size) -> T {
-                    T val = *part_begin;
-                    return detail::sequential_reduce<ExPolicy>(
-                        ++part_begin, --part_size, HPX_MOVE(val), r);
+                    return reduce_partition<ExPolicy, FwdIterB, T>(
+                        part_begin, part_size, r);
                 };
 
                 return util::partitioner<ExPolicy, T>::call(

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
@@ -384,10 +384,11 @@ namespace hpx::parallel {
 
         /// \cond NOINTERNAL
 
-        // Custom executor parameters for reduce algorithm to prevent single-element partitions.
-        // reduce_partition requires at least 2 elements per partition because it initializes
-        // the accumulator via op(*first, *next(first)), which is the only way to produce a T
-        // from value_type elements when T may differ from value_type (e.g. minmax).
+        // Custom executor parameters for reduce algorithm to prevent
+        // single-element partitions. reduce_partition requires at least 2
+        // elements per partition because it initializes the accumulator via
+        // op(*first, *next(first)), which is the only way to produce a T from
+        // value_type elements when T may differ from value_type (e.g. minmax).
         struct reduce_executor_parameters
         {
             template <typename Executor>
@@ -404,9 +405,10 @@ namespace hpx::parallel {
                     chunk_size = (std::max) (chunk_size, std::size_t(2));
                 }
 
-                // chunk_size_iterator gives the last partition num_elements % chunk_size
-                // elements (or chunk_size if evenly divisible). If the remainder is 1,
-                // that partition would violate reduce_partition's >= 2 requirement.
+                // chunk_size_iterator gives the last partition
+                // num_elements % chunk_size elements (or chunk_size if
+                // evenly divisible). If the remainder is 1, that partition
+                // would violate reduce_partition's >= 2 requirement.
                 // Bump chunk_size until the remainder is 0 or >= 2.
                 while (
                     num_elements > chunk_size && num_elements % chunk_size == 1)
@@ -424,7 +426,8 @@ namespace hpx::parallel {
     }    // namespace detail
 }    // namespace hpx::parallel
 
-// Specialize trait to make reduce_executor_parameters a valid executor parameters type
+// Specialize trait to make reduce_executor_parameters a valid executor
+// parameters type
 namespace hpx::execution::experimental {
 
     template <>
@@ -437,7 +440,7 @@ namespace hpx::execution::experimental {
 namespace hpx::parallel { namespace detail {
 
     // Helper function to reduce a partition without requiring an init value.
-    // Assumes partition size is always >= 2 (enforced by reduce_executor_parameters).
+    // Assumes partition size >= 2 (enforced by reduce_executor_parameters).
     template <typename ExPolicy, typename FwdIterB, typename T, typename Reduce>
     T reduce_partition(
         FwdIterB part_begin, std::size_t part_size, Reduce const& r)

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
@@ -528,7 +528,7 @@ namespace hpx::parallel { namespace detail {
 
             return util::partitioner<reduce_policy_type, T>::call(
                 HPX_MOVE(reduce_policy), first,
-                count, HPX_MOVE(f1),
+                hpx::parallel::detail::distance(first, last), HPX_MOVE(f1),
                 hpx::unwrapping(
                     [init = HPX_FORWARD(T_, init), r = HPX_FORWARD(Reduce, r)](
                         auto&& results) -> T {

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
@@ -357,9 +357,10 @@ namespace hpx {
 
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
-#include <hpx/execution/executors/rebind_executor_parameters.hpp>
 #include <hpx/modules/concepts.hpp>
+#include <hpx/modules/execution.hpp>
 #include <hpx/modules/executors.hpp>
+#include <hpx/modules/functional.hpp>
 #include <hpx/modules/iterator_support.hpp>
 #include <hpx/modules/pack_traversal.hpp>
 #include <hpx/parallel/algorithms/detail/accumulate.hpp>

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
@@ -393,14 +393,18 @@ namespace hpx::parallel {
         // value_type elements when T may differ from value_type (e.g. minmax).
         struct reduce_executor_parameters
         {
-            template <typename Executor>
-            HPX_FORCEINLINE constexpr std::pair<std::size_t, std::size_t>
-            adjust_chunk_size_and_max_chunks(Executor&&,
-                std::size_t num_elements, std::size_t num_cores,
-                std::size_t /*max_chunks*/,
-                std::size_t chunk_size) const noexcept
+        private:
+            static HPX_FORCEINLINE constexpr std::pair<std::size_t, std::size_t>
+            adjust_chunk_size_and_max_chunks_impl(std::size_t num_elements,
+                std::size_t num_cores, std::size_t max_chunks,
+                std::size_t chunk_size) noexcept
             {
-                // Ensure minimum chunk size of 2
+                if (num_elements <= 1)
+                {
+                    return {chunk_size, max_chunks};
+                }
+
+                // Ensure minimum chunk size of 2 for reduce_partition.
                 if (chunk_size < 2)
                 {
                     chunk_size = (num_elements + num_cores - 1) / num_cores;
@@ -415,13 +419,41 @@ namespace hpx::parallel {
                 while (
                     num_elements > chunk_size && num_elements % chunk_size == 1)
                 {
-                    chunk_size++;
+                    ++chunk_size;
                 }
 
-                std::size_t new_max_chunks =
-                    (num_elements + chunk_size - 1) / chunk_size;
+                max_chunks = (num_elements + chunk_size - 1) / chunk_size;
+                return {chunk_size, max_chunks};
+            }
 
-                return {chunk_size, new_max_chunks};
+        public:
+            template <typename Executor>
+            HPX_FORCEINLINE constexpr std::pair<std::size_t, std::size_t>
+            adjust_chunk_size_and_max_chunks(Executor&&,
+                std::size_t num_elements, std::size_t num_cores,
+                std::size_t max_chunks, std::size_t chunk_size) const noexcept
+            {
+                return adjust_chunk_size_and_max_chunks_impl(
+                    num_elements, num_cores, max_chunks, chunk_size);
+            }
+
+            template <typename InnerParams, typename Executor>
+            friend HPX_FORCEINLINE constexpr std::pair<std::size_t, std::size_t>
+            tag_override_invoke(hpx::execution::experimental::
+                                    adjust_chunk_size_and_max_chunks_t,
+                reduce_executor_parameters const&, InnerParams&& inner,
+                Executor&& exec, std::size_t num_elements,
+                std::size_t num_cores, std::size_t max_chunks,
+                std::size_t chunk_size)
+            {
+                auto [adjusted_chunk_size, adjusted_max_chunks] = hpx::
+                    execution::experimental::adjust_chunk_size_and_max_chunks(
+                        HPX_FORWARD(InnerParams, inner),
+                        HPX_FORWARD(Executor, exec), num_elements, num_cores,
+                        max_chunks, chunk_size);
+
+                return adjust_chunk_size_and_max_chunks_impl(num_elements,
+                    num_cores, adjusted_max_chunks, adjusted_chunk_size);
             }
         };
         /// \endcond
@@ -528,8 +560,7 @@ namespace hpx::parallel { namespace detail {
             using reduce_policy_type = std::decay_t<decltype(reduce_policy)>;
 
             return util::partitioner<reduce_policy_type, T>::call(
-                HPX_MOVE(reduce_policy), first,
-                hpx::parallel::detail::distance(first, last), HPX_MOVE(f1),
+                HPX_MOVE(reduce_policy), first, count, HPX_MOVE(f1),
                 hpx::unwrapping(
                     [init = HPX_FORWARD(T_, init), r = HPX_FORWARD(Reduce, r)](
                         auto&& results) -> T {

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
@@ -408,12 +408,8 @@ namespace hpx::parallel {
                         HPX_FORWARD(Executor, exec), num_elements, num_cores,
                         max_chunks, chunk_size);
 
-                auto result = hpx::execution::experimental::
-                    adjust_chunk_size_and_max_chunks_default(num_elements,
-                        num_cores, adjusted_max_chunks, adjusted_chunk_size);
-
-                std::size_t new_chunk_size = result.first;
-                std::size_t new_max_chunks = result.second;
+                std::size_t new_chunk_size = adjusted_chunk_size;
+                std::size_t new_max_chunks = adjusted_max_chunks;
 
                 if (num_elements <= 1)
                 {
@@ -431,14 +427,27 @@ namespace hpx::parallel {
                 // num_elements % chunk_size elements (or chunk_size if
                 // evenly divisible). If the remainder is 1, that partition
                 // would violate reduce_partition's >= 2 requirement.
-                // Bump chunk_size until the remainder is 0 or >= 2.
-                while (
-                    num_elements > new_chunk_size && num_elements % new_chunk_size == 1)
+                // Reduce the number of chunks by 1 so the last partition
+                // absorbs the extra element and stays >= 2.
+                if (num_elements > new_chunk_size &&
+                    num_elements % new_chunk_size == 1)
                 {
-                    ++new_chunk_size;
+                    if (new_max_chunks > 1)
+                    {
+                        --new_max_chunks;
+                        new_chunk_size = (num_elements + new_max_chunks - 1) /
+                            new_max_chunks;
+                    }
+                    else
+                    {
+                        new_chunk_size = num_elements;
+                    }
                 }
-
-                new_max_chunks = (num_elements + new_chunk_size - 1) / new_chunk_size;
+                else
+                {
+                    new_max_chunks =
+                        (num_elements + new_chunk_size - 1) / new_chunk_size;
+                }
                 return {new_chunk_size, new_max_chunks};
             }
         };

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
@@ -514,58 +514,99 @@ namespace hpx::parallel::detail {
             constexpr bool has_scheduler_executor =
                 hpx::execution_policy_has_scheduler_executor_v<ExPolicy>;
 
-            // Handle empty range
-            if constexpr (!has_scheduler_executor)
+            if constexpr (has_scheduler_executor)
             {
+                // Scheduler-executor path: all returns must be
+                // consistently typed (the partitioner returns a sender,
+                // so early returns must also go through the partitioner
+                // or return a compatible type).
+                auto const count =
+                    hpx::parallel::detail::distance(first, last);
+
+                // Handle empty range and single-element case before
+                // entering the partitioner (which requires chunks >= 2).
+                if (count <= 1)
+                {
+                    T result = (count == 0)
+                        ? T(HPX_FORWARD(T_, init))
+                        : HPX_INVOKE(r, HPX_FORWARD(T_, init), *first);
+                    return result;
+                }
+
+                auto f1 =
+                    [r](FwdIterB part_begin, std::size_t part_size) -> T {
+                    return reduce_partition<ExPolicy, FwdIterB, T>(
+                        part_begin, part_size, r);
+                };
+
+                auto rebound_params =
+                    hpx::execution::experimental::rebind_executor_parameters(
+                        policy.parameters(), reduce_executor_parameters{});
+                auto reduce_policy =
+                    hpx::execution::experimental::create_rebound_policy(
+                        policy, HPX_MOVE(rebound_params));
+                using reduce_policy_type =
+                    std::decay_t<decltype(reduce_policy)>;
+
+                return util::partitioner<reduce_policy_type, T>::call(
+                    HPX_MOVE(reduce_policy), first, count, HPX_MOVE(f1),
+                    hpx::unwrapping(
+                        [init = HPX_FORWARD(T_, init),
+                            r = HPX_FORWARD(Reduce, r)](
+                            auto&& results) -> T {
+                            return sequential_reduce<ExPolicy>(
+                                hpx::util::begin(results),
+                                hpx::util::size(results), init, r);
+                        }));
+            }
+            else
+            {
+                // Non-scheduler path: all returns go through
+                // algorithm_result for consistent return type.
                 if (first == last)
                 {
                     return util::detail::algorithm_result<ExPolicy, T>::get(
                         HPX_FORWARD(T_, init));
                 }
-            }
 
-            // Handle single-element case: can't partition into size >= 2
-            // This must be checked for all execution policies
-            auto const count = hpx::parallel::detail::distance(first, last);
-            if (count == 1)
-            {
-                T result = HPX_INVOKE(r, HPX_FORWARD(T_, init), *first);
-                if constexpr (has_scheduler_executor)
+                auto const count =
+                    hpx::parallel::detail::distance(first, last);
+                if (count == 1)
                 {
-                    return result;
-                }
-                else
-                {
+                    T result =
+                        HPX_INVOKE(r, HPX_FORWARD(T_, init), *first);
                     return util::detail::algorithm_result<ExPolicy, T>::get(
                         HPX_MOVE(result));
                 }
+
+                auto f1 =
+                    [r](FwdIterB part_begin, std::size_t part_size) -> T {
+                    return reduce_partition<ExPolicy, FwdIterB, T>(
+                        part_begin, part_size, r);
+                };
+
+                auto rebound_params =
+                    hpx::execution::experimental::rebind_executor_parameters(
+                        policy.parameters(), reduce_executor_parameters{});
+                auto reduce_policy =
+                    hpx::execution::experimental::create_rebound_policy(
+                        policy, HPX_MOVE(rebound_params));
+                using reduce_policy_type =
+                    std::decay_t<decltype(reduce_policy)>;
+
+                return util::partitioner<reduce_policy_type, T>::call(
+                    HPX_MOVE(reduce_policy), first, count, HPX_MOVE(f1),
+                    hpx::unwrapping(
+                        [init = HPX_FORWARD(T_, init),
+                            r = HPX_FORWARD(Reduce, r)](
+                            auto&& results) -> T {
+                            return sequential_reduce<ExPolicy>(
+                                hpx::util::begin(results),
+                                hpx::util::size(results), init, r);
+                        }));
             }
-
-            auto f1 = [r](FwdIterB part_begin, std::size_t part_size) -> T {
-                return reduce_partition<ExPolicy, FwdIterB, T>(
-                    part_begin, part_size, r);
-            };
-
-            auto rebound_params =
-                hpx::execution::experimental::rebind_executor_parameters(
-                    policy.parameters(), reduce_executor_parameters{});
-            auto reduce_policy =
-                hpx::execution::experimental::create_rebound_policy(
-                    policy, HPX_MOVE(rebound_params));
-            using reduce_policy_type = std::decay_t<decltype(reduce_policy)>;
-
-            return util::partitioner<reduce_policy_type, T>::call(
-                HPX_MOVE(reduce_policy), first, count, HPX_MOVE(f1),
-                hpx::unwrapping(
-                    [init = HPX_FORWARD(T_, init), r = HPX_FORWARD(Reduce, r)](
-                        auto&& results) -> T {
-                        return sequential_reduce<ExPolicy>(
-                            hpx::util::begin(results), hpx::util::size(results),
-                            init, r);
-                    }));
         }
     };
-    /// \endcond
 }    // namespace hpx::parallel::detail
 
 namespace hpx {

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
@@ -402,25 +402,29 @@ namespace hpx::parallel {
                 std::size_t num_cores, std::size_t max_chunks,
                 std::size_t chunk_size)
             {
-                // First get the base adjustment from the inner parameters.
                 auto [adjusted_chunk_size, adjusted_max_chunks] = hpx::
                     execution::experimental::adjust_chunk_size_and_max_chunks(
                         HPX_FORWARD(InnerParams, inner),
                         HPX_FORWARD(Executor, exec), num_elements, num_cores,
                         max_chunks, chunk_size);
 
+                auto result = hpx::execution::experimental::
+                    adjust_chunk_size_and_max_chunks_default(num_elements,
+                        num_cores, adjusted_max_chunks, adjusted_chunk_size);
+
+                std::size_t new_chunk_size = result.first;
+                std::size_t new_max_chunks = result.second;
+
                 if (num_elements <= 1)
                 {
-                    return {adjusted_chunk_size, adjusted_max_chunks};
+                    return {new_chunk_size, new_max_chunks};
                 }
 
                 // Ensure minimum chunk size of 2 for reduce_partition.
-                if (adjusted_chunk_size < 2)
+                if (new_chunk_size < 2)
                 {
-                    adjusted_chunk_size =
-                        (num_elements + num_cores - 1) / num_cores;
-                    adjusted_chunk_size =
-                        (std::max) (adjusted_chunk_size, std::size_t(2));
+                    new_chunk_size = (num_elements + num_cores - 1) / num_cores;
+                    new_chunk_size = (std::max) (new_chunk_size, std::size_t(2));
                 }
 
                 // chunk_size_iterator gives the last partition
@@ -428,16 +432,14 @@ namespace hpx::parallel {
                 // evenly divisible). If the remainder is 1, that partition
                 // would violate reduce_partition's >= 2 requirement.
                 // Bump chunk_size until the remainder is 0 or >= 2.
-                while (num_elements > adjusted_chunk_size &&
-                    num_elements % adjusted_chunk_size == 1)
+                while (
+                    num_elements > new_chunk_size && num_elements % new_chunk_size == 1)
                 {
-                    ++adjusted_chunk_size;
+                    ++new_chunk_size;
                 }
 
-                adjusted_max_chunks =
-                    (num_elements + adjusted_chunk_size - 1) /
-                    adjusted_chunk_size;
-                return {adjusted_chunk_size, adjusted_max_chunks};
+                new_max_chunks = (num_elements + new_chunk_size - 1) / new_chunk_size;
+                return {new_chunk_size, new_max_chunks};
             }
         };
         /// \endcond
@@ -462,12 +464,7 @@ namespace hpx::parallel { namespace detail {
     T reduce_partition(
         FwdIterB part_begin, std::size_t part_size, Reduce const& r)
     {
-        HPX_ASSERT(part_size != 0);
-
-        if (part_size == 1)
-        {
-            return *part_begin;
-        }
+        HPX_ASSERT(part_size >= 2);
 
         // Combine first two elements using the reduction operator
         T init = HPX_INVOKE(r, *part_begin, *std::next(part_begin));

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
@@ -420,7 +420,8 @@ namespace hpx::parallel {
                 if (new_chunk_size < 2)
                 {
                     new_chunk_size = (num_elements + num_cores - 1) / num_cores;
-                    new_chunk_size = (std::max) (new_chunk_size, std::size_t(2));
+                    new_chunk_size =
+                        (std::max) (new_chunk_size, std::size_t(2));
                 }
 
                 // chunk_size_iterator gives the last partition

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
@@ -466,7 +466,7 @@ namespace hpx::execution::experimental {
     };
 }    // namespace hpx::execution::experimental
 
-namespace hpx::parallel { namespace detail {
+namespace hpx::parallel::detail {
 
     // Helper function to reduce a partition without requiring an init value.
     template <typename ExPolicy, typename FwdIterB, typename T, typename Reduce>
@@ -565,7 +565,7 @@ namespace hpx::parallel { namespace detail {
         }
     };
     /// \endcond
-}}    // namespace hpx::parallel::detail
+}    // namespace hpx::parallel::detail
 
 namespace hpx {
 

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
@@ -469,7 +469,7 @@ namespace hpx::execution::experimental {
 }    // namespace hpx::execution::experimental
 
 namespace hpx::parallel::detail {
-
+    /// \cond NOINTERNAL
     // Helper function to reduce a partition without requiring an init value.
     template <typename ExPolicy, typename FwdIterB, typename T, typename Reduce>
     T reduce_partition(
@@ -570,6 +570,10 @@ namespace hpx::parallel::detail {
                 }
 
                 auto f1 = [r](FwdIterB part_begin, std::size_t part_size) -> T {
+                    if (part_size == 1)
+                    {
+                        return *part_begin;
+                    }
                     return reduce_partition<ExPolicy, FwdIterB, T>(
                         part_begin, part_size, r);
                 };
@@ -595,6 +599,7 @@ namespace hpx::parallel::detail {
             }
         }
     };
+    /// \endcond
 }    // namespace hpx::parallel::detail
 
 namespace hpx {

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
@@ -393,50 +393,6 @@ namespace hpx::parallel {
         // value_type elements when T may differ from value_type (e.g. minmax).
         struct reduce_executor_parameters
         {
-        private:
-            static HPX_FORCEINLINE constexpr std::pair<std::size_t, std::size_t>
-            adjust_chunk_size_and_max_chunks_impl(std::size_t num_elements,
-                std::size_t num_cores, std::size_t max_chunks,
-                std::size_t chunk_size) noexcept
-            {
-                if (num_elements <= 1)
-                {
-                    return {chunk_size, max_chunks};
-                }
-
-                // Ensure minimum chunk size of 2 for reduce_partition.
-                if (chunk_size < 2)
-                {
-                    chunk_size = (num_elements + num_cores - 1) / num_cores;
-                    chunk_size = (std::max) (chunk_size, std::size_t(2));
-                }
-
-                // chunk_size_iterator gives the last partition
-                // num_elements % chunk_size elements (or chunk_size if
-                // evenly divisible). If the remainder is 1, that partition
-                // would violate reduce_partition's >= 2 requirement.
-                // Bump chunk_size until the remainder is 0 or >= 2.
-                while (
-                    num_elements > chunk_size && num_elements % chunk_size == 1)
-                {
-                    ++chunk_size;
-                }
-
-                max_chunks = (num_elements + chunk_size - 1) / chunk_size;
-                return {chunk_size, max_chunks};
-            }
-
-        public:
-            template <typename Executor>
-            HPX_FORCEINLINE constexpr std::pair<std::size_t, std::size_t>
-            adjust_chunk_size_and_max_chunks(Executor&&,
-                std::size_t num_elements, std::size_t num_cores,
-                std::size_t max_chunks, std::size_t chunk_size) const noexcept
-            {
-                return adjust_chunk_size_and_max_chunks_impl(
-                    num_elements, num_cores, max_chunks, chunk_size);
-            }
-
             template <typename InnerParams, typename Executor>
             friend HPX_FORCEINLINE constexpr std::pair<std::size_t, std::size_t>
             tag_override_invoke(hpx::execution::experimental::
@@ -446,14 +402,42 @@ namespace hpx::parallel {
                 std::size_t num_cores, std::size_t max_chunks,
                 std::size_t chunk_size)
             {
+                // First get the base adjustment from the inner parameters.
                 auto [adjusted_chunk_size, adjusted_max_chunks] = hpx::
                     execution::experimental::adjust_chunk_size_and_max_chunks(
                         HPX_FORWARD(InnerParams, inner),
                         HPX_FORWARD(Executor, exec), num_elements, num_cores,
                         max_chunks, chunk_size);
 
-                return adjust_chunk_size_and_max_chunks_impl(num_elements,
-                    num_cores, adjusted_max_chunks, adjusted_chunk_size);
+                if (num_elements <= 1)
+                {
+                    return {adjusted_chunk_size, adjusted_max_chunks};
+                }
+
+                // Ensure minimum chunk size of 2 for reduce_partition.
+                if (adjusted_chunk_size < 2)
+                {
+                    adjusted_chunk_size =
+                        (num_elements + num_cores - 1) / num_cores;
+                    adjusted_chunk_size =
+                        (std::max) (adjusted_chunk_size, std::size_t(2));
+                }
+
+                // chunk_size_iterator gives the last partition
+                // num_elements % chunk_size elements (or chunk_size if
+                // evenly divisible). If the remainder is 1, that partition
+                // would violate reduce_partition's >= 2 requirement.
+                // Bump chunk_size until the remainder is 0 or >= 2.
+                while (num_elements > adjusted_chunk_size &&
+                    num_elements % adjusted_chunk_size == 1)
+                {
+                    ++adjusted_chunk_size;
+                }
+
+                adjusted_max_chunks =
+                    (num_elements + adjusted_chunk_size - 1) /
+                    adjusted_chunk_size;
+                return {adjusted_chunk_size, adjusted_max_chunks};
             }
         };
         /// \endcond
@@ -474,12 +458,16 @@ namespace hpx::execution::experimental {
 namespace hpx::parallel { namespace detail {
 
     // Helper function to reduce a partition without requiring an init value.
-    // Assumes partition size >= 2 (enforced by reduce_executor_parameters).
     template <typename ExPolicy, typename FwdIterB, typename T, typename Reduce>
     T reduce_partition(
         FwdIterB part_begin, std::size_t part_size, Reduce const& r)
     {
-        HPX_ASSERT(part_size >= 2);
+        HPX_ASSERT(part_size != 0);
+
+        if (part_size == 1)
+        {
+            return *part_begin;
+        }
 
         // Combine first two elements using the reduction operator
         T init = HPX_INVOKE(r, *part_begin, *std::next(part_begin));

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
@@ -419,7 +419,10 @@ namespace hpx::parallel {
                 // Ensure minimum chunk size of 2 for reduce_partition.
                 if (new_chunk_size < 2)
                 {
-                    new_chunk_size = (num_elements + num_cores - 1) / num_cores;
+                    std::size_t safe_cores =
+                        (std::max) (std::size_t(1), num_cores);
+                    new_chunk_size =
+                        (num_elements + safe_cores - 1) / safe_cores;
                     new_chunk_size =
                         (std::max) (new_chunk_size, std::size_t(2));
                 }
@@ -526,13 +529,13 @@ namespace hpx::parallel::detail {
                 {
                     if (count == 0)
                     {
-                        return util::detail::algorithm_result<ExPolicy, T>::get(
+                        return hpx::execution::experimental::just(
                             T(HPX_FORWARD(T_, init)));
                     }
                     else
                     {
                         T result = HPX_INVOKE(r, HPX_FORWARD(T_, init), *first);
-                        return util::detail::algorithm_result<ExPolicy, T>::get(
+                        return hpx::execution::experimental::just(
                             HPX_MOVE(result));
                     }
                 }

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
@@ -430,7 +430,7 @@ namespace hpx::parallel {
                 // would violate reduce_partition's >= 2 requirement.
                 // Reduce the number of chunks by 1 so the last partition
                 // absorbs the extra element and stays >= 2.
-                if (num_elements > new_chunk_size &&
+                while (num_elements > new_chunk_size &&
                     num_elements % new_chunk_size == 1)
                 {
                     if (new_max_chunks > 1)
@@ -444,11 +444,9 @@ namespace hpx::parallel {
                         new_chunk_size = num_elements;
                     }
                 }
-                else
-                {
-                    new_max_chunks =
-                        (num_elements + new_chunk_size - 1) / new_chunk_size;
-                }
+                new_max_chunks =
+                    (num_elements + new_chunk_size - 1) / new_chunk_size;
+
                 return {new_chunk_size, new_max_chunks};
             }
         };
@@ -526,10 +524,17 @@ namespace hpx::parallel::detail {
                 // entering the partitioner (which requires chunks >= 2).
                 if (count <= 1)
                 {
-                    T result = (count == 0) ?
-                        T(HPX_FORWARD(T_, init)) :
-                        HPX_INVOKE(r, HPX_FORWARD(T_, init), *first);
-                    return result;
+                    if (count == 0)
+                    {
+                        return util::detail::algorithm_result<ExPolicy, T>::get(
+                            T(HPX_FORWARD(T_, init)));
+                    }
+                    else
+                    {
+                        T result = HPX_INVOKE(r, HPX_FORWARD(T_, init), *first);
+                        return util::detail::algorithm_result<ExPolicy, T>::get(
+                            HPX_MOVE(result));
+                    }
                 }
 
                 auto f1 = [r](FwdIterB part_begin, std::size_t part_size) -> T {

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
@@ -523,24 +523,11 @@ namespace hpx::parallel::detail {
                 // or return a compatible type).
                 auto const count = hpx::parallel::detail::distance(first, last);
 
-                // Handle empty range and single-element case before
-                // entering the partitioner (which requires chunks >= 2).
-                if (count <= 1)
-                {
-                    if (count == 0)
-                    {
-                        return hpx::execution::experimental::just(
-                            T(HPX_FORWARD(T_, init)));
-                    }
-                    else
-                    {
-                        T result = HPX_INVOKE(r, HPX_FORWARD(T_, init), *first);
-                        return hpx::execution::experimental::just(
-                            HPX_MOVE(result));
-                    }
-                }
-
                 auto f1 = [r](FwdIterB part_begin, std::size_t part_size) -> T {
+                    if (part_size == 1)
+                    {
+                        return *part_begin;
+                    }
                     return reduce_partition<ExPolicy, FwdIterB, T>(
                         part_begin, part_size, r);
                 };

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/reduce.hpp
@@ -520,21 +520,19 @@ namespace hpx::parallel::detail {
                 // consistently typed (the partitioner returns a sender,
                 // so early returns must also go through the partitioner
                 // or return a compatible type).
-                auto const count =
-                    hpx::parallel::detail::distance(first, last);
+                auto const count = hpx::parallel::detail::distance(first, last);
 
                 // Handle empty range and single-element case before
                 // entering the partitioner (which requires chunks >= 2).
                 if (count <= 1)
                 {
-                    T result = (count == 0)
-                        ? T(HPX_FORWARD(T_, init))
-                        : HPX_INVOKE(r, HPX_FORWARD(T_, init), *first);
+                    T result = (count == 0) ?
+                        T(HPX_FORWARD(T_, init)) :
+                        HPX_INVOKE(r, HPX_FORWARD(T_, init), *first);
                     return result;
                 }
 
-                auto f1 =
-                    [r](FwdIterB part_begin, std::size_t part_size) -> T {
+                auto f1 = [r](FwdIterB part_begin, std::size_t part_size) -> T {
                     return reduce_partition<ExPolicy, FwdIterB, T>(
                         part_begin, part_size, r);
                 };
@@ -552,8 +550,7 @@ namespace hpx::parallel::detail {
                     HPX_MOVE(reduce_policy), first, count, HPX_MOVE(f1),
                     hpx::unwrapping(
                         [init = HPX_FORWARD(T_, init),
-                            r = HPX_FORWARD(Reduce, r)](
-                            auto&& results) -> T {
+                            r = HPX_FORWARD(Reduce, r)](auto&& results) -> T {
                             return sequential_reduce<ExPolicy>(
                                 hpx::util::begin(results),
                                 hpx::util::size(results), init, r);
@@ -569,18 +566,15 @@ namespace hpx::parallel::detail {
                         HPX_FORWARD(T_, init));
                 }
 
-                auto const count =
-                    hpx::parallel::detail::distance(first, last);
+                auto const count = hpx::parallel::detail::distance(first, last);
                 if (count == 1)
                 {
-                    T result =
-                        HPX_INVOKE(r, HPX_FORWARD(T_, init), *first);
+                    T result = HPX_INVOKE(r, HPX_FORWARD(T_, init), *first);
                     return util::detail::algorithm_result<ExPolicy, T>::get(
                         HPX_MOVE(result));
                 }
 
-                auto f1 =
-                    [r](FwdIterB part_begin, std::size_t part_size) -> T {
+                auto f1 = [r](FwdIterB part_begin, std::size_t part_size) -> T {
                     return reduce_partition<ExPolicy, FwdIterB, T>(
                         part_begin, part_size, r);
                 };
@@ -598,8 +592,7 @@ namespace hpx::parallel::detail {
                     HPX_MOVE(reduce_policy), first, count, HPX_MOVE(f1),
                     hpx::unwrapping(
                         [init = HPX_FORWARD(T_, init),
-                            r = HPX_FORWARD(Reduce, r)](
-                            auto&& results) -> T {
+                            r = HPX_FORWARD(Reduce, r)](auto&& results) -> T {
                             return sequential_reduce<ExPolicy>(
                                 hpx::util::begin(results),
                                 hpx::util::size(results), init, r);

--- a/libs/core/algorithms/include/hpx/parallel/container_algorithms/reduce.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/container_algorithms/reduce.hpp
@@ -805,7 +805,7 @@ namespace hpx::ranges {
             using value_type =
                 typename std::iterator_traits<FwdIter>::value_type;
 
-            return hpx::parallel::reduce<value_type>().call(
+            return hpx::parallel::detail::reduce<value_type>().call(
                 HPX_FORWARD(ExPolicy, policy), first, last, value_type{},
                 std::plus<value_type>{});
         }
@@ -830,7 +830,7 @@ namespace hpx::ranges {
             static_assert(std::forward_iterator<iterator_type>,
                 "Requires at least forward iterator.");
 
-            return hpx::parallel::reduce<value_type>().call(
+            return hpx::parallel::detail::reduce<value_type>().call(
                 HPX_FORWARD(ExPolicy, policy), hpx::util::begin(rng),
                 hpx::util::end(rng), value_type{}, std::plus<value_type>{});
         }
@@ -876,8 +876,8 @@ namespace hpx::ranges {
             static_assert(std::input_iterator<FwdIter>,
                 "Requires at least input iterator.");
 
-            return hpx::parallel::detail::reduce<T>().call(hpx::execution::seq, first,
-                last, HPX_MOVE(init), std::plus<T>{});
+            return hpx::parallel::detail::reduce<T>().call(hpx::execution::seq,
+                first, last, HPX_MOVE(init), std::plus<T>{});
         }
 
         template <typename Rng,
@@ -907,8 +907,9 @@ namespace hpx::ranges {
             using value_type =
                 typename std::iterator_traits<FwdIter>::value_type;
 
-            return hpx::parallel::reduce<value_type>().call(hpx::execution::seq,
-                first, last, value_type{}, std::plus<value_type>{});
+            return hpx::parallel::detail::reduce<value_type>().call(
+                hpx::execution::seq, first, last, value_type{},
+                std::plus<value_type>{});
         }
 
         template <typename Rng>
@@ -925,9 +926,9 @@ namespace hpx::ranges {
             static_assert(std::input_iterator<iterator_type>,
                 "Requires at least input iterator.");
 
-            return hpx::parallel::reduce<value_type>().call(hpx::execution::seq,
-                hpx::util::begin(rng), hpx::util::end(rng), value_type{},
-                std::plus<value_type>{});
+            return hpx::parallel::detail::reduce<value_type>().call(
+                hpx::execution::seq, hpx::util::begin(rng), hpx::util::end(rng),
+                value_type{}, std::plus<value_type>{});
         }
     } reduce{};
 }    // namespace hpx::ranges

--- a/libs/core/algorithms/include/hpx/parallel/container_algorithms/reduce.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/container_algorithms/reduce.hpp
@@ -805,7 +805,7 @@ namespace hpx::ranges {
             using value_type =
                 typename std::iterator_traits<FwdIter>::value_type;
 
-            return hpx::parallel::detail::reduce<value_type>().call(
+            return hpx::parallel::reduce<value_type>().call(
                 HPX_FORWARD(ExPolicy, policy), first, last, value_type{},
                 std::plus<value_type>{});
         }
@@ -830,7 +830,7 @@ namespace hpx::ranges {
             static_assert(std::forward_iterator<iterator_type>,
                 "Requires at least forward iterator.");
 
-            return hpx::parallel::detail::reduce<value_type>().call(
+            return hpx::parallel::reduce<value_type>().call(
                 HPX_FORWARD(ExPolicy, policy), hpx::util::begin(rng),
                 hpx::util::end(rng), value_type{}, std::plus<value_type>{});
         }
@@ -876,8 +876,8 @@ namespace hpx::ranges {
             static_assert(std::input_iterator<FwdIter>,
                 "Requires at least input iterator.");
 
-            return hpx::parallel::detail::reduce<T>().call(hpx::execution::seq,
-                first, last, HPX_MOVE(init), std::plus<T>{});
+            return hpx::parallel::detail::reduce<T>().call(hpx::execution::seq, first,
+                last, HPX_MOVE(init), std::plus<T>{});
         }
 
         template <typename Rng,
@@ -907,9 +907,8 @@ namespace hpx::ranges {
             using value_type =
                 typename std::iterator_traits<FwdIter>::value_type;
 
-            return hpx::parallel::detail::reduce<value_type>().call(
-                hpx::execution::seq, first, last, value_type{},
-                std::plus<value_type>{});
+            return hpx::parallel::reduce<value_type>().call(hpx::execution::seq,
+                first, last, value_type{}, std::plus<value_type>{});
         }
 
         template <typename Rng>
@@ -926,9 +925,9 @@ namespace hpx::ranges {
             static_assert(std::input_iterator<iterator_type>,
                 "Requires at least input iterator.");
 
-            return hpx::parallel::detail::reduce<value_type>().call(
-                hpx::execution::seq, hpx::util::begin(rng), hpx::util::end(rng),
-                value_type{}, std::plus<value_type>{});
+            return hpx::parallel::reduce<value_type>().call(hpx::execution::seq,
+                hpx::util::begin(rng), hpx::util::end(rng), value_type{},
+                std::plus<value_type>{});
         }
     } reduce{};
 }    // namespace hpx::ranges

--- a/libs/core/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <concepts>
 #include <cstddef>
+#include <tuple>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -205,12 +206,10 @@ namespace hpx::parallel::util::detail {
             hpx::execution::experimental::get_chunk_size(policy.parameters(),
                 policy.executor(), hpx::chrono::null_duration, cores, count);
 
-        auto [adj_chunk, adj_max] =
+        std::tie(chunk_size, max_chunks) =
             hpx::execution::experimental::adjust_chunk_size_and_max_chunks(
                 policy.parameters(), policy.executor(), count, cores,
                 max_chunks, chunk_size);
-        chunk_size = adj_chunk;
-        max_chunks = adj_max;
 
         auto last = next_or_subrange(it_or_r, count, 0);
         Stride stride = parallel::detail::abs(s);
@@ -289,12 +288,10 @@ namespace hpx::parallel::util::detail {
             hpx::execution::experimental::get_chunk_size(policy.parameters(),
                 policy.executor(), iteration_duration, cores, count);
 
-        auto [adj_chunk, adj_max] =
+        std::tie(chunk_size, max_chunks) =
             hpx::execution::experimental::adjust_chunk_size_and_max_chunks(
                 policy.parameters(), policy.executor(), count, cores,
                 max_chunks, chunk_size);
-        chunk_size = adj_chunk;
-        max_chunks = adj_max;
 
         auto last = next_or_subrange(it_or_r, count, 0);
 
@@ -358,8 +355,10 @@ namespace hpx::parallel::util::detail {
                     hpx::chrono::null_duration, cores, count);
 
             // make sure, chunk size and max_chunks are consistent
-            adjust_chunk_size_and_max_chunks(
-                cores, count, max_chunks, chunk_size, true);
+            std::tie(chunk_size, max_chunks) =
+                hpx::execution::experimental::adjust_chunk_size_and_max_chunks(
+                    policy.parameters(), policy.executor(), count, cores,
+                    max_chunks, chunk_size);
 
             if (stride != 1)
             {
@@ -467,12 +466,10 @@ namespace hpx::parallel::util::detail {
             hpx::execution::experimental::get_chunk_size(policy.parameters(),
                 policy.executor(), hpx::chrono::null_duration, cores, count);
 
-        auto [adj_chunk, adj_max] =
+        std::tie(chunk_size, max_chunks) =
             hpx::execution::experimental::adjust_chunk_size_and_max_chunks(
                 policy.parameters(), policy.executor(), count, cores,
                 max_chunks, chunk_size);
-        chunk_size = adj_chunk;
-        max_chunks = adj_max;
 
         if (stride != 1)
         {
@@ -560,12 +557,10 @@ namespace hpx::parallel::util::detail {
             hpx::execution::experimental::get_chunk_size(policy.parameters(),
                 policy.executor(), iteration_duration, cores, count);
 
-        auto [adj_chunk, adj_max] =
+        std::tie(chunk_size, max_chunks) =
             hpx::execution::experimental::adjust_chunk_size_and_max_chunks(
                 policy.parameters(), policy.executor(), count, cores,
                 max_chunks, chunk_size);
-        chunk_size = adj_chunk;
-        max_chunks = adj_max;
 
         if (stride != 1)
         {
@@ -631,8 +626,10 @@ namespace hpx::parallel::util::detail {
                     hpx::chrono::null_duration, cores, count);
 
             // make sure, chunk size and max_chunks are consistent
-            adjust_chunk_size_and_max_chunks(
-                cores, count, max_chunks, chunk_size, true);
+            std::tie(chunk_size, max_chunks) =
+                hpx::execution::experimental::adjust_chunk_size_and_max_chunks(
+                    policy.parameters(), policy.executor(), count, cores,
+                    max_chunks, chunk_size);
 
             if (stride != 1)
             {

--- a/libs/core/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
@@ -120,8 +120,8 @@ namespace hpx::parallel::util::detail {
 
                 // we should not make chunks smaller than what's determined by
                 // the max chunk size
-                chunk_size = (std::max) (chunk_size,
-                    (count + max_chunks - 1) / max_chunks);
+                chunk_size = (std::max)(
+                    chunk_size, (count + max_chunks - 1) / max_chunks);
             }
             else
             {
@@ -205,15 +205,24 @@ namespace hpx::parallel::util::detail {
             hpx::execution::experimental::get_chunk_size(policy.parameters(),
                 policy.executor(), hpx::chrono::null_duration, cores, count);
 
-        // make sure, chunk size and max_chunks are consistent
-        adjust_chunk_size_and_max_chunks(cores, count, max_chunks, chunk_size);
+        auto [adj_chunk, adj_max] =
+            hpx::execution::experimental::adjust_chunk_size_and_max_chunks(
+                policy.parameters(), policy.executor(), count, cores,
+                max_chunks, chunk_size);
+        if (adj_chunk != 0)
+            chunk_size = adj_chunk;
+        if (adj_max != 0)
+            max_chunks = adj_max;
+        else if (adj_chunk == 0)
+            adjust_chunk_size_and_max_chunks(
+                cores, count, max_chunks, chunk_size);
 
         auto last = next_or_subrange(it_or_r, count, 0);
         Stride stride = parallel::detail::abs(s);
 
         if (stride != 1)
         {
-            chunk_size = (std::max) (static_cast<std::size_t>(stride),
+            chunk_size = (std::max)(static_cast<std::size_t>(stride),
                 (chunk_size + stride - 1) / stride * stride);
         }
 
@@ -255,13 +264,13 @@ namespace hpx::parallel::util::detail {
             if (stride != 1)
             {
                 // rounding up
-                test_chunk_size = (std::max) (static_cast<std::size_t>(stride),
+                test_chunk_size = (std::max)(static_cast<std::size_t>(stride),
                     (test_chunk_size + stride - 1) / stride * stride);
             }
 
             add_ready_future(workitems, f1, it_or_r, test_chunk_size);
 
-            test_chunk_size = (std::min) (count, test_chunk_size);
+            test_chunk_size = (std::min)(count, test_chunk_size);
 
             count -= test_chunk_size;
             it_or_r = next_or_subrange(it_or_r, test_chunk_size, count);
@@ -285,14 +294,23 @@ namespace hpx::parallel::util::detail {
             hpx::execution::experimental::get_chunk_size(policy.parameters(),
                 policy.executor(), iteration_duration, cores, count);
 
-        // make sure, chunk size and max_chunks are consistent
-        adjust_chunk_size_and_max_chunks(cores, count, max_chunks, chunk_size);
+        auto [adj_chunk, adj_max] =
+            hpx::execution::experimental::adjust_chunk_size_and_max_chunks(
+                policy.parameters(), policy.executor(), count, cores,
+                max_chunks, chunk_size);
+        if (adj_chunk != 0)
+            chunk_size = adj_chunk;
+        if (adj_max != 0)
+            max_chunks = adj_max;
+        else if (adj_chunk == 0)
+            adjust_chunk_size_and_max_chunks(
+                cores, count, max_chunks, chunk_size);
 
         auto last = next_or_subrange(it_or_r, count, 0);
 
         if (stride != 1)
         {
-            chunk_size = (std::max) (static_cast<std::size_t>(stride),
+            chunk_size = (std::max)(static_cast<std::size_t>(stride),
                 (chunk_size + stride - 1) / stride * stride);
         }
 
@@ -339,7 +357,7 @@ namespace hpx::parallel::util::detail {
         // we should not consider more chunks than we have elements
         if (max_chunks != 0)
         {
-            max_chunks = (std::min) (max_chunks, count);
+            max_chunks = (std::min)(max_chunks, count);
         }
 
         while (count != 0)
@@ -355,16 +373,16 @@ namespace hpx::parallel::util::detail {
 
             if (stride != 1)
             {
-                chunk_size = (std::max) (static_cast<std::size_t>(stride),
+                chunk_size = (std::max)(static_cast<std::size_t>(stride),
                     (chunk_size + stride - 1) / stride * stride);
             }
 
             // in last chunk, consider only remaining number of elements
-            std::size_t chunk = (std::min) (chunk_size, count);
+            std::size_t chunk = (std::min)(chunk_size, count);
 
             shape.emplace_back(it_or_r, chunk);
 
-            chunk = (std::min) (count, chunk);
+            chunk = (std::min)(count, chunk);
             count -= chunk;
 
             it_or_r = next_or_subrange(it_or_r, chunk, count);
@@ -459,12 +477,21 @@ namespace hpx::parallel::util::detail {
             hpx::execution::experimental::get_chunk_size(policy.parameters(),
                 policy.executor(), hpx::chrono::null_duration, cores, count);
 
-        // make sure, chunk size and max_chunks are consistent
-        adjust_chunk_size_and_max_chunks(cores, count, max_chunks, chunk_size);
+        auto [adj_chunk, adj_max] =
+            hpx::execution::experimental::adjust_chunk_size_and_max_chunks(
+                policy.parameters(), policy.executor(), count, cores,
+                max_chunks, chunk_size);
+        if (adj_chunk != 0)
+            chunk_size = adj_chunk;
+        if (adj_max != 0)
+            max_chunks = adj_max;
+        else if (adj_chunk == 0)
+            adjust_chunk_size_and_max_chunks(
+                cores, count, max_chunks, chunk_size);
 
         if (stride != 1)
         {
-            chunk_size = (std::max) (static_cast<std::size_t>(stride),
+            chunk_size = (std::max)(static_cast<std::size_t>(stride),
                 static_cast<std::size_t>(
                     (chunk_size + stride - 1) / stride * stride));
         }
@@ -514,7 +541,7 @@ namespace hpx::parallel::util::detail {
 
             if (stride != 1)
             {
-                test_chunk_size = (std::max) (static_cast<std::size_t>(stride),
+                test_chunk_size = (std::max)(static_cast<std::size_t>(stride),
                     (test_chunk_size + stride - 1) / stride * stride);
             }
 
@@ -548,12 +575,21 @@ namespace hpx::parallel::util::detail {
             hpx::execution::experimental::get_chunk_size(policy.parameters(),
                 policy.executor(), iteration_duration, cores, count);
 
-        // make sure, chunk size and max_chunks are consistent
-        adjust_chunk_size_and_max_chunks(cores, count, max_chunks, chunk_size);
+        auto [adj_chunk, adj_max] =
+            hpx::execution::experimental::adjust_chunk_size_and_max_chunks(
+                policy.parameters(), policy.executor(), count, cores,
+                max_chunks, chunk_size);
+        if (adj_chunk != 0)
+            chunk_size = adj_chunk;
+        if (adj_max != 0)
+            max_chunks = adj_max;
+        else if (adj_chunk == 0)
+            adjust_chunk_size_and_max_chunks(
+                cores, count, max_chunks, chunk_size);
 
         if (stride != 1)
         {
-            chunk_size = (std::max) (static_cast<std::size_t>(stride),
+            chunk_size = (std::max)(static_cast<std::size_t>(stride),
                 (chunk_size + stride - 1) / stride * stride);
         }
 
@@ -603,7 +639,7 @@ namespace hpx::parallel::util::detail {
         // we should not consider more chunks than we have elements
         if (max_chunks != 0)
         {
-            max_chunks = (std::min) (max_chunks, count);
+            max_chunks = (std::min)(max_chunks, count);
         }
 
         std::size_t base_idx = 0;
@@ -620,12 +656,12 @@ namespace hpx::parallel::util::detail {
 
             if (stride != 1)
             {
-                chunk_size = (std::max) (static_cast<std::size_t>(stride),
+                chunk_size = (std::max)(static_cast<std::size_t>(stride),
                     (chunk_size + stride - 1) / stride * stride);
             }
 
             // in last chunk, consider only remaining number of elements
-            std::size_t chunk = (std::min) (chunk_size, count);
+            std::size_t chunk = (std::min)(chunk_size, count);
 
             shape.emplace_back(first, chunk, base_idx);
 

--- a/libs/core/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
@@ -355,10 +355,8 @@ namespace hpx::parallel::util::detail {
                     hpx::chrono::null_duration, cores, count);
 
             // make sure, chunk size and max_chunks are consistent
-            std::tie(chunk_size, max_chunks) =
-                hpx::execution::experimental::adjust_chunk_size_and_max_chunks(
-                    policy.parameters(), policy.executor(), count, cores,
-                    max_chunks, chunk_size);
+            adjust_chunk_size_and_max_chunks(
+                cores, count, max_chunks, chunk_size, true);
 
             if (stride != 1)
             {
@@ -626,10 +624,8 @@ namespace hpx::parallel::util::detail {
                     hpx::chrono::null_duration, cores, count);
 
             // make sure, chunk size and max_chunks are consistent
-            std::tie(chunk_size, max_chunks) =
-                hpx::execution::experimental::adjust_chunk_size_and_max_chunks(
-                    policy.parameters(), policy.executor(), count, cores,
-                    max_chunks, chunk_size);
+            adjust_chunk_size_and_max_chunks(
+                cores, count, max_chunks, chunk_size, true);
 
             if (stride != 1)
             {

--- a/libs/core/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
@@ -209,13 +209,8 @@ namespace hpx::parallel::util::detail {
             hpx::execution::experimental::adjust_chunk_size_and_max_chunks(
                 policy.parameters(), policy.executor(), count, cores,
                 max_chunks, chunk_size);
-        if (adj_chunk != 0)
-            chunk_size = adj_chunk;
-        if (adj_max != 0)
-            max_chunks = adj_max;
-        else if (adj_chunk == 0)
-            adjust_chunk_size_and_max_chunks(
-                cores, count, max_chunks, chunk_size);
+        chunk_size = adj_chunk;
+        max_chunks = adj_max;
 
         auto last = next_or_subrange(it_or_r, count, 0);
         Stride stride = parallel::detail::abs(s);
@@ -298,13 +293,8 @@ namespace hpx::parallel::util::detail {
             hpx::execution::experimental::adjust_chunk_size_and_max_chunks(
                 policy.parameters(), policy.executor(), count, cores,
                 max_chunks, chunk_size);
-        if (adj_chunk != 0)
-            chunk_size = adj_chunk;
-        if (adj_max != 0)
-            max_chunks = adj_max;
-        else if (adj_chunk == 0)
-            adjust_chunk_size_and_max_chunks(
-                cores, count, max_chunks, chunk_size);
+        chunk_size = adj_chunk;
+        max_chunks = adj_max;
 
         auto last = next_or_subrange(it_or_r, count, 0);
 
@@ -481,13 +471,8 @@ namespace hpx::parallel::util::detail {
             hpx::execution::experimental::adjust_chunk_size_and_max_chunks(
                 policy.parameters(), policy.executor(), count, cores,
                 max_chunks, chunk_size);
-        if (adj_chunk != 0)
-            chunk_size = adj_chunk;
-        if (adj_max != 0)
-            max_chunks = adj_max;
-        else if (adj_chunk == 0)
-            adjust_chunk_size_and_max_chunks(
-                cores, count, max_chunks, chunk_size);
+        chunk_size = adj_chunk;
+        max_chunks = adj_max;
 
         if (stride != 1)
         {
@@ -579,13 +564,8 @@ namespace hpx::parallel::util::detail {
             hpx::execution::experimental::adjust_chunk_size_and_max_chunks(
                 policy.parameters(), policy.executor(), count, cores,
                 max_chunks, chunk_size);
-        if (adj_chunk != 0)
-            chunk_size = adj_chunk;
-        if (adj_max != 0)
-            max_chunks = adj_max;
-        else if (adj_chunk == 0)
-            adjust_chunk_size_and_max_chunks(
-                cores, count, max_chunks, chunk_size);
+        chunk_size = adj_chunk;
+        max_chunks = adj_max;
 
         if (stride != 1)
         {

--- a/libs/core/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
@@ -120,8 +120,8 @@ namespace hpx::parallel::util::detail {
 
                 // we should not make chunks smaller than what's determined by
                 // the max chunk size
-                chunk_size = (std::max)(
-                    chunk_size, (count + max_chunks - 1) / max_chunks);
+                chunk_size = (std::max) (chunk_size,
+                    (count + max_chunks - 1) / max_chunks);
             }
             else
             {
@@ -222,7 +222,7 @@ namespace hpx::parallel::util::detail {
 
         if (stride != 1)
         {
-            chunk_size = (std::max)(static_cast<std::size_t>(stride),
+            chunk_size = (std::max) (static_cast<std::size_t>(stride),
                 (chunk_size + stride - 1) / stride * stride);
         }
 
@@ -264,13 +264,13 @@ namespace hpx::parallel::util::detail {
             if (stride != 1)
             {
                 // rounding up
-                test_chunk_size = (std::max)(static_cast<std::size_t>(stride),
+                test_chunk_size = (std::max) (static_cast<std::size_t>(stride),
                     (test_chunk_size + stride - 1) / stride * stride);
             }
 
             add_ready_future(workitems, f1, it_or_r, test_chunk_size);
 
-            test_chunk_size = (std::min)(count, test_chunk_size);
+            test_chunk_size = (std::min) (count, test_chunk_size);
 
             count -= test_chunk_size;
             it_or_r = next_or_subrange(it_or_r, test_chunk_size, count);
@@ -310,7 +310,7 @@ namespace hpx::parallel::util::detail {
 
         if (stride != 1)
         {
-            chunk_size = (std::max)(static_cast<std::size_t>(stride),
+            chunk_size = (std::max) (static_cast<std::size_t>(stride),
                 (chunk_size + stride - 1) / stride * stride);
         }
 
@@ -357,7 +357,7 @@ namespace hpx::parallel::util::detail {
         // we should not consider more chunks than we have elements
         if (max_chunks != 0)
         {
-            max_chunks = (std::min)(max_chunks, count);
+            max_chunks = (std::min) (max_chunks, count);
         }
 
         while (count != 0)
@@ -373,16 +373,16 @@ namespace hpx::parallel::util::detail {
 
             if (stride != 1)
             {
-                chunk_size = (std::max)(static_cast<std::size_t>(stride),
+                chunk_size = (std::max) (static_cast<std::size_t>(stride),
                     (chunk_size + stride - 1) / stride * stride);
             }
 
             // in last chunk, consider only remaining number of elements
-            std::size_t chunk = (std::min)(chunk_size, count);
+            std::size_t chunk = (std::min) (chunk_size, count);
 
             shape.emplace_back(it_or_r, chunk);
 
-            chunk = (std::min)(count, chunk);
+            chunk = (std::min) (count, chunk);
             count -= chunk;
 
             it_or_r = next_or_subrange(it_or_r, chunk, count);
@@ -491,7 +491,7 @@ namespace hpx::parallel::util::detail {
 
         if (stride != 1)
         {
-            chunk_size = (std::max)(static_cast<std::size_t>(stride),
+            chunk_size = (std::max) (static_cast<std::size_t>(stride),
                 static_cast<std::size_t>(
                     (chunk_size + stride - 1) / stride * stride));
         }
@@ -541,7 +541,7 @@ namespace hpx::parallel::util::detail {
 
             if (stride != 1)
             {
-                test_chunk_size = (std::max)(static_cast<std::size_t>(stride),
+                test_chunk_size = (std::max) (static_cast<std::size_t>(stride),
                     (test_chunk_size + stride - 1) / stride * stride);
             }
 
@@ -589,7 +589,7 @@ namespace hpx::parallel::util::detail {
 
         if (stride != 1)
         {
-            chunk_size = (std::max)(static_cast<std::size_t>(stride),
+            chunk_size = (std::max) (static_cast<std::size_t>(stride),
                 (chunk_size + stride - 1) / stride * stride);
         }
 
@@ -639,7 +639,7 @@ namespace hpx::parallel::util::detail {
         // we should not consider more chunks than we have elements
         if (max_chunks != 0)
         {
-            max_chunks = (std::min)(max_chunks, count);
+            max_chunks = (std::min) (max_chunks, count);
         }
 
         std::size_t base_idx = 0;
@@ -656,12 +656,12 @@ namespace hpx::parallel::util::detail {
 
             if (stride != 1)
             {
-                chunk_size = (std::max)(static_cast<std::size_t>(stride),
+                chunk_size = (std::max) (static_cast<std::size_t>(stride),
                     (chunk_size + stride - 1) / stride * stride);
             }
 
             // in last chunk, consider only remaining number of elements
-            std::size_t chunk = (std::min)(chunk_size, count);
+            std::size_t chunk = (std::min) (chunk_size, count);
 
             shape.emplace_back(first, chunk, base_idx);
 

--- a/libs/core/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
@@ -112,8 +112,8 @@ namespace hpx::parallel::util::detail {
             return;
         }
 
-        auto const result =
-            hpx::execution::experimental::adjust_chunk_size_and_max_chunks_default(
+        auto const result = hpx::execution::experimental::
+            adjust_chunk_size_and_max_chunks_default(
                 count, cores, max_chunks, chunk_size);
         chunk_size = result.first;
         max_chunks = result.second;

--- a/libs/core/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
@@ -8,6 +8,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
+#include <hpx/execution/executors/execution_parameters_fwd.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/datastructures.hpp>
 #include <hpx/modules/execution.hpp>
@@ -105,64 +106,17 @@ namespace hpx::parallel::util::detail {
         std::size_t& max_chunks, std::size_t& chunk_size,
         bool const has_variable_chunk_size = false) noexcept
     {
-        if (max_chunks == 0)
-        {
-            if (chunk_size == 0)
-            {
-                std::size_t const cores_times_4 = 4 * cores;    // -V112
-
-                // try to calculate chunk-size and maximum number of chunks
-                chunk_size = (count + cores_times_4 - 1) / cores_times_4;
-
-                max_chunks = (count + chunk_size - 1) / chunk_size;
-
-                // we should not consider more chunks than we have elements
-                max_chunks = (std::min) (max_chunks, count);    // -V112
-
-                // we should not make chunks smaller than what's determined by
-                // the max chunk size
-                chunk_size = (std::max) (chunk_size,
-                    (count + max_chunks - 1) / max_chunks);
-            }
-            else
-            {
-                // max_chunks == 0 && chunk_size != 0
-                max_chunks = (count + chunk_size - 1) / chunk_size;
-            }
-            return;
-        }
-
-        if (has_variable_chunk_size)
+        if (max_chunks != 0 && has_variable_chunk_size)
         {
             HPX_ASSERT(chunk_size != 0);
             return;
         }
 
-        if (chunk_size == 0)
-        {
-            // max_chunks != 0
-            chunk_size = (count + max_chunks - 1) / max_chunks;
-
-            max_chunks = (count + chunk_size - 1) / chunk_size;
-        }
-        else
-        {
-            // max_chunks != 0 && chunk_size != 0
-
-            // in this case we make sure that there are no more chunks than
-            // max_chunks
-            std::size_t const calculated_max_chunks =
-                (count + chunk_size - 1) / chunk_size;
-
-            if (calculated_max_chunks > max_chunks)
-            {
-                chunk_size = (count + max_chunks - 1) / max_chunks;
-            }
-            else if (calculated_max_chunks < max_chunks)
-            {
-                max_chunks = calculated_max_chunks;
-            }
-        }
+        auto const result =
+            hpx::execution::experimental::adjust_chunk_size_and_max_chunks_default(
+                count, cores, max_chunks, chunk_size);
+        chunk_size = result.first;
+        max_chunks = result.second;
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/libs/core/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
@@ -112,7 +112,7 @@ namespace hpx::parallel::util::detail {
             return;
         }
 
-        auto const result = hpx::execution::experimental::
+        auto const result = hpx::execution::experimental::detail::
             adjust_chunk_size_and_max_chunks_default(
                 count, cores, max_chunks, chunk_size);
         chunk_size = result.first;

--- a/libs/core/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
@@ -106,9 +106,8 @@ namespace hpx::parallel::util::detail {
         std::size_t& max_chunks, std::size_t& chunk_size,
         bool const has_variable_chunk_size = false) noexcept
     {
-        if (max_chunks != 0 && has_variable_chunk_size)
+        if (has_variable_chunk_size)
         {
-            HPX_ASSERT(chunk_size != 0);
             return;
         }
 

--- a/libs/core/algorithms/tests/regressions/CMakeLists.txt
+++ b/libs/core/algorithms/tests/regressions/CMakeLists.txt
@@ -1,8 +1,8 @@
-# Copyright (c) 2014-2025 Hartmut Kaiser
+#Copyright(c) 2014 - 2025 Hartmut Kaiser
 #
-# SPDX-License-Identifier: BSL-1.0
-# Distributed under the Boost Software License, Version 1.0. (See accompanying
-# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#SPDX - License - Identifier : BSL - 1.0
+#Distributed under the Boost Software License, Version 1.0.(See accompanying
+#file LICENSE_1_0.txt or copy at http:    //www.boost.org/LICENSE_1_0.txt)
 
 set(tests
     chunk_size_variable_regression
@@ -40,24 +40,19 @@ if(HPX_WITH_DATAPAR)
   list(APPEND tests counting_iterator_datapar for_each_datapar)
 endif()
 
-foreach(test ${tests})
-  set(sources ${test}.cpp)
+        foreach (test ${tests}) set(sources ${test}.cpp)
 
-  set(${test}_PARAMETERS THREADS_PER_LOCALITY 4)
+            set(${test} _PARAMETERS THREADS_PER_LOCALITY 4)
 
-  source_group("Source Files" FILES ${sources})
+                source_group("Source Files" FILES ${sources})
 
-  # add example executable
-  add_hpx_executable(
-    ${test}_test INTERNAL_FLAGS
-    SOURCES ${sources}
-    EXCLUDE_FROM_ALL ${${test}_FLAGS}
-    FOLDER "Tests/Regressions/Modules/Core/Algorithms/"
-  )
+#add example executable
+                    add_hpx_executable(${test} _test INTERNAL_FLAGS SOURCES ${
+                        sources} EXCLUDE_FROM_ALL ${${test} _FLAGS} FOLDER
+                        "Tests/Regressions/Modules/Core/Algorithms/")
 
-  target_link_libraries(
-    ${test}_test PRIVATE hpx_iterator_support_test_utilities
-  )
+                        target_link_libraries(${test} _test PRIVATE
+                                hpx_iterator_support_test_utilities)
 
-  add_hpx_regression_test("modules.algorithms" ${test} ${${test}_PARAMETERS})
-endforeach()
+                            add_hpx_regression_test("modules.algorithms" ${
+                                test} ${${test} _PARAMETERS}) endforeach()

--- a/libs/core/algorithms/tests/regressions/CMakeLists.txt
+++ b/libs/core/algorithms/tests/regressions/CMakeLists.txt
@@ -1,8 +1,8 @@
-# Copyright (c) 2014-2025 Hartmut Kaiser
+#Copyright(c) 2014 - 2025 Hartmut Kaiser
 #
-# SPDX-License-Identifier: BSL-1.0
-# Distributed under the Boost Software License, Version 1.0. (See accompanying
-# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#SPDX - License - Identifier : BSL - 1.0
+#Distributed under the Boost Software License, Version 1.0.(See accompanying
+#file LICENSE_1_0.txt or copy at http:    //www.boost.org/LICENSE_1_0.txt)
 
 set(tests
     chunk_size_variable_regression
@@ -22,6 +22,7 @@ set(tests
     num_cores
     prefetching_iterator
     reduce_3641
+    reduce_6647
     scan_different_inits
     scan_non_commutative
     scan_shortlength
@@ -39,24 +40,19 @@ if(HPX_WITH_DATAPAR)
   list(APPEND tests counting_iterator_datapar for_each_datapar)
 endif()
 
-foreach(test ${tests})
-  set(sources ${test}.cpp)
+        foreach (test ${tests}) set(sources ${test}.cpp)
 
-  set(${test}_PARAMETERS THREADS_PER_LOCALITY 4)
+            set(${test} _PARAMETERS THREADS_PER_LOCALITY 4)
 
-  source_group("Source Files" FILES ${sources})
+                source_group("Source Files" FILES ${sources})
 
-  # add example executable
-  add_hpx_executable(
-    ${test}_test INTERNAL_FLAGS
-    SOURCES ${sources}
-    EXCLUDE_FROM_ALL ${${test}_FLAGS}
-    FOLDER "Tests/Regressions/Modules/Core/Algorithms/"
-  )
+#add example executable
+                    add_hpx_executable(${test} _test INTERNAL_FLAGS SOURCES ${
+                        sources} EXCLUDE_FROM_ALL ${${test} _FLAGS} FOLDER
+                        "Tests/Regressions/Modules/Core/Algorithms/")
 
-  target_link_libraries(
-    ${test}_test PRIVATE hpx_iterator_support_test_utilities
-  )
+                        target_link_libraries(${test} _test PRIVATE
+                                hpx_iterator_support_test_utilities)
 
-  add_hpx_regression_test("modules.algorithms" ${test} ${${test}_PARAMETERS})
-endforeach()
+                            add_hpx_regression_test("modules.algorithms" ${
+                                test} ${${test} _PARAMETERS}) endforeach()

--- a/libs/core/algorithms/tests/regressions/CMakeLists.txt
+++ b/libs/core/algorithms/tests/regressions/CMakeLists.txt
@@ -1,8 +1,8 @@
-#Copyright(c) 2014 - 2025 Hartmut Kaiser
+# Copyright (c) 2014-2025 Hartmut Kaiser
 #
-#SPDX - License - Identifier : BSL - 1.0
-#Distributed under the Boost Software License, Version 1.0.(See accompanying
-#file LICENSE_1_0.txt or copy at http:    //www.boost.org/LICENSE_1_0.txt)
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests
     chunk_size_variable_regression
@@ -40,19 +40,24 @@ if(HPX_WITH_DATAPAR)
   list(APPEND tests counting_iterator_datapar for_each_datapar)
 endif()
 
-        foreach (test ${tests}) set(sources ${test}.cpp)
+foreach(test ${tests})
+  set(sources ${test}.cpp)
 
-            set(${test} _PARAMETERS THREADS_PER_LOCALITY 4)
+  set(${test}_PARAMETERS THREADS_PER_LOCALITY 4)
 
-                source_group("Source Files" FILES ${sources})
+  source_group("Source Files" FILES ${sources})
 
-#add example executable
-                    add_hpx_executable(${test} _test INTERNAL_FLAGS SOURCES ${
-                        sources} EXCLUDE_FROM_ALL ${${test} _FLAGS} FOLDER
-                        "Tests/Regressions/Modules/Core/Algorithms/")
+  # add example executable
+  add_hpx_executable(
+    ${test}_test INTERNAL_FLAGS
+    SOURCES ${sources}
+    EXCLUDE_FROM_ALL ${${test}_FLAGS}
+    FOLDER "Tests/Regressions/Modules/Core/Algorithms/"
+  )
 
-                        target_link_libraries(${test} _test PRIVATE
-                                hpx_iterator_support_test_utilities)
+  target_link_libraries(
+    ${test}_test PRIVATE hpx_iterator_support_test_utilities
+  )
 
-                            add_hpx_regression_test("modules.algorithms" ${
-                                test} ${${test} _PARAMETERS}) endforeach()
+  add_hpx_regression_test("modules.algorithms" ${test} ${${test}_PARAMETERS})
+endforeach()

--- a/libs/core/algorithms/tests/regressions/reduce_6647.cpp
+++ b/libs/core/algorithms/tests/regressions/reduce_6647.cpp
@@ -1,6 +1,6 @@
 //  Copyright (c) 2026 Bhoomish Gupta
-//  SPDX - License - Identifier : BSL - 1.0
 //
+//  SPDX - License - Identifier : BSL - 1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 

--- a/libs/core/algorithms/tests/regressions/reduce_6647.cpp
+++ b/libs/core/algorithms/tests/regressions/reduce_6647.cpp
@@ -1,0 +1,69 @@
+//  Copyright (c) 2026 Bhoomish Gupta
+//
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// #6647:Incorrect reduce implementation
+
+#include <hpx/algorithm.hpp>
+#include <hpx/init.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <climits>
+#include <utility>
+#include <vector>
+
+struct minmax
+{
+    std::pair<int, int> operator()(
+        std::pair<int, int> lhs, std::pair<int, int> rhs) const
+    {
+        return {
+            lhs.first < rhs.first ? lhs.first : rhs.first,
+            lhs.second < rhs.second ? rhs.second : lhs.second,
+        };
+    }
+
+    std::pair<int, int> operator()(std::pair<int, int> lhs, int rhs) const
+    {
+        return (*this)(lhs, std::pair<int, int>{rhs, rhs});
+    }
+
+    std::pair<int, int> operator()(int lhs, std::pair<int, int> rhs) const
+    {
+        return (*this)(std::pair<int, int>{lhs, lhs}, rhs);
+    }
+
+    std::pair<int, int> operator()(int lhs, int rhs) const
+    {
+        return (*this)(
+            std::pair<int, int>{lhs, lhs}, std::pair<int, int>{rhs, rhs});
+    }
+};
+
+int hpx_main()
+{
+    std::vector<int> c = {3, 1, 4, 1, 5, 9, 2, 6};
+
+    auto result = hpx::reduce(hpx::execution::seq, c.begin(), c.end(),
+        std::pair<int, int>{INT_MAX, INT_MIN}, minmax{});
+
+    HPX_TEST_EQ(result.first, 1);
+    HPX_TEST_EQ(result.second, 9);
+
+    result = hpx::reduce(hpx::execution::par, c.begin(), c.end(),
+        std::pair<int, int>{INT_MAX, INT_MIN}, minmax{});
+
+    HPX_TEST_EQ(result.first, 1);
+    HPX_TEST_EQ(result.second, 9);
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/algorithms/tests/regressions/reduce_6647.cpp
+++ b/libs/core/algorithms/tests/regressions/reduce_6647.cpp
@@ -1,9 +1,6 @@
 //  Copyright (c) 2026 Bhoomish Gupta
-//
-<<<<<<< HEAD
 //  SPDX - License - Identifier : BSL - 1.0
-=======
->>>>>>> 7cd0cb47ab (Fix bug #6647: Correct type handling in reduce)
+//
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 

--- a/libs/core/algorithms/tests/regressions/reduce_6647.cpp
+++ b/libs/core/algorithms/tests/regressions/reduce_6647.cpp
@@ -1,6 +1,9 @@
 //  Copyright (c) 2026 Bhoomish Gupta
 //
+<<<<<<< HEAD
 //  SPDX - License - Identifier : BSL - 1.0
+=======
+>>>>>>> 7cd0cb47ab (Fix bug #6647: Correct type handling in reduce)
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 

--- a/libs/core/algorithms/tests/regressions/reduce_6647.cpp
+++ b/libs/core/algorithms/tests/regressions/reduce_6647.cpp
@@ -1,5 +1,6 @@
 //  Copyright (c) 2026 Bhoomish Gupta
-//  #SPDX - License - Identifier : BSL - 1.0
+//
+//  SPDX - License - Identifier : BSL - 1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 

--- a/libs/core/algorithms/tests/regressions/reduce_6647.cpp
+++ b/libs/core/algorithms/tests/regressions/reduce_6647.cpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2026 Bhoomish Gupta
-//
+//  #SPDX - License - Identifier : BSL - 1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 

--- a/libs/core/algorithms/tests/regressions/reduce_6647.cpp
+++ b/libs/core/algorithms/tests/regressions/reduce_6647.cpp
@@ -42,21 +42,30 @@ struct minmax
     }
 };
 
+void test_reduce_case(
+    std::vector<int> const& c, std::pair<int, int> const& expected)
+{
+    auto const init = std::pair<int, int>{INT_MAX, INT_MIN};
+
+    auto result =
+        hpx::reduce(hpx::execution::seq, c.begin(), c.end(), init, minmax{});
+    HPX_TEST_EQ(result.first, expected.first);
+    HPX_TEST_EQ(result.second, expected.second);
+
+    result =
+        hpx::reduce(hpx::execution::par, c.begin(), c.end(), init, minmax{});
+    HPX_TEST_EQ(result.first, expected.first);
+    HPX_TEST_EQ(result.second, expected.second);
+}
+
 int hpx_main()
 {
-    std::vector<int> c = {3, 1, 4, 1, 5, 9, 2, 6};
-
-    auto result = hpx::reduce(hpx::execution::seq, c.begin(), c.end(),
-        std::pair<int, int>{INT_MAX, INT_MIN}, minmax{});
-
-    HPX_TEST_EQ(result.first, 1);
-    HPX_TEST_EQ(result.second, 9);
-
-    result = hpx::reduce(hpx::execution::par, c.begin(), c.end(),
-        std::pair<int, int>{INT_MAX, INT_MIN}, minmax{});
-
-    HPX_TEST_EQ(result.first, 1);
-    HPX_TEST_EQ(result.second, 9);
+    test_reduce_case({}, {INT_MAX, INT_MIN});
+    test_reduce_case({5}, {5, 5});
+    test_reduce_case({3, 1}, {1, 3});
+    test_reduce_case({3, 1, 4}, {1, 4});
+    test_reduce_case({9, 2, 7, 1, 6}, {1, 9});
+    test_reduce_case({3, 1, 4, 1, 5, 9, 2, 6}, {1, 9});
 
     return hpx::local::finalize();
 }

--- a/libs/core/algorithms/tests/regressions/reduce_6647.cpp
+++ b/libs/core/algorithms/tests/regressions/reduce_6647.cpp
@@ -1,10 +1,10 @@
 //  Copyright (c) 2026 Bhoomish Gupta
 //
-//  SPDX - License - Identifier : BSL - 1.0
+//  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// #6647:Incorrect reduce implementation
+// #6647: Incorrect reduce implementation
 
 #include <hpx/algorithm.hpp>
 #include <hpx/init.hpp>

--- a/libs/core/algorithms/tests/regressions/reduce_6647.cpp
+++ b/libs/core/algorithms/tests/regressions/reduce_6647.cpp
@@ -11,6 +11,7 @@
 #include <hpx/modules/testing.hpp>
 
 #include <climits>
+#include <numeric>
 #include <utility>
 #include <vector>
 
@@ -66,6 +67,13 @@ int hpx_main()
     test_reduce_case({3, 1, 4}, {1, 4});
     test_reduce_case({9, 2, 7, 1, 6}, {1, 9});
     test_reduce_case({3, 1, 4, 1, 5, 9, 2, 6}, {1, 9});
+
+    for (int i = 1; i <= 200; ++i)
+    {
+        std::vector<int> v(i);
+        std::iota(v.begin(), v.end(), 1);
+        test_reduce_case(v, {1, i});
+    }
 
     return hpx::local::finalize();
 }

--- a/libs/core/algorithms/tests/regressions/reduce_6647.cpp
+++ b/libs/core/algorithms/tests/regressions/reduce_6647.cpp
@@ -75,6 +75,16 @@ int hpx_main()
         test_reduce_case(v, {1, i});
     }
 
+    // Larger inputs that force multiple partitions on any machine and
+    // exercise the num_elements % chunk_size == 1 edge case in
+    // reduce_executor_parameters.
+    for (int n : {997, 1000, 1024, 4096, 10000})
+    {
+        std::vector<int> v(n);
+        std::iota(v.begin(), v.end(), 1);
+        test_reduce_case(v, {1, n});
+    }
+
     return hpx::local::finalize();
 }
 

--- a/libs/core/execution/include/hpx/execution/executors/execution_parameters.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution_parameters.hpp
@@ -662,14 +662,50 @@ namespace hpx::execution::experimental::detail {
     // adjust_chunk_size_and_max_chunks
     struct adjust_chunk_size_and_max_chunks_property
     {
-        // default implementation
         template <typename Target>
         HPX_FORCEINLINE static constexpr std::pair<std::size_t, std::size_t>
-        adjust_chunk_size_and_max_chunks(
-            Target, std::size_t, std::size_t, std::size_t, std::size_t) noexcept
+        adjust_chunk_size_and_max_chunks(Target, std::size_t num_elements,
+            std::size_t num_cores, std::size_t max_chunks,
+            std::size_t chunk_size) noexcept
         {
-            // return zero which means no adjustment
-            return {0, 0};    // {adjusted_chunk_size, adjusted_max_chunks}
+            if (max_chunks == 0)
+            {
+                if (chunk_size == 0)
+                {
+                    std::size_t const cores_times_4 = 4 * num_cores;    // -V112
+
+                    chunk_size =
+                        (num_elements + cores_times_4 - 1) / cores_times_4;
+
+                    max_chunks =
+                        (std::min) (cores_times_4, num_elements);    // -V112
+
+                    chunk_size = (std::max) (chunk_size,
+                        (num_elements + max_chunks - 1) / max_chunks);
+                }
+                else
+                {
+                    // max_chunks == 0 && chunk_size != 0
+                    max_chunks = (num_elements + chunk_size - 1) / chunk_size;
+                }
+            }
+            else if (chunk_size == 0)
+            {
+                chunk_size = (num_elements + max_chunks - 1) / max_chunks;
+            }
+            else
+            {
+                // max_chunks != 0 && chunk_size != 0
+                std::size_t const calculated_max_chunks =
+                    (num_elements + chunk_size - 1) / chunk_size;
+
+                if (calculated_max_chunks > max_chunks)
+                {
+                    chunk_size = (num_elements + max_chunks - 1) / max_chunks;
+                }
+            }
+
+            return {chunk_size, max_chunks};
         }
     };
 

--- a/libs/core/execution/include/hpx/execution/executors/execution_parameters.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution_parameters.hpp
@@ -660,50 +660,6 @@ namespace hpx::execution::experimental::detail {
     ///////////////////////////////////////////////////////////////////////
     // shared default implementation allowing to handle
     // adjust_chunk_size_and_max_chunks
-    HPX_FORCEINLINE constexpr std::pair<std::size_t, std::size_t>
-    adjust_chunk_size_and_max_chunks_default(std::size_t num_elements,
-        std::size_t num_cores, std::size_t max_chunks,
-        std::size_t chunk_size) noexcept
-    {
-        if (max_chunks == 0)
-        {
-            if (chunk_size == 0)
-            {
-                std::size_t const cores_times_4 = 4 * num_cores;    // -V112
-
-                chunk_size = (num_elements + cores_times_4 - 1) / cores_times_4;
-
-                max_chunks =
-                    (std::min) (cores_times_4, num_elements);    // -V112
-
-                chunk_size = (std::max) (chunk_size,
-                    (num_elements + max_chunks - 1) / max_chunks);
-            }
-            else
-            {
-                // max_chunks == 0 && chunk_size != 0
-                max_chunks = (num_elements + chunk_size - 1) / chunk_size;
-            }
-        }
-        else if (chunk_size == 0)
-        {
-            chunk_size = (num_elements + max_chunks - 1) / max_chunks;
-        }
-        else
-        {
-            // max_chunks != 0 && chunk_size != 0
-            std::size_t const calculated_max_chunks =
-                (num_elements + chunk_size - 1) / chunk_size;
-
-            if (calculated_max_chunks > max_chunks)
-            {
-                chunk_size = (num_elements + max_chunks - 1) / max_chunks;
-            }
-        }
-
-        return {chunk_size, max_chunks};
-    }
-
     ///////////////////////////////////////////////////////////////////////
     // default property implementation allowing to handle
     // adjust_chunk_size_and_max_chunks

--- a/libs/core/execution/include/hpx/execution/executors/execution_parameters.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution_parameters.hpp
@@ -671,7 +671,7 @@ namespace hpx::execution::experimental::detail {
             std::size_t num_cores, std::size_t max_chunks,
             std::size_t chunk_size) noexcept
         {
-            return adjust_chunk_size_and_max_chunks_default(
+            return detail::adjust_chunk_size_and_max_chunks_default(
                 num_elements, num_cores, max_chunks, chunk_size);
         }
     };

--- a/libs/core/execution/include/hpx/execution/executors/execution_parameters.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution_parameters.hpp
@@ -652,6 +652,69 @@ namespace hpx::execution::experimental::detail {
             call(static_cast<Parameters&>(params), HPX_FORWARD(Executor, exec));
         }
     };
+
+    ///////////////////////////////////////////////////////////////////////
+    // define member traits
+    HPX_HAS_MEMBER_XXX_TRAIT_DEF(adjust_chunk_size_and_max_chunks)
+
+    ///////////////////////////////////////////////////////////////////////
+    // default property implementation allowing to handle
+    // adjust_chunk_size_and_max_chunks
+    struct adjust_chunk_size_and_max_chunks_property
+    {
+        // default implementation
+        template <typename Target>
+        HPX_FORCEINLINE static constexpr std::pair<std::size_t, std::size_t>
+        adjust_chunk_size_and_max_chunks(
+            Target, std::size_t, std::size_t, std::size_t, std::size_t) noexcept
+        {
+            // return zero which means no adjustment
+            return {0, 0};    // {adjusted_chunk_size, adjusted_max_chunks}
+        }
+    };
+
+    //////////////////////////////////////////////////////////////////////
+    // Generate a type that is guaranteed to support
+    // adjust_chunk_size_and_max_chunks
+    using get_adjust_chunk_size_and_max_chunks_t =
+        get_parameters_property_t<adjust_chunk_size_and_max_chunks_property,
+            has_adjust_chunk_size_and_max_chunks_t>;
+
+    inline constexpr get_adjust_chunk_size_and_max_chunks_t
+        get_adjust_chunk_size_and_max_chunks{};
+
+    ///////////////////////////////////////////////////////////////////////
+    // customization point for interface adjust_chunk_size_and_max_chunks()
+    template <typename Parameters, typename Executor_>
+    struct adjust_chunk_size_and_max_chunks_fn_helper<Parameters, Executor_,
+        std::enable_if_t<hpx::traits::is_executor_any_v<Executor_>>>
+    {
+        template <typename Executor>
+        HPX_FORCEINLINE static constexpr std::pair<std::size_t, std::size_t>
+        call(Parameters& params, Executor&& exec, std::size_t num_elements,
+            std::size_t num_cores, std::size_t num_chunks,
+            std::size_t chunk_size)
+        {
+            auto get_prop = get_adjust_chunk_size_and_max_chunks(
+                HPX_FORWARD(Executor, exec), params,
+                adjust_chunk_size_and_max_chunks_property{});
+
+            return get_prop.first.adjust_chunk_size_and_max_chunks(
+                HPX_FORWARD(decltype(get_prop.second), get_prop.second),
+                num_elements, num_cores, num_chunks, chunk_size);
+        }
+
+        template <typename AnyParameters, typename Executor>
+        HPX_FORCEINLINE static constexpr std::pair<std::size_t, std::size_t>
+        call(AnyParameters params, Executor&& exec, std::size_t num_elements,
+            std::size_t num_cores, std::size_t num_chunks,
+            std::size_t chunk_size)
+        {
+            return call(static_cast<Parameters&>(params),
+                HPX_FORWARD(Executor, exec), num_elements, num_cores,
+                num_chunks, chunk_size);
+        }
+    };
     /// \endcond
 
     /// \cond NOINTERNAL

--- a/libs/core/execution/include/hpx/execution/executors/execution_parameters.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution_parameters.hpp
@@ -959,6 +959,30 @@ namespace hpx::execution::experimental::detail {
     };
 
     ///////////////////////////////////////////////////////////////////////
+    template <typename T, typename Wrapper, typename Enable = void>
+    struct adjust_chunk_size_and_max_chunks_call_helper
+    {
+    };
+
+    template <typename T, typename Wrapper>
+    struct adjust_chunk_size_and_max_chunks_call_helper<T, Wrapper,
+        std::enable_if_t<has_adjust_chunk_size_and_max_chunks_v<T>>>
+    {
+        template <typename Executor>
+        HPX_FORCEINLINE std::pair<std::size_t, std::size_t>
+        adjust_chunk_size_and_max_chunks(Executor&& exec,
+            std::size_t num_elements, std::size_t num_cores,
+            std::size_t num_chunks, std::size_t chunk_size)
+        {
+            auto& wrapped =
+                static_cast<unwrapper<Wrapper>*>(this)->member_.get();
+            return wrapped.adjust_chunk_size_and_max_chunks(
+                HPX_FORWARD(Executor, exec), num_elements, num_cores,
+                num_chunks, chunk_size);
+        }
+    };
+
+    ///////////////////////////////////////////////////////////////////////
     template <typename T>
     struct base_member_helper
     {
@@ -984,6 +1008,8 @@ namespace hpx::execution::experimental::detail {
       , processing_units_count_call_helper<T, std::reference_wrapper<T>>
       , reset_thread_distribution_call_helper<T, std::reference_wrapper<T>>
       , collect_execution_parameters_call_helper<T, std::reference_wrapper<T>>
+      , adjust_chunk_size_and_max_chunks_call_helper<T,
+            std::reference_wrapper<T>>
     {
         using wrapper_type = std::reference_wrapper<T>;
 
@@ -1024,6 +1050,8 @@ namespace hpx::execution::experimental::detail {
         HPX_STATIC_ASSERT_ON_PARAMETERS_AMBIGUITY(maximal_number_of_chunks);
         HPX_STATIC_ASSERT_ON_PARAMETERS_AMBIGUITY(reset_thread_distribution);
         HPX_STATIC_ASSERT_ON_PARAMETERS_AMBIGUITY(collect_execution_parameters);
+        HPX_STATIC_ASSERT_ON_PARAMETERS_AMBIGUITY(
+            adjust_chunk_size_and_max_chunks);
 
         constexpr executor_parameters()
             requires(hpx::util::all_of_v<std::is_constructible<Params>...>)

--- a/libs/core/execution/include/hpx/execution/executors/execution_parameters.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution_parameters.hpp
@@ -658,6 +658,53 @@ namespace hpx::execution::experimental::detail {
     HPX_HAS_MEMBER_XXX_TRAIT_DEF(adjust_chunk_size_and_max_chunks)
 
     ///////////////////////////////////////////////////////////////////////
+    // shared default implementation allowing to handle
+    // adjust_chunk_size_and_max_chunks
+    HPX_FORCEINLINE constexpr std::pair<std::size_t, std::size_t>
+    adjust_chunk_size_and_max_chunks_default(std::size_t num_elements,
+        std::size_t num_cores, std::size_t max_chunks,
+        std::size_t chunk_size) noexcept
+    {
+        if (max_chunks == 0)
+        {
+            if (chunk_size == 0)
+            {
+                std::size_t const cores_times_4 = 4 * num_cores;    // -V112
+
+                chunk_size = (num_elements + cores_times_4 - 1) / cores_times_4;
+
+                max_chunks =
+                    (std::min) (cores_times_4, num_elements);    // -V112
+
+                chunk_size = (std::max) (chunk_size,
+                    (num_elements + max_chunks - 1) / max_chunks);
+            }
+            else
+            {
+                // max_chunks == 0 && chunk_size != 0
+                max_chunks = (num_elements + chunk_size - 1) / chunk_size;
+            }
+        }
+        else if (chunk_size == 0)
+        {
+            chunk_size = (num_elements + max_chunks - 1) / max_chunks;
+        }
+        else
+        {
+            // max_chunks != 0 && chunk_size != 0
+            std::size_t const calculated_max_chunks =
+                (num_elements + chunk_size - 1) / chunk_size;
+
+            if (calculated_max_chunks > max_chunks)
+            {
+                chunk_size = (num_elements + max_chunks - 1) / max_chunks;
+            }
+        }
+
+        return {chunk_size, max_chunks};
+    }
+
+    ///////////////////////////////////////////////////////////////////////
     // default property implementation allowing to handle
     // adjust_chunk_size_and_max_chunks
     struct adjust_chunk_size_and_max_chunks_property
@@ -668,44 +715,8 @@ namespace hpx::execution::experimental::detail {
             std::size_t num_cores, std::size_t max_chunks,
             std::size_t chunk_size) noexcept
         {
-            if (max_chunks == 0)
-            {
-                if (chunk_size == 0)
-                {
-                    std::size_t const cores_times_4 = 4 * num_cores;    // -V112
-
-                    chunk_size =
-                        (num_elements + cores_times_4 - 1) / cores_times_4;
-
-                    max_chunks =
-                        (std::min) (cores_times_4, num_elements);    // -V112
-
-                    chunk_size = (std::max) (chunk_size,
-                        (num_elements + max_chunks - 1) / max_chunks);
-                }
-                else
-                {
-                    // max_chunks == 0 && chunk_size != 0
-                    max_chunks = (num_elements + chunk_size - 1) / chunk_size;
-                }
-            }
-            else if (chunk_size == 0)
-            {
-                chunk_size = (num_elements + max_chunks - 1) / max_chunks;
-            }
-            else
-            {
-                // max_chunks != 0 && chunk_size != 0
-                std::size_t const calculated_max_chunks =
-                    (num_elements + chunk_size - 1) / chunk_size;
-
-                if (calculated_max_chunks > max_chunks)
-                {
-                    chunk_size = (num_elements + max_chunks - 1) / max_chunks;
-                }
-            }
-
-            return {chunk_size, max_chunks};
+            return adjust_chunk_size_and_max_chunks_default(
+                num_elements, num_cores, max_chunks, chunk_size);
         }
     };
 

--- a/libs/core/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
@@ -17,9 +17,67 @@
 
 #include <cstddef>
 #include <type_traits>
+#include <algorithm>
 #include <utility>
 
 namespace hpx::execution::experimental {
+
+    HPX_FORCEINLINE constexpr std::pair<std::size_t, std::size_t>
+    adjust_chunk_size_and_max_chunks_default(std::size_t num_elements,
+        std::size_t num_cores, std::size_t max_chunks,
+        std::size_t chunk_size) noexcept
+    {
+        if (num_elements == 0)
+        {
+            return {0, 0};
+        }
+
+        if (max_chunks == 0)
+        {
+            if (chunk_size == 0)
+            {
+                std::size_t const cores_times_4 = 4 * num_cores;    // -V112
+
+                chunk_size = (num_elements + cores_times_4 - 1) / cores_times_4;
+
+                max_chunks = (num_elements + chunk_size - 1) / chunk_size;
+
+                max_chunks =
+                    (std::min) (max_chunks, num_elements);    // -V112
+
+                chunk_size = (std::max) (chunk_size,
+                    (num_elements + max_chunks - 1) / max_chunks);
+            }
+            else
+            {
+                // max_chunks == 0 && chunk_size != 0
+                max_chunks = (num_elements + chunk_size - 1) / chunk_size;
+            }
+        }
+        else if (chunk_size == 0)
+        {
+            chunk_size = (num_elements + max_chunks - 1) / max_chunks;
+
+            max_chunks = (num_elements + chunk_size - 1) / chunk_size;
+        }
+        else
+        {
+            // max_chunks != 0 && chunk_size != 0
+            std::size_t const calculated_max_chunks =
+                (num_elements + chunk_size - 1) / chunk_size;
+
+            if (calculated_max_chunks > max_chunks)
+            {
+                chunk_size = (num_elements + max_chunks - 1) / max_chunks;
+            }
+            else if (calculated_max_chunks < max_chunks)
+            {
+                max_chunks = calculated_max_chunks;
+            }
+        }
+
+        return {chunk_size, max_chunks};
+    }
 
     ///////////////////////////////////////////////////////////////////////////
     // Executor information customization points

--- a/libs/core/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
@@ -21,68 +21,71 @@
 #include <utility>
 
 namespace hpx::execution::experimental {
-
-    HPX_FORCEINLINE constexpr std::pair<std::size_t, std::size_t>
-    adjust_chunk_size_and_max_chunks_default(std::size_t num_elements,
-        std::size_t num_cores, std::size_t max_chunks,
-        std::size_t chunk_size) noexcept
-    {
-        if (num_elements == 0)
+    namespace detail {
+        HPX_FORCEINLINE constexpr std::pair<std::size_t, std::size_t>
+        adjust_chunk_size_and_max_chunks_default(std::size_t num_elements,
+            std::size_t num_cores, std::size_t max_chunks,
+            std::size_t chunk_size) noexcept
         {
-            return {0, 0};
-        }
-
-        // Ensure num_cores is at least 1 to prevent division by zero.
-        if (num_cores == 0)
-        {
-            num_cores = 1;
-        }
-
-        if (max_chunks == 0)
-        {
-            if (chunk_size == 0)
+            if (num_elements == 0)
             {
-                std::size_t const cores_times_4 = 4 * num_cores;    // -V112
+                return {0, 0};
+            }
 
-                chunk_size = (num_elements + cores_times_4 - 1) / cores_times_4;
+            // Ensure num_cores is at least 1 to prevent division by zero.
+            if (num_cores == 0)
+            {
+                num_cores = 1;
+            }
+
+            if (max_chunks == 0)
+            {
+                if (chunk_size == 0)
+                {
+                    std::size_t const cores_times_4 = 4 * num_cores;    // -V112
+
+                    chunk_size =
+                        (num_elements + cores_times_4 - 1) / cores_times_4;
+
+                    max_chunks = (num_elements + chunk_size - 1) / chunk_size;
+
+                    max_chunks =
+                        (std::min) (max_chunks, num_elements);    // -V112
+
+                    chunk_size = (std::max) (chunk_size,
+                        (num_elements + max_chunks - 1) / max_chunks);
+                }
+                else
+                {
+                    // max_chunks == 0 && chunk_size != 0
+                    max_chunks = (num_elements + chunk_size - 1) / chunk_size;
+                }
+            }
+            else if (chunk_size == 0)
+            {
+                chunk_size = (num_elements + max_chunks - 1) / max_chunks;
 
                 max_chunks = (num_elements + chunk_size - 1) / chunk_size;
-
-                max_chunks = (std::min) (max_chunks, num_elements);    // -V112
-
-                chunk_size = (std::max) (chunk_size,
-                    (num_elements + max_chunks - 1) / max_chunks);
             }
             else
             {
-                // max_chunks == 0 && chunk_size != 0
-                max_chunks = (num_elements + chunk_size - 1) / chunk_size;
-            }
-        }
-        else if (chunk_size == 0)
-        {
-            chunk_size = (num_elements + max_chunks - 1) / max_chunks;
+                // max_chunks != 0 && chunk_size != 0
+                std::size_t const calculated_max_chunks =
+                    (num_elements + chunk_size - 1) / chunk_size;
 
-            max_chunks = (num_elements + chunk_size - 1) / chunk_size;
-        }
-        else
-        {
-            // max_chunks != 0 && chunk_size != 0
-            std::size_t const calculated_max_chunks =
-                (num_elements + chunk_size - 1) / chunk_size;
-
-            if (calculated_max_chunks > max_chunks)
-            {
-                chunk_size = (num_elements + max_chunks - 1) / max_chunks;
+                if (calculated_max_chunks > max_chunks)
+                {
+                    chunk_size = (num_elements + max_chunks - 1) / max_chunks;
+                }
+                else if (calculated_max_chunks < max_chunks)
+                {
+                    max_chunks = calculated_max_chunks;
+                }
             }
-            else if (calculated_max_chunks < max_chunks)
-            {
-                max_chunks = calculated_max_chunks;
-            }
-        }
 
-        return {chunk_size, max_chunks};
-    }
+            return {chunk_size, max_chunks};
+        }
+    }    // namespace detail
 
     ///////////////////////////////////////////////////////////////////////////
     // Executor information customization points
@@ -566,8 +569,9 @@ namespace hpx::execution::experimental {
     ///                     algorithm.
     /// \param num_cores    [in] The overall number of cores to utilize
     ///                     for the algorithm.
-    /// \param num_chunks   [in] The overall number of chunks for the
-    ///                     algorithm.
+    /// \param max_chunks   [in] The overall maximal number of chunks for the
+    ///                     algorithm. A value of 0 denotes unspecified/compute
+    ///                     from num_elements and chunk_size.
     /// \param chunk_size   [in] The size of the chunks created for the
     ///                     algorithm.
     ///
@@ -585,13 +589,13 @@ namespace hpx::execution::experimental {
         friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
             collect_execution_parameters_t, Parameters&& params,
             Executor&& exec, std::size_t num_elements, std::size_t num_cores,
-            std::size_t num_chunks, std::size_t chunk_size)
+            std::size_t max_chunks, std::size_t chunk_size)
         {
             return detail::collect_execution_parameters_fn_helper<
                 hpx::util::decay_unwrap_t<Parameters>,
                 std::decay_t<Executor>>::call(HPX_FORWARD(Parameters, params),
                 HPX_FORWARD(Executor, exec), num_elements, num_cores,
-                num_chunks, chunk_size);
+                max_chunks, chunk_size);
         }
     } collect_execution_parameters{};
 
@@ -606,8 +610,9 @@ namespace hpx::execution::experimental {
     ///                     algorithm.
     /// \param num_cores    [in] The overall number of cores to utilize
     ///                     for the algorithm.
-    /// \param num_chunks   [in] The overall number of chunks for the
-    ///                     algorithm.
+    /// \param max_chunks   [in] The overall maximal number of chunks for the
+    ///                     algorithm. A value of 0 denotes unspecified/compute
+    ///                     from num_elements and chunk_size.
     /// \param chunk_size   [in] The size of the chunks created for the
     ///                     algorithm.
     ///
@@ -627,13 +632,13 @@ namespace hpx::execution::experimental {
         friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
             adjust_chunk_size_and_max_chunks_t, Parameters&& params,
             Executor&& exec, std::size_t num_elements, std::size_t num_cores,
-            std::size_t num_chunks, std::size_t chunk_size)
+            std::size_t max_chunks, std::size_t chunk_size)
         {
             return detail::adjust_chunk_size_and_max_chunks_fn_helper<
                 hpx::util::decay_unwrap_t<Parameters>,
                 std::decay_t<Executor>>::call(HPX_FORWARD(Parameters, params),
                 HPX_FORWARD(Executor, exec), num_elements, num_cores,
-                num_chunks, chunk_size);
+                max_chunks, chunk_size);
         }
     } adjust_chunk_size_and_max_chunks{};
 

--- a/libs/core/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
@@ -32,6 +32,12 @@ namespace hpx::execution::experimental {
             return {0, 0};
         }
 
+        // Ensure num_cores is at least 1 to prevent division by zero.
+        if (num_cores == 0)
+        {
+            num_cores = 1;
+        }
+
         if (max_chunks == 0)
         {
             if (chunk_size == 0)

--- a/libs/core/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
@@ -15,9 +15,9 @@
 #include <hpx/modules/timing.hpp>
 #include <hpx/modules/type_support.hpp>
 
+#include <algorithm>
 #include <cstddef>
 #include <type_traits>
-#include <algorithm>
 #include <utility>
 
 namespace hpx::execution::experimental {

--- a/libs/core/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
@@ -48,8 +48,7 @@ namespace hpx::execution::experimental {
 
                 max_chunks = (num_elements + chunk_size - 1) / chunk_size;
 
-                max_chunks =
-                    (std::min) (max_chunks, num_elements);    // -V112
+                max_chunks = (std::min) (max_chunks, num_elements);    // -V112
 
                 chunk_size = (std::max) (chunk_size,
                     (num_elements + max_chunks - 1) / max_chunks);

--- a/libs/core/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
@@ -65,6 +65,10 @@ namespace hpx::execution::experimental {
         template <typename Parameters, typename Executor,
             typename Enable = void>
         struct collect_execution_parameters_fn_helper;
+
+        template <typename Parameters, typename Executor,
+            typename Enable = void>
+        struct adjust_chunk_size_and_max_chunks_fn_helper;
         /// \endcond
     }    // namespace detail
 
@@ -527,6 +531,29 @@ namespace hpx::execution::experimental {
                 num_chunks, chunk_size);
         }
     } collect_execution_parameters{};
+
+    HPX_CXX_EXPORT inline constexpr struct adjust_chunk_size_and_max_chunks_t
+        final
+      : hpx::functional::detail::tag_priority<
+            adjust_chunk_size_and_max_chunks_t>
+    {
+    private:
+        template <typename Parameters, typename Executor>
+            requires(hpx::traits::is_executor_parameters_v<Parameters> &&
+                hpx::traits::is_executor_any_v<Executor>)
+        friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
+            adjust_chunk_size_and_max_chunks_t, Parameters&& params,
+            Executor&& exec, std::size_t num_elements, std::size_t num_cores,
+            std::size_t num_chunks, std::size_t chunk_size)
+        {
+            return detail::adjust_chunk_size_and_max_chunks_fn_helper<
+                hpx::util::decay_unwrap_t<Parameters>,
+                std::decay_t<Executor>>::call(HPX_FORWARD(Parameters, params),
+                HPX_FORWARD(Executor, exec), num_elements, num_cores,
+                num_chunks, chunk_size);
+        }
+
+    } adjust_chunk_size_and_max_chunks{};
 
     template <>
     struct is_scheduling_property<with_processing_units_count_t>

--- a/libs/core/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
@@ -532,8 +532,28 @@ namespace hpx::execution::experimental {
         }
     } collect_execution_parameters{};
 
-    HPX_CXX_EXPORT inline constexpr struct adjust_chunk_size_and_max_chunks_t
-        final
+    /// Adjust the chunk size and maximal number of chunks for a parallel
+    /// algorithm execution
+    ///
+    /// \param params   [in] The executor parameters object to use for
+    ///                 adjusting the chunk size.
+    /// \param exec     [in] The executor object which will be used
+    ///                 for scheduling of the loop iterations.
+    /// \param num_elements [in] The overall number of elements for the
+    ///                     algorithm.
+    /// \param num_cores    [in] The overall number of cores to utilize
+    ///                     for the algorithm.
+    /// \param num_chunks   [in] The overall number of chunks for the
+    ///                     algorithm.
+    /// \param chunk_size   [in] The size of the chunks created for the
+    ///                     algorithm.
+    ///
+    /// \note This calls params.adjust_chunk_size_and_max_chunks(exec, ...)
+    ///       if it exists; otherwise it returns {0, 0} indicating no
+    ///       adjustment.
+    ///
+    HPX_CXX_CORE_EXPORT inline constexpr struct
+        adjust_chunk_size_and_max_chunks_t final
       : hpx::functional::detail::tag_priority<
             adjust_chunk_size_and_max_chunks_t>
     {
@@ -552,7 +572,6 @@ namespace hpx::execution::experimental {
                 HPX_FORWARD(Executor, exec), num_elements, num_cores,
                 num_chunks, chunk_size);
         }
-
     } adjust_chunk_size_and_max_chunks{};
 
     template <>

--- a/libs/core/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
@@ -549,8 +549,8 @@ namespace hpx::execution::experimental {
     ///                     algorithm.
     ///
     /// \note This calls params.adjust_chunk_size_and_max_chunks(exec, ...)
-    ///       if it exists; otherwise it returns {0, 0} indicating no
-    ///       adjustment.
+    ///       if it exists; otherwise it applies the default chunk size and
+    ///       max chunks adjustment logic.
     ///
     HPX_CXX_CORE_EXPORT inline constexpr struct
         adjust_chunk_size_and_max_chunks_t final

--- a/libs/core/execution/include/hpx/execution/executors/rebind_executor_parameters.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/rebind_executor_parameters.hpp
@@ -16,6 +16,7 @@
 #include <concepts>
 #include <cstddef>
 #include <type_traits>
+#include <utility>
 
 namespace hpx::execution::experimental {
 
@@ -253,6 +254,22 @@ namespace hpx::execution::experimental {
             collect_execution_parameters_t, Params&&, InnerParams&&, Executor&&,
             std::size_t, std::size_t, std::size_t, std::size_t>;
 
+    // wrapping adjust_chunk_size_and_max_chunks
+    HPX_CXX_CORE_EXPORT template <typename Params, typename Executor>
+    inline constexpr bool supports_adjust_chunk_size_and_max_chunks_v =
+        hpx::functional::detail::is_tag_override_invocable_v<
+            adjust_chunk_size_and_max_chunks_t, Params&&, Executor&&,
+            std::size_t, std::size_t, std::size_t, std::size_t> ||
+        hpx::execution::experimental::detail::
+            has_adjust_chunk_size_and_max_chunks_v<std::decay_t<Params>>;
+
+    HPX_CXX_CORE_EXPORT template <typename Params, typename InnerParams,
+        typename Executor>
+    inline constexpr bool supports_wrapping_adjust_chunk_size_and_max_chunks_v =
+        hpx::functional::detail::is_tag_override_invocable_v<
+            adjust_chunk_size_and_max_chunks_t, Params&&, InnerParams&&,
+            Executor&&, std::size_t, std::size_t, std::size_t, std::size_t>;
+
     ///////////////////////////////////////////////////////////////////////////
     HPX_CXX_CORE_EXPORT template <typename Wrapped, typename Wrapping>
         requires(hpx::executor_parameters<Wrapped> &&
@@ -415,8 +432,8 @@ namespace hpx::execution::experimental {
                     detail::wrapped_forward<Params>(this_),
                     HPX_FORWARD(Executor, exec));
             }
-            if constexpr (supports_mark_begin_execution_v<
-                              detail::wrapping_t<Params>, Executor>)
+            else if constexpr (supports_mark_begin_execution_v<
+                                   detail::wrapping_t<Params>, Executor>)
             {
                 mark_begin_execution(detail::wrapping_forward<Params>(this_),
                     HPX_FORWARD(Executor, exec));
@@ -672,6 +689,54 @@ namespace hpx::execution::experimental {
             else
             {
                 collect_execution_parameters(
+                    detail::wrapped_forward<Params>(this_),
+                    HPX_FORWARD(Executor, exec), num_elements, num_cores,
+                    num_chunks, chunk_size);
+            }
+        }
+
+        // wrapping adjust_chunk_size_and_max_chunks
+
+        // clang-format off
+        template <typename Params, typename Executor>
+            requires(std::same_as<wrapped_params, std::decay_t<Params>> && (
+                supports_wrapping_adjust_chunk_size_and_max_chunks_v<
+                    detail::wrapping_t<Params>, detail::wrapped_t<Params>,
+                    Executor> ||
+                supports_adjust_chunk_size_and_max_chunks_v<
+                    detail::wrapping_t<Params>, Executor> ||
+                supports_adjust_chunk_size_and_max_chunks_v<
+                    detail::wrapped_t<Params>, Executor>
+            ))
+        // clang-format on
+        friend constexpr std::pair<std::size_t, std::size_t>
+        tag_override_invoke(
+            hpx::execution::experimental::adjust_chunk_size_and_max_chunks_t,
+            Params&& this_, Executor&& exec, std::size_t const num_elements,
+            std::size_t const num_cores, std::size_t const num_chunks,
+            std::size_t const chunk_size)
+        {
+            if constexpr (supports_wrapping_adjust_chunk_size_and_max_chunks_v<
+                              detail::wrapping_t<Params>,
+                              detail::wrapped_t<Params>, Executor>)
+            {
+                return adjust_chunk_size_and_max_chunks(
+                    detail::wrapping_forward<Params>(this_),
+                    detail::wrapped_forward<Params>(this_),
+                    HPX_FORWARD(Executor, exec), num_elements, num_cores,
+                    num_chunks, chunk_size);
+            }
+            else if constexpr (supports_adjust_chunk_size_and_max_chunks_v<
+                                   detail::wrapping_t<Params>, Executor>)
+            {
+                return adjust_chunk_size_and_max_chunks(
+                    detail::wrapping_forward<Params>(this_),
+                    HPX_FORWARD(Executor, exec), num_elements, num_cores,
+                    num_chunks, chunk_size);
+            }
+            else
+            {
+                return adjust_chunk_size_and_max_chunks(
                     detail::wrapped_forward<Params>(this_),
                     HPX_FORWARD(Executor, exec), num_elements, num_cores,
                     num_chunks, chunk_size);

--- a/libs/core/execution/tests/unit/executor_parameters_dispatching.cpp
+++ b/libs/core/execution/tests/unit/executor_parameters_dispatching.cpp
@@ -747,6 +747,7 @@ int hpx_main()
     test_mark_begin_execution();
     test_mark_end_of_scheduling();
     test_mark_end_execution();
+    test_adjust_chunk_size_and_max_chunks();
 
     return hpx::local::finalize();
 }

--- a/libs/core/execution/tests/unit/rebind_executor_parameters.cpp
+++ b/libs/core/execution/tests/unit/rebind_executor_parameters.cpp
@@ -896,11 +896,11 @@ void replace_adjust_chunk_size_and_max_chunks()
     {
         std::atomic<bool> invoked_replaced(false);
 
-        auto params =
-            join_executor_parameters(experimental::static_chunk_size());
+        auto params = join_executor_parameters(
+            hpx::execution::experimental::static_chunk_size());
         auto bound_params = rebind_executor_parameters(params,
             test_replaced_adjust_chunk_size_and_max_chunks(invoked_replaced));
-        auto policy = create_rebound_policy(par, bound_params);
+        auto policy = create_rebound_policy(hpx::execution::par, bound_params);
         parameters_test(policy);
 
         HPX_TEST(invoked_replaced);
@@ -910,10 +910,11 @@ void replace_adjust_chunk_size_and_max_chunks()
     {
         std::atomic<bool> invoked_replaced(false);
 
-        auto params = join_executor_parameters(experimental::max_num_chunks());
+        auto params = join_executor_parameters(
+            hpx::execution::experimental::max_num_chunks());
         auto bound_params = rebind_executor_parameters(params,
             test_replaced_adjust_chunk_size_and_max_chunks(invoked_replaced));
-        auto policy = create_rebound_policy(par, bound_params);
+        auto policy = create_rebound_policy(hpx::execution::par, bound_params);
         parameters_test(policy);
 
         HPX_TEST(invoked_replaced);
@@ -925,9 +926,9 @@ void replace_adjust_chunk_size_and_max_chunks()
 
         auto params = join_executor_parameters(
             test_replaced_adjust_chunk_size_and_max_chunks(invoked_replaced));
-        auto bound_params =
-            rebind_executor_parameters(params, experimental::num_cores(4));
-        auto policy = create_rebound_policy(par, bound_params);
+        auto bound_params = rebind_executor_parameters(
+            params, hpx::execution::experimental::num_cores(4));
+        auto policy = create_rebound_policy(hpx::execution::par, bound_params);
         parameters_test(policy);
 
         HPX_TEST(invoked_replaced);
@@ -943,7 +944,7 @@ void replace_adjust_chunk_size_and_max_chunks()
                 invoked_inner_replaced));
         auto bound_params = rebind_executor_parameters(params,
             test_wrapping_adjust_chunk_size_and_max_chunks(invoked_replaced));
-        auto policy = create_rebound_policy(par, bound_params);
+        auto policy = create_rebound_policy(hpx::execution::par, bound_params);
         parameters_test(policy);
 
         HPX_TEST(invoked_replaced);
@@ -1000,16 +1001,65 @@ void verify_single_mark_begin_dispatch()
     std::atomic<int> wrapping_wrapped_count(0);
     std::atomic<int> wrapping_only_count(0);
 
-    auto params = join_executor_parameters(experimental::num_cores(4));
+    auto params =
+        join_executor_parameters(hpx::execution::experimental::num_cores(4));
     auto bound_params = rebind_executor_parameters(params,
         test_dual_mark_begin_execution(
             wrapping_wrapped_count, wrapping_only_count));
-    auto policy = create_rebound_policy(par, bound_params);
+    auto policy = create_rebound_policy(hpx::execution::par, bound_params);
 
     parameters_test(policy);
 
     HPX_TEST_EQ(wrapping_wrapped_count.load(), 1);
     HPX_TEST_EQ(wrapping_only_count.load(), 0);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// test mark_begin_execution with non-wrapping overload only
+struct test_non_wrapping_mark_begin_execution
+{
+    explicit test_non_wrapping_mark_begin_execution(
+        std::atomic<int>& wrapping_only) noexcept
+      : wrapping_only(&wrapping_only)
+    {
+    }
+
+    template <typename Executor>
+    friend void tag_override_invoke(
+        hpx::execution::experimental::mark_begin_execution_t,
+        test_non_wrapping_mark_begin_execution const& self, Executor&&) noexcept
+    {
+        ++*self.wrapping_only;
+    }
+
+    std::atomic<int>* wrapping_only;
+};
+
+namespace hpx::execution::experimental {
+
+    template <>
+    struct is_executor_parameters<test_non_wrapping_mark_begin_execution>
+      : std::true_type
+    {
+    };
+}    // namespace hpx::execution::experimental
+
+void verify_non_wrapping_mark_begin_dispatch()
+{
+    using namespace hpx::execution;
+    using namespace hpx::execution::experimental;
+
+    std::atomic<int> wrapping_only_count(0);
+
+    auto params =
+        join_executor_parameters(hpx::execution::experimental::num_cores(4));
+    auto bound_params = rebind_executor_parameters(
+        params, test_non_wrapping_mark_begin_execution(wrapping_only_count));
+    auto policy = create_rebound_policy(hpx::execution::par, bound_params);
+
+    parameters_test(policy);
+
+    HPX_TEST_EQ(wrapping_only_count.load(), 1);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1023,6 +1073,7 @@ int hpx_main()
     replace_collect_execution_parameters();
     replace_adjust_chunk_size_and_max_chunks();
     verify_single_mark_begin_dispatch();
+    verify_non_wrapping_mark_begin_dispatch();
 
     return hpx::local::finalize();
 }

--- a/libs/core/execution/tests/unit/rebind_executor_parameters.cpp
+++ b/libs/core/execution/tests/unit/rebind_executor_parameters.cpp
@@ -478,6 +478,28 @@ struct test_replaced_execution_markers
     std::atomic<bool>* invoked_end_execution;
 };
 
+struct test_wrapping_replaced_execution_markers
+{
+    explicit test_wrapping_replaced_execution_markers(
+        std::atomic<bool>& invoked_begin) noexcept
+      : invoked_begin(&invoked_begin)
+    {
+    }
+
+    template <typename InnerParams, typename Executor>
+    friend void tag_override_invoke(
+        hpx::execution::experimental::mark_begin_execution_t,
+        test_wrapping_replaced_execution_markers self, InnerParams&& inner,
+        Executor&& exec) noexcept
+    {
+        hpx::execution::experimental::mark_begin_execution(
+            HPX_FORWARD(InnerParams, inner), HPX_FORWARD(Executor, exec));
+        *self.invoked_begin = true;
+    }
+
+    std::atomic<bool>* invoked_begin;
+};
+
 namespace hpx::execution::experimental {
 
     template <>
@@ -487,6 +509,12 @@ namespace hpx::execution::experimental {
 
     template <>
     struct is_executor_parameters<test_replaced_execution_markers>
+      : std::true_type
+    {
+    };
+
+    template <>
+    struct is_executor_parameters<test_wrapping_replaced_execution_markers>
       : std::true_type
     {
     };
@@ -575,6 +603,26 @@ void replace_execution_markers()
         HPX_TEST(invoked_begin);
         HPX_TEST(invoked_end);
         HPX_TEST(invoked_end_execution);
+    }
+
+    // test wrapped mark_begin_execution
+    {
+        std::atomic<bool> invoked_replaced(false);
+        std::atomic<bool> invoked_inner_replaced(false);
+        std::atomic<bool> invoked_inner_end(false);
+        std::atomic<bool> invoked_inner_end_execution(false);
+
+        auto params = join_executor_parameters(
+            test_replaced_execution_markers(invoked_inner_replaced,
+                invoked_inner_end, invoked_inner_end_execution));
+        auto rebound_params = rebind_executor_parameters(
+            params, test_wrapping_replaced_execution_markers(invoked_replaced));
+        auto policy =
+            create_rebound_policy(hpx::execution::par, rebound_params);
+        parameters_test(policy);
+
+        HPX_TEST(invoked_replaced);
+        HPX_TEST(invoked_inner_replaced);
     }
 }
 

--- a/libs/core/execution/tests/unit/rebind_executor_parameters.cpp
+++ b/libs/core/execution/tests/unit/rebind_executor_parameters.cpp
@@ -806,6 +806,213 @@ void replace_collect_execution_parameters()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// test parameters object with adjust_chunk_size_and_max_chunks
+struct test_replaced_adjust_chunk_size_and_max_chunks
+{
+    explicit test_replaced_adjust_chunk_size_and_max_chunks(
+        std::atomic<bool>& invoked) noexcept
+      : invoked(&invoked)
+    {
+    }
+
+    template <typename Executor>
+    friend std::pair<std::size_t, std::size_t> tag_override_invoke(
+        hpx::execution::experimental::adjust_chunk_size_and_max_chunks_t,
+        test_replaced_adjust_chunk_size_and_max_chunks& self, Executor&&,
+        std::size_t num_elements, std::size_t num_cores, std::size_t num_chunks,
+        std::size_t chunk_size) noexcept
+    {
+        *self.invoked = true;
+
+        if (chunk_size == 0)
+        {
+            chunk_size = (num_elements + num_cores - 1) / num_cores;
+        }
+
+        if (chunk_size == 0)
+        {
+            chunk_size = 1;
+        }
+
+        if (num_chunks == 0)
+        {
+            num_chunks = (num_elements + chunk_size - 1) / chunk_size;
+        }
+
+        return {chunk_size, num_chunks};
+    }
+
+    std::atomic<bool>* invoked;
+};
+
+struct test_wrapping_adjust_chunk_size_and_max_chunks
+{
+    explicit test_wrapping_adjust_chunk_size_and_max_chunks(
+        std::atomic<bool>& invoked) noexcept
+      : invoked(&invoked)
+    {
+    }
+
+    template <typename InnerParams, typename Executor>
+    friend std::pair<std::size_t, std::size_t> tag_override_invoke(
+        hpx::execution::experimental::adjust_chunk_size_and_max_chunks_t,
+        test_wrapping_adjust_chunk_size_and_max_chunks& self,
+        InnerParams&& inner, Executor&& exec, std::size_t num_elements,
+        std::size_t num_cores, std::size_t num_chunks, std::size_t chunk_size)
+    {
+        auto result =
+            hpx::execution::experimental::adjust_chunk_size_and_max_chunks(
+                HPX_FORWARD(InnerParams, inner), HPX_FORWARD(Executor, exec),
+                num_elements, num_cores, num_chunks, chunk_size);
+
+        *self.invoked = true;
+        return result;
+    }
+
+    std::atomic<bool>* invoked;
+};
+
+namespace hpx::execution::experimental {
+
+    template <>
+    struct is_executor_parameters<
+        test_replaced_adjust_chunk_size_and_max_chunks> : std::true_type
+    {
+    };
+
+    template <>
+    struct is_executor_parameters<
+        test_wrapping_adjust_chunk_size_and_max_chunks> : std::true_type
+    {
+    };
+}    // namespace hpx::execution::experimental
+
+void replace_adjust_chunk_size_and_max_chunks()
+{
+    using namespace hpx::execution;
+    using namespace hpx::execution::experimental;
+
+    // replace chunk adjustment with another parameters object exposing it
+    {
+        std::atomic<bool> invoked_replaced(false);
+
+        auto params =
+            join_executor_parameters(experimental::static_chunk_size());
+        auto bound_params = rebind_executor_parameters(params,
+            test_replaced_adjust_chunk_size_and_max_chunks(invoked_replaced));
+        auto policy = create_rebound_policy(par, bound_params);
+        parameters_test(policy);
+
+        HPX_TEST(invoked_replaced);
+    }
+
+    // replace a parameters object not exposing chunk adjustment
+    {
+        std::atomic<bool> invoked_replaced(false);
+
+        auto params = join_executor_parameters(experimental::max_num_chunks());
+        auto bound_params = rebind_executor_parameters(params,
+            test_replaced_adjust_chunk_size_and_max_chunks(invoked_replaced));
+        auto policy = create_rebound_policy(par, bound_params);
+        parameters_test(policy);
+
+        HPX_TEST(invoked_replaced);
+    }
+
+    // replace chunk adjustment with a parameters object not exposing it
+    {
+        std::atomic<bool> invoked_replaced(false);
+
+        auto params = join_executor_parameters(
+            test_replaced_adjust_chunk_size_and_max_chunks(invoked_replaced));
+        auto bound_params =
+            rebind_executor_parameters(params, experimental::num_cores(4));
+        auto policy = create_rebound_policy(par, bound_params);
+        parameters_test(policy);
+
+        HPX_TEST(invoked_replaced);
+    }
+
+    // test wrapped chunk adjustment
+    {
+        std::atomic<bool> invoked_replaced(false);
+        std::atomic<bool> invoked_inner_replaced(false);
+
+        auto params = join_executor_parameters(
+            test_replaced_adjust_chunk_size_and_max_chunks(
+                invoked_inner_replaced));
+        auto bound_params = rebind_executor_parameters(params,
+            test_wrapping_adjust_chunk_size_and_max_chunks(invoked_replaced));
+        auto policy = create_rebound_policy(par, bound_params);
+        parameters_test(policy);
+
+        HPX_TEST(invoked_replaced);
+        HPX_TEST(invoked_inner_replaced);
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// test mark_begin_execution dispatching order
+struct test_dual_mark_begin_execution
+{
+    explicit test_dual_mark_begin_execution(std::atomic<int>& wrapping_wrapped,
+        std::atomic<int>& wrapping_only) noexcept
+      : wrapping_wrapped(&wrapping_wrapped)
+      , wrapping_only(&wrapping_only)
+    {
+    }
+
+    template <typename InnerParams, typename Executor>
+    friend void tag_override_invoke(
+        hpx::execution::experimental::mark_begin_execution_t,
+        test_dual_mark_begin_execution& self, InnerParams&&,
+        Executor&&) noexcept
+    {
+        ++*self.wrapping_wrapped;
+    }
+
+    template <typename Executor>
+    friend void tag_override_invoke(
+        hpx::execution::experimental::mark_begin_execution_t,
+        test_dual_mark_begin_execution& self, Executor&&) noexcept
+    {
+        ++*self.wrapping_only;
+    }
+
+    std::atomic<int>* wrapping_wrapped;
+    std::atomic<int>* wrapping_only;
+};
+
+namespace hpx::execution::experimental {
+
+    template <>
+    struct is_executor_parameters<test_dual_mark_begin_execution>
+      : std::true_type
+    {
+    };
+}    // namespace hpx::execution::experimental
+
+void verify_single_mark_begin_dispatch()
+{
+    using namespace hpx::execution;
+    using namespace hpx::execution::experimental;
+
+    std::atomic<int> wrapping_wrapped_count(0);
+    std::atomic<int> wrapping_only_count(0);
+
+    auto params = join_executor_parameters(experimental::num_cores(4));
+    auto bound_params = rebind_executor_parameters(params,
+        test_dual_mark_begin_execution(
+            wrapping_wrapped_count, wrapping_only_count));
+    auto policy = create_rebound_policy(par, bound_params);
+
+    parameters_test(policy);
+
+    HPX_TEST_EQ(wrapping_wrapped_count.load(), 1);
+    HPX_TEST_EQ(wrapping_only_count.load(), 0);
+}
+
+///////////////////////////////////////////////////////////////////////////////
 int hpx_main()
 {
     replace_chunk_size();
@@ -814,6 +1021,8 @@ int hpx_main()
     replace_execution_markers();
     replace_processing_units_count();
     replace_collect_execution_parameters();
+    replace_adjust_chunk_size_and_max_chunks();
+    verify_single_mark_begin_dispatch();
 
     return hpx::local::finalize();
 }

--- a/libs/core/execution/tests/unit/rebind_executor_parameters.cpp
+++ b/libs/core/execution/tests/unit/rebind_executor_parameters.cpp
@@ -1063,6 +1063,30 @@ void verify_single_mark_begin_dispatch()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// test mark_begin_execution dispatching order with inner param providing marker
+void verify_single_mark_begin_dispatch_with_inner_marker()
+{
+    using namespace hpx::execution;
+    using namespace hpx::execution::experimental;
+
+    std::atomic<int> wrapping_wrapped_count(0);
+    std::atomic<int> wrapping_only_count(0);
+
+    // Use base_execution_markers as inner -- it provides mark_begin_execution
+    auto params = join_executor_parameters(base_execution_markers());
+    auto bound_params = rebind_executor_parameters(params,
+        test_dual_mark_begin_execution(
+            wrapping_wrapped_count, wrapping_only_count));
+    auto policy = create_rebound_policy(hpx::execution::par, bound_params);
+
+    parameters_test(policy);
+
+    // The wrapping-aware (3-arg) overload must be preferred
+    HPX_TEST_EQ(wrapping_wrapped_count.load(), 1);
+    HPX_TEST_EQ(wrapping_only_count.load(), 0);
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // test mark_begin_execution with non-wrapping overload only
 struct test_non_wrapping_mark_begin_execution
 {
@@ -1121,6 +1145,7 @@ int hpx_main()
     replace_collect_execution_parameters();
     replace_adjust_chunk_size_and_max_chunks();
     verify_single_mark_begin_dispatch();
+    verify_single_mark_begin_dispatch_with_inner_marker();
     verify_non_wrapping_mark_begin_dispatch();
 
     return hpx::local::finalize();

--- a/libs/core/execution/tests/unit/rebind_executor_parameters.cpp
+++ b/libs/core/execution/tests/unit/rebind_executor_parameters.cpp
@@ -965,7 +965,7 @@ struct test_dual_mark_begin_execution
     template <typename InnerParams, typename Executor>
     friend void tag_override_invoke(
         hpx::execution::experimental::mark_begin_execution_t,
-        test_dual_mark_begin_execution& self, InnerParams&&,
+        test_dual_mark_begin_execution const& self, InnerParams&&,
         Executor&&) noexcept
     {
         ++*self.wrapping_wrapped;
@@ -974,7 +974,7 @@ struct test_dual_mark_begin_execution
     template <typename Executor>
     friend void tag_override_invoke(
         hpx::execution::experimental::mark_begin_execution_t,
-        test_dual_mark_begin_execution& self, Executor&&) noexcept
+        test_dual_mark_begin_execution const& self, Executor&&) noexcept
     {
         ++*self.wrapping_only;
     }

--- a/libs/core/executors/include/hpx/executors/thread_pool_scheduler.hpp
+++ b/libs/core/executors/include/hpx/executors/thread_pool_scheduler.hpp
@@ -179,7 +179,14 @@ namespace hpx::execution::experimental {
             thread_pool_policy_scheduler const& lhs,
             thread_pool_policy_scheduler const& rhs) noexcept
         {
-            return lhs.pool_ == rhs.pool_ && lhs.policy_ == rhs.policy_;
+            if constexpr (requires { lhs.policy_ == rhs.policy_; })
+            {
+                return lhs.pool_ == rhs.pool_ && lhs.policy_ == rhs.policy_;
+            }
+            else
+            {
+                return lhs.pool_ == rhs.pool_;
+            }
         }
 
         friend constexpr bool operator!=(


### PR DESCRIPTION
Fixes #6647

## Proposed Changes
  Created a helper function that reduces the partition value without the need of initial value..
  Added a test case that was mentioned in the issue #6647. 
  Corrected a typo in documentation.

I only did changes in :
1) hpx\libs\core\algorithms\include\hpx\parallel\algorithms\reduce.hpp
2) hpx\libs\core\algorithms\tests\regressions\CMakeLists.txt
3) the rest were changes due to clang and editor.config

And created this :
1) hpx\libs\core\algorithms\tests\regressions\reduce_6647.cpp


## Any background context you want to provide?
Previously, the implementation assumed that the *first was convertible to T. This assumption does not hold for the actual function logic required here. This PR removes that dependency, ensuring the type handling is correct.


## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [x] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
