### PR TITLE
Cleaning up recently added debug suffix configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2601,15 +2601,14 @@ endif()
 # Only set debug postfix for Debug builds to maintain ABI separation
 get_property(is_multi_config GLOBAL PROPERTY GENERATOR_IS_MULTI_CONFIG)
 if(is_multi_config OR CMAKE_BUILD_TYPE STREQUAL "Debug")
-  if(NOT DEFINED HPX_DEBUG_POSTFIX)
-    set(HPX_DEBUG_POSTFIX
-        "d"
-        CACHE STRING "Postfix for debug libraries"
-    )
-  endif()
-  set(CMAKE_DEBUG_POSTFIX "${HPX_DEBUG_POSTFIX}")
-  if(NOT "${HPX_DEBUG_POSTFIX}" STREQUAL "")
-    hpx_add_config_define(HPX_DEBUG_POSTFIX "${HPX_DEBUG_POSTFIX}")
+  hpx_option(
+    HPX_WITH_DEBUG_POSTFIX STRING
+    "Postfix for debug libraries. (default: \"d\")" "d" ADVANCED
+    CATEGORY "Build Targets"
+  )
+  set(CMAKE_DEBUG_POSTFIX "${HPX_WITH_DEBUG_POSTFIX}")
+  if(NOT "${HPX_WITH_DEBUG_POSTFIX}" STREQUAL "")
+    hpx_add_config_define(HPX_HAVE_DEBUG_POSTFIX "${HPX_WITH_DEBUG_POSTFIX}")
   endif()
 endif()
 

--- a/cmake/templates/HPXConfig.cmake.in
+++ b/cmake/templates/HPXConfig.cmake.in
@@ -140,7 +140,6 @@ set(HPX_VERSION_MINOR @HPX_VERSION_MINOR@)
 set(HPX_VERSION_SUBMINOR @HPX_VERSION_SUBMINOR@)
 
 set(HPX_PREFIX "${_hpx_root_dir}")
-set(HPX_DEBUG_POSTFIX "@HPX_DEBUG_POSTFIX@")
 set(HPX_BUILD_TYPE "@CMAKE_BUILD_TYPE@")
 set(HPX_CXX_STANDARD "@HPX_CXX_STANDARD@")
 # We explicitly set the default to 98 to force CMake to emit a -std=c++XX flag.

--- a/docs/sphinx/manual/building_hpx.rst
+++ b/docs/sphinx/manual/building_hpx.rst
@@ -121,7 +121,7 @@ used CMake options.
 
    Build tests.
 
-.. option:: HPX_DEBUG_POSTFIX
+.. option:: HPX_WITH_DEBUG_POSTFIX
 
    Set the postfix for debug libraries. The default is ``d``. This variable is used to set ``CMAKE_DEBUG_POSTFIX`` and is only relevant for Debug builds or multi-configuration generators. The default rarely needs to be changed. It ensures that generated debug binaries have a different name than release binaries, which is important to avoid ABI problems when both debug and release binaries are installed on the same system.
 

--- a/libs/core/config/include/hpx/config.hpp
+++ b/libs/core/config/include/hpx/config.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2018 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c) 2011 Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -259,28 +259,28 @@
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
-#if defined(HPX_DEBUG) && defined(HPX_DEBUG_POSTFIX)
-#  define HPX_DEBUG_POSTFIX_STR HPX_PP_STRINGIZE(HPX_DEBUG_POSTFIX)
+#if defined(HPX_DEBUG) && defined(HPX_HAVE_DEBUG_POSTFIX)
+#  define HPX_DEBUG_POSTFIX_STR HPX_PP_STRINGIZE(HPX_HAVE_DEBUG_POSTFIX)
 #else
 #  define HPX_DEBUG_POSTFIX_STR ""
 #endif
 
 #if !defined(HPX_WINDOWS)
-#  if defined(HPX_DEBUG) && defined(HPX_DEBUG_POSTFIX)
+#  if defined(HPX_DEBUG) && defined(HPX_HAVE_DEBUG_POSTFIX)
 #    define HPX_MAKE_DLL_STRING(n)                                             \
         "lib" + (n) + HPX_DEBUG_POSTFIX_STR + HPX_SHARED_LIB_EXTENSION
 #  else
 #    define HPX_MAKE_DLL_STRING(n)  "lib" + (n) + HPX_SHARED_LIB_EXTENSION
 #  endif
-#elif defined(HPX_DEBUG) && defined(HPX_DEBUG_POSTFIX)
+#elif defined(HPX_DEBUG) && defined(HPX_HAVE_DEBUG_POSTFIX)
 #  define HPX_MAKE_DLL_STRING(n)                                               \
       ((n) + HPX_DEBUG_POSTFIX_STR + HPX_SHARED_LIB_EXTENSION)
 #else
 #  define HPX_MAKE_DLL_STRING(n)   ((n) + HPX_SHARED_LIB_EXTENSION)
 #endif
 
-#if defined(HPX_DEBUG) && defined(HPX_DEBUG_POSTFIX)
-#  define HPX_MANGLE_NAME(n)     HPX_PP_CAT(n, HPX_DEBUG_POSTFIX)
+#if defined(HPX_DEBUG) && defined(HPX_HAVE_DEBUG_POSTFIX)
+#  define HPX_MANGLE_NAME(n)     HPX_PP_CAT(n, HPX_HAVE_DEBUG_POSTFIX)
 #  define HPX_MANGLE_STRING(n)   ((n) + HPX_DEBUG_POSTFIX_STR)
 #else
 #  define HPX_MANGLE_NAME(n)     n


### PR DESCRIPTION
- flyby: adjusting to HPX naming conventions
