### PR TITLE
Fixing various compilation regressions

### DIFF
--- a/.circleci/tests.unit1.algorithms
+++ b/.circleci/tests.unit1.algorithms
@@ -35,3 +35,6 @@ tests.unit.modules.algorithms.algorithms.findfirstof
 tests.unit.modules.algorithms.algorithms.findfirstof_binary
 tests.unit.modules.algorithms.algorithms.findif
 tests.unit.modules.algorithms.algorithms.findifnot
+tests.unit.modules.algorithms.algorithms.find_last
+tests.unit.modules.algorithms.algorithms.find_last_if
+tests.unit.modules.algorithms.algorithms.find_last_if_not

--- a/.github/test-targets/tests.unit1.algorithms
+++ b/.github/test-targets/tests.unit1.algorithms
@@ -35,3 +35,6 @@ tests.unit.modules.algorithms.algorithms.findfirstof
 tests.unit.modules.algorithms.algorithms.findfirstof_binary
 tests.unit.modules.algorithms.algorithms.findif
 tests.unit.modules.algorithms.algorithms.findifnot
+tests.unit.modules.algorithms.algorithms.find_last
+tests.unit.modules.algorithms.algorithms.find_last_if
+tests.unit.modules.algorithms.algorithms.find_last_if_not

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/find.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/find.hpp
@@ -1898,8 +1898,7 @@ namespace hpx::parallel::detail {
                     base_idx, it, part_size, tok, val, HPX_FORWARD(Proj, proj));
             };
 
-            auto f2 = [tok, count, first, last](
-                          auto&&... data) mutable -> Iter {
+            auto f2 = [tok, first, last](auto&&... data) mutable -> Iter {
                 static_assert(sizeof...(data) < 2);
                 if constexpr (sizeof...(data) == 1)
                 {
@@ -1986,8 +1985,7 @@ namespace hpx::parallel::detail {
                     tok, HPX_FORWARD(F, f), HPX_FORWARD(Proj, proj));
             };
 
-            auto f2 = [tok, count, first, last](
-                          auto&&... data) mutable -> Iter {
+            auto f2 = [tok, first, last](auto&&... data) mutable -> Iter {
                 static_assert(sizeof...(data) < 2);
                 if constexpr (sizeof...(data) == 1)
                 {
@@ -2075,8 +2073,7 @@ namespace hpx::parallel::detail {
                     part_size, tok, HPX_FORWARD(F, f), HPX_FORWARD(Proj, proj));
             };
 
-            auto f2 = [tok, count, first, last](
-                          auto&&... data) mutable -> Iter {
+            auto f2 = [tok, first, last](auto&&... data) mutable -> Iter {
                 static_assert(sizeof...(data) < 2);
                 if constexpr (sizeof...(data) == 1)
                 {

--- a/libs/core/algorithms/include/hpx/parallel/container_algorithms/find.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/container_algorithms/find.hpp
@@ -2051,11 +2051,11 @@ namespace hpx::ranges {
                 hpx::traits::is_range_v<Rng> &&
                 hpx::parallel::traits::is_projected_range_v<Proj, Rng>
             )
-        // clang-format on
         friend hpx::parallel::util::detail::algorithm_result_t<ExPolicy,
             hpx::traits::range_iterator_t<Rng>>
-        tag_fallback_invoke(find_t, ExPolicy&& policy, Rng&& rng, T const& val,
-            Proj proj = Proj())
+        tag_fallback_invoke(find_t,
+            ExPolicy&& policy, Rng&& rng, T const& val, Proj proj = Proj())
+        // clang-format on
         {
             using iterator_type = hpx::traits::range_iterator_t<Rng>;
 
@@ -2127,8 +2127,7 @@ namespace hpx::ranges {
                 >
             )
         // clang-format on
-        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
-            Iter>::type
+        friend hpx::parallel::util::detail::algorithm_result_t<ExPolicy, Iter>
         tag_fallback_invoke(find_if_t, ExPolicy&& policy, Iter first, Sent last,
             Pred&& pred, Proj&& proj = Proj())
         {
@@ -2153,11 +2152,11 @@ namespace hpx::ranges {
                     >::value_type
                 >
             )
-        // clang-format on
         friend hpx::parallel::util::detail::algorithm_result_t<ExPolicy,
             hpx::traits::range_iterator_t<Rng>>
-        tag_fallback_invoke(find_if_t, ExPolicy&& policy, Rng&& rng, Pred pred,
-            Proj proj = Proj())
+        tag_fallback_invoke(find_if_t,
+            ExPolicy&& policy, Rng&& rng, Pred pred, Proj proj = Proj())
+        // clang-format on
         {
             using iterator_type = hpx::traits::range_iterator_t<Rng>;
 
@@ -2342,12 +2341,12 @@ namespace hpx::ranges {
                     hpx::parallel::traits::projected_range<Proj2, Rng2>
                 >
             )
-        // clang-format on
         friend hpx::parallel::util::detail::algorithm_result_t<ExPolicy,
             hpx::traits::range_iterator_t<Rng1>>
-        tag_fallback_invoke(find_end_t, ExPolicy&& policy, Rng1&& rng1,
-            Rng2&& rng2, Pred op = Pred(), Proj1 proj1 = Proj1(),
-            Proj2 proj2 = Proj2())
+        tag_fallback_invoke(find_end_t,
+            ExPolicy&& policy, Rng1&& rng1, Rng2&& rng2, Pred op = Pred(),
+            Proj1 proj1 = Proj1(), Proj2 proj2 = Proj2())
+        // clang-format on
         {
             using iterator_type = hpx::traits::range_iterator_t<Rng1>;
 
@@ -2591,8 +2590,8 @@ namespace hpx::ranges {
       : hpx::detail::tag_parallel_algorithm<find_last_t>
     {
     private:
-        template <typename ExPolicy, typename Iter, typename Sent,
-            typename Proj = hpx::identity, typename T>
+        template <typename ExPolicy, typename Iter, typename Sent, typename T,
+            typename Proj = hpx::identity>
         // clang-format off
             requires(
                 hpx::is_execution_policy_v<ExPolicy> &&
@@ -2632,8 +2631,8 @@ namespace hpx::ranges {
             }
         }
 
-        template <typename ExPolicy, typename Rng,
-            typename Proj = hpx::identity, typename T>
+        template <typename ExPolicy, typename Rng, typename T,
+            typename Proj = hpx::identity>
         // clang-format off
             requires(
                 hpx::is_execution_policy_v<ExPolicy> &&
@@ -2659,8 +2658,8 @@ namespace hpx::ranges {
                     hpx::util::end(rng), val, HPX_MOVE(proj)));
         }
 
-        template <typename Iter, typename Sent, typename Proj = hpx::identity,
-            typename T>
+        template <typename Iter, typename Sent, typename T,
+            typename Proj = hpx::identity>
         // clang-format off
             requires(
                 hpx::traits::is_sentinel_for_v<Sent, Iter> &&
@@ -2680,7 +2679,7 @@ namespace hpx::ranges {
                 last);
         }
 
-        template <typename Rng, typename Proj = hpx::identity, typename T>
+        template <typename Rng, typename T, typename Proj = hpx::identity>
         // clang-format off
             requires(
                 hpx::traits::is_range_v<Rng> &&

--- a/libs/core/runtime_local/tests/unit/CMakeLists.txt
+++ b/libs/core/runtime_local/tests/unit/CMakeLists.txt
@@ -1,13 +1,13 @@
-# Copyright (c) 2020 Hartmut Kaiser
+# Copyright (c) 2020-2026 Hartmut Kaiser
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(tests thread_mapper test_termination_detection)
+set(tests thread_mapper termination_detection)
 
 set(thread_mapper_PARAMETERS THREADS_PER_LOCALITY 4)
-set(test_termination_detection_PARAMETERS THREADS_PER_LOCALITY 4)
+set(termination_detection_PARAMETERS THREADS_PER_LOCALITY 4)
 
 foreach(test ${tests})
   set(sources ${test}.cpp)

--- a/libs/core/runtime_local/tests/unit/termination_detection.cpp
+++ b/libs/core/runtime_local/tests/unit/termination_detection.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Arpit Khandelwal
+// Copyright (c) 2026 Arpit Khandelwal
 //
 // SPDX-License-Identifier: BSL-1.0
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -6,8 +6,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/hpx_init.hpp>
-#include <hpx/include/async.hpp>
-#include <hpx/include/post.hpp>
+#include <hpx/modules/async_local.hpp>
 #include <hpx/modules/runtime_local.hpp>
 #include <hpx/modules/synchronization.hpp>
 #include <hpx/modules/testing.hpp>


### PR DESCRIPTION
- flyby: rename test
- flyby: adding missing test targets
