### PR TITLE
refactor execution parameters and steady clock usage

### DIFF
--- a/libs/core/execution/include/hpx/execution/executors/auto_chunk_size.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/auto_chunk_size.hpp
@@ -45,7 +45,7 @@ namespace hpx::execution::experimental {
         ///
         constexpr explicit auto_chunk_size(
             std::uint64_t const num_iters_for_timing = 0) noexcept
-          : min_time_(200000)
+          : min_time_(std::chrono::nanoseconds(200000))
           , num_iters_for_timing_(num_iters_for_timing)
         {
         }
@@ -60,7 +60,8 @@ namespace hpx::execution::experimental {
         ///
         explicit auto_chunk_size(hpx::chrono::steady_duration const& rel_time,
             std::uint64_t const num_iters_for_timing = 0) noexcept
-          : min_time_(rel_time.value().count())
+          : min_time_(std::chrono::duration_cast<std::chrono::nanoseconds>(
+                rel_time.value()))
           , num_iters_for_timing_(num_iters_for_timing)
         {
         }
@@ -98,7 +99,8 @@ namespace hpx::execution::experimental {
                 if (test_chunk_size != 0)
                 {
                     t = (high_resolution_clock::now() - t) / test_chunk_size;
-                    if (t != 0 && this_.min_time_ >= t)
+                    if (t != 0 &&
+                        this_.min_time_ >= std::chrono::nanoseconds(t))
                     {
                         // return execution time for one iteration
                         return std::chrono::nanoseconds(t);
@@ -118,13 +120,14 @@ namespace hpx::execution::experimental {
             std::size_t const cores, std::size_t const count) noexcept
         {
             // return chunk size which will create the required amount of work
-            if (iteration_duration.value().count() != 0)
+            if (iteration_duration.value() !=
+                std::chrono::steady_clock::duration::zero())
             {
                 auto const ns =
                     std::chrono::duration_cast<std::chrono::nanoseconds>(
                         iteration_duration.value());
                 return (std::min) (count,
-                    (std::size_t) (this_.min_time_ / ns.count()));
+                    (std::size_t) (this_.min_time_.count() / ns.count()));
             }
             return (count + cores - 1) / cores;
         }
@@ -145,8 +148,8 @@ namespace hpx::execution::experimental {
 
     private:
         /// \cond NOINTERNAL
-        // target time for on thread (nanoseconds)
-        std::uint64_t min_time_;
+        // target time for one thread (nanoseconds)
+        std::chrono::nanoseconds min_time_;
 
         // number of iteration to use for timing
         std::uint64_t num_iters_for_timing_;

--- a/libs/core/execution/include/hpx/execution/executors/persistent_auto_chunk_size.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/persistent_auto_chunk_size.hpp
@@ -44,8 +44,8 @@ namespace hpx::execution::experimental {
         ///
         constexpr explicit persistent_auto_chunk_size(
             std::uint64_t const num_iters_for_timing = 0) noexcept
-          : chunk_size_time_(0)
-          , min_time_(200000)
+          : chunk_size_time_(std::chrono::nanoseconds(0))
+          , min_time_(std::chrono::nanoseconds(200000))
           , num_iters_for_timing_(num_iters_for_timing)
         {
         }
@@ -61,8 +61,10 @@ namespace hpx::execution::experimental {
         explicit persistent_auto_chunk_size(
             hpx::chrono::steady_duration const& time_cs,
             std::uint64_t const num_iters_for_timing = 0) noexcept
-          : chunk_size_time_(time_cs.value().count())
-          , min_time_(200000)
+          : chunk_size_time_(
+                std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    time_cs.value()))
+          , min_time_(std::chrono::nanoseconds(200000))
           , num_iters_for_timing_(num_iters_for_timing)
         {
         }
@@ -80,8 +82,11 @@ namespace hpx::execution::experimental {
         persistent_auto_chunk_size(hpx::chrono::steady_duration const& time_cs,
             hpx::chrono::steady_duration const& rel_time,
             std::uint64_t const num_iters_for_timing = 0) noexcept
-          : chunk_size_time_(time_cs.value().count())
-          , min_time_(rel_time.value().count())
+          : chunk_size_time_(
+                std::chrono::duration_cast<std::chrono::nanoseconds>(
+                    time_cs.value()))
+          , min_time_(std::chrono::duration_cast<std::chrono::nanoseconds>(
+                rel_time.value()))
           , num_iters_for_timing_(num_iters_for_timing)
         {
         }
@@ -114,18 +119,20 @@ namespace hpx::execution::experimental {
                     f(this_.num_iters_for_timing_);
                 if (test_chunk_size != 0)
                 {
-                    if (this_.chunk_size_time_ == 0)
+                    if (this_.chunk_size_time_ == std::chrono::nanoseconds(0))
                     {
                         t = (high_resolution_clock::now() - t) /
                             test_chunk_size;
-                        this_.chunk_size_time_ = t;
+                        this_.chunk_size_time_ = std::chrono::nanoseconds(t);
                     }
                     else
                     {
-                        t = this_.chunk_size_time_;
+                        t = static_cast<std::uint64_t>(
+                            this_.chunk_size_time_.count());
                     }
 
-                    if (t != 0 && this_.min_time_ >= t)
+                    if (t != 0 &&
+                        this_.min_time_ >= std::chrono::nanoseconds(t))
                     {
                         // return execution time for one iteration
                         return std::chrono::nanoseconds(t);
@@ -145,13 +152,14 @@ namespace hpx::execution::experimental {
             std::size_t const cores, std::size_t const count) noexcept
         {
             // return chunk size which will create the required amount of work
-            if (iteration_duration.value().count() != 0)
+            if (iteration_duration.value() !=
+                std::chrono::steady_clock::duration::zero())
             {
                 auto const ns =
                     std::chrono::duration_cast<std::chrono::nanoseconds>(
                         iteration_duration.value());
                 return (std::min) (count,
-                    (std::size_t) (this_.min_time_ / ns.count()));
+                    (std::size_t) (this_.min_time_.count() / ns.count()));
             }
             return (count + cores - 1) / cores;
         }
@@ -172,8 +180,8 @@ namespace hpx::execution::experimental {
 
     private:
         /// \cond NOINTERNAL
-        std::uint64_t chunk_size_time_;    // nanoseconds
-        std::uint64_t min_time_;           // nanoseconds
+        std::chrono::nanoseconds chunk_size_time_;
+        std::chrono::nanoseconds min_time_;
         // number of iteration to use for timing
         std::uint64_t num_iters_for_timing_;
         /// \endcond

--- a/libs/core/execution_base/include/hpx/execution_base/agent_ref.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/agent_ref.hpp
@@ -59,18 +59,28 @@ namespace hpx::execution_base {
 
         template <typename Rep, typename Period>
         void sleep_for(std::chrono::duration<Rep, Period> const& sleep_duration,
-            char const* desc = "hpx::execution_base::agent_ref::sleep_for")
+            char const* desc =
+                "hpx::execution_base::agent_ref::sleep_for") const
         {
             sleep_for(hpx::chrono::steady_duration{sleep_duration}, desc);
         }
 
+        void sleep_for(hpx::chrono::steady_duration const& sleep_duration,
+            char const* desc =
+                "hpx::execution_base::agent_ref::sleep_for") const;
+
         template <typename Clock, typename Duration>
         void sleep_until(
             std::chrono::time_point<Clock, Duration> const& sleep_time,
-            char const* desc = "hpx::execution_base::agent_ref::sleep_until")
+            char const* desc =
+                "hpx::execution_base::agent_ref::sleep_until") const
         {
             sleep_until(hpx::chrono::steady_time_point{sleep_time}, desc);
         }
+
+        void sleep_until(hpx::chrono::steady_time_point const& sleep_time,
+            char const* desc =
+                "hpx::execution_base::agent_ref::sleep_until") const;
 
         [[nodiscard]] agent_base& ref() const noexcept
         {
@@ -84,11 +94,6 @@ namespace hpx::execution_base {
 
     private:
         agent_base* impl_ = nullptr;
-
-        void sleep_for(hpx::chrono::steady_duration const& sleep_duration,
-            char const* desc) const;
-        void sleep_until(hpx::chrono::steady_time_point const& sleep_time,
-            char const* desc) const;
 
         friend constexpr bool operator==(
             agent_ref const& lhs, agent_ref const& rhs) noexcept

--- a/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
+++ b/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
@@ -627,7 +627,9 @@ namespace hpx { namespace components { namespace server {
                         return tm.is_busy();
                     },
                     shutdown_check_count,
-                    std::chrono::duration<double>(timeout),
+                    hpx::chrono::steady_duration(
+                        std::chrono::duration_cast<std::chrono::nanoseconds>(
+                            std::chrono::duration<double>(timeout))),
                     "runtime_support::stop");
 
                 // If it took longer than expected, kill all suspended threads as
@@ -642,7 +644,9 @@ namespace hpx { namespace components { namespace server {
                             return tm.is_busy();
                         },
                         shutdown_check_count,
-                        std::chrono::duration<double>(timeout),
+                        hpx::chrono::steady_duration(std::chrono::duration_cast<
+                            std::chrono::nanoseconds>(
+                            std::chrono::duration<double>(timeout))),
                         "runtime_support::stop");
                 }
 


### PR DESCRIPTION
Fixes #6000 

## Proposed Changes

  - removed deprecated aliases for executor parameters (e.g., auto_chunk_size) from hpx::execution namespace, fully moving them to hpx::execution::experimental.
  - refactored steady_clock usage across core modules (threading, synchronization, timers) to use standard std::chrono types directly, removing reliance on custom HPX wrapper methods like .from_now() and .value().
  - fixed duration casting in runtime_support_server to ensure correct shutdown behavior with the updated clock implementation.

## Any background context you want to provide?

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
