### PR TITLE
shared_mutex : add ignore_while_checking around upgrade_cond notify in unlock_shared()

### DIFF
--- a/libs/core/synchronization/include/hpx/synchronization/shared_mutex.hpp
+++ b/libs/core/synchronization/include/hpx/synchronization/shared_mutex.hpp
@@ -158,7 +158,11 @@ namespace hpx::detail {
                         if (set_state(s1, s, lk))
                         {
                             HPX_ASSERT_OWNS_LOCK(lk);
-                            upgrade_cond.notify_one_no_unlock(lk);
+                            {
+                                [[maybe_unused]] hpx::util::
+                                    ignore_while_checking il(&lk);
+                                upgrade_cond.notify_one_no_unlock(lk);
+                            }
                             release_waiters(lk);
                             break;
                         }


### PR DESCRIPTION
Fixes #

## Proposed Changes
- Add `ignore_while_checking` guard around `upgrade_cond.notify_one_no_unlock(lk)` in `unlock_shared()` to suppress HPX lock verification during the notify call which might yield the thread and cause ```hpx::util::verify_no_locks()``` exception in debug builds.

## Background context
- ```shared_mutex_6854``` regression test fails in debug builds with ```hpx::util::verify_no_locks()``` failing

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [x] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
