### PR TITLE
Added SPDX License Identifier

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -36,7 +36,7 @@ It should be easy!
 If you create new files, please use our License Header:
 
     //  Copyright (c) <year> <your name>
-    //
+    //  SPDX-License-Identifier: BSL-1.0
     //  Distributed under the Boost Software License, Version 1.0. (See accompanying
     //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 


### PR DESCRIPTION
Fixes #

## Proposed Changes
Updated the license header template in CONTRIBUTING.md to explicitly include the SPDX License Identifier (// SPDX-License-Identifier: BSL-1.0).

## Any background context you want to provide?
The CI inspect tool requires an SPDX identifier to pass on new files. However, the previous documentation in CONTRIBUTING.md did not include this line in the example header, leading to potential CI failures for new contributors following the guide exactly.

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
