### PR TITLE
Fix initialization hang when --hpx:threads exceeds --hpx:cores

### DIFF
--- a/libs/core/affinity/src/parse_affinity_options.cpp
+++ b/libs/core/affinity/src/parse_affinity_options.cpp
@@ -837,8 +837,12 @@ namespace hpx::threads::detail {
         std::vector<std::size_t> next_pu_index(num_cores, 0);
         num_pus.resize(num_threads);
 
-        for (std::size_t num_thread = 0; num_thread < num_threads; /**/)
+        bool made_progress = true;
+        for (std::size_t num_thread = 0;
+            num_thread < num_threads && made_progress;
+            /**/)
         {
+            made_progress = false;
             for (std::size_t num_core = 0; num_core < num_cores; ++num_core)
             {
                 if (any(affinities[num_thread]))
@@ -880,8 +884,14 @@ namespace hpx::threads::detail {
                 affinities[num_thread] = t.init_thread_affinity_mask(
                     num_core + used_cores, next_pu_index[num_core] - 1);
 
+                made_progress = true;
                 if (++num_thread == num_threads)
                     return;
+            }
+            if (num_thread < num_threads && !made_progress)
+            {
+                std::fill(next_pu_index.begin(), next_pu_index.end(), 0);
+                made_progress = true;
             }
         }
     }
@@ -894,7 +904,7 @@ namespace hpx::threads::detail {
     {
         std::size_t const num_threads = affinities.size();
 
-        // check_num_threads(use_process_mask, t, num_threads, ec);
+        check_num_threads(use_process_mask, t, num_threads, ec);
 
         if (use_process_mask)
         {


### PR DESCRIPTION
Fixes #6345

## Proposed Changes

- Modified libs/core/affinity/src/parse_affinity_options.cpp to add wrap-around logic to decode_balanced_distribution.
- When using balanced distribution with oversubscription (more threads than available PUs), the loop now resets the PU cursor (next_pu_index) when progress stops, allowing it to reuse PUs instead of hanging in an infinite loop.
- Added a made_progress flag to detect when a full sweep of cores yields no new PU assignments.

## Any background context you want to provide?

Previously, when --hpx:threads exceeded the number of available PUs , given by the set --hpx:cores (oversubscription) and the balanced distribution was used, the affinity binder would hang indefinitely during initialization. This occurred because the affinity loop expected to find a unique, unoccupied PU for every thread but had no mechanism to reuse PUs once all were exhausted. This fix implements the missing wrap-around logic, similar to how compact (implicitly) handles oversubscription.

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [x] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
