### PR TITLE
implement c++20 modules for full libraries

### DIFF
--- a/libs/core/lcw_base/CMakeLists.txt
+++ b/libs/core/lcw_base/CMakeLists.txt
@@ -23,6 +23,7 @@ include(HPX_AddModule)
 add_hpx_module(
   core lcw_base
   GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_MODULE_GEN ON
   SOURCES ${lcw_base_sources}
   HEADERS ${lcw_base_headers}
   MODULE_DEPENDENCIES hpx_logging hpx_runtime_configuration hpx_string_util

--- a/libs/core/lcw_base/include/hpx/lcw_base/lcw_environment.hpp
+++ b/libs/core/lcw_base/include/hpx/lcw_base/lcw_environment.hpp
@@ -26,7 +26,7 @@
 #include "lcw.hpp"
 
 namespace hpx { namespace util {
-    struct HPX_EXPORT lcw_environment
+    HPX_CXX_CORE_EXPORT struct HPX_EXPORT lcw_environment
     {
         static bool check_lcw_environment(runtime_configuration& cfg);
 
@@ -105,7 +105,7 @@ namespace hpx { namespace util {
 #include <hpx/config/warnings_prefix.hpp>
 
 namespace hpx { namespace util {
-    struct HPX_EXPORT lcw_environment
+    HPX_CXX_CORE_EXPORT struct HPX_EXPORT lcw_environment
     {
         static bool check_lcw_environment(runtime_configuration& cfg);
     };

--- a/libs/full/actions/CMakeLists.txt
+++ b/libs/full/actions/CMakeLists.txt
@@ -43,6 +43,7 @@ include(HPX_AddModule)
 add_hpx_module(
   full actions
   GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_MODULE_GEN ON
   SOURCES ${actions_sources}
   HEADERS ${actions_headers}
   COMPAT_HEADERS ${actions_compat_headers}

--- a/libs/full/actions/include/hpx/actions/actions_fwd.hpp
+++ b/libs/full/actions/include/hpx/actions/actions_fwd.hpp
@@ -16,7 +16,7 @@ namespace hpx::actions {
     /// \cond NOINTERNAL
 
     struct base_action;
-    struct HPX_EXPORT base_action_data;
+    HPX_CXX_EXPORT struct HPX_EXPORT base_action_data;
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action>

--- a/libs/full/actions/include/hpx/actions/base_action.hpp
+++ b/libs/full/actions/include/hpx/actions/base_action.hpp
@@ -208,7 +208,8 @@ namespace hpx::serialization {
     HPX_DEFINE_GET_ACTION_NAME_ITT(action, actionname)                         \
     namespace hpx::actions::detail {                                           \
         template <>                                                            \
-        HPX_ALWAYS_EXPORT char const* get_action_name</**/ action>() noexcept  \
+        HPX_CXX_EXPORT HPX_ALWAYS_EXPORT char const*                           \
+        get_action_name</**/ action>() noexcept                                \
         {                                                                      \
             return HPX_PP_STRINGIZE(actionname);                               \
         }                                                                      \
@@ -222,7 +223,7 @@ namespace hpx::serialization {
 #define HPX_DEFINE_GET_ACTION_NAME_ITT(action, actionname)                     \
     namespace hpx::actions::detail {                                           \
         template <>                                                            \
-        HPX_ALWAYS_EXPORT util::itt::string_handle const&                      \
+        HPX_CXX_EXPORT HPX_ALWAYS_EXPORT util::itt::string_handle const&       \
         get_action_name_itt</**/ action>() noexcept                            \
         {                                                                      \
             static util::itt::string_handle sh(HPX_PP_STRINGIZE(actionname));  \
@@ -234,7 +235,7 @@ namespace hpx::serialization {
 #define HPX_REGISTER_ACTION_DECLARATION_NO_DEFAULT_GUID_ITT(action)            \
     namespace hpx::actions::detail {                                           \
         template <>                                                            \
-        HPX_ALWAYS_EXPORT util::itt::string_handle const&                      \
+        HPX_CXX_EXPORT HPX_ALWAYS_EXPORT util::itt::string_handle const&       \
         get_action_name_itt</**/ action>() noexcept;                           \
     }                                                                          \
 /**/
@@ -247,7 +248,8 @@ namespace hpx::serialization {
     HPX_REGISTER_ACTION_DECLARATION_NO_DEFAULT_GUID_ITT(action)                \
     namespace hpx::actions::detail {                                           \
         template <>                                                            \
-        HPX_ALWAYS_EXPORT char const* get_action_name<action>() noexcept;      \
+        HPX_CXX_EXPORT HPX_ALWAYS_EXPORT char const*                           \
+        get_action_name<action>() noexcept;                                    \
     }                                                                          \
     HPX_REGISTER_ACTION_EXTERN_DECLARATION(action)                             \
                                                                                \
@@ -273,8 +275,9 @@ namespace hpx::serialization {
     HPX_REGISTER_ACTION_INVOCATION_COUNT(action)                               \
     HPX_REGISTER_PER_ACTION_DATA_COUNTER_TYPES(action)                         \
     namespace hpx::actions {                                                   \
-        template struct HPX_ALWAYS_EXPORT transfer_action</**/ action>;        \
-        template struct HPX_ALWAYS_EXPORT                                      \
+        template HPX_CXX_EXPORT struct HPX_ALWAYS_EXPORT                       \
+            transfer_action</**/ action>;                                      \
+        template HPX_CXX_EXPORT struct HPX_ALWAYS_EXPORT                       \
             transfer_continuation_action</**/ action>;                         \
     }                                                                          \
 /**/

--- a/libs/full/actions_base/CMakeLists.txt
+++ b/libs/full/actions_base/CMakeLists.txt
@@ -86,6 +86,7 @@ include(HPX_AddModule)
 add_hpx_module(
   full actions_base
   GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_MODULE_GEN ON
   SOURCES ${actions_base_sources}
   HEADERS ${actions_base_headers}
   COMPAT_HEADERS ${actions_base_compat_headers}

--- a/libs/full/actions_base/include/hpx/actions_base/actions_base_fwd.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/actions_base_fwd.hpp
@@ -29,11 +29,11 @@ namespace hpx::actions {
     /// The \a base_action class is an abstract class used as the base class
     /// for all action types. It's main purpose is to allow polymorphic
     /// serialization of action instances through a unique_ptr.
-    struct HPX_EXPORT base_action;
+    HPX_CXX_EXPORT struct HPX_EXPORT base_action;
 
     namespace detail {
 
-        HPX_EXPORT std::uint32_t get_action_id_from_name(
+        HPX_CXX_EXPORT HPX_EXPORT std::uint32_t get_action_id_from_name(
             char const* action_name);
     }    // namespace detail
 

--- a/libs/full/actions_base/include/hpx/actions_base/detail/action_factory.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/detail/action_factory.hpp
@@ -36,22 +36,25 @@ namespace hpx::actions::detail {
 
         static constexpr std::uint32_t invalid_id = ~0;
 
-        HPX_EXPORT action_registry();
-        HPX_EXPORT ~action_registry();
+        HPX_CXX_EXPORT HPX_EXPORT action_registry();
+        HPX_CXX_EXPORT HPX_EXPORT ~action_registry();
 
-        HPX_EXPORT void register_factory(
+        HPX_CXX_EXPORT HPX_EXPORT void register_factory(
             std::string const& type_name, ctor_t ctor, ctor_t ctor_cont);
-        HPX_EXPORT void register_typename(
+        HPX_CXX_EXPORT HPX_EXPORT void register_typename(
             std::string const& type_name, std::uint32_t id);
-        HPX_EXPORT void fill_missing_typenames();
-        HPX_EXPORT std::uint32_t try_get_id(std::string const& type_name) const;
-        HPX_EXPORT std::vector<std::string> get_unassigned_typenames() const;
+        HPX_CXX_EXPORT HPX_EXPORT void fill_missing_typenames();
+        HPX_CXX_EXPORT HPX_EXPORT std::uint32_t try_get_id(
+            std::string const& type_name) const;
+        HPX_CXX_EXPORT HPX_EXPORT std::vector<std::string>
+        get_unassigned_typenames() const;
 
-        HPX_EXPORT static std::uint32_t get_id(std::string const& type_name);
-        HPX_EXPORT static base_action* create(
+        HPX_CXX_EXPORT HPX_EXPORT static std::uint32_t get_id(
+            std::string const& type_name);
+        HPX_CXX_EXPORT HPX_EXPORT static base_action* create(
             std::uint32_t id, bool, std::string const* name = nullptr);
 
-        HPX_EXPORT static action_registry& instance();
+        HPX_CXX_EXPORT HPX_EXPORT static action_registry& instance();
 
         void cache_id(std::uint32_t id, ctor_t ctor, ctor_t ctor_cont);
         std::string collect_registered_typenames() const;
@@ -63,7 +66,7 @@ namespace hpx::actions::detail {
     };
 
     template <std::uint32_t Id>
-    HPX_ALWAYS_EXPORT std::string get_action_name_id();
+    HPX_CXX_EXPORT HPX_ALWAYS_EXPORT std::string get_action_name_id();
 
     template <std::uint32_t Id>
     struct add_constant_entry
@@ -93,7 +96,7 @@ namespace hpx::actions::detail {
 #define HPX_REGISTER_ACTION_FACTORY_ID(Name, Id)                               \
     namespace hpx::actions::detail {                                           \
         template <>                                                            \
-        HPX_ALWAYS_EXPORT std::string get_action_name_id<Id>()                 \
+        HPX_CXX_EXPORT HPX_ALWAYS_EXPORT std::string get_action_name_id<Id>()  \
         {                                                                      \
             return HPX_PP_STRINGIZE(Name);                                     \
         }                                                                      \

--- a/libs/full/actions_base/include/hpx/actions_base/detail/invocation_count_registry.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/detail/invocation_count_registry.hpp
@@ -18,7 +18,7 @@
 
 namespace hpx::actions::detail {
 
-    class HPX_EXPORT invocation_count_registry
+    HPX_CXX_EXPORT class HPX_EXPORT invocation_count_registry
     {
     public:
         using get_invocation_count_type = std::int64_t (*)(bool);

--- a/libs/full/actions_base/include/hpx/actions_base/detail/per_action_data_counter_registry.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/detail/per_action_data_counter_registry.hpp
@@ -23,7 +23,7 @@
 
 namespace hpx::actions::detail {
 
-    class HPX_EXPORT per_action_data_counter_registry
+    HPX_CXX_EXPORT class HPX_EXPORT per_action_data_counter_registry
     {
     public:
         using counter_function_type = hpx::function<std::int64_t(bool)>;

--- a/libs/full/actions_base/include/hpx/actions_base/plain_action.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/plain_action.hpp
@@ -113,7 +113,8 @@ namespace hpx::traits {
 
     /// \cond NOINTERNAL
     template <>
-    HPX_ALWAYS_EXPORT inline components::component_type component_type_database<
+    HPX_CXX_EXPORT HPX_ALWAYS_EXPORT inline components::component_type
+    component_type_database<
         hpx::actions::detail::plain_function>::get() noexcept
     {
         return to_int(hpx::components::component_enum_type::plain_function);
@@ -121,7 +122,7 @@ namespace hpx::traits {
 
     // clang-format off
     template <>
-    HPX_ALWAYS_EXPORT inline void
+    HPX_CXX_EXPORT HPX_ALWAYS_EXPORT inline void
         component_type_database<hpx::actions::detail::plain_function>::set(
             components::component_type)
     {

--- a/libs/full/agas/CMakeLists.txt
+++ b/libs/full/agas/CMakeLists.txt
@@ -29,6 +29,7 @@ include(HPX_AddModule)
 add_hpx_module(
   full agas
   GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_MODULE_GEN ON
   SOURCES ${agas_sources}
   HEADERS ${agas_headers}
   COMPAT_HEADERS ${agas_compat_headers}

--- a/libs/full/agas/include/hpx/agas/addressing_service.hpp
+++ b/libs/full/agas/include/hpx/agas/addressing_service.hpp
@@ -40,7 +40,7 @@
 namespace hpx { namespace agas {
 
 #if defined(HPX_HAVE_NETWORKING)
-    HPX_EXPORT void destroy_big_boot_barrier();
+    HPX_CXX_EXPORT HPX_EXPORT void destroy_big_boot_barrier();
 #endif
 
     struct addressing_service

--- a/libs/full/agas/include/hpx/agas/agas_fwd.hpp
+++ b/libs/full/agas/include/hpx/agas/agas_fwd.hpp
@@ -13,12 +13,13 @@
 namespace hpx {
     namespace agas {
 
-        struct HPX_EXPORT addressing_service;
+        HPX_CXX_EXPORT struct HPX_EXPORT addressing_service;
     }    // namespace agas
 
     namespace naming {
 
-        HPX_EXPORT agas::addressing_service& get_agas_client();
-        HPX_EXPORT agas::addressing_service* get_agas_client_ptr();
+        HPX_CXX_EXPORT HPX_EXPORT agas::addressing_service& get_agas_client();
+        HPX_CXX_EXPORT HPX_EXPORT agas::addressing_service*
+        get_agas_client_ptr();
     }    // namespace naming
 }    // namespace hpx

--- a/libs/full/agas/include/hpx/agas/state.hpp
+++ b/libs/full/agas/include/hpx/agas/state.hpp
@@ -12,5 +12,5 @@
 namespace hpx { namespace agas {
 
     // return whether resolver client is in state described by 'mask'
-    HPX_EXPORT bool router_is(state st);
+    HPX_CXX_EXPORT HPX_EXPORT bool router_is(state st);
 }}    // namespace hpx::agas

--- a/libs/full/agas_base/CMakeLists.txt
+++ b/libs/full/agas_base/CMakeLists.txt
@@ -66,6 +66,7 @@ include(HPX_AddModule)
 add_hpx_module(
   full agas_base
   GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_MODULE_GEN ON
   SOURCES ${agas_base_sources}
   HEADERS ${agas_base_headers}
   COMPAT_HEADERS ${agas_base_compat_headers}

--- a/libs/full/agas_base/include/hpx/agas_base/agas_fwd.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/agas_fwd.hpp
@@ -39,16 +39,16 @@ namespace hpx::agas {
         hpx::function<void(std::string const&, components::component_type),
             true>;
 
-    struct HPX_EXPORT component_namespace;
-    struct HPX_EXPORT locality_namespace;
-    struct HPX_EXPORT primary_namespace;
-    struct HPX_EXPORT symbol_namespace;
+    HPX_CXX_EXPORT struct HPX_EXPORT component_namespace;
+    HPX_CXX_EXPORT struct HPX_EXPORT locality_namespace;
+    HPX_CXX_EXPORT struct HPX_EXPORT primary_namespace;
+    HPX_CXX_EXPORT struct HPX_EXPORT symbol_namespace;
 
     namespace server {
 
-        struct HPX_EXPORT component_namespace;
-        struct HPX_EXPORT locality_namespace;
-        struct HPX_EXPORT primary_namespace;
-        struct HPX_EXPORT symbol_namespace;
+        HPX_CXX_EXPORT struct HPX_EXPORT component_namespace;
+        HPX_CXX_EXPORT struct HPX_EXPORT locality_namespace;
+        HPX_CXX_EXPORT struct HPX_EXPORT primary_namespace;
+        HPX_CXX_EXPORT struct HPX_EXPORT symbol_namespace;
     }    // namespace server
 }    // namespace hpx::agas

--- a/libs/full/agas_base/include/hpx/agas_base/gva.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/gva.hpp
@@ -121,13 +121,16 @@ namespace hpx::agas {
         friend class hpx::serialization::access;
 
         template <typename Archive>
-        HPX_EXPORT void save(Archive& ar, unsigned int const /*version*/) const;
+        HPX_CXX_EXPORT HPX_EXPORT void save(
+            Archive& ar, unsigned int const /*version*/) const;
 
         template <typename Archive>
-        HPX_EXPORT void load(Archive& ar, unsigned int const version);
+        HPX_CXX_EXPORT HPX_EXPORT void load(
+            Archive& ar, unsigned int const version);
 
         HPX_SERIALIZATION_SPLIT_MEMBER()
     };
 
-    HPX_EXPORT std::ostream& operator<<(std::ostream& os, gva const& addr);
+    HPX_CXX_EXPORT HPX_EXPORT std::ostream& operator<<(
+        std::ostream& os, gva const& addr);
 }    // namespace hpx::agas

--- a/libs/full/agas_base/include/hpx/agas_base/primary_namespace.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/primary_namespace.hpp
@@ -27,7 +27,7 @@
 
 namespace hpx { namespace agas {
 
-    struct HPX_EXPORT primary_namespace
+    HPX_CXX_EXPORT struct HPX_EXPORT primary_namespace
     {
         typedef hpx::tuple<naming::gid_type, gva, naming::gid_type>
             resolved_type;

--- a/libs/full/agas_base/include/hpx/agas_base/route.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/route.hpp
@@ -14,7 +14,7 @@
 
 namespace hpx::agas::server {
 
-    extern HPX_EXPORT void (*route)(
+    HPX_CXX_EXPORT extern HPX_EXPORT void (*route)(
         primary_namespace& server, parcelset::parcel&& p);
 }    // namespace hpx::agas::server
 

--- a/libs/full/agas_base/include/hpx/agas_base/server/component_namespace.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/server/component_namespace.hpp
@@ -32,8 +32,9 @@
 
 namespace hpx::agas {
 
-    HPX_EXPORT naming::gid_type bootstrap_component_namespace_gid();
-    HPX_EXPORT hpx::id_type bootstrap_component_namespace_id();
+    HPX_CXX_EXPORT HPX_EXPORT naming::gid_type
+    bootstrap_component_namespace_gid();
+    HPX_CXX_EXPORT HPX_EXPORT hpx::id_type bootstrap_component_namespace_id();
 }    // namespace hpx::agas
 
 namespace hpx::agas::server {
@@ -42,7 +43,7 @@ namespace hpx::agas::server {
     static constexpr char const* const component_namespace_service_name =
         "component/";
 
-    struct HPX_EXPORT component_namespace
+    HPX_CXX_EXPORT struct HPX_EXPORT component_namespace
       : components::fixed_component_base<component_namespace>
     {
         using mutex_type = hpx::spinlock;

--- a/libs/full/agas_base/include/hpx/agas_base/server/locality_namespace.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/server/locality_namespace.hpp
@@ -30,8 +30,9 @@
 
 namespace hpx { namespace agas {
 
-    HPX_EXPORT naming::gid_type bootstrap_locality_namespace_gid();
-    HPX_EXPORT hpx::id_type bootstrap_locality_namespace_id();
+    HPX_CXX_EXPORT HPX_EXPORT naming::gid_type
+    bootstrap_locality_namespace_gid();
+    HPX_CXX_EXPORT HPX_EXPORT hpx::id_type bootstrap_locality_namespace_id();
 }}    // namespace hpx::agas
 
 namespace hpx { namespace agas { namespace server {
@@ -40,7 +41,7 @@ namespace hpx { namespace agas { namespace server {
     static constexpr char const* const locality_namespace_service_name =
         "locality/";
 
-    struct HPX_EXPORT locality_namespace
+    HPX_CXX_EXPORT struct HPX_EXPORT locality_namespace
       : components::fixed_component_base<locality_namespace>
     {
         using mutex_type = hpx::spinlock;

--- a/libs/full/agas_base/include/hpx/agas_base/server/primary_namespace.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/server/primary_namespace.hpp
@@ -39,8 +39,9 @@
 
 namespace hpx::agas {
 
-    HPX_EXPORT naming::gid_type bootstrap_primary_namespace_gid();
-    HPX_EXPORT hpx::id_type bootstrap_primary_namespace_id();
+    HPX_CXX_EXPORT HPX_EXPORT naming::gid_type
+    bootstrap_primary_namespace_gid();
+    HPX_CXX_EXPORT HPX_EXPORT hpx::id_type bootstrap_primary_namespace_id();
 }    // namespace hpx::agas
 
 /// \brief AGAS's primary namespace maps 128-bit global identifiers (GIDs) to
@@ -111,7 +112,7 @@ namespace hpx::agas::server {
     static constexpr char const* const primary_namespace_service_name =
         "primary/";
 
-    struct HPX_EXPORT primary_namespace
+    HPX_CXX_EXPORT struct HPX_EXPORT primary_namespace
       : components::fixed_component_base<primary_namespace>
     {
         using mutex_type = hpx::spinlock;

--- a/libs/full/agas_base/include/hpx/agas_base/server/symbol_namespace.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/server/symbol_namespace.hpp
@@ -30,8 +30,8 @@
 
 namespace hpx::agas {
 
-    HPX_EXPORT naming::gid_type bootstrap_symbol_namespace_gid();
-    HPX_EXPORT hpx::id_type bootstrap_symbol_namespace_id();
+    HPX_CXX_EXPORT HPX_EXPORT naming::gid_type bootstrap_symbol_namespace_gid();
+    HPX_CXX_EXPORT HPX_EXPORT hpx::id_type bootstrap_symbol_namespace_id();
 }    // namespace hpx::agas
 
 namespace hpx::agas::server {
@@ -40,7 +40,7 @@ namespace hpx::agas::server {
     inline constexpr char const* const symbol_namespace_service_name =
         "symbol/";
 
-    struct HPX_EXPORT symbol_namespace
+    HPX_CXX_EXPORT struct HPX_EXPORT symbol_namespace
       : components::fixed_component_base<symbol_namespace>
     {
         using mutex_type = hpx::spinlock;

--- a/libs/full/async_colocated/CMakeLists.txt
+++ b/libs/full/async_colocated/CMakeLists.txt
@@ -48,6 +48,7 @@ include(HPX_AddModule)
 add_hpx_module(
   full async_colocated
   GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_MODULE_GEN ON
   SOURCES ${async_colocated_sources}
   HEADERS ${async_colocated_headers}
   COMPAT_HEADERS ${async_colocated_compat_headers}

--- a/libs/full/async_colocated/include/hpx/async_colocated/get_colocation_id.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/get_colocation_id.hpp
@@ -36,7 +36,7 @@ namespace hpx {
     ///           hpx::exception.
     ///
     /// \see    \a hpx::get_colocation_id()
-    HPX_EXPORT hpx::id_type get_colocation_id(
+    HPX_CXX_EXPORT HPX_EXPORT hpx::id_type get_colocation_id(
         launch::sync_policy, hpx::id_type const& id, error_code& ec = throws);
 
     /// \brief Asynchronously return the id of the locality where the object
@@ -45,6 +45,6 @@ namespace hpx {
     /// \param id [in] The id of the object to locate.
     ///
     /// \see    \a hpx::get_colocation_id(launch::sync_policy)
-    HPX_EXPORT hpx::future<hpx::id_type> get_colocation_id(
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future<hpx::id_type> get_colocation_id(
         hpx::id_type const& id);
 }    // namespace hpx

--- a/libs/full/async_colocated/include/hpx/async_colocated/server/destroy_component.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/server/destroy_component.hpp
@@ -19,7 +19,7 @@
 namespace hpx::components::server {
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT void destroy_component(
+    HPX_CXX_EXPORT HPX_EXPORT void destroy_component(
         naming::gid_type const& gid, naming::address const& addr);
 
     ///////////////////////////////////////////////////////////////////////////

--- a/libs/full/async_distributed/CMakeLists.txt
+++ b/libs/full/async_distributed/CMakeLists.txt
@@ -120,6 +120,7 @@ include(HPX_AddModule)
 add_hpx_module(
   full async_distributed
   GLOBAL_HEADER_GEN OFF
+  GLOBAL_HEADER_MODULE_GEN ON
   SOURCES ${async_sources}
   HEADERS ${async_headers}
   COMPAT_HEADERS ${async_compat_headers}

--- a/libs/full/async_distributed/include/hpx/async_distributed/base_lco_with_value.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/base_lco_with_value.hpp
@@ -266,7 +266,9 @@ namespace hpx::components::detail {
             hpx::components::managed_component<hpx::lcos::base_lco_with_value<
                 Result, RemoteResult, traits::detail::managed_component_tag>>;
 
-        HPX_ALWAYS_EXPORT static typename component_type::heap_type& call()
+        HPX_CXX_EXPORT HPX_ALWAYS_EXPORT static
+            typename component_type::heap_type&
+            call()
         {
             util::reinitializable_static<typename component_type::heap_type>
                 heap;
@@ -284,7 +286,9 @@ namespace hpx::components::detail {
             hpx::components::managed_component<hpx::lcos::base_lco_with_value<
                 Result, RemoteResult, traits::detail::component_tag>>;
 
-        HPX_ALWAYS_EXPORT static typename component_type::heap_type& call()
+        HPX_CXX_EXPORT HPX_ALWAYS_EXPORT static
+            typename component_type::heap_type&
+            call()
         {
             util::reinitializable_static<typename component_type::heap_type>
                 heap;

--- a/libs/full/async_distributed/include/hpx/async_distributed/continuation.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/continuation.hpp
@@ -36,7 +36,7 @@ namespace hpx::actions {
     ///////////////////////////////////////////////////////////////////////////
     // Continuations are polymorphic objects encapsulating the
     // id_type of the destination where the result has to be sent.
-    class HPX_EXPORT continuation
+    HPX_CXX_EXPORT class HPX_EXPORT continuation
     {
     public:
         using continuation_tag = void;
@@ -300,7 +300,8 @@ namespace hpx::actions {
 
     ///////////////////////////////////////////////////////////////////////////
     template <>
-    struct HPX_EXPORT typed_continuation<void, util::unused_type> : continuation
+    HPX_CXX_EXPORT struct HPX_EXPORT
+        typed_continuation<void, util::unused_type> : continuation
     {
     private:
         using function_type =

--- a/libs/full/async_distributed/include/hpx/async_distributed/continuation_fwd.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/continuation_fwd.hpp
@@ -11,7 +11,7 @@
 
 namespace hpx { namespace actions {
 
-    class HPX_EXPORT continuation;
+    HPX_CXX_EXPORT class HPX_EXPORT continuation;
 
     template <typename Result, typename RemoteResult, typename F,
         typename... Ts>

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/promise_lco.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/promise_lco.hpp
@@ -172,7 +172,7 @@ namespace hpx::lcos::detail {
 namespace hpx {
     namespace traits {
         namespace detail {
-            HPX_EXPORT extern util::atomic_count unique_type;
+            HPX_CXX_EXPORT HPX_EXPORT extern util::atomic_count unique_type;
         }
 
         template <typename Result, typename RemoteResult>
@@ -214,7 +214,7 @@ namespace hpx {
 
         // Forward declare promise_lco<void> to avoid duplicate instantiations
         template <>
-        HPX_ALWAYS_EXPORT hpx::components::managed_component<
+        HPX_CXX_EXPORT HPX_ALWAYS_EXPORT hpx::components::managed_component<
             lcos::detail::promise_lco<void, hpx::util::unused_type>>::heap_type&
         component_heap_helper<hpx::components::managed_component<
             lcos::detail::promise_lco<void, hpx::util::unused_type>>>(...);
@@ -225,7 +225,7 @@ namespace hpx {
         {
             using valid = void;
 
-            HPX_ALWAYS_EXPORT static
+            HPX_CXX_EXPORT HPX_ALWAYS_EXPORT static
                 typename hpx::components::managed_component<
                     lcos::detail::promise_lco<Result, RemoteResult>>::heap_type&
                 call()

--- a/libs/full/async_distributed/include/hpx/async_distributed/lcos_fwd.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/lcos_fwd.hpp
@@ -20,7 +20,7 @@ namespace hpx {
 
     /// \namespace lcos
     namespace lcos {
-        class HPX_EXPORT base_lco;
+        HPX_CXX_EXPORT class HPX_EXPORT base_lco;
 
         template <typename Result,
             typename RemoteResult =

--- a/libs/full/async_distributed/include/hpx/async_distributed/trigger_lco_fwd.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/trigger_lco_fwd.hpp
@@ -29,7 +29,7 @@ namespace hpx {
     /// \param move_credits [in] If this is set to \a true then it is ok to
     ///                     send all credits in \a id along with the generated
     ///                     message. The default value is \a true.
-    HPX_EXPORT void trigger_lco_event(
+    HPX_CXX_EXPORT HPX_EXPORT void trigger_lco_event(
         hpx::id_type id, naming::address&& addr, bool move_credits = true);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -56,8 +56,9 @@ namespace hpx {
     /// \param move_credits [in] If this is set to \a true then it is ok to
     ///                     send all credits in \a id along with the generated
     ///                     message. The default value is \a true.
-    HPX_EXPORT void trigger_lco_event(hpx::id_type id, naming::address&& addr,
-        hpx::id_type const& cont, bool move_credits = true);
+    HPX_CXX_EXPORT HPX_EXPORT void trigger_lco_event(hpx::id_type id,
+        naming::address&& addr, hpx::id_type const& cont,
+        bool move_credits = true);
 
     /// \brief Trigger the LCO referenced by the given id
     ///
@@ -190,8 +191,9 @@ namespace hpx {
     /// \param move_credits [in] If this is set to \a true then it is ok to
     ///                     send all credits in \a id along with the generated
     ///                     message. The default value is \a true.
-    HPX_EXPORT void set_lco_error(hpx::id_type id, naming::address&& addr,
-        std::exception_ptr const& e, bool move_credits = true);
+    HPX_CXX_EXPORT HPX_EXPORT void set_lco_error(hpx::id_type id,
+        naming::address&& addr, std::exception_ptr const& e,
+        bool move_credits = true);
 
     /// \brief Set the error state for the LCO referenced by the given id
     ///
@@ -204,8 +206,9 @@ namespace hpx {
     /// \param move_credits [in] If this is set to \a true then it is ok to
     ///                     send all credits in \a id along with the generated
     ///                     message. The default value is \a true.
-    HPX_EXPORT void set_lco_error(hpx::id_type id, naming::address&& addr,
-        std::exception_ptr&& e, bool move_credits = true);
+    HPX_CXX_EXPORT HPX_EXPORT void set_lco_error(hpx::id_type id,
+        naming::address&& addr, std::exception_ptr&& e,
+        bool move_credits = true);
 
     /// \brief Set the error state for the LCO referenced by the given id
     ///
@@ -249,9 +252,9 @@ namespace hpx {
     /// \param move_credits [in] If this is set to \a true then it is ok to
     ///                     send all credits in \a id along with the generated
     ///                     message. The default value is \a true.
-    HPX_EXPORT void set_lco_error(hpx::id_type id, naming::address&& addr,
-        std::exception_ptr const& e, hpx::id_type const& cont,
-        bool move_credits = true);
+    HPX_CXX_EXPORT HPX_EXPORT void set_lco_error(hpx::id_type id,
+        naming::address&& addr, std::exception_ptr const& e,
+        hpx::id_type const& cont, bool move_credits = true);
 
     /// \brief Set the error state for the LCO referenced by the given id
     ///
@@ -265,9 +268,9 @@ namespace hpx {
     /// \param move_credits [in] If this is set to \a true then it is ok to
     ///                     send all credits in \a id along with the generated
     ///                     message. The default value is \a true.
-    HPX_EXPORT void set_lco_error(hpx::id_type id, naming::address&& addr,
-        std::exception_ptr&& e, hpx::id_type const& cont,
-        bool move_credits = true);
+    HPX_CXX_EXPORT HPX_EXPORT void set_lco_error(hpx::id_type id,
+        naming::address&& addr, std::exception_ptr&& e,
+        hpx::id_type const& cont, bool move_credits = true);
 
     /// \brief Set the error state for the LCO referenced by the given id
     ///

--- a/libs/full/checkpoint/CMakeLists.txt
+++ b/libs/full/checkpoint/CMakeLists.txt
@@ -27,6 +27,7 @@ include(HPX_AddModule)
 add_hpx_module(
   full checkpoint
   GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_MODULE_GEN OFF
   SOURCES ${checkpoint_sources}
   HEADERS ${checkpoint_headers}
   COMPAT_HEADERS ${checkpoint_compat_headers}

--- a/libs/full/collectives/CMakeLists.txt
+++ b/libs/full/collectives/CMakeLists.txt
@@ -74,6 +74,8 @@ set(collectives_sources
 include(HPX_AddModule)
 add_hpx_module(
   full collectives
+  GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_MODULE_GEN ON
   SOURCES ${collectives_sources}
   HEADERS ${collectives_headers}
   COMPAT_HEADERS ${collectives_compat_headers}

--- a/libs/full/collectives/include/hpx/collectives/all_gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_gather.hpp
@@ -232,7 +232,7 @@ namespace hpx::traits {
         template <>
         struct communicator_data<all_gather_tag>
         {
-            HPX_EXPORT static char const* name() noexcept;
+            HPX_CXX_EXPORT HPX_EXPORT static char const* name() noexcept;
         };
     }    // namespace communication
 

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -242,7 +242,7 @@ namespace hpx::traits {
         template <>
         struct communicator_data<all_reduce_tag>
         {
-            HPX_EXPORT static char const* name() noexcept;
+            HPX_CXX_EXPORT HPX_EXPORT static char const* name() noexcept;
         };
     }    // namespace communication
 

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -233,7 +233,7 @@ namespace hpx::traits {
         template <>
         struct communicator_data<all_to_all_tag>
         {
-            HPX_EXPORT static char const* name() noexcept;
+            HPX_CXX_EXPORT HPX_EXPORT static char const* name() noexcept;
         };
     }    // namespace communication
 

--- a/libs/full/collectives/include/hpx/collectives/barrier.hpp
+++ b/libs/full/collectives/include/hpx/collectives/barrier.hpp
@@ -19,7 +19,7 @@ namespace hpx { namespace distributed {
     /// same locality. This barrier can be invoked in a distributed application.
     ///
     /// For a local only barrier \see hpx::barrier.
-    class HPX_EXPORT barrier;
+    HPX_CXX_EXPORT class HPX_EXPORT barrier;
 
     /// Creates a barrier, rank is locality id, size is number of localities
     ///
@@ -110,7 +110,7 @@ namespace hpx::distributed {
         struct barrier_node;
     }
 
-    class HPX_EXPORT barrier
+    HPX_CXX_EXPORT class HPX_EXPORT barrier
     {
         typedef detail::barrier_node wrapped_type;
         typedef components::managed_component<wrapped_type> wrapping_type;

--- a/libs/full/collectives/include/hpx/collectives/broadcast.hpp
+++ b/libs/full/collectives/include/hpx/collectives/broadcast.hpp
@@ -410,7 +410,7 @@ namespace hpx::traits {
         template <>
         struct communicator_data<broadcast_tag>
         {
-            HPX_EXPORT static char const* name() noexcept;
+            HPX_CXX_EXPORT HPX_EXPORT static char const* name() noexcept;
         };
     }    // namespace communication
 

--- a/libs/full/collectives/include/hpx/collectives/channel_communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/channel_communicator.hpp
@@ -138,13 +138,14 @@ namespace hpx::collectives {
     class channel_communicator
     {
     private:
-        friend HPX_EXPORT hpx::future<channel_communicator>
+        friend HPX_CXX_EXPORT HPX_EXPORT hpx::future<channel_communicator>
         create_channel_communicator(char const* basename,
             num_sites_arg num_sites, this_site_arg this_site);
 
-        friend HPX_EXPORT channel_communicator create_channel_communicator(
-            hpx::launch::sync_policy, char const* basename,
-            num_sites_arg num_sites, this_site_arg this_site);
+        friend HPX_CXX_EXPORT HPX_EXPORT channel_communicator
+        create_channel_communicator(hpx::launch::sync_policy,
+            char const* basename, num_sites_arg num_sites,
+            this_site_arg this_site);
 
         template <typename T>
         friend hpx::future<T> get(channel_communicator, that_site_arg, tag_arg);
@@ -162,18 +163,18 @@ namespace hpx::collectives {
             that_site_arg, T&&, tag_arg);
 
     private:
-        HPX_EXPORT channel_communicator(char const* basename,
+        HPX_CXX_EXPORT HPX_EXPORT channel_communicator(char const* basename,
             num_sites_arg num_sites, this_site_arg this_site,
             components::client<detail::channel_communicator_server>&& here);
 
-        HPX_EXPORT channel_communicator(hpx::launch::sync_policy,
+        HPX_CXX_EXPORT HPX_EXPORT channel_communicator(hpx::launch::sync_policy,
             char const* basename, num_sites_arg num_sites,
             this_site_arg this_site,
             components::client<detail::channel_communicator_server>&& here);
 
     public:
-        HPX_EXPORT channel_communicator();
-        HPX_EXPORT ~channel_communicator();
+        HPX_CXX_EXPORT HPX_EXPORT channel_communicator();
+        HPX_CXX_EXPORT HPX_EXPORT ~channel_communicator();
 
         channel_communicator(channel_communicator const& rhs) = default;
         channel_communicator& operator=(
@@ -183,26 +184,27 @@ namespace hpx::collectives {
         channel_communicator& operator=(
             channel_communicator&& rhs) noexcept = default;
 
-        HPX_EXPORT void free();
+        HPX_CXX_EXPORT HPX_EXPORT void free();
 
         explicit operator bool() const noexcept
         {
             return !!comm_;
         }
 
-        HPX_EXPORT std::pair<num_sites_arg, this_site_arg> get_info()
-            const noexcept;
+        HPX_CXX_EXPORT HPX_EXPORT std::pair<num_sites_arg, this_site_arg>
+        get_info() const noexcept;
 
     private:
         std::shared_ptr<detail::channel_communicator> comm_;
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT hpx::future<channel_communicator> create_channel_communicator(
-        char const* basename, num_sites_arg num_sites = num_sites_arg(),
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future<channel_communicator>
+    create_channel_communicator(char const* basename,
+        num_sites_arg num_sites = num_sites_arg(),
         this_site_arg this_site = this_site_arg());
 
-    HPX_EXPORT channel_communicator create_channel_communicator(
+    HPX_CXX_EXPORT HPX_EXPORT channel_communicator create_channel_communicator(
         hpx::launch::sync_policy, char const* basename,
         num_sites_arg num_sites = num_sites_arg(),
         this_site_arg this_site = this_site_arg());
@@ -242,12 +244,13 @@ namespace hpx::collectives {
 
     ///////////////////////////////////////////////////////////////////////////
     // Predefined p2p communicator (refers to all localities)
-    HPX_EXPORT channel_communicator get_world_channel_communicator();
+    HPX_CXX_EXPORT HPX_EXPORT channel_communicator
+    get_world_channel_communicator();
 
     namespace detail {
 
-        HPX_EXPORT void create_world_channel_communicator();
-        HPX_EXPORT void reset_world_channel_communicator();
+        HPX_CXX_EXPORT HPX_EXPORT void create_world_channel_communicator();
+        HPX_CXX_EXPORT HPX_EXPORT void reset_world_channel_communicator();
     }    // namespace detail
 }    // namespace hpx::collectives
 

--- a/libs/full/collectives/include/hpx/collectives/create_communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/create_communicator.hpp
@@ -174,7 +174,7 @@ namespace hpx::collectives::detail {
 template <>
 struct hpx::util::extra_data_helper<hpx::collectives::detail::communicator_data>
 {
-    HPX_EXPORT static extra_data_id_type id() noexcept;
+    HPX_CXX_EXPORT HPX_EXPORT static extra_data_id_type id() noexcept;
     static constexpr void reset(
         collectives::detail::communicator_data*) noexcept
     {
@@ -216,16 +216,17 @@ namespace hpx::collectives {
         {
         }
 
-        HPX_EXPORT void set_info(num_sites_arg num_sites,
+        HPX_CXX_EXPORT HPX_EXPORT void set_info(num_sites_arg num_sites,
             this_site_arg this_site,
             root_site_arg root_site = root_site_arg()) noexcept;
 
-        [[nodiscard]] HPX_EXPORT
+        [[nodiscard]] HPX_CXX_EXPORT HPX_EXPORT
             std::tuple<num_sites_arg, this_site_arg, root_site_arg>
             get_info_ex() const noexcept;
 
-        [[nodiscard]] HPX_EXPORT std::pair<num_sites_arg, this_site_arg>
-        get_info() const noexcept;
+        [[nodiscard]] HPX_CXX_EXPORT HPX_EXPORT
+            std::pair<num_sites_arg, this_site_arg>
+            get_info() const noexcept;
 
         [[nodiscard]] bool is_root() const
         {
@@ -235,53 +236,55 @@ namespace hpx::collectives {
 
     ///////////////////////////////////////////////////////////////////////////
     // Predefined global communicator (refers to all localities)
-    HPX_EXPORT communicator get_world_communicator();
+    HPX_CXX_EXPORT HPX_EXPORT communicator get_world_communicator();
 
     namespace detail {
 
-        HPX_EXPORT void create_global_communicator();
-        HPX_EXPORT void reset_global_communicator();
+        HPX_CXX_EXPORT HPX_EXPORT void create_global_communicator();
+        HPX_CXX_EXPORT HPX_EXPORT void reset_global_communicator();
     }    // namespace detail
 
     ///////////////////////////////////////////////////////////////////////////
     // Predefined local communicator (refers to all threads on the calling
     // locality)
-    HPX_EXPORT communicator get_local_communicator();
+    HPX_CXX_EXPORT HPX_EXPORT communicator get_local_communicator();
 
     namespace detail {
 
-        HPX_EXPORT void create_local_communicator();
-        HPX_EXPORT void reset_local_communicator();
+        HPX_CXX_EXPORT HPX_EXPORT void create_local_communicator();
+        HPX_CXX_EXPORT HPX_EXPORT void reset_local_communicator();
     }    // namespace detail
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT communicator create_communicator(char const* basename,
+    HPX_CXX_EXPORT HPX_EXPORT communicator create_communicator(
+        char const* basename, num_sites_arg num_sites = num_sites_arg(),
+        this_site_arg this_site = this_site_arg(),
+        generation_arg generation = generation_arg(),
+        root_site_arg root_site = root_site_arg());
+
+    HPX_CXX_EXPORT HPX_EXPORT communicator create_communicator(
+        hpx::launch::sync_policy, char const* basename,
         num_sites_arg num_sites = num_sites_arg(),
         this_site_arg this_site = this_site_arg(),
         generation_arg generation = generation_arg(),
         root_site_arg root_site = root_site_arg());
 
-    HPX_EXPORT communicator create_communicator(hpx::launch::sync_policy,
-        char const* basename, num_sites_arg num_sites = num_sites_arg(),
-        this_site_arg this_site = this_site_arg(),
-        generation_arg generation = generation_arg(),
-        root_site_arg root_site = root_site_arg());
-
-    HPX_EXPORT communicator create_local_communicator(char const* basename,
-        num_sites_arg num_sites, this_site_arg this_site,
-        generation_arg generation = generation_arg(),
-        root_site_arg root_site = root_site_arg());
-
-    HPX_EXPORT communicator create_local_communicator(hpx::launch::sync_policy,
+    HPX_CXX_EXPORT HPX_EXPORT communicator create_local_communicator(
         char const* basename, num_sites_arg num_sites, this_site_arg this_site,
         generation_arg generation = generation_arg(),
+        root_site_arg root_site = root_site_arg());
+
+    HPX_CXX_EXPORT HPX_EXPORT communicator create_local_communicator(
+        hpx::launch::sync_policy, char const* basename, num_sites_arg num_sites,
+        this_site_arg this_site, generation_arg generation = generation_arg(),
         root_site_arg root_site = root_site_arg());
 
     ///////////////////////////////////////////////////////////////////////////
     struct hierarchical_communicator;
 
-    HPX_EXPORT hierarchical_communicator create_hierarchical_communicator(
-        char const* basename, num_sites_arg num_sites = num_sites_arg(),
+    HPX_CXX_EXPORT HPX_EXPORT hierarchical_communicator
+    create_hierarchical_communicator(char const* basename,
+        num_sites_arg num_sites = num_sites_arg(),
         this_site_arg this_site = this_site_arg(),
         arity_arg arity = arity_arg(),
         generation_arg generation = generation_arg(),
@@ -302,7 +305,7 @@ namespace hpx::collectives {
         {
         }
 
-        friend HPX_EXPORT hierarchical_communicator
+        friend HPX_CXX_EXPORT HPX_EXPORT hierarchical_communicator
         create_hierarchical_communicator(char const* basename,
             num_sites_arg num_sites, this_site_arg this_site, arity_arg arity,
             generation_arg generation, root_site_arg root_site);
@@ -352,12 +355,13 @@ namespace hpx::collectives {
             return arity;
         }
 
-        [[nodiscard]] HPX_EXPORT
+        [[nodiscard]] HPX_CXX_EXPORT HPX_EXPORT
             hpx::tuple<num_sites_arg, this_site_arg, root_site_arg>
             get_info_ex() const noexcept;
 
-        [[nodiscard]] HPX_EXPORT hpx::tuple<num_sites_arg, this_site_arg>
-        get_info() const noexcept;
+        [[nodiscard]] HPX_CXX_EXPORT HPX_EXPORT
+            hpx::tuple<num_sites_arg, this_site_arg>
+            get_info() const noexcept;
 
     private:
         std::vector<hpx::tuple<communicator, this_site_arg>> communicators;

--- a/libs/full/collectives/include/hpx/collectives/detail/barrier_node.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/barrier_node.hpp
@@ -29,7 +29,7 @@
 
 namespace hpx { namespace distributed { namespace detail {
 
-    struct HPX_EXPORT barrier_node;
+    HPX_CXX_EXPORT struct HPX_EXPORT barrier_node;
 }}}    // namespace hpx::distributed::detail
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/full/collectives/include/hpx/collectives/detail/channel_communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/channel_communicator.hpp
@@ -112,10 +112,10 @@ namespace hpx::collectives::detail {
         using client_type = components::client<channel_communicator_server>;
 
     public:
-        HPX_EXPORT channel_communicator(char const* basename,
+        HPX_CXX_EXPORT HPX_EXPORT channel_communicator(char const* basename,
             std::size_t num_sites, std::size_t this_site, client_type here);
 
-        HPX_EXPORT channel_communicator(hpx::launch::sync_policy,
+        HPX_CXX_EXPORT HPX_EXPORT channel_communicator(hpx::launch::sync_policy,
             char const* basename, std::size_t num_sites, std::size_t this_site,
             client_type here);
 
@@ -127,7 +127,7 @@ namespace hpx::collectives::detail {
         channel_communicator& operator=(
             channel_communicator&& rhs) noexcept = delete;
 
-        HPX_EXPORT ~channel_communicator();
+        HPX_CXX_EXPORT HPX_EXPORT ~channel_communicator();
 
         template <typename T>
         hpx::future<T> get(std::size_t site, std::size_t tag) const

--- a/libs/full/collectives/include/hpx/collectives/detail/communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/communicator.hpp
@@ -57,9 +57,9 @@ namespace hpx::collectives::detail {
         using mutex_type = hpx::spinlock;
 
     public:
-        HPX_EXPORT communicator_server() noexcept;
+        HPX_CXX_EXPORT HPX_EXPORT communicator_server() noexcept;
 
-        HPX_EXPORT explicit communicator_server(
+        HPX_CXX_EXPORT HPX_EXPORT explicit communicator_server(
             std::size_t num_sites, char const* basename) noexcept;
 
         communicator_server(communicator_server const&) = delete;
@@ -67,7 +67,7 @@ namespace hpx::collectives::detail {
         communicator_server& operator=(communicator_server const&) = delete;
         communicator_server& operator=(communicator_server&&) = delete;
 
-        HPX_EXPORT ~communicator_server();
+        HPX_CXX_EXPORT HPX_EXPORT ~communicator_server();
 
     private:
         template <typename Operation>

--- a/libs/full/collectives/include/hpx/collectives/exclusive_scan.hpp
+++ b/libs/full/collectives/include/hpx/collectives/exclusive_scan.hpp
@@ -332,13 +332,13 @@ namespace hpx::traits {
         template <>
         struct communicator_data<exclusive_scan_tag>
         {
-            HPX_EXPORT static char const* name() noexcept;
+            HPX_CXX_EXPORT HPX_EXPORT static char const* name() noexcept;
         };
 
         template <>
         struct communicator_data<exclusive_scan_init_tag>
         {
-            HPX_EXPORT static char const* name() noexcept;
+            HPX_CXX_EXPORT HPX_EXPORT static char const* name() noexcept;
         };
     }    // namespace communication
 

--- a/libs/full/collectives/include/hpx/collectives/gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/gather.hpp
@@ -429,7 +429,7 @@ namespace hpx::traits {
         template <>
         struct communicator_data<gather_tag>
         {
-            HPX_EXPORT static char const* name() noexcept;
+            HPX_CXX_EXPORT HPX_EXPORT static char const* name() noexcept;
         };
     }    // namespace communication
 

--- a/libs/full/collectives/include/hpx/collectives/inclusive_scan.hpp
+++ b/libs/full/collectives/include/hpx/collectives/inclusive_scan.hpp
@@ -263,7 +263,7 @@ namespace hpx::traits {
         template <>
         struct communicator_data<inclusive_scan_tag>
         {
-            HPX_EXPORT static char const* name() noexcept;
+            HPX_CXX_EXPORT HPX_EXPORT static char const* name() noexcept;
         };
     }    // namespace communication
 

--- a/libs/full/collectives/include/hpx/collectives/latch.hpp
+++ b/libs/full/collectives/include/hpx/collectives/latch.hpp
@@ -28,7 +28,7 @@ namespace hpx::distributed {
     /// This latch can be invoked in a distributed application.
     ///
     /// For a local only latch \see hpx::latch.
-    class HPX_EXPORT latch
+    HPX_CXX_EXPORT class HPX_EXPORT latch
       : public components::client_base<latch, hpx::lcos::server::latch>
     {
         typedef components::client_base<latch, hpx::lcos::server::latch>

--- a/libs/full/collectives/include/hpx/collectives/reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/reduce.hpp
@@ -421,7 +421,7 @@ namespace hpx::traits {
         template <>
         struct communicator_data<reduce_tag>
         {
-            HPX_EXPORT static char const* name() noexcept;
+            HPX_CXX_EXPORT HPX_EXPORT static char const* name() noexcept;
         };
     }    // namespace communication
 

--- a/libs/full/collectives/include/hpx/collectives/scatter.hpp
+++ b/libs/full/collectives/include/hpx/collectives/scatter.hpp
@@ -414,7 +414,7 @@ namespace hpx::traits {
         template <>
         struct communicator_data<scatter_tag>
         {
-            HPX_EXPORT static char const* name() noexcept;
+            HPX_CXX_EXPORT HPX_EXPORT static char const* name() noexcept;
         };
     }    // namespace communication
 

--- a/libs/full/components/CMakeLists.txt
+++ b/libs/full/components/CMakeLists.txt
@@ -40,6 +40,7 @@ include(HPX_AddModule)
 add_hpx_module(
   full components
   GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_MODULE_GEN ON
   SOURCES ${components_sources}
   HEADERS ${components_headers}
   COMPAT_HEADERS ${components_compat_headers}

--- a/libs/full/components/include/hpx/components/basename_registration_fwd.hpp
+++ b/libs/full/components/include/hpx/components/basename_registration_fwd.hpp
@@ -25,9 +25,9 @@ namespace hpx {
     /// \cond NOINTERNAL
     namespace detail {
 
-        HPX_EXPORT std::string name_from_basename(
+        HPX_CXX_EXPORT HPX_EXPORT std::string name_from_basename(
             std::string const& basename, std::size_t idx);
-        HPX_EXPORT std::string name_from_basename(
+        HPX_CXX_EXPORT HPX_EXPORT std::string name_from_basename(
             std::string&& basename, std::size_t idx);
     }    // namespace detail
     /// \endcond
@@ -51,10 +51,11 @@ namespace hpx {
     ///         This is important in order to reliably retrieve ids from a
     ///         name, even if the name was already registered.
     ///
-    HPX_EXPORT std::vector<hpx::future<hpx::id_type>> find_all_from_basename(
-        std::string base_name, std::size_t num_ids);
+    HPX_CXX_EXPORT HPX_EXPORT std::vector<hpx::future<hpx::id_type>>
+    find_all_from_basename(std::string base_name, std::size_t num_ids);
 
-    HPX_EXPORT std::vector<hpx::future<hpx::id_type>> find_all_from_basename(
+    HPX_CXX_EXPORT HPX_EXPORT std::vector<hpx::future<hpx::id_type>>
+    find_all_from_basename(
         hpx::launch::sync_policy, std::string base_name, std::size_t num_ids);
 
     /// Return registered ids from the given base name and sequence numbers.
@@ -75,11 +76,12 @@ namespace hpx {
     ///         This is important in order to reliably retrieve ids from a
     ///         name, even if the name was already registered.
     ///
-    HPX_EXPORT std::vector<hpx::future<hpx::id_type>> find_from_basename(
+    HPX_CXX_EXPORT HPX_EXPORT std::vector<hpx::future<hpx::id_type>>
+    find_from_basename(
         std::string base_name, std::vector<std::size_t> const& ids);
 
-    HPX_EXPORT std::vector<hpx::future<hpx::id_type>> find_from_basename(
-        hpx::launch::sync_policy, std::string base_name,
+    HPX_CXX_EXPORT HPX_EXPORT std::vector<hpx::future<hpx::id_type>>
+    find_from_basename(hpx::launch::sync_policy, std::string base_name,
         std::vector<std::size_t> const& ids);
 
     /// \brief Return registered id from the given base name and sequence number.
@@ -100,12 +102,12 @@ namespace hpx {
     ///         This is important in order to reliably retrieve ids from a
     ///         name, even if the name was already registered.
     ///
-    HPX_EXPORT hpx::future<hpx::id_type> find_from_basename(
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future<hpx::id_type> find_from_basename(
         std::string base_name,
         std::size_t sequence_nr = ~static_cast<std::size_t>(0));
 
-    HPX_EXPORT hpx::id_type find_from_basename(hpx::launch::sync_policy,
-        std::string base_name,
+    HPX_CXX_EXPORT HPX_EXPORT hpx::id_type find_from_basename(
+        hpx::launch::sync_policy, std::string base_name,
         std::size_t sequence_nr = ~static_cast<std::size_t>(0));
 
     ///////////////////////////////////////////////////////////////////////////
@@ -129,12 +131,12 @@ namespace hpx {
     /// \note    The operation will fail if the given sequence number is not
     ///          unique.
     ///
-    HPX_EXPORT hpx::future<bool> register_with_basename(std::string base_name,
-        hpx::id_type const& id,
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future<bool> register_with_basename(
+        std::string base_name, hpx::id_type const& id,
         std::size_t sequence_nr = ~static_cast<std::size_t>(0));
 
-    HPX_EXPORT bool register_with_basename(hpx::launch::sync_policy,
-        std::string base_name, hpx::id_type const& id,
+    HPX_CXX_EXPORT HPX_EXPORT bool register_with_basename(
+        hpx::launch::sync_policy, std::string base_name, hpx::id_type const& id,
         std::size_t sequence_nr = ~static_cast<std::size_t>(0),
         error_code& ec = throws);
 
@@ -160,8 +162,8 @@ namespace hpx {
     /// \note    The operation will fail if the given sequence number is not
     ///          unique.
     ///
-    HPX_EXPORT hpx::future<bool> register_with_basename(std::string base_name,
-        hpx::future<hpx::id_type> f,
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future<bool> register_with_basename(
+        std::string base_name, hpx::future<hpx::id_type> f,
         std::size_t sequence_nr = ~static_cast<std::size_t>(0));
 
     /// \brief Unregister the given id using the given base name.
@@ -178,8 +180,8 @@ namespace hpx {
     /// \returns A future representing the result of the un-registration
     ///          operation itself.
     ///
-    HPX_EXPORT hpx::future<hpx::id_type> unregister_with_basename(
-        std::string base_name,
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future<hpx::id_type>
+    unregister_with_basename(std::string base_name,
         std::size_t sequence_nr = ~static_cast<std::size_t>(0));
 
     ///////////////////////////////////////////////////////////////////////////

--- a/libs/full/components/include/hpx/components/client_base.hpp
+++ b/libs/full/components/include/hpx/components/client_base.hpp
@@ -183,15 +183,15 @@ namespace hpx::lcos::detail {
 template <>
 struct hpx::util::extra_data_helper<hpx::lcos::detail::registered_name_tracker>
 {
-    HPX_EXPORT static extra_data_id_type id() noexcept;
-    HPX_EXPORT static void reset(
+    HPX_CXX_EXPORT HPX_EXPORT static extra_data_id_type id() noexcept;
+    HPX_CXX_EXPORT HPX_EXPORT static void reset(
         lcos::detail::registered_name_tracker*) noexcept;
 };    // namespace hpx::util
 
 // Specialization for shared state of id_type, additionally (optionally) holds a
 // registered name for the object it refers to.
 template <>
-struct HPX_EXPORT hpx::lcos::detail::future_data<hpx::id_type>
+HPX_CXX_EXPORT struct HPX_EXPORT hpx::lcos::detail::future_data<hpx::id_type>
   : future_data_base<id_type>
 {
     using init_no_addref = future_data_base<hpx::id_type>::init_no_addref;

--- a/libs/full/components_base/CMakeLists.txt
+++ b/libs/full/components_base/CMakeLists.txt
@@ -105,6 +105,7 @@ include(HPX_AddModule)
 add_hpx_module(
   full components_base
   GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_MODULE_GEN ON
   SOURCES ${components_base_sources}
   HEADERS ${components_base_headers}
   COMPAT_HEADERS ${components_base_compat_headers}

--- a/libs/full/components_base/include/hpx/components_base/agas_interface.hpp
+++ b/libs/full/components_base/include/hpx/components_base/agas_interface.hpp
@@ -30,43 +30,48 @@
 // FIXME: this is pulled from the main library
 namespace hpx::detail {
 
-    HPX_EXPORT naming::gid_type get_next_id(std::size_t count = 1);
+    HPX_CXX_EXPORT HPX_EXPORT naming::gid_type get_next_id(
+        std::size_t count = 1);
 }    // namespace hpx::detail
 
 namespace hpx::agas {
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT bool is_console();
+    HPX_CXX_EXPORT HPX_EXPORT bool is_console();
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT bool register_name(launch::sync_policy, std::string const& name,
-        naming::gid_type const& gid, error_code& ec = throws);
+    HPX_CXX_EXPORT HPX_EXPORT bool register_name(launch::sync_policy,
+        std::string const& name, naming::gid_type const& gid,
+        error_code& ec = throws);
 
-    HPX_EXPORT bool register_name(launch::sync_policy, std::string const& name,
-        hpx::id_type const& id, error_code& ec = throws);
+    HPX_CXX_EXPORT HPX_EXPORT bool register_name(launch::sync_policy,
+        std::string const& name, hpx::id_type const& id,
+        error_code& ec = throws);
 
-    HPX_EXPORT hpx::future<bool> register_name(
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future<bool> register_name(
         std::string const& name, hpx::id_type const& id);
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT hpx::id_type unregister_name(
+    HPX_CXX_EXPORT HPX_EXPORT hpx::id_type unregister_name(
         launch::sync_policy, std::string const& name, error_code& ec = throws);
 
-    HPX_EXPORT hpx::future<hpx::id_type> unregister_name(
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future<hpx::id_type> unregister_name(
         std::string const& name);
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT hpx::id_type resolve_name(
+    HPX_CXX_EXPORT HPX_EXPORT hpx::id_type resolve_name(
         launch::sync_policy, std::string const& name, error_code& ec = throws);
 
-    HPX_EXPORT hpx::future<hpx::id_type> resolve_name(std::string const& name);
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future<hpx::id_type> resolve_name(
+        std::string const& name);
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT hpx::future<std::uint32_t> get_num_localities(
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future<std::uint32_t> get_num_localities(
         naming::component_type type = naming::component_invalid);
 
-    HPX_EXPORT std::uint32_t get_num_localities(launch::sync_policy,
-        naming::component_type type, error_code& ec = throws);
+    HPX_CXX_EXPORT HPX_EXPORT std::uint32_t get_num_localities(
+        launch::sync_policy, naming::component_type type,
+        error_code& ec = throws);
 
     inline std::uint32_t get_num_localities(
         launch::sync_policy, error_code& ec = throws)
@@ -76,23 +81,26 @@ namespace hpx::agas {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT std::string get_component_type_name(
+    HPX_CXX_EXPORT HPX_EXPORT std::string get_component_type_name(
         naming::component_type type, error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT hpx::future<std::vector<std::uint32_t>> get_num_threads();
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future<std::vector<std::uint32_t>>
+    get_num_threads();
 
-    HPX_EXPORT std::vector<std::uint32_t> get_num_threads(
+    HPX_CXX_EXPORT HPX_EXPORT std::vector<std::uint32_t> get_num_threads(
         launch::sync_policy, error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT hpx::future<std::uint32_t> get_num_overall_threads();
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future<std::uint32_t>
+    get_num_overall_threads();
 
-    HPX_EXPORT std::uint32_t get_num_overall_threads(
+    HPX_CXX_EXPORT HPX_EXPORT std::uint32_t get_num_overall_threads(
         launch::sync_policy, error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT std::uint32_t get_locality_id(error_code& ec = throws);
+    HPX_CXX_EXPORT HPX_EXPORT std::uint32_t get_locality_id(
+        error_code& ec = throws);
 
     inline hpx::naming::gid_type get_locality()
     {
@@ -100,7 +108,7 @@ namespace hpx::agas {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT std::vector<std::uint32_t> get_all_locality_ids(
+    HPX_CXX_EXPORT HPX_EXPORT std::vector<std::uint32_t> get_all_locality_ids(
         naming::component_type type, error_code& ec = throws);
 
     inline std::vector<std::uint32_t> get_all_locality_ids(
@@ -111,21 +119,24 @@ namespace hpx::agas {
 
     ///////////////////////////////////////////////////////////////////////////
 #if defined(HPX_HAVE_NETWORKING)
-    HPX_EXPORT parcelset::endpoints_type const& resolve_locality(
+    HPX_CXX_EXPORT HPX_EXPORT parcelset::endpoints_type const& resolve_locality(
         naming::gid_type const& gid, error_code& ec = throws);
 
-    HPX_EXPORT void remove_resolved_locality(naming::gid_type const& gid);
+    HPX_CXX_EXPORT HPX_EXPORT void remove_resolved_locality(
+        naming::gid_type const& gid);
 #endif
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT bool is_local_address_cached(
+    HPX_CXX_EXPORT HPX_EXPORT bool is_local_address_cached(
         naming::gid_type const& gid, error_code& ec = throws);
 
-    HPX_EXPORT bool is_local_address_cached(naming::gid_type const& gid,
-        naming::address& addr, error_code& ec = throws);
+    HPX_CXX_EXPORT HPX_EXPORT bool is_local_address_cached(
+        naming::gid_type const& gid, naming::address& addr,
+        error_code& ec = throws);
 
-    HPX_EXPORT bool is_local_address_cached(naming::gid_type const& gid,
-        naming::address& addr, std::pair<bool, components::pinned_ptr>& r,
+    HPX_CXX_EXPORT HPX_EXPORT bool is_local_address_cached(
+        naming::gid_type const& gid, naming::address& addr,
+        std::pair<bool, components::pinned_ptr>& r,
         hpx::move_only_function<std::pair<bool, components::pinned_ptr>(
             naming::address const&)>&& f,
         error_code& ec = throws);
@@ -151,12 +162,14 @@ namespace hpx::agas {
         return is_local_address_cached(id.get_gid(), addr, r, HPX_MOVE(f), ec);
     }
 
-    HPX_EXPORT void update_cache_entry(naming::gid_type const& gid,
-        naming::address const& addr, std::uint64_t count = 0,
-        std::uint64_t offset = 0, error_code& ec = throws);
+    HPX_CXX_EXPORT HPX_EXPORT void update_cache_entry(
+        naming::gid_type const& gid, naming::address const& addr,
+        std::uint64_t count = 0, std::uint64_t offset = 0,
+        error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT bool is_local_lva_encoded_address(naming::gid_type const& gid);
+    HPX_CXX_EXPORT HPX_EXPORT bool is_local_lva_encoded_address(
+        naming::gid_type const& gid);
 
     inline bool is_local_lva_encoded_address(hpx::id_type const& id)
     {
@@ -164,144 +177,154 @@ namespace hpx::agas {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT hpx::future_or_value<naming::address> resolve_async(
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future_or_value<naming::address>
+    resolve_async(hpx::id_type const& id);
+
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future<naming::address> resolve(
         hpx::id_type const& id);
 
-    HPX_EXPORT hpx::future<naming::address> resolve(hpx::id_type const& id);
-
-    HPX_EXPORT naming::address resolve(
+    HPX_CXX_EXPORT HPX_EXPORT naming::address resolve(
         launch::sync_policy, hpx::id_type const& id, error_code& ec = throws);
 
-    HPX_EXPORT bool resolve_local(naming::gid_type const& gid,
+    HPX_CXX_EXPORT HPX_EXPORT bool resolve_local(naming::gid_type const& gid,
         naming::address& addr, error_code& ec = throws);
 
-    HPX_EXPORT bool resolve_cached(
+    HPX_CXX_EXPORT HPX_EXPORT bool resolve_cached(
         naming::gid_type const& gid, naming::address& addr);
 
-    HPX_EXPORT hpx::future<bool> bind(naming::gid_type const& gid,
-        naming::address const& addr, std::uint32_t locality_id);
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future<bool> bind(
+        naming::gid_type const& gid, naming::address const& addr,
+        std::uint32_t locality_id);
 
-    HPX_EXPORT bool bind(launch::sync_policy, naming::gid_type const& gid,
-        naming::address const& addr, std::uint32_t locality_id,
-        error_code& ec = throws);
+    HPX_CXX_EXPORT HPX_EXPORT bool bind(launch::sync_policy,
+        naming::gid_type const& gid, naming::address const& addr,
+        std::uint32_t locality_id, error_code& ec = throws);
 
-    HPX_EXPORT hpx::future<bool> bind(naming::gid_type const& gid,
-        naming::address const& addr, naming::gid_type const& locality_);
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future<bool> bind(
+        naming::gid_type const& gid, naming::address const& addr,
+        naming::gid_type const& locality_);
 
-    HPX_EXPORT bool bind(launch::sync_policy, naming::gid_type const& gid,
-        naming::address const& addr, naming::gid_type const& locality_,
-        error_code& ec = throws);
+    HPX_CXX_EXPORT HPX_EXPORT bool bind(launch::sync_policy,
+        naming::gid_type const& gid, naming::address const& addr,
+        naming::gid_type const& locality_, error_code& ec = throws);
 
-    HPX_EXPORT hpx::future<naming::address> unbind(
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future<naming::address> unbind(
         naming::gid_type const& gid, std::uint64_t count = 1);
 
-    HPX_EXPORT naming::address unbind(launch::sync_policy,
+    HPX_CXX_EXPORT HPX_EXPORT naming::address unbind(launch::sync_policy,
         naming::gid_type const& gid, std::uint64_t count = 1,
         error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
     // helper functions allowing to locally bind and unbind a GID to a given
     // address
-    HPX_EXPORT bool bind_gid_local(naming::gid_type const& gid,
+    HPX_CXX_EXPORT HPX_EXPORT bool bind_gid_local(naming::gid_type const& gid,
         naming::address const& addr, error_code& ec = throws);
-    HPX_EXPORT void unbind_gid_local(
+    HPX_CXX_EXPORT HPX_EXPORT void unbind_gid_local(
         naming::gid_type const& gid, error_code& ec = throws);
 
-    HPX_EXPORT bool bind_range_local(naming::gid_type const& gid,
+    HPX_CXX_EXPORT HPX_EXPORT bool bind_range_local(naming::gid_type const& gid,
         std::size_t count, naming::address const& addr, std::size_t offset,
         error_code& ec = throws);
-    HPX_EXPORT void unbind_range_local(naming::gid_type const& gid,
-        std::size_t count, error_code& ec = throws);
+    HPX_CXX_EXPORT HPX_EXPORT void unbind_range_local(
+        naming::gid_type const& gid, std::size_t count,
+        error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT void garbage_collect_non_blocking(error_code& ec = throws);
+    HPX_CXX_EXPORT HPX_EXPORT void garbage_collect_non_blocking(
+        error_code& ec = throws);
 
-    HPX_EXPORT void garbage_collect(error_code& ec = throws);
+    HPX_CXX_EXPORT HPX_EXPORT void garbage_collect(error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Invoke an asynchronous garbage collection step on the given target
     ///        locality.
-    HPX_EXPORT void garbage_collect_non_blocking(
+    HPX_CXX_EXPORT HPX_EXPORT void garbage_collect_non_blocking(
         hpx::id_type const& id, error_code& ec = throws);
 
     /// \brief Invoke a synchronous garbage collection step on the given target
     ///        locality.
-    HPX_EXPORT void garbage_collect(
+    HPX_CXX_EXPORT HPX_EXPORT void garbage_collect(
         hpx::id_type const& id, error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Return an id_type referring to the console locality.
-    HPX_EXPORT hpx::id_type get_console_locality(error_code& ec = throws);
-
-    ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT naming::gid_type get_next_id(
-        std::size_t count, error_code& ec = throws);
-
-    ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT void decref(naming::gid_type const& id, std::int64_t credits,
+    HPX_CXX_EXPORT HPX_EXPORT hpx::id_type get_console_locality(
         error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT hpx::future_or_value<std::int64_t> incref(
+    HPX_CXX_EXPORT HPX_EXPORT naming::gid_type get_next_id(
+        std::size_t count, error_code& ec = throws);
+
+    ///////////////////////////////////////////////////////////////////////////
+    HPX_CXX_EXPORT HPX_EXPORT void decref(naming::gid_type const& id,
+        std::int64_t credits, error_code& ec = throws);
+
+    ///////////////////////////////////////////////////////////////////////////
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future_or_value<std::int64_t> incref(
         naming::gid_type const& gid, std::int64_t credits,
         hpx::id_type const& keep_alive = hpx::invalid_id);
 
-    HPX_EXPORT std::int64_t incref(launch::sync_policy,
+    HPX_CXX_EXPORT HPX_EXPORT std::int64_t incref(launch::sync_policy,
         naming::gid_type const& gid, std::int64_t credits = 1,
         hpx::id_type const& keep_alive = hpx::invalid_id,
         error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT std::int64_t replenish_credits(naming::gid_type& gid);
+    HPX_CXX_EXPORT HPX_EXPORT std::int64_t replenish_credits(
+        naming::gid_type& gid);
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT hpx::future_or_value<id_type> get_colocation_id(
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future_or_value<id_type> get_colocation_id(
         hpx::id_type const& id);
 
-    HPX_EXPORT hpx::id_type get_colocation_id(
+    HPX_CXX_EXPORT HPX_EXPORT hpx::id_type get_colocation_id(
         launch::sync_policy, hpx::id_type const& id, error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT hpx::future<hpx::id_type> on_symbol_namespace_event(
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future<hpx::id_type>
+    on_symbol_namespace_event(
         std::string const& name, bool call_for_past_events);
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT hpx::future<std::pair<hpx::id_type, naming::address>>
-    begin_migration(hpx::id_type const& id);
+    HPX_CXX_EXPORT HPX_EXPORT
+        hpx::future<std::pair<hpx::id_type, naming::address>>
+        begin_migration(hpx::id_type const& id);
 
-    HPX_EXPORT bool end_migration(hpx::id_type const& id);
+    HPX_CXX_EXPORT HPX_EXPORT bool end_migration(hpx::id_type const& id);
 
-    HPX_EXPORT hpx::future<void> mark_as_migrated(naming::gid_type const& gid,
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future<void> mark_as_migrated(
+        naming::gid_type const& gid,
         hpx::move_only_function<std::pair<bool, hpx::future<void>>()>&& f,
         bool expect_to_be_marked_as_migrating);
 
-    HPX_EXPORT std::pair<bool, components::pinned_ptr> was_object_migrated(
-        naming::gid_type const& gid,
+    HPX_CXX_EXPORT HPX_EXPORT std::pair<bool, components::pinned_ptr>
+    was_object_migrated(naming::gid_type const& gid,
         hpx::move_only_function<components::pinned_ptr()>&& f);
 
-    HPX_EXPORT void unmark_as_migrated(
+    HPX_CXX_EXPORT HPX_EXPORT void unmark_as_migrated(
         naming::gid_type const& gid, hpx::move_only_function<void()>&& f);
 
-    HPX_EXPORT hpx::future<std::map<std::string, hpx::id_type>> find_symbols(
-        std::string const& pattern = "*");
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future<std::map<std::string, hpx::id_type>>
+    find_symbols(std::string const& pattern = "*");
 
-    HPX_EXPORT std::map<std::string, hpx::id_type> find_symbols(
+    HPX_CXX_EXPORT HPX_EXPORT std::map<std::string, hpx::id_type> find_symbols(
         hpx::launch::sync_policy, std::string const& pattern = "*");
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT naming::component_type register_factory(
+    HPX_CXX_EXPORT HPX_EXPORT naming::component_type register_factory(
         std::uint32_t prefix, std::string const& name, error_code& ec = throws);
 
-    HPX_EXPORT naming::component_type get_component_id(
+    HPX_CXX_EXPORT HPX_EXPORT naming::component_type get_component_id(
         std::string const& name, error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT void destroy_component(
+    HPX_CXX_EXPORT HPX_EXPORT void destroy_component(
         naming::gid_type const& gid, naming::address const& addr);
 
     ///////////////////////////////////////////////////////////////////////////
 #if defined(HPX_HAVE_NETWORKING)
-    HPX_EXPORT void route(parcelset::parcel&& p,
+    HPX_CXX_EXPORT HPX_EXPORT void route(parcelset::parcel&& p,
         hpx::function<void(std::error_code const&, parcelset::parcel const&)>&&
             f,
         threads::thread_priority local_priority =
@@ -309,9 +332,9 @@ namespace hpx::agas {
 #endif
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT naming::address_type get_primary_ns_lva();
-    HPX_EXPORT naming::address_type get_symbol_ns_lva();
-    HPX_EXPORT naming::address_type get_runtime_support_lva();
+    HPX_CXX_EXPORT HPX_EXPORT naming::address_type get_primary_ns_lva();
+    HPX_CXX_EXPORT HPX_EXPORT naming::address_type get_symbol_ns_lva();
+    HPX_CXX_EXPORT HPX_EXPORT naming::address_type get_runtime_support_lva();
 
     ///////////////////////////////////////////////////////////////////////////
     // initialize AGAS interface function wrappers

--- a/libs/full/components_base/include/hpx/components_base/component_type.hpp
+++ b/libs/full/components_base/include/hpx/components_base/component_type.hpp
@@ -153,18 +153,21 @@ namespace hpx::components {
 #undef HPX_FACTORY_STATE_ENUM_DEPRECATION_MSG
 
     // access data related to component instance counts
-    HPX_EXPORT bool& enabled(component_type type);
-    HPX_EXPORT util::atomic_count& instance_count(component_type type);
+    HPX_CXX_EXPORT HPX_EXPORT bool& enabled(component_type type);
+    HPX_CXX_EXPORT HPX_EXPORT util::atomic_count& instance_count(
+        component_type type);
 
     using component_deleter_type = void (*)(
         hpx::naming::gid_type const&, hpx::naming::address const&);
-    HPX_EXPORT component_deleter_type& deleter(component_type type);
+    HPX_CXX_EXPORT HPX_EXPORT component_deleter_type& deleter(
+        component_type type);
 
-    HPX_EXPORT bool enumerate_instance_counts(
+    HPX_CXX_EXPORT HPX_EXPORT bool enumerate_instance_counts(
         hpx::move_only_function<bool(component_type)> const& f);
 
     /// \brief Return the string representation for a given component type id
-    HPX_EXPORT std::string get_component_type_name(component_type type);
+    HPX_CXX_EXPORT HPX_EXPORT std::string get_component_type_name(
+        component_type type);
 
     /// The lower short word of the component type is the type of the component
     /// exposing the actions.
@@ -252,18 +255,19 @@ namespace hpx::components {
     namespace detail {
 
         // Resolve the type from AGAS
-        HPX_EXPORT component_type get_agas_component_type(
+        HPX_CXX_EXPORT HPX_EXPORT component_type get_agas_component_type(
             char const* name, char const* base_name, component_type, bool);
     }    // namespace detail
 
     // Returns the (unique) name for a given component
     template <typename Component, typename Enable = void>
-    HPX_ALWAYS_EXPORT char const* get_component_name() noexcept;
+    HPX_CXX_EXPORT HPX_ALWAYS_EXPORT char const* get_component_name() noexcept;
 
     // Returns the (unique) name of the base component. If there is none,
     // nullptr is returned
     template <typename Component, typename Enable = void>
-    HPX_ALWAYS_EXPORT char const* get_component_base_name() noexcept;
+    HPX_CXX_EXPORT HPX_ALWAYS_EXPORT char const*
+    get_component_base_name() noexcept;
 
     template <typename Component>
     component_type get_component_type() noexcept
@@ -282,14 +286,14 @@ namespace hpx::components {
 #define HPX_DEFINE_GET_COMPONENT_TYPE(component)                               \
     namespace hpx::traits {                                                    \
         template <>                                                            \
-        HPX_ALWAYS_EXPORT components::component_type                           \
+        HPX_CXX_EXPORT HPX_ALWAYS_EXPORT components::component_type            \
         component_type_database<component>::get() noexcept                     \
         {                                                                      \
             return value;                                                      \
         }                                                                      \
         template <>                                                            \
-        HPX_ALWAYS_EXPORT void component_type_database<component>::set(        \
-            components::component_type t)                                      \
+        HPX_CXX_EXPORT HPX_ALWAYS_EXPORT void                                  \
+        component_type_database<component>::set(components::component_type t)  \
         {                                                                      \
             value = t;                                                         \
         }                                                                      \
@@ -303,11 +307,13 @@ namespace hpx::components {
         {                                                                      \
             static components::component_type value;                           \
                                                                                \
-            HPX_ALWAYS_EXPORT static components::component_type get() noexcept \
+            HPX_CXX_EXPORT HPX_ALWAYS_EXPORT static components::component_type \
+            get() noexcept                                                     \
             {                                                                  \
                 return value;                                                  \
             }                                                                  \
-            HPX_ALWAYS_EXPORT static void set(components::component_type t)    \
+            HPX_CXX_EXPORT HPX_ALWAYS_EXPORT static void set(                  \
+                components::component_type t)                                  \
             {                                                                  \
                 value = t;                                                     \
             }                                                                  \
@@ -324,14 +330,14 @@ namespace hpx::components {
 #define HPX_DEFINE_GET_COMPONENT_TYPE_STATIC(component, type)                  \
     namespace hpx::traits {                                                    \
         template <>                                                            \
-        HPX_ALWAYS_EXPORT components::component_type                           \
+        HPX_CXX_EXPORT HPX_ALWAYS_EXPORT components::component_type            \
         component_type_database<component>::get() noexcept                     \
         {                                                                      \
             return type;                                                       \
         }                                                                      \
         template <>                                                            \
-        HPX_ALWAYS_EXPORT void component_type_database<component>::set(        \
-            components::component_type)                                        \
+        HPX_CXX_EXPORT HPX_ALWAYS_EXPORT void                                  \
+        component_type_database<component>::set(components::component_type)    \
         {                                                                      \
             HPX_ASSERT(false);                                                 \
         }                                                                      \
@@ -348,13 +354,13 @@ namespace hpx::components {
 #define HPX_DEFINE_COMPONENT_NAME_2(Component, name)                           \
     namespace hpx::components {                                                \
         template <>                                                            \
-        HPX_ALWAYS_EXPORT char const*                                          \
+        HPX_CXX_EXPORT HPX_ALWAYS_EXPORT char const*                           \
         get_component_name<Component, void>() noexcept                         \
         {                                                                      \
             return HPX_PP_STRINGIZE(name);                                     \
         }                                                                      \
         template <>                                                            \
-        HPX_ALWAYS_EXPORT char const*                                          \
+        HPX_CXX_EXPORT HPX_ALWAYS_EXPORT char const*                           \
         get_component_base_name<Component, void>() noexcept                    \
         {                                                                      \
             return nullptr;                                                    \
@@ -365,13 +371,13 @@ namespace hpx::components {
 #define HPX_DEFINE_COMPONENT_NAME_3(Component, name, base_name)                \
     namespace hpx::components {                                                \
         template <>                                                            \
-        HPX_ALWAYS_EXPORT char const*                                          \
+        HPX_CXX_EXPORT HPX_ALWAYS_EXPORT char const*                           \
         get_component_name<Component, void>() noexcept                         \
         {                                                                      \
             return HPX_PP_STRINGIZE(name);                                     \
         }                                                                      \
         template <>                                                            \
-        HPX_ALWAYS_EXPORT char const*                                          \
+        HPX_CXX_EXPORT HPX_ALWAYS_EXPORT char const*                           \
         get_component_base_name<Component, void>() noexcept                    \
         {                                                                      \
             return base_name;                                                  \

--- a/libs/full/components_base/include/hpx/components_base/detail/agas_interface_functions.hpp
+++ b/libs/full/components_base/include/hpx/components_base/detail/agas_interface_functions.hpp
@@ -26,225 +26,239 @@
 namespace hpx::agas::detail {
 
     ///////////////////////////////////////////////////////////////////////////
-    extern HPX_EXPORT bool (*is_console)();
+    HPX_CXX_EXPORT extern HPX_EXPORT bool (*is_console)();
 
     ///////////////////////////////////////////////////////////////////////////
-    extern HPX_EXPORT bool (*register_name)(
+    HPX_CXX_EXPORT extern HPX_EXPORT bool (*register_name)(
         std::string const& name, naming::gid_type const& gid, error_code& ec);
 
-    extern HPX_EXPORT bool (*register_name_id)(
+    HPX_CXX_EXPORT extern HPX_EXPORT bool (*register_name_id)(
         std::string const& name, hpx::id_type const& id, error_code& ec);
 
-    extern HPX_EXPORT future<bool> (*register_name_async)(
+    HPX_CXX_EXPORT extern HPX_EXPORT future<bool> (*register_name_async)(
         std::string const& name, hpx::id_type const& id);
 
     ///////////////////////////////////////////////////////////////////////////
-    extern HPX_EXPORT hpx::id_type (*unregister_name)(
+    HPX_CXX_EXPORT extern HPX_EXPORT hpx::id_type (*unregister_name)(
         std::string const& name, error_code& ec);
 
-    extern HPX_EXPORT future<hpx::id_type> (*unregister_name_async)(
+    HPX_CXX_EXPORT extern HPX_EXPORT future<hpx::id_type> (
+        *unregister_name_async)(std::string const& name);
+
+    ///////////////////////////////////////////////////////////////////////////
+    HPX_CXX_EXPORT extern HPX_EXPORT hpx::id_type (*resolve_name)(
+        std::string const& name, error_code& ec);
+
+    HPX_CXX_EXPORT extern HPX_EXPORT future<hpx::id_type> (*resolve_name_async)(
         std::string const& name);
 
     ///////////////////////////////////////////////////////////////////////////
-    extern HPX_EXPORT hpx::id_type (*resolve_name)(
-        std::string const& name, error_code& ec);
+    HPX_CXX_EXPORT extern HPX_EXPORT future<std::uint32_t> (
+        *get_num_localities_async)(naming::component_type type);
 
-    extern HPX_EXPORT future<hpx::id_type> (*resolve_name_async)(
-        std::string const& name);
-
-    ///////////////////////////////////////////////////////////////////////////
-    extern HPX_EXPORT future<std::uint32_t> (*get_num_localities_async)(
-        naming::component_type type);
-
-    extern HPX_EXPORT std::uint32_t (*get_num_localities)(
+    HPX_CXX_EXPORT extern HPX_EXPORT std::uint32_t (*get_num_localities)(
         naming::component_type type, error_code& ec);
 
     ///////////////////////////////////////////////////////////////////////////
-    extern HPX_EXPORT std::string (*get_component_type_name)(
+    HPX_CXX_EXPORT extern HPX_EXPORT std::string (*get_component_type_name)(
         naming::component_type type, error_code& ec);
 
     ///////////////////////////////////////////////////////////////////////////
-    extern HPX_EXPORT future<std::vector<std::uint32_t>> (
+    HPX_CXX_EXPORT extern HPX_EXPORT future<std::vector<std::uint32_t>> (
         *get_num_threads_async)();
 
-    extern HPX_EXPORT std::vector<std::uint32_t> (*get_num_threads)(
+    HPX_CXX_EXPORT extern HPX_EXPORT std::vector<std::uint32_t> (
+        *get_num_threads)(error_code& ec);
+
+    ///////////////////////////////////////////////////////////////////////////
+    HPX_CXX_EXPORT extern HPX_EXPORT future<std::uint32_t> (
+        *get_num_overall_threads_async)();
+
+    HPX_CXX_EXPORT extern HPX_EXPORT std::uint32_t (*get_num_overall_threads)(
         error_code& ec);
 
     ///////////////////////////////////////////////////////////////////////////
-    extern HPX_EXPORT future<std::uint32_t> (*get_num_overall_threads_async)();
+    HPX_CXX_EXPORT extern HPX_EXPORT std::uint32_t (*get_locality_id)(
+        error_code& ec);
 
-    extern HPX_EXPORT std::uint32_t (*get_num_overall_threads)(error_code& ec);
-
-    ///////////////////////////////////////////////////////////////////////////
-    extern HPX_EXPORT std::uint32_t (*get_locality_id)(error_code& ec);
-
-    extern HPX_EXPORT std::vector<std::uint32_t> (*get_all_locality_ids)(
-        naming::component_type type, error_code& ec);
+    HPX_CXX_EXPORT extern HPX_EXPORT std::vector<std::uint32_t> (
+        *get_all_locality_ids)(naming::component_type type, error_code& ec);
 
     ///////////////////////////////////////////////////////////////////////////
 #if defined(HPX_HAVE_NETWORKING)
-    extern HPX_EXPORT parcelset::endpoints_type const& (*resolve_locality)(
-        naming::gid_type const& gid, error_code& ec);
+    HPX_CXX_EXPORT extern HPX_EXPORT parcelset::endpoints_type const& (
+        *resolve_locality)(naming::gid_type const& gid, error_code& ec);
 
-    extern HPX_EXPORT void (*remove_resolved_locality)(
+    HPX_CXX_EXPORT extern HPX_EXPORT void (*remove_resolved_locality)(
         naming::gid_type const& gid);
 #endif
 
     ///////////////////////////////////////////////////////////////////////////
-    extern HPX_EXPORT bool (*is_local_address_cached)(
+    HPX_CXX_EXPORT extern HPX_EXPORT bool (*is_local_address_cached)(
         naming::gid_type const& gid, error_code& ec);
 
-    extern HPX_EXPORT bool (*is_local_address_cached_addr)(
+    HPX_CXX_EXPORT extern HPX_EXPORT bool (*is_local_address_cached_addr)(
         naming::gid_type const& gid, naming::address& addr, error_code& ec);
 
-    extern HPX_EXPORT bool (*is_local_address_cached_addr_pinned_ptr)(
-        naming::gid_type const& gid, naming::address& addr,
-        std::pair<bool, components::pinned_ptr>& r,
+    HPX_CXX_EXPORT extern HPX_EXPORT bool (
+        *is_local_address_cached_addr_pinned_ptr)(naming::gid_type const& gid,
+        naming::address& addr, std::pair<bool, components::pinned_ptr>& r,
         hpx::move_only_function<std::pair<bool, components::pinned_ptr>(
             naming::address const&)>&& f,
         error_code& ec);
 
-    extern HPX_EXPORT void (*update_cache_entry)(naming::gid_type const& gid,
-        naming::address const& addr, std::uint64_t count, std::uint64_t offset,
-        error_code& ec);
+    HPX_CXX_EXPORT extern HPX_EXPORT void (*update_cache_entry)(
+        naming::gid_type const& gid, naming::address const& addr,
+        std::uint64_t count, std::uint64_t offset, error_code& ec);
 
     ///////////////////////////////////////////////////////////////////////////
-    extern HPX_EXPORT bool (*is_local_lva_encoded_address)(
+    HPX_CXX_EXPORT extern HPX_EXPORT bool (*is_local_lva_encoded_address)(
         naming::gid_type const& gid);
 
     ///////////////////////////////////////////////////////////////////////////
-    extern HPX_EXPORT hpx::future_or_value<naming::address> (*resolve_async)(
-        hpx::id_type const& id);
+    HPX_CXX_EXPORT extern HPX_EXPORT hpx::future_or_value<naming::address> (
+        *resolve_async)(hpx::id_type const& id);
 
-    extern HPX_EXPORT naming::address (*resolve)(
+    HPX_CXX_EXPORT extern HPX_EXPORT naming::address (*resolve)(
         hpx::id_type const& id, error_code& ec);
 
-    extern HPX_EXPORT bool (*resolve_local)(
+    HPX_CXX_EXPORT extern HPX_EXPORT bool (*resolve_local)(
         naming::gid_type const& gid, naming::address& addr, error_code& ec);
 
-    extern HPX_EXPORT bool (*resolve_cached)(
+    HPX_CXX_EXPORT extern HPX_EXPORT bool (*resolve_cached)(
         naming::gid_type const& gid, naming::address& addr);
 
     ///////////////////////////////////////////////////////////////////////////
-    extern HPX_EXPORT hpx::future<bool> (*bind_async)(
+    HPX_CXX_EXPORT extern HPX_EXPORT hpx::future<bool> (*bind_async)(
         naming::gid_type const& gid, naming::address const& addr,
         std::uint32_t locality_id);
 
-    extern HPX_EXPORT bool (*bind)(naming::gid_type const& gid,
+    HPX_CXX_EXPORT extern HPX_EXPORT bool (*bind)(naming::gid_type const& gid,
         naming::address const& addr, std::uint32_t locality_id, error_code& ec);
 
-    extern HPX_EXPORT hpx::future<bool> (*bind_async_locality)(
+    HPX_CXX_EXPORT extern HPX_EXPORT hpx::future<bool> (*bind_async_locality)(
         naming::gid_type const& gid, naming::address const& addr,
         naming::gid_type const& locality_);
 
-    extern HPX_EXPORT bool (*bind_locality)(naming::gid_type const& gid,
-        naming::address const& addr, naming::gid_type const& locality_,
-        error_code& ec);
+    HPX_CXX_EXPORT extern HPX_EXPORT bool (*bind_locality)(
+        naming::gid_type const& gid, naming::address const& addr,
+        naming::gid_type const& locality_, error_code& ec);
 
-    extern HPX_EXPORT hpx::future<naming::address> (*unbind_async)(
-        naming::gid_type const& gid, std::uint64_t count);
+    HPX_CXX_EXPORT extern HPX_EXPORT hpx::future<naming::address> (
+        *unbind_async)(naming::gid_type const& gid, std::uint64_t count);
 
-    extern HPX_EXPORT naming::address (*unbind)(
+    HPX_CXX_EXPORT extern HPX_EXPORT naming::address (*unbind)(
         naming::gid_type const& gid, std::uint64_t count, error_code& ec);
 
     ///////////////////////////////////////////////////////////////////////////
-    extern HPX_EXPORT bool (*bind_gid_local)(naming::gid_type const& gid,
-        naming::address const& addr, error_code& ec);
-    extern HPX_EXPORT void (*unbind_gid_local)(
+    HPX_CXX_EXPORT extern HPX_EXPORT bool (*bind_gid_local)(
+        naming::gid_type const& gid, naming::address const& addr,
+        error_code& ec);
+    HPX_CXX_EXPORT extern HPX_EXPORT void (*unbind_gid_local)(
         naming::gid_type const& gid, error_code& ec);
 
-    extern HPX_EXPORT bool (*bind_range_local)(naming::gid_type const& gid,
-        std::size_t count, naming::address const& addr, std::size_t offset,
-        error_code& ec);
-    extern HPX_EXPORT void (*unbind_range_local)(
+    HPX_CXX_EXPORT extern HPX_EXPORT bool (*bind_range_local)(
+        naming::gid_type const& gid, std::size_t count,
+        naming::address const& addr, std::size_t offset, error_code& ec);
+    HPX_CXX_EXPORT extern HPX_EXPORT void (*unbind_range_local)(
         naming::gid_type const& gid, std::size_t count, error_code& ec);
 
     ///////////////////////////////////////////////////////////////////////////
-    extern HPX_EXPORT void (*garbage_collect_non_blocking)(error_code& ec);
+    HPX_CXX_EXPORT extern HPX_EXPORT void (*garbage_collect_non_blocking)(
+        error_code& ec);
 
-    extern HPX_EXPORT void (*garbage_collect)(error_code& ec);
+    HPX_CXX_EXPORT extern HPX_EXPORT void (*garbage_collect)(error_code& ec);
 
-    extern HPX_EXPORT void (*garbage_collect_non_blocking_id)(
+    HPX_CXX_EXPORT extern HPX_EXPORT void (*garbage_collect_non_blocking_id)(
         hpx::id_type const& id, error_code& ec);
 
-    extern HPX_EXPORT void (*garbage_collect_id)(
+    HPX_CXX_EXPORT extern HPX_EXPORT void (*garbage_collect_id)(
         hpx::id_type const& id, error_code& ec);
 
     ///////////////////////////////////////////////////////////////////////////
-    extern HPX_EXPORT hpx::id_type (*get_console_locality)(error_code& ec);
+    HPX_CXX_EXPORT extern HPX_EXPORT hpx::id_type (*get_console_locality)(
+        error_code& ec);
 
     ///////////////////////////////////////////////////////////////////////////
-    extern HPX_EXPORT naming::gid_type (*get_next_id)(
+    HPX_CXX_EXPORT extern HPX_EXPORT naming::gid_type (*get_next_id)(
         std::size_t count, error_code& ec);
 
     ///////////////////////////////////////////////////////////////////////////
-    extern HPX_EXPORT void (*decref)(
+    HPX_CXX_EXPORT extern HPX_EXPORT void (*decref)(
         naming::gid_type const& id, std::int64_t credits, error_code& ec);
 
     ///////////////////////////////////////////////////////////////////////////
-    extern HPX_EXPORT hpx::future_or_value<std::int64_t> (*incref_async)(
-        naming::gid_type const& gid, std::int64_t credits,
+    HPX_CXX_EXPORT extern HPX_EXPORT hpx::future_or_value<std::int64_t> (
+        *incref_async)(naming::gid_type const& gid, std::int64_t credits,
         hpx::id_type const& keep_alive);
 
     ///////////////////////////////////////////////////////////////////////////
-    extern HPX_EXPORT std::int64_t (*replenish_credits)(naming::gid_type& gid);
+    HPX_CXX_EXPORT extern HPX_EXPORT std::int64_t (*replenish_credits)(
+        naming::gid_type& gid);
 
     ///////////////////////////////////////////////////////////////////////////
-    extern HPX_EXPORT hpx::future_or_value<id_type> (*get_colocation_id_async)(
-        hpx::id_type const& id);
+    HPX_CXX_EXPORT extern HPX_EXPORT hpx::future_or_value<id_type> (
+        *get_colocation_id_async)(hpx::id_type const& id);
 
-    extern HPX_EXPORT hpx::id_type (*get_colocation_id)(
+    HPX_CXX_EXPORT extern HPX_EXPORT hpx::id_type (*get_colocation_id)(
         hpx::id_type const& id, error_code& ec);
 
     ///////////////////////////////////////////////////////////////////////////
-    extern HPX_EXPORT hpx::future<hpx::id_type> (*on_symbol_namespace_event)(
+    HPX_CXX_EXPORT extern HPX_EXPORT hpx::future<hpx::id_type> (
+        *on_symbol_namespace_event)(
         std::string const& name, bool call_for_past_events);
 
     ///////////////////////////////////////////////////////////////////////////
-    extern HPX_EXPORT hpx::future<std::pair<hpx::id_type, naming::address>> (
-        *begin_migration)(hpx::id_type const& id);
+    HPX_CXX_EXPORT extern HPX_EXPORT
+        hpx::future<std::pair<hpx::id_type, naming::address>> (
+            *begin_migration)(hpx::id_type const& id);
 
-    extern HPX_EXPORT bool (*end_migration)(hpx::id_type const& id);
+    HPX_CXX_EXPORT extern HPX_EXPORT bool (*end_migration)(
+        hpx::id_type const& id);
 
-    extern HPX_EXPORT hpx::future<void> (*mark_as_migrated)(
+    HPX_CXX_EXPORT extern HPX_EXPORT hpx::future<void> (*mark_as_migrated)(
         naming::gid_type const& gid,
         hpx::move_only_function<std::pair<bool, hpx::future<void>>()>&& f,
         bool expect_to_be_marked_as_migrating);
 
-    extern HPX_EXPORT std::pair<bool, components::pinned_ptr> (
+    HPX_CXX_EXPORT extern HPX_EXPORT std::pair<bool, components::pinned_ptr> (
         *was_object_migrated)(naming::gid_type const& gid,
         hpx::move_only_function<components::pinned_ptr()>&& f);
 
-    extern HPX_EXPORT void (*unmark_as_migrated)(
+    HPX_CXX_EXPORT extern HPX_EXPORT void (*unmark_as_migrated)(
         naming::gid_type const& gid, hpx::move_only_function<void()>&& f);
 
     ///////////////////////////////////////////////////////////////////////////
-    extern HPX_EXPORT hpx::future<std::map<std::string, hpx::id_type>> (
-        *find_symbols_async)(std::string const& pattern);
+    HPX_CXX_EXPORT extern HPX_EXPORT
+        hpx::future<std::map<std::string, hpx::id_type>> (*find_symbols_async)(
+            std::string const& pattern);
 
-    extern HPX_EXPORT std::map<std::string, hpx::id_type> (*find_symbols)(
-        std::string const& pattern);
+    HPX_CXX_EXPORT extern HPX_EXPORT std::map<std::string, hpx::id_type> (
+        *find_symbols)(std::string const& pattern);
 
     ///////////////////////////////////////////////////////////////////////////
-    extern HPX_EXPORT naming::component_type (*register_factory)(
+    HPX_CXX_EXPORT extern HPX_EXPORT naming::component_type (*register_factory)(
         std::uint32_t prefix, std::string const& name, error_code& ec);
 
-    extern HPX_EXPORT naming::component_type (*get_component_id)(
+    HPX_CXX_EXPORT extern HPX_EXPORT naming::component_type (*get_component_id)(
         std::string const& name, error_code& ec);
 
     ///////////////////////////////////////////////////////////////////////////
-    extern HPX_EXPORT void (*destroy_component)(
+    HPX_CXX_EXPORT extern HPX_EXPORT void (*destroy_component)(
         naming::gid_type const& gid, naming::address const& addr);
 
     ///////////////////////////////////////////////////////////////////////////
 #if defined(HPX_HAVE_NETWORKING)
-    extern HPX_EXPORT void (*route)(parcelset::parcel&& p,
+    HPX_CXX_EXPORT extern HPX_EXPORT void (*route)(parcelset::parcel&& p,
         hpx::function<void(std::error_code const&, parcelset::parcel const&)>&&,
         threads::thread_priority local_priority);
 #endif
 
     ///////////////////////////////////////////////////////////////////////////
-    extern HPX_EXPORT naming::address_type (*get_primary_ns_lva)();
-    extern HPX_EXPORT naming::address_type (*get_symbol_ns_lva)();
-    extern HPX_EXPORT naming::address_type (*get_runtime_support_lva)();
+    HPX_CXX_EXPORT extern HPX_EXPORT naming::address_type (
+        *get_primary_ns_lva)();
+    HPX_CXX_EXPORT extern HPX_EXPORT naming::address_type (
+        *get_symbol_ns_lva)();
+    HPX_CXX_EXPORT extern HPX_EXPORT naming::address_type (
+        *get_runtime_support_lva)();
 }    // namespace hpx::agas::detail

--- a/libs/full/components_base/include/hpx/components_base/generate_unique_ids.hpp
+++ b/libs/full/components_base/include/hpx/components_base/generate_unique_ids.hpp
@@ -19,7 +19,7 @@ namespace hpx::util {
 
     // The unique_id_ranges class is a type responsible for generating unique
     // ids for components, parcels, threads etc.
-    class HPX_EXPORT unique_id_ranges
+    HPX_CXX_EXPORT class HPX_EXPORT unique_id_ranges
     {
         // size of the id range returned by get_id
         static constexpr std::size_t range_delta = 0x100000;

--- a/libs/full/components_base/include/hpx/components_base/server/component_base.hpp
+++ b/libs/full/components_base/include/hpx/components_base/server/component_base.hpp
@@ -28,7 +28,7 @@ namespace hpx::components {
         struct base_component : traits::detail::component_tag
         {
             constexpr base_component() = default;
-            HPX_EXPORT ~base_component();
+            HPX_CXX_EXPORT HPX_EXPORT ~base_component();
 
             // do not copy the gid_
             base_component(base_component const&) noexcept {}
@@ -46,8 +46,9 @@ namespace hpx::components {
             // destructed
             static constexpr void finalize() noexcept {}
 
-            HPX_EXPORT static hpx::id_type get_id(naming::gid_type gid);
-            HPX_EXPORT static hpx::id_type get_unmanaged_id(
+            HPX_CXX_EXPORT HPX_EXPORT static hpx::id_type get_id(
+                naming::gid_type gid);
+            HPX_CXX_EXPORT HPX_EXPORT static hpx::id_type get_unmanaged_id(
                 naming::gid_type const& gid);
 
             static void mark_as_migrated() noexcept
@@ -73,11 +74,11 @@ namespace hpx::components {
             //
             // Returns the global id (GID) assigned to this instance of a
             // component
-            HPX_EXPORT naming::gid_type get_base_gid_dynamic(
+            HPX_CXX_EXPORT HPX_EXPORT naming::gid_type get_base_gid_dynamic(
                 naming::gid_type const& assign_gid, naming::address const& addr,
                 naming::gid_type (*f)(naming::gid_type) = nullptr) const;
 
-            HPX_EXPORT naming::gid_type get_base_gid(
+            HPX_CXX_EXPORT HPX_EXPORT naming::gid_type get_base_gid(
                 naming::address const& addr,
                 naming::gid_type (*f)(naming::gid_type) = nullptr) const;
 

--- a/libs/full/components_base/include/hpx/components_base/server/component_heap.hpp
+++ b/libs/full/components_base/include/hpx/components_base/server/component_heap.hpp
@@ -30,8 +30,8 @@ namespace hpx::components {
         }
 
         template <typename Component>
-        HPX_ALWAYS_EXPORT typename Component::heap_type& component_heap_helper(
-            ...);
+        HPX_CXX_EXPORT HPX_ALWAYS_EXPORT typename Component::heap_type&
+        component_heap_helper(...);
     }    // namespace detail
 
     template <typename Component>
@@ -44,7 +44,7 @@ namespace hpx::components {
 #define HPX_REGISTER_COMPONENT_HEAP(Component)                                 \
     namespace hpx::components::detail {                                        \
         template <>                                                            \
-        HPX_ALWAYS_EXPORT Component::heap_type&                                \
+        HPX_CXX_EXPORT HPX_ALWAYS_EXPORT Component::heap_type&                 \
         component_heap_helper<Component>(...)                                  \
         {                                                                      \
             util::reinitializable_static<Component::heap_type> heap;           \

--- a/libs/full/components_base/include/hpx/components_base/server/one_size_heap_list.hpp
+++ b/libs/full/components_base/include/hpx/components_base/server/one_size_heap_list.hpp
@@ -21,7 +21,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx::util {
 
-    class HPX_EXPORT one_size_heap_list
+    HPX_CXX_EXPORT class HPX_EXPORT one_size_heap_list
     {
     public:
         using list_type = std::list<std::shared_ptr<util::wrapper_heap_base>>;

--- a/libs/full/components_base/include/hpx/components_base/server/wrapper_heap.hpp
+++ b/libs/full/components_base/include/hpx/components_base/server/wrapper_heap.hpp
@@ -52,12 +52,14 @@ namespace hpx::components::detail {
                 return nullptr;
             }
 
-            HPX_EXPORT static util::internal_allocator<char> alloc_;
+            HPX_CXX_EXPORT HPX_EXPORT static util::internal_allocator<char>
+                alloc_;
         };
     }    // namespace one_size_heap_allocators
 
     ///////////////////////////////////////////////////////////////////////////
-    class HPX_EXPORT wrapper_heap : public util::wrapper_heap_base
+    HPX_CXX_EXPORT class HPX_EXPORT wrapper_heap
+      : public util::wrapper_heap_base
     {
     public:
         using allocator_type = one_size_heap_allocators::fixed_mallocator;

--- a/libs/full/components_base/include/hpx/components_base/traits/component_type_database.hpp
+++ b/libs/full/components_base/include/hpx/components_base/traits/component_type_database.hpp
@@ -23,8 +23,10 @@ namespace hpx::traits {
     {
         static components::component_type value;
 
-        HPX_ALWAYS_EXPORT static components::component_type get() noexcept;
-        HPX_ALWAYS_EXPORT static void set(components::component_type);
+        HPX_CXX_EXPORT HPX_ALWAYS_EXPORT static components::component_type
+        get() noexcept;
+        HPX_CXX_EXPORT HPX_ALWAYS_EXPORT static void set(
+            components::component_type);
     };
 
     // components::component_invalid;

--- a/libs/full/compute/CMakeLists.txt
+++ b/libs/full/compute/CMakeLists.txt
@@ -41,6 +41,7 @@ include(HPX_AddModule)
 add_hpx_module(
   full compute
   GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_MODULE_GEN ON
   SOURCES ${compute_sources}
   HEADERS ${compute_headers}
   COMPAT_HEADERS ${compute_compat_headers}

--- a/libs/full/compute/include/hpx/compute/host/distributed_target.hpp
+++ b/libs/full/compute/include/hpx/compute/host/distributed_target.hpp
@@ -26,7 +26,7 @@
 
 namespace hpx::compute::host::distributed {
 
-    struct HPX_EXPORT target : hpx::compute::host::target
+    HPX_CXX_EXPORT struct HPX_EXPORT target : hpx::compute::host::target
     {
     public:
         // Constructs default target

--- a/libs/full/compute/include/hpx/compute/host/get_targets.hpp
+++ b/libs/full/compute/include/hpx/compute/host/get_targets.hpp
@@ -18,15 +18,15 @@
 
 namespace hpx::compute::host::distributed {
 
-    struct HPX_EXPORT target;
+    HPX_CXX_EXPORT struct HPX_EXPORT target;
 
-    HPX_EXPORT hpx::future<std::vector<target>> get_targets(
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future<std::vector<target>> get_targets(
         hpx::id_type const& locality);
 
     namespace detail {
 
-        HPX_EXPORT std::vector<host::distributed::target> get_remote_targets(
-            std::vector<host::target> const& targets);
+        HPX_CXX_EXPORT HPX_EXPORT std::vector<host::distributed::target>
+        get_remote_targets(std::vector<host::target> const& targets);
     }
 }    // namespace hpx::compute::host::distributed
 

--- a/libs/full/distribution_policies/CMakeLists.txt
+++ b/libs/full/distribution_policies/CMakeLists.txt
@@ -37,6 +37,7 @@ include(HPX_AddModule)
 add_hpx_module(
   full distribution_policies
   GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_MODULE_GEN ON
   SOURCES ${distribution_policies_sources}
   HEADERS ${distribution_policies_headers}
   COMPAT_HEADERS ${distribution_policies_compat_headers}

--- a/libs/full/distribution_policies/include/hpx/distribution_policies/binpacking_distribution_policy.hpp
+++ b/libs/full/distribution_policies/include/hpx/distribution_policies/binpacking_distribution_policy.hpp
@@ -39,18 +39,19 @@ namespace hpx::components {
     namespace detail {
 
         /// \cond NOINTERNAL
-        HPX_EXPORT std::vector<std::size_t> get_items_count(
+        HPX_CXX_EXPORT HPX_EXPORT std::vector<std::size_t> get_items_count(
             std::size_t count, std::vector<std::uint64_t> const& values);
 
-        HPX_EXPORT hpx::future<std::vector<std::uint64_t>>
+        HPX_CXX_EXPORT HPX_EXPORT hpx::future<std::vector<std::uint64_t>>
         retrieve_counter_values(
             std::vector<performance_counters::performance_counter>&& counters);
 
-        HPX_EXPORT hpx::future<std::vector<std::uint64_t>> get_counter_values(
-            std::string const& component_name, std::string const& counter_name,
+        HPX_CXX_EXPORT HPX_EXPORT hpx::future<std::vector<std::uint64_t>>
+        get_counter_values(std::string const& component_name,
+            std::string const& counter_name,
             std::vector<hpx::id_type> const& localities);
 
-        HPX_EXPORT hpx::id_type const& get_best_locality(
+        HPX_CXX_EXPORT HPX_EXPORT hpx::id_type const& get_best_locality(
             hpx::future<std::vector<std::uint64_t>>&& f,
             std::vector<hpx::id_type> const& localities);
 

--- a/libs/full/executors_distributed/CMakeLists.txt
+++ b/libs/full/executors_distributed/CMakeLists.txt
@@ -24,6 +24,7 @@ include(HPX_AddModule)
 add_hpx_module(
   full executors_distributed
   GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_MODULE_GEN OFF
   HEADERS ${executors_distributed_headers}
   COMPAT_HEADERS ${executors_distributed_compat_headers}
   DEPENDENCIES hpx_core

--- a/libs/full/include/CMakeLists.txt
+++ b/libs/full/include/CMakeLists.txt
@@ -121,6 +121,7 @@ include(HPX_AddModule)
 add_hpx_module(
   full include
   GLOBAL_HEADER_GEN OFF
+  GLOBAL_HEADER_MODULE_GEN OFF
   HEADERS ${include_headers}
   DEPENDENCIES hpx_core
   MODULE_DEPENDENCIES hpx_command_line_handling hpx_compute hpx_naming_base

--- a/libs/full/init_runtime/CMakeLists.txt
+++ b/libs/full/init_runtime/CMakeLists.txt
@@ -40,6 +40,7 @@ include(HPX_AddModule)
 add_hpx_module(
   full init_runtime
   GLOBAL_HEADER_GEN OFF
+  GLOBAL_HEADER_MODULE_GEN ON
   HEADERS ${init_runtime_headers}
   SOURCES ${init_runtime_sources}
   DEPENDENCIES hpx_core

--- a/libs/full/init_runtime/include/hpx/hpx_finalize.hpp
+++ b/libs/full/init_runtime/include/hpx/hpx_finalize.hpp
@@ -70,8 +70,8 @@ namespace hpx {
     ///
     /// Using this function is an alternative to \a hpx::disconnect, these
     /// functions do not need to be called both.
-    HPX_EXPORT int finalize(double shutdown_timeout, double localwait = -1.0,
-        hpx::error_code& ec = throws);
+    HPX_CXX_EXPORT HPX_EXPORT int finalize(double shutdown_timeout,
+        double localwait = -1.0, hpx::error_code& ec = throws);
 
     /// \brief Main function to gracefully terminate the HPX runtime system.
     ///
@@ -117,7 +117,7 @@ namespace hpx {
     ///          all localities associated with this application. If the function
     ///          is called not from an HPX thread it will fail and return an error
     ///          using the argument \a ec.
-    [[noreturn]] HPX_EXPORT void terminate();
+    [[noreturn]] HPX_CXX_EXPORT HPX_EXPORT void terminate();
 
     /// \brief Disconnect this locality from the application.
     ///
@@ -166,8 +166,8 @@ namespace hpx {
     /// before returning to the caller. It should be the last HPX-function
     /// called by any locality being disconnected.
     ///
-    HPX_EXPORT int disconnect(double shutdown_timeout, double localwait = -1.0,
-        hpx::error_code& ec = throws);
+    HPX_CXX_EXPORT HPX_EXPORT int disconnect(double shutdown_timeout,
+        double localwait = -1.0, hpx::error_code& ec = throws);
 
     /// \brief Disconnect this locality from the application.
     ///
@@ -208,7 +208,7 @@ namespace hpx {
     /// called on every locality. This function should be used only if the
     /// runtime system was started using `hpx::start`.
     ///
-    HPX_EXPORT int stop(hpx::error_code& ec = throws);
+    HPX_CXX_EXPORT HPX_EXPORT int stop(hpx::error_code& ec = throws);
 }    // namespace hpx
 
 #include <hpx/config/warnings_suffix.hpp>

--- a/libs/full/init_runtime/include/hpx/hpx_main_winsocket.hpp
+++ b/libs/full/init_runtime/include/hpx/hpx_main_winsocket.hpp
@@ -11,7 +11,7 @@
 #if defined(HPX_WINDOWS)
 
 namespace hpx { namespace detail {
-    HPX_EXPORT void init_winsocket();
+    HPX_CXX_EXPORT HPX_EXPORT void init_winsocket();
 }}    // namespace hpx::detail
 
 #endif

--- a/libs/full/init_runtime/include/hpx/hpx_suspend.hpp
+++ b/libs/full/init_runtime/include/hpx/hpx_suspend.hpp
@@ -32,7 +32,7 @@ namespace hpx {
     ///           function doesn't throw but returns the result code using the
     ///           parameter \a ec. Otherwise it throws an instance of
     ///           hpx::exception.
-    HPX_EXPORT int suspend(error_code& ec = throws);
+    HPX_CXX_EXPORT HPX_EXPORT int suspend(error_code& ec = throws);
 
     /// \brief Resume the HPX runtime system.
     ///
@@ -52,5 +52,5 @@ namespace hpx {
     ///           function doesn't throw but returns the result code using the
     ///           parameter \a ec. Otherwise it throws an instance of
     ///           hpx::exception.
-    HPX_EXPORT int resume(error_code& ec = throws);
+    HPX_CXX_EXPORT HPX_EXPORT int resume(error_code& ec = throws);
 }    // namespace hpx

--- a/libs/full/init_runtime/include/hpx/hpx_user_main_config.hpp
+++ b/libs/full/init_runtime/include/hpx/hpx_user_main_config.hpp
@@ -14,8 +14,8 @@
 namespace hpx_startup {
 
     // Allow applications to add configuration settings if HPX_MAIN is set
-    HPX_EXPORT extern std::vector<std::string> (*user_main_config_function)(
-        std::vector<std::string> const&);
+    HPX_CXX_EXPORT HPX_EXPORT extern std::vector<std::string> (
+        *user_main_config_function)(std::vector<std::string> const&);
 
     inline std::vector<std::string> user_main_config(
         std::vector<std::string> const& cfg)

--- a/libs/full/init_runtime/include/hpx/init_runtime/detail/init_logging.hpp
+++ b/libs/full/init_runtime/include/hpx/init_runtime/detail/init_logging.hpp
@@ -16,7 +16,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx::util::detail {
 
-    HPX_EXPORT void init_logging_full(runtime_configuration&);
+    HPX_CXX_EXPORT HPX_EXPORT void init_logging_full(runtime_configuration&);
 }    // namespace hpx::util::detail
 
 #endif

--- a/libs/full/init_runtime/include/hpx/init_runtime/detail/run_or_start.hpp
+++ b/libs/full/init_runtime/include/hpx/init_runtime/detail/run_or_start.hpp
@@ -14,17 +14,17 @@ namespace hpx {
     /// \cond NOINTERNAL
     namespace detail {
 
-        HPX_EXPORT int run_or_start(
+        HPX_CXX_EXPORT HPX_EXPORT int run_or_start(
             hpx::function<int(hpx::program_options::variables_map& vm)> const&
                 f,
             int argc, char** argv, init_params const& params, bool blocking);
 
-        HPX_EXPORT int init_impl(
+        HPX_CXX_EXPORT HPX_EXPORT int init_impl(
             hpx::function<int(hpx::program_options::variables_map&)> const& f,
             int argc, char** argv, init_params const& params,
             char const* hpx_prefix, char** env);
 
-        HPX_EXPORT bool start_impl(
+        HPX_CXX_EXPORT HPX_EXPORT bool start_impl(
             hpx::function<int(hpx::program_options::variables_map&)> const& f,
             int argc, char** argv, init_params const& params,
             char const* hpx_prefix, char** env);

--- a/libs/full/init_runtime/include/hpx/init_runtime/pre_main.hpp
+++ b/libs/full/init_runtime/include/hpx/init_runtime/pre_main.hpp
@@ -14,8 +14,8 @@
 
 namespace hpx { namespace detail {
 
-    HPX_EXPORT int pre_main(runtime_mode);
-    HPX_EXPORT void post_main();
+    HPX_CXX_EXPORT HPX_EXPORT int pre_main(runtime_mode);
+    HPX_CXX_EXPORT HPX_EXPORT void post_main();
 }}    // namespace hpx::detail
 
 #endif

--- a/libs/full/lcos_distributed/CMakeLists.txt
+++ b/libs/full/lcos_distributed/CMakeLists.txt
@@ -27,6 +27,7 @@ include(HPX_AddModule)
 add_hpx_module(
   full lcos_distributed
   GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_MODULE_GEN OFF
   SOURCES ${lcos_distributed_sources}
   HEADERS ${lcos_distributed_headers}
   COMPAT_HEADERS ${lcos_distributed_compat_headers}

--- a/libs/full/naming/CMakeLists.txt
+++ b/libs/full/naming/CMakeLists.txt
@@ -28,6 +28,7 @@ include(HPX_AddModule)
 add_hpx_module(
   full naming
   GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_MODULE_GEN ON
   SOURCES ${naming_sources}
   HEADERS ${naming_headers}
   COMPAT_HEADERS ${naming_compat_headers}

--- a/libs/full/naming/include/hpx/naming/credit_handling.hpp
+++ b/libs/full/naming/include/hpx/naming/credit_handling.hpp
@@ -20,41 +20,42 @@
 namespace hpx::naming {
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT void decrement_refcnt(gid_type const& gid);
+    HPX_CXX_EXPORT HPX_EXPORT void decrement_refcnt(gid_type const& gid);
 
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
 
         ///////////////////////////////////////////////////////////////////////
         // has side effects, can't be pure
-        HPX_EXPORT std::int64_t add_credit_to_gid(
+        HPX_CXX_EXPORT HPX_EXPORT std::int64_t add_credit_to_gid(
             gid_type& id, std::int64_t credits);
 
-        HPX_EXPORT std::int64_t remove_credit_from_gid(
+        HPX_CXX_EXPORT HPX_EXPORT std::int64_t remove_credit_from_gid(
             gid_type& id, std::int64_t debit);
 
-        HPX_EXPORT std::int64_t fill_credit_for_gid(gid_type& id,
+        HPX_CXX_EXPORT HPX_EXPORT std::int64_t fill_credit_for_gid(gid_type& id,
             std::int64_t credits = static_cast<std::int64_t>(
                 HPX_GLOBALCREDIT_INITIAL));
 
         ///////////////////////////////////////////////////////////////////////
-        HPX_EXPORT gid_type move_gid(gid_type& id);
-        HPX_EXPORT gid_type move_gid_locked(
+        HPX_CXX_EXPORT HPX_EXPORT gid_type move_gid(gid_type& id);
+        HPX_CXX_EXPORT HPX_EXPORT gid_type move_gid_locked(
             std::unique_lock<gid_type::mutex_type> l, gid_type& gid);
 
-        HPX_EXPORT std::int64_t replenish_credits(gid_type& id);
-        HPX_EXPORT std::int64_t replenish_credits_locked(
+        HPX_CXX_EXPORT HPX_EXPORT std::int64_t replenish_credits(gid_type& id);
+        HPX_CXX_EXPORT HPX_EXPORT std::int64_t replenish_credits_locked(
             std::unique_lock<gid_type::mutex_type>& l, gid_type& id);
 
         ///////////////////////////////////////////////////////////////////////
         // splits the current credit of the given id and assigns half of it to
         // the returned copy
-        HPX_EXPORT gid_type split_credits_for_gid(gid_type& id);
-        HPX_EXPORT gid_type split_credits_for_gid_locked(
+        HPX_CXX_EXPORT HPX_EXPORT gid_type split_credits_for_gid(gid_type& id);
+        HPX_CXX_EXPORT HPX_EXPORT gid_type split_credits_for_gid_locked(
             std::unique_lock<gid_type::mutex_type>& l, gid_type& id);
 
         ///////////////////////////////////////////////////////////////////////
-        HPX_EXPORT void decrement_refcnt(id_type_impl const* gid) noexcept;
+        HPX_CXX_EXPORT HPX_EXPORT void decrement_refcnt(
+            id_type_impl const* gid) noexcept;
 
         ///////////////////////////////////////////////////////////////////////
         // credit management (called during serialization), this function
@@ -64,9 +65,9 @@ namespace hpx::naming {
 
         ///////////////////////////////////////////////////////////////////////
         // serialization
-        HPX_EXPORT void save(
+        HPX_CXX_EXPORT HPX_EXPORT void save(
             serialization::output_archive& ar, id_type_impl const&, unsigned);
-        HPX_EXPORT void load(
+        HPX_CXX_EXPORT HPX_EXPORT void load(
             serialization::input_archive& ar, id_type_impl&, unsigned);
 
         HPX_SERIALIZATION_SPLIT_FREE(id_type_impl)
@@ -76,9 +77,9 @@ namespace hpx::naming {
 namespace hpx {
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT void save(
+    HPX_CXX_EXPORT HPX_EXPORT void save(
         serialization::output_archive& ar, hpx::id_type const&, unsigned int);
-    HPX_EXPORT void load(
+    HPX_CXX_EXPORT HPX_EXPORT void load(
         serialization::input_archive& ar, hpx::id_type&, unsigned int);
 
     HPX_SERIALIZATION_SPLIT_FREE(hpx::id_type)

--- a/libs/full/naming/include/hpx/naming/detail/preprocess_gid_types.hpp
+++ b/libs/full/naming/include/hpx/naming/detail/preprocess_gid_types.hpp
@@ -134,7 +134,7 @@ template <>
 struct hpx::util::extra_data_helper<
     hpx::serialization::detail::preprocess_gid_types>
 {
-    HPX_EXPORT static extra_data_id_type id() noexcept;
+    HPX_CXX_EXPORT HPX_EXPORT static extra_data_id_type id() noexcept;
     static constexpr void reset(
         serialization::detail::preprocess_gid_types*) noexcept
     {

--- a/libs/full/naming/include/hpx/naming/split_gid.hpp
+++ b/libs/full/naming/include/hpx/naming/split_gid.hpp
@@ -17,11 +17,13 @@
 
 namespace hpx::naming::detail {
 
-    HPX_EXPORT hpx::future_or_value<gid_type> split_gid_if_needed(gid_type& id);
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future_or_value<gid_type>
+    split_gid_if_needed(gid_type& id);
 
-    HPX_EXPORT gid_type split_gid_if_needed(
+    HPX_CXX_EXPORT HPX_EXPORT gid_type split_gid_if_needed(
         hpx::launch::sync_policy, gid_type& id);
 
-    HPX_EXPORT hpx::future_or_value<gid_type> split_gid_if_needed_locked(
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future_or_value<gid_type>
+    split_gid_if_needed_locked(
         std::unique_lock<gid_type::mutex_type>& l, gid_type& gid);
 }    // namespace hpx::naming::detail

--- a/libs/full/naming_base/include/hpx/naming_base/gid_type.hpp
+++ b/libs/full/naming_base/include/hpx/naming_base/gid_type.hpp
@@ -156,7 +156,7 @@ namespace hpx::naming {
         }
 
         // GID + GID
-        friend HPX_EXPORT gid_type operator+(
+        friend HPX_CXX_EXPORT HPX_EXPORT gid_type operator+(
             gid_type const& lhs, gid_type const& rhs) noexcept;
         gid_type operator+=(gid_type const& rhs) noexcept
         {
@@ -175,7 +175,7 @@ namespace hpx::naming {
         }
 
         // GID - GID
-        friend HPX_EXPORT gid_type operator-(
+        friend HPX_CXX_EXPORT HPX_EXPORT gid_type operator-(
             gid_type const& lhs, gid_type const& rhs) noexcept;
         gid_type operator-=(gid_type const& rhs) noexcept
         {
@@ -217,7 +217,7 @@ namespace hpx::naming {
             return !(lhs == rhs);
         }
 
-        friend HPX_EXPORT bool operator<(
+        friend HPX_CXX_EXPORT HPX_EXPORT bool operator<(
             gid_type const& lhs, gid_type const& rhs) noexcept;
         friend bool operator>=(
             gid_type const& lhs, gid_type const& rhs) noexcept
@@ -225,7 +225,7 @@ namespace hpx::naming {
             return !(lhs < rhs);
         }
 
-        friend HPX_EXPORT bool operator<=(
+        friend HPX_CXX_EXPORT HPX_EXPORT bool operator<=(
             gid_type const& lhs, gid_type const& rhs) noexcept;
         friend bool operator>(gid_type const& lhs, gid_type const& rhs) noexcept
         {
@@ -304,12 +304,12 @@ namespace hpx::naming {
         }
 
     private:
-        friend HPX_EXPORT std::ostream& operator<<(
+        friend HPX_CXX_EXPORT HPX_EXPORT std::ostream& operator<<(
             std::ostream& os, gid_type const& id);
 
-        friend HPX_EXPORT void save(
+        friend HPX_CXX_EXPORT HPX_EXPORT void save(
             serialization::output_archive& ar, gid_type const&, unsigned int);
-        friend HPX_EXPORT void load(
+        friend HPX_CXX_EXPORT HPX_EXPORT void load(
             serialization::input_archive& ar, gid_type&, unsigned int);
 
         // lock implementation

--- a/libs/full/naming_base/include/hpx/naming_base/id_type.hpp
+++ b/libs/full/naming_base/include/hpx/naming_base/id_type.hpp
@@ -98,11 +98,11 @@ namespace hpx {
         explicit operator bool() const noexcept;
 
         // comparison is required as well
-        friend HPX_EXPORT bool operator==(
+        friend HPX_CXX_EXPORT HPX_EXPORT bool operator==(
             id_type const& lhs, id_type const& rhs) noexcept;
         friend bool operator!=(id_type const& lhs, id_type const& rhs) noexcept;
 
-        friend HPX_EXPORT bool operator<(
+        friend HPX_CXX_EXPORT HPX_EXPORT bool operator<(
             id_type const& lhs, id_type const& rhs) noexcept;
         friend bool operator<=(id_type const& lhs, id_type const& rhs) noexcept;
         friend bool operator>(id_type const& lhs, id_type const& rhs) noexcept;
@@ -132,7 +132,7 @@ namespace hpx {
         }
 
     private:
-        friend HPX_EXPORT std::ostream& operator<<(
+        friend HPX_CXX_EXPORT HPX_EXPORT std::ostream& operator<<(
             std::ostream& os, id_type const& id);
 
         hpx::intrusive_ptr<naming::detail::id_type_impl> gid_;
@@ -281,9 +281,9 @@ namespace hpx {
 
         private:
             // reference counting
-            friend HPX_EXPORT void intrusive_ptr_add_ref(
+            friend HPX_CXX_EXPORT HPX_EXPORT void intrusive_ptr_add_ref(
                 id_type_impl* p) noexcept;
-            friend HPX_EXPORT void intrusive_ptr_release(
+            friend HPX_CXX_EXPORT HPX_EXPORT void intrusive_ptr_release(
                 id_type_impl* p) noexcept;
 
             util::atomic_count count_;
@@ -420,7 +420,8 @@ namespace hpx::traits {
     template <>
     struct get_remote_result<hpx::id_type, naming::gid_type>
     {
-        HPX_EXPORT static hpx::id_type call(naming::gid_type const& rhs);
+        HPX_CXX_EXPORT HPX_EXPORT static hpx::id_type call(
+            naming::gid_type const& rhs);
     };
 
     template <>
@@ -435,7 +436,7 @@ namespace hpx::traits {
     struct get_remote_result<std::vector<hpx::id_type>,
         std::vector<naming::gid_type>>
     {
-        HPX_EXPORT static std::vector<hpx::id_type> call(
+        HPX_CXX_EXPORT HPX_EXPORT static std::vector<hpx::id_type> call(
             std::vector<naming::gid_type> const& rhs);
     };
 

--- a/libs/full/naming_base/include/hpx/naming_base/naming_base.hpp
+++ b/libs/full/naming_base/include/hpx/naming_base/naming_base.hpp
@@ -17,7 +17,7 @@ namespace hpx {
 
         namespace detail {
 
-            struct HPX_EXPORT id_type_impl;
+            HPX_CXX_EXPORT struct HPX_EXPORT id_type_impl;
         }    // namespace detail
 
         HPX_CXX_EXPORT using component_type = std::int32_t;

--- a/libs/full/naming_base/include/hpx/naming_base/unmanaged.hpp
+++ b/libs/full/naming_base/include/hpx/naming_base/unmanaged.hpp
@@ -38,5 +38,5 @@ namespace hpx::naming {
 
     HPX_DEPRECATED_V(1, 9,
         "hpx::naming::unmanaged is deprecated, use hpx::unmanaged instead")
-    HPX_EXPORT hpx::id_type unmanaged(hpx::id_type const& id);
+    HPX_CXX_EXPORT HPX_EXPORT hpx::id_type unmanaged(hpx::id_type const& id);
 }    // namespace hpx::naming

--- a/libs/full/parcelport_gasnet/CMakeLists.txt
+++ b/libs/full/parcelport_gasnet/CMakeLists.txt
@@ -36,6 +36,7 @@ include(HPX_AddModule)
 add_hpx_module(
   full parcelport_gasnet
   GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_MODULE_GEN ON
   SOURCES ${parcelport_gasnet_sources}
   HEADERS ${parcelport_gasnet_headers}
   DEPENDENCIES hpx_core hpx_gasnet_base PkgConfig::GASNET

--- a/libs/full/parcelport_gasnet/include/hpx/parcelport_gasnet/locality.hpp
+++ b/libs/full/parcelport_gasnet/include/hpx/parcelport_gasnet/locality.hpp
@@ -46,8 +46,9 @@ namespace hpx::parcelset::policies::gasnet {
             return rank_ != ((unsigned int) -1);
         }
 
-        HPX_EXPORT void save(serialization::output_archive& ar) const;
-        HPX_EXPORT void load(serialization::input_archive& ar);
+        HPX_CXX_EXPORT HPX_EXPORT void save(
+            serialization::output_archive& ar) const;
+        HPX_CXX_EXPORT HPX_EXPORT void load(serialization::input_archive& ar);
 
     private:
         friend bool operator==(
@@ -61,7 +62,7 @@ namespace hpx::parcelset::policies::gasnet {
             return lhs.rank_ < rhs.rank_;
         }
 
-        friend HPX_EXPORT std::ostream& operator<<(
+        friend HPX_CXX_EXPORT HPX_EXPORT std::ostream& operator<<(
             std::ostream& os, locality const& loc) noexcept;
 
         gasnet_node_t rank_;

--- a/libs/full/parcelport_lci/CMakeLists.txt
+++ b/libs/full/parcelport_lci/CMakeLists.txt
@@ -58,6 +58,7 @@ include(HPX_AddModule)
 add_hpx_module(
   full parcelport_lci
   GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_MODULE_GEN ON
   SOURCES ${parcelport_lci_sources}
   HEADERS ${parcelport_lci_headers}
   COMPAT_HEADERS ${parcelport_lci_compat_headers}

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/completion_manager_base.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/completion_manager_base.hpp
@@ -14,7 +14,7 @@
 #include <hpx/modules/lci_base.hpp>
 
 namespace hpx::parcelset::policies::lci {
-    class HPX_EXPORT parcelport;
+    HPX_CXX_EXPORT class HPX_EXPORT parcelport;
     struct completion_manager_base
     {
         completion_manager_base(parcelport* pp) noexcept

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/locality.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/locality.hpp
@@ -45,8 +45,9 @@ namespace hpx::parcelset::policies::lci {
             return rank_ != -1;
         }
 
-        HPX_EXPORT void save(serialization::output_archive& ar) const;
-        HPX_EXPORT void load(serialization::input_archive& ar);
+        HPX_CXX_EXPORT HPX_EXPORT void save(
+            serialization::output_archive& ar) const;
+        HPX_CXX_EXPORT HPX_EXPORT void load(serialization::input_archive& ar);
 
     private:
         friend bool operator==(
@@ -60,7 +61,7 @@ namespace hpx::parcelset::policies::lci {
             return lhs.rank_ < rhs.rank_;
         }
 
-        friend HPX_EXPORT std::ostream& operator<<(
+        friend HPX_CXX_EXPORT HPX_EXPORT std::ostream& operator<<(
             std::ostream& os, locality const& loc) noexcept;
 
         std::int32_t rank_;

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/parcelport_lci.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/parcelport_lci.hpp
@@ -30,7 +30,7 @@
 
 namespace hpx::parcelset {
     namespace policies::lci {
-        class HPX_EXPORT parcelport;
+        HPX_CXX_EXPORT class HPX_EXPORT parcelport;
     }    // namespace policies::lci
 
     template <>
@@ -59,7 +59,8 @@ namespace hpx::parcelset {
     };
 
     namespace policies::lci {
-        class HPX_EXPORT parcelport : public parcelport_impl<parcelport>
+        HPX_CXX_EXPORT class HPX_EXPORT parcelport
+          : public parcelport_impl<parcelport>
         {
             using base_type = parcelport_impl<parcelport>;
             static parcelset::locality here();

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/receiver_base.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/receiver_base.hpp
@@ -29,7 +29,7 @@
 #include <vector>
 
 namespace hpx::parcelset::policies::lci {
-    class HPX_EXPORT parcelport;
+    HPX_CXX_EXPORT class HPX_EXPORT parcelport;
     struct buffer_wrapper
     {
         struct fake_allocator

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/sender_base.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/sender_base.hpp
@@ -46,7 +46,7 @@
 #include <vector>
 
 namespace hpx::parcelset::policies::lci {
-    class HPX_EXPORT parcelport;
+    HPX_CXX_EXPORT class HPX_EXPORT parcelport;
     struct sender_connection_base;
     struct sender_base
     {

--- a/libs/full/parcelport_lcw/CMakeLists.txt
+++ b/libs/full/parcelport_lcw/CMakeLists.txt
@@ -53,6 +53,7 @@ include(HPX_AddModule)
 add_hpx_module(
   full parcelport_lcw
   GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_MODULE_GEN ON
   SOURCES ${parcelport_lcw_sources}
   HEADERS ${parcelport_lcw_headers}
   COMPAT_HEADERS ${parcelport_lcw_compat_headers}

--- a/libs/full/parcelport_lcw/include/hpx/parcelport_lcw/locality.hpp
+++ b/libs/full/parcelport_lcw/include/hpx/parcelport_lcw/locality.hpp
@@ -45,8 +45,9 @@ namespace hpx::parcelset::policies::lcw {
             return rank_ != -1;
         }
 
-        HPX_EXPORT void save(serialization::output_archive& ar) const;
-        HPX_EXPORT void load(serialization::input_archive& ar);
+        HPX_CXX_EXPORT HPX_EXPORT void save(
+            serialization::output_archive& ar) const;
+        HPX_CXX_EXPORT HPX_EXPORT void load(serialization::input_archive& ar);
 
     private:
         friend bool operator==(
@@ -60,7 +61,7 @@ namespace hpx::parcelset::policies::lcw {
             return lhs.rank_ < rhs.rank_;
         }
 
-        friend HPX_EXPORT std::ostream& operator<<(
+        friend HPX_CXX_EXPORT HPX_EXPORT std::ostream& operator<<(
             std::ostream& os, locality const& loc) noexcept;
 
         std::int32_t rank_;

--- a/libs/full/parcelport_lcw/include/hpx/parcelport_lcw/parcelport_lcw.hpp
+++ b/libs/full/parcelport_lcw/include/hpx/parcelport_lcw/parcelport_lcw.hpp
@@ -31,7 +31,7 @@
 
 namespace hpx::parcelset {
     namespace policies::lcw {
-        class HPX_EXPORT parcelport;
+        HPX_CXX_EXPORT class HPX_EXPORT parcelport;
     }    // namespace policies::lcw
 
     template <>
@@ -60,7 +60,8 @@ namespace hpx::parcelset {
     };
 
     namespace policies::lcw {
-        class HPX_EXPORT parcelport : public parcelport_impl<parcelport>
+        HPX_CXX_EXPORT class HPX_EXPORT parcelport
+          : public parcelport_impl<parcelport>
         {
             using base_type = parcelport_impl<parcelport>;
             static parcelset::locality here();

--- a/libs/full/parcelport_lcw/include/hpx/parcelport_lcw/receiver_base.hpp
+++ b/libs/full/parcelport_lcw/include/hpx/parcelport_lcw/receiver_base.hpp
@@ -29,7 +29,7 @@
 #include <vector>
 
 namespace hpx::parcelset::policies::lcw {
-    class HPX_EXPORT parcelport;
+    HPX_CXX_EXPORT class HPX_EXPORT parcelport;
     struct buffer_wrapper
     {
         struct fake_allocator

--- a/libs/full/parcelport_lcw/include/hpx/parcelport_lcw/sender_base.hpp
+++ b/libs/full/parcelport_lcw/include/hpx/parcelport_lcw/sender_base.hpp
@@ -49,7 +49,7 @@
 #include <vector>
 
 namespace hpx::parcelset::policies::lcw {
-    class HPX_EXPORT parcelport;
+    HPX_CXX_EXPORT class HPX_EXPORT parcelport;
     struct sender_connection_base;
     struct sender_base
     {

--- a/libs/full/parcelport_mpi/CMakeLists.txt
+++ b/libs/full/parcelport_mpi/CMakeLists.txt
@@ -33,6 +33,7 @@ include(HPX_AddModule)
 add_hpx_module(
   full parcelport_mpi
   GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_MODULE_GEN ON
   SOURCES ${parcelport_mpi_sources}
   HEADERS ${parcelport_mpi_headers}
   COMPAT_HEADERS ${parcelport_mpi_compat_headers}

--- a/libs/full/parcelport_mpi/include/hpx/parcelport_mpi/locality.hpp
+++ b/libs/full/parcelport_mpi/include/hpx/parcelport_mpi/locality.hpp
@@ -45,8 +45,9 @@ namespace hpx::parcelset::policies::mpi {
             return rank_ != -1;
         }
 
-        HPX_EXPORT void save(serialization::output_archive& ar) const;
-        HPX_EXPORT void load(serialization::input_archive& ar);
+        HPX_CXX_EXPORT HPX_EXPORT void save(
+            serialization::output_archive& ar) const;
+        HPX_CXX_EXPORT HPX_EXPORT void load(serialization::input_archive& ar);
 
     private:
         friend constexpr bool operator==(
@@ -61,7 +62,7 @@ namespace hpx::parcelset::policies::mpi {
             return lhs.rank_ < rhs.rank_;
         }
 
-        friend HPX_EXPORT std::ostream& operator<<(
+        friend HPX_CXX_EXPORT HPX_EXPORT std::ostream& operator<<(
             std::ostream& os, locality const& loc) noexcept;
 
         std::int32_t rank_;

--- a/libs/full/parcelport_tcp/CMakeLists.txt
+++ b/libs/full/parcelport_tcp/CMakeLists.txt
@@ -27,6 +27,7 @@ include(HPX_AddModule)
 add_hpx_module(
   full parcelport_tcp
   GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_MODULE_GEN ON
   SOURCES ${parcelport_tcp_sources}
   HEADERS ${parcelport_tcp_headers}
   COMPAT_HEADERS ${parcelport_tcp_compat_headers}

--- a/libs/full/parcelport_tcp/include/hpx/parcelport_tcp/connection_handler.hpp
+++ b/libs/full/parcelport_tcp/include/hpx/parcelport_tcp/connection_handler.hpp
@@ -39,7 +39,7 @@ namespace hpx::parcelset {
     namespace policies::tcp {
 
         class receiver;
-        class HPX_EXPORT connection_handler;
+        HPX_CXX_EXPORT class HPX_EXPORT connection_handler;
     }    // namespace policies::tcp
 
     template <>
@@ -72,7 +72,7 @@ namespace hpx::parcelset {
         parcelset::locality parcelport_address(
             util::runtime_configuration const& ini);
 
-        class HPX_EXPORT connection_handler
+        HPX_CXX_EXPORT class HPX_EXPORT connection_handler
           : public parcelport_impl<connection_handler>
         {
             using base_type = parcelport_impl<connection_handler>;

--- a/libs/full/parcelport_tcp/include/hpx/parcelport_tcp/locality.hpp
+++ b/libs/full/parcelport_tcp/include/hpx/parcelport_tcp/locality.hpp
@@ -54,8 +54,9 @@ namespace hpx::parcelset::policies::tcp {
             return port_ != static_cast<std::uint16_t>(-1);
         }
 
-        HPX_EXPORT void save(serialization::output_archive& ar) const;
-        HPX_EXPORT void load(serialization::input_archive& ar);
+        HPX_CXX_EXPORT HPX_EXPORT void save(
+            serialization::output_archive& ar) const;
+        HPX_CXX_EXPORT HPX_EXPORT void load(serialization::input_archive& ar);
 
     private:
         friend bool operator==(
@@ -70,7 +71,7 @@ namespace hpx::parcelset::policies::tcp {
                 (lhs.address_ == rhs.address_ && lhs.port_ < rhs.port_);
         }
 
-        friend HPX_EXPORT std::ostream& operator<<(
+        friend HPX_CXX_EXPORT HPX_EXPORT std::ostream& operator<<(
             std::ostream& os, locality const& loc) noexcept;
 
         std::string address_;

--- a/libs/full/parcelports/CMakeLists.txt
+++ b/libs/full/parcelports/CMakeLists.txt
@@ -27,7 +27,7 @@ foreach(parcelport ${HPX_STATIC_PARCELPORT_PLUGINS})
 
   # generate header defining initialization functions for parcelports
   set(parcelport_export_declarations
-      "${parcelport_export_declarations}HPX_EXPORT hpx::plugins::parcelport_factory_base *\n"
+      "${parcelport_export_declarations}HPX_CXX_EXPORT HPX_EXPORT hpx::plugins::parcelport_factory_base *\n"
   )
   set(parcelport_export_declarations
       "${parcelport_export_declarations}    ${parcelport}_factory_init(\n"
@@ -50,6 +50,7 @@ include(HPX_AddModule)
 add_hpx_module(
   full parcelports
   GLOBAL_HEADER_GEN OFF
+  GLOBAL_HEADER_MODULE_GEN ON
   GENERATED_HEADERS ${parcelports_generated_headers}
   SOURCES ${parcelports_sources}
   HEADERS ${parcelports_headers}

--- a/libs/full/parcelports/cmake/templates/static_parcelports.hpp.in
+++ b/libs/full/parcelports/cmake/templates/static_parcelports.hpp.in
@@ -20,7 +20,7 @@
 namespace hpx::parcelset
 {
     // force linking with this module
-    HPX_EXPORT void init_parcel_ports();
+    HPX_CXX_EXPORT HPX_EXPORT void init_parcel_ports();
 
     inline void init_static_parcelport_factories_impl(
         std::vector<plugins::parcelport_factory_base *>& factories)

--- a/libs/full/parcelports/include/hpx/parcelports/init_all_parcelports.hpp
+++ b/libs/full/parcelports/include/hpx/parcelports/init_all_parcelports.hpp
@@ -13,7 +13,7 @@
 namespace hpx::parcelset {
 
     // force linking with this module
-    HPX_EXPORT void init_all_parcelports();
+    HPX_CXX_EXPORT HPX_EXPORT void init_all_parcelports();
 }    // namespace hpx::parcelset
 
 #endif

--- a/libs/full/parcelset/CMakeLists.txt
+++ b/libs/full/parcelset/CMakeLists.txt
@@ -56,6 +56,7 @@ include(HPX_AddModule)
 add_hpx_module(
   full parcelset
   GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_MODULE_GEN ON
   SOURCES ${parcelset_sources}
   HEADERS ${parcelset_headers}
   COMPAT_HEADERS ${parcelset_compat_headers}

--- a/libs/full/parcelset/include/hpx/parcelset/coalescing_message_handler_registration.hpp
+++ b/libs/full/parcelset/include/hpx/parcelset/coalescing_message_handler_registration.hpp
@@ -51,7 +51,7 @@ namespace hpx::parcelset {
 #define HPX_REGISTER_COALESCING_COUNTERS(Action, coalescing_name)              \
     namespace hpx::parcelset {                                                 \
         template <>                                                            \
-        HPX_ALWAYS_EXPORT constexpr char const*                                \
+        HPX_CXX_EXPORT HPX_ALWAYS_EXPORT constexpr char const*                 \
         get_action_coalescing_name<Action>() noexcept                          \
         {                                                                      \
             return coalescing_name;                                            \

--- a/libs/full/parcelset/include/hpx/parcelset/detail/message_handler_interface_functions.hpp
+++ b/libs/full/parcelset/include/hpx/parcelset/detail/message_handler_interface_functions.hpp
@@ -19,14 +19,15 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx::parcelset::detail {
 
-    extern HPX_EXPORT policies::message_handler* (*get_message_handler)(
-        char const* action, char const* type, std::size_t num,
-        std::size_t interval, locality const& loc, error_code& ec);
+    HPX_CXX_EXPORT extern HPX_EXPORT policies::message_handler* (
+        *get_message_handler)(char const* action, char const* type,
+        std::size_t num, std::size_t interval, locality const& loc,
+        error_code& ec);
 
-    extern HPX_EXPORT void (*register_message_handler)(
+    HPX_CXX_EXPORT extern HPX_EXPORT void (*register_message_handler)(
         char const* message_handler_type, char const* action, error_code& ec);
 
-    extern HPX_EXPORT parcelset::policies::message_handler* (
+    HPX_CXX_EXPORT extern HPX_EXPORT parcelset::policies::message_handler* (
         *create_message_handler)(char const* message_handler_type,
         char const* action, parcelset::parcelport* pp, std::size_t num_messages,
         std::size_t interval, error_code& ec);

--- a/libs/full/parcelset/include/hpx/parcelset/detail/parcel_await.hpp
+++ b/libs/full/parcelset/include/hpx/parcelset/detail/parcel_await.hpp
@@ -22,16 +22,16 @@ namespace hpx::parcelset::detail {
     using put_parcel_type = hpx::move_only_function<void(
         parcelset::parcel&&, write_handler_type&&)>;
 
-    void HPX_EXPORT parcel_await_apply(parcelset::parcel&& p,
+    void HPX_CXX_EXPORT HPX_EXPORT parcel_await_apply(parcelset::parcel&& p,
         write_handler_type&& f, std::uint32_t archive_flags,
         put_parcel_type pp);
 
     using put_parcels_type = hpx::move_only_function<void(
         std::vector<parcelset::parcel>&&, std::vector<write_handler_type>&&)>;
 
-    void HPX_EXPORT parcels_await_apply(std::vector<parcelset::parcel>&& p,
-        std::vector<write_handler_type>&& f, std::uint32_t archive_flags,
-        put_parcels_type pp);
+    void HPX_CXX_EXPORT HPX_EXPORT parcels_await_apply(
+        std::vector<parcelset::parcel>&& p, std::vector<write_handler_type>&& f,
+        std::uint32_t archive_flags, put_parcels_type pp);
 }    // namespace hpx::parcelset::detail
 
 #endif

--- a/libs/full/parcelset/include/hpx/parcelset/init_parcelports.hpp
+++ b/libs/full/parcelset/include/hpx/parcelset/init_parcelports.hpp
@@ -15,7 +15,7 @@
 
 namespace hpx::parcelset {
 
-    extern HPX_EXPORT void (*init_static_parcelport_factories)(
+    HPX_CXX_EXPORT extern HPX_EXPORT void (*init_static_parcelport_factories)(
         std::vector<plugins::parcelport_factory_base*>& factories);
 }
 

--- a/libs/full/parcelset/include/hpx/parcelset/message_handler_fwd.hpp
+++ b/libs/full/parcelset/include/hpx/parcelset/message_handler_fwd.hpp
@@ -25,14 +25,16 @@ namespace hpx {
         namespace detail {
 
             // Get access to the registry of registered message handlers
-            HPX_EXPORT std::vector<hpx::tuple<char const*, char const*>>&
-            get_message_handler_registrations();
+            HPX_CXX_EXPORT HPX_EXPORT
+                std::vector<hpx::tuple<char const*, char const*>>&
+                get_message_handler_registrations();
         }    // namespace detail
 
-        HPX_EXPORT parcelset::policies::message_handler* get_message_handler(
-            char const* action, char const* message_handler_type,
-            std::size_t num_messages, std::size_t interval,
-            parcelset::locality const& loc, error_code& ec = throws);
+        HPX_CXX_EXPORT HPX_EXPORT parcelset::policies::message_handler*
+        get_message_handler(char const* action,
+            char const* message_handler_type, std::size_t num_messages,
+            std::size_t interval, parcelset::locality const& loc,
+            error_code& ec = throws);
     }    // namespace parcelset
     /// \endcond
 
@@ -53,8 +55,9 @@ namespace hpx {
     ///           function doesn't throw but returns the result code using the
     ///           parameter \a ec. Otherwise it throws an instance of
     ///           hpx::exception.
-    HPX_EXPORT void register_message_handler(char const* message_handler_type,
-        char const* action, error_code& ec = throws);
+    HPX_CXX_EXPORT HPX_EXPORT void register_message_handler(
+        char const* message_handler_type, char const* action,
+        error_code& ec = throws);
 
     /// \brief Create an instance of a message handler plugin
     ///
@@ -74,8 +77,8 @@ namespace hpx {
     ///           function doesn't throw but returns the result code using the
     ///           parameter \a ec. Otherwise it throws an instance of
     ///           hpx::exception.
-    HPX_EXPORT parcelset::policies::message_handler* create_message_handler(
-        char const* message_handler_type, char const* action,
+    HPX_CXX_EXPORT HPX_EXPORT parcelset::policies::message_handler*
+    create_message_handler(char const* message_handler_type, char const* action,
         parcelset::parcelport* pp, std::size_t num_messages,
         std::size_t interval, error_code& ec = throws);
 }    // namespace hpx

--- a/libs/full/parcelset/include/hpx/parcelset/parcel.hpp
+++ b/libs/full/parcelset/include/hpx/parcelset/parcel.hpp
@@ -28,7 +28,7 @@
 
 namespace hpx::parcelset::detail {
 
-    struct HPX_EXPORT parcel_data
+    HPX_CXX_EXPORT struct HPX_EXPORT parcel_data
     {
     public:
         inline parcel_data();
@@ -55,7 +55,7 @@ namespace hpx::parcelset::detail {
     };
 
     // actual parcel implementation
-    class HPX_EXPORT parcel final : public parcel_base
+    HPX_CXX_EXPORT class HPX_EXPORT parcel final : public parcel_base
     {
     private:
         parcel(parcel const&) = delete;
@@ -157,7 +157,8 @@ namespace hpx::parcelset::detail {
         std::size_t num_chunks_;
     };
 
-    HPX_EXPORT std::ostream& operator<<(std::ostream& os, parcel const& p);
+    HPX_CXX_EXPORT HPX_EXPORT std::ostream& operator<<(
+        std::ostream& os, parcel const& p);
 }    // namespace hpx::parcelset::detail
 
 #include <hpx/config/warnings_suffix.hpp>

--- a/libs/full/parcelset/include/hpx/parcelset/parcelhandler.hpp
+++ b/libs/full/parcelset/include/hpx/parcelset/parcelhandler.hpp
@@ -46,7 +46,7 @@ namespace hpx::parcelset {
     /// The \a parcelhandler is the representation of the parcelset inside a
     /// locality. It is built on top of a single parcelport. Several
     /// parcel-handlers may be connected to a single parcelport.
-    class HPX_EXPORT parcelhandler
+    HPX_CXX_EXPORT class HPX_EXPORT parcelhandler
     {
     public:
         parcelhandler(parcelhandler const&) = delete;

--- a/libs/full/parcelset/include/hpx/parcelset/parcelport_impl.hpp
+++ b/libs/full/parcelset/include/hpx/parcelset/parcelport_impl.hpp
@@ -56,7 +56,7 @@ namespace hpx::parcelset {
     struct connection_handler_traits;
 
     template <typename ConnectionHandler>
-    class HPX_EXPORT parcelport_impl : public parcelport
+    HPX_CXX_EXPORT class HPX_EXPORT parcelport_impl : public parcelport
     {
         using connection = typename connection_handler_traits<
             ConnectionHandler>::connection_type;

--- a/libs/full/parcelset/include/hpx/parcelset/parcelset_fwd.hpp
+++ b/libs/full/parcelset/include/hpx/parcelset/parcelset_fwd.hpp
@@ -24,7 +24,7 @@ namespace hpx::parcelset {
     template <typename ConnectionHandler>
     class parcelport_impl;
 
-    class HPX_EXPORT parcelhandler;
+    HPX_CXX_EXPORT class HPX_EXPORT parcelhandler;
 
     namespace policies {
         struct message_handler;
@@ -42,27 +42,29 @@ namespace hpx::parcelset {
     /// \param num_thread this represents the number of threads.
     /// \param mode
     ///
-    HPX_EXPORT bool do_background_work(std::size_t num_thread = 0,
+    HPX_CXX_EXPORT HPX_EXPORT bool do_background_work(
+        std::size_t num_thread = 0,
         parcelport_background_mode mode = parcelport_background_mode::all);
 
     using write_handler_type = parcel_write_handler_type;
 
     ///////////////////////////////////////////////////////////////////////
     // default callback for put_parcel
-    HPX_EXPORT void default_write_handler(
+    HPX_CXX_EXPORT HPX_EXPORT void default_write_handler(
         std::error_code const&, parcel const&);
 
     ///////////////////////////////////////////////////////////////////////
     /// Hand a parcel to the underlying parcel layer for delivery.
-    HPX_EXPORT void put_parcel(
+    HPX_CXX_EXPORT HPX_EXPORT void put_parcel(
         parcel&& p, write_handler_type&& f = &default_write_handler);
 
     /// Hand a parcel to the underlying parcel layer for delivery.
     /// Wait for the operation to finish before returning to the user.
-    HPX_EXPORT void sync_put_parcel(parcelset::parcel&& p);
+    HPX_CXX_EXPORT HPX_EXPORT void sync_put_parcel(parcelset::parcel&& p);
 
     /// Return the maximally allowed size of an inbound message (in bytes)
-    HPX_EXPORT std::int64_t get_max_inbound_size(parcelport const&);
+    HPX_CXX_EXPORT HPX_EXPORT std::int64_t get_max_inbound_size(
+        parcelport const&);
 }    // namespace hpx::parcelset
 
 #endif

--- a/libs/full/parcelset_base/include/hpx/parcelset_base/detail/locality_interface_functions.hpp
+++ b/libs/full/parcelset_base/include/hpx/parcelset_base/detail/locality_interface_functions.hpp
@@ -18,19 +18,21 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx::parcelset::detail {
 
-    extern HPX_EXPORT parcelset::parcel (*create_parcel)();
+    HPX_CXX_EXPORT extern HPX_EXPORT parcelset::parcel (*create_parcel)();
 
-    extern HPX_EXPORT locality (*create_locality)(std::string const& name);
+    HPX_CXX_EXPORT extern HPX_EXPORT locality (*create_locality)(
+        std::string const& name);
 
-    extern HPX_EXPORT parcel_write_handler_type (*set_parcel_write_handler)(
-        parcel_write_handler_type const& f);
+    HPX_CXX_EXPORT extern HPX_EXPORT parcel_write_handler_type (
+        *set_parcel_write_handler)(parcel_write_handler_type const& f);
 
-    extern HPX_EXPORT void (*put_parcel)(
+    HPX_CXX_EXPORT extern HPX_EXPORT void (*put_parcel)(
         parcelset::parcel&& p, parcel_write_handler_type&& f);
 
-    extern HPX_EXPORT void (*sync_put_parcel)(parcelset::parcel&& p);
+    HPX_CXX_EXPORT extern HPX_EXPORT void (*sync_put_parcel)(
+        parcelset::parcel&& p);
 
-    extern HPX_EXPORT void (*parcel_route_handler_func)(
+    HPX_CXX_EXPORT extern HPX_EXPORT void (*parcel_route_handler_func)(
         std::error_code const& ec, parcelset::parcel const& p);
 }    // namespace hpx::parcelset::detail
 

--- a/libs/full/parcelset_base/include/hpx/parcelset_base/detail/parcel_route_handler.hpp
+++ b/libs/full/parcelset_base/include/hpx/parcelset_base/detail/parcel_route_handler.hpp
@@ -19,7 +19,7 @@ namespace hpx::parcelset::detail {
     // The original parcel-sent handler is wrapped to keep the parcel alive
     // until after the data has been reliably sent (which is needed for zero
     // copy serialization).
-    void HPX_EXPORT parcel_route_handler(
+    void HPX_CXX_EXPORT HPX_EXPORT parcel_route_handler(
         std::error_code const& ec, parcelset::parcel const& p);
 }    // namespace hpx::parcelset::detail
 

--- a/libs/full/parcelset_base/include/hpx/parcelset_base/locality.hpp
+++ b/libs/full/parcelset_base/include/hpx/parcelset_base/locality.hpp
@@ -108,16 +108,16 @@ namespace hpx::parcelset {
         }
 
     private:
-        friend HPX_EXPORT bool operator==(
+        friend HPX_CXX_EXPORT HPX_EXPORT bool operator==(
             locality const& lhs, locality const& rhs);
-        friend HPX_EXPORT bool operator!=(
+        friend HPX_CXX_EXPORT HPX_EXPORT bool operator!=(
             locality const& lhs, locality const& rhs);
-        friend HPX_EXPORT bool operator<(
+        friend HPX_CXX_EXPORT HPX_EXPORT bool operator<(
             locality const& lhs, locality const& rhs);
-        friend HPX_EXPORT bool operator>(
+        friend HPX_CXX_EXPORT HPX_EXPORT bool operator>(
             locality const& lhs, locality const& rhs);
 
-        friend HPX_EXPORT std::ostream& operator<<(
+        friend HPX_CXX_EXPORT HPX_EXPORT std::ostream& operator<<(
             std::ostream& os, locality const& l);
 
         // serialization support

--- a/libs/full/performance_counters/CMakeLists.txt
+++ b/libs/full/performance_counters/CMakeLists.txt
@@ -87,6 +87,7 @@ include(HPX_AddModule)
 add_hpx_module(
   full performance_counters
   GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_MODULE_GEN ON
   SOURCES ${performance_counters_sources}
   HEADERS ${performance_counters_headers}
   DEPENDENCIES hpx_core

--- a/libs/full/performance_counters/include/hpx/performance_counters/action_invocation_counter_discoverer.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/action_invocation_counter_discoverer.hpp
@@ -12,7 +12,7 @@
 
 namespace hpx { namespace performance_counters {
 
-    HPX_EXPORT bool action_invocation_counter_discoverer(
+    HPX_CXX_EXPORT HPX_EXPORT bool action_invocation_counter_discoverer(
         hpx::actions::detail::invocation_count_registry const& registry,
         counter_info const& info, counter_path_elements& p,
         discover_counter_func const& f, discover_counters_mode mode,

--- a/libs/full/performance_counters/include/hpx/performance_counters/agas_counter_types.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/agas_counter_types.hpp
@@ -14,6 +14,6 @@ namespace hpx { namespace performance_counters {
 
     /// Install performance counter types exposing properties from the local
     /// cache.
-    void HPX_EXPORT register_agas_counter_types(
+    void HPX_CXX_EXPORT HPX_EXPORT register_agas_counter_types(
         agas::addressing_service& client);
 }}    // namespace hpx::performance_counters

--- a/libs/full/performance_counters/include/hpx/performance_counters/agas_namespace_action_code.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/agas_namespace_action_code.hpp
@@ -246,10 +246,11 @@ namespace hpx::agas::detail {
 
     ///////////////////////////////////////////////////////////////////////////
     // get action code from counter type
-    HPX_EXPORT namespace_action_code retrieve_action_code(
+    HPX_CXX_EXPORT HPX_EXPORT namespace_action_code retrieve_action_code(
         std::string const& name, error_code& ec = throws);
 
     // get service action code from counter type
-    HPX_EXPORT namespace_action_code retrieve_action_service_code(
+    HPX_CXX_EXPORT HPX_EXPORT namespace_action_code
+    retrieve_action_service_code(
         std::string const& name, error_code& ec = throws);
 }    // namespace hpx::agas::detail

--- a/libs/full/performance_counters/include/hpx/performance_counters/component_namespace_counters.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/component_namespace_counters.hpp
@@ -15,6 +15,6 @@
 namespace hpx { namespace agas {
 
     // Register all performance counter types exposed by the component_namespace
-    HPX_EXPORT void component_namespace_register_counter_types(
+    HPX_CXX_EXPORT HPX_EXPORT void component_namespace_register_counter_types(
         error_code& ec = throws);
 }}    // namespace hpx::agas

--- a/libs/full/performance_counters/include/hpx/performance_counters/counter_creators.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/counter_creators.hpp
@@ -23,8 +23,9 @@ namespace hpx { namespace performance_counters {
     /// Default discovery function for performance counters; to be registered
     /// with the counter types. It will pass the \a counter_info and the
     /// \a error_code to the supplied function.
-    HPX_EXPORT bool default_counter_discoverer(counter_info const&,
-        discover_counter_func const&, discover_counters_mode, error_code&);
+    HPX_CXX_EXPORT HPX_EXPORT bool default_counter_discoverer(
+        counter_info const&, discover_counter_func const&,
+        discover_counters_mode, error_code&);
 
     /// Default discoverer function for performance counters; to be registered
     /// with the counter types. It is suitable to be used for all counters
@@ -32,8 +33,9 @@ namespace hpx { namespace performance_counters {
     ///
     ///   /<objectname>(locality#<locality_id>/total)/<instancename>
     ///
-    HPX_EXPORT bool locality_counter_discoverer(counter_info const&,
-        discover_counter_func const&, discover_counters_mode, error_code&);
+    HPX_CXX_EXPORT HPX_EXPORT bool locality_counter_discoverer(
+        counter_info const&, discover_counter_func const&,
+        discover_counters_mode, error_code&);
 
     /// Default discoverer function for performance counters; to be registered
     /// with the counter types. It is suitable to be used for all counters
@@ -41,8 +43,9 @@ namespace hpx { namespace performance_counters {
     ///
     ///   /<objectname>(locality#<locality_id>/pool#<pool_name>/total)/<instancename>
     ///
-    HPX_EXPORT bool locality_pool_counter_discoverer(counter_info const&,
-        discover_counter_func const&, discover_counters_mode, error_code&);
+    HPX_CXX_EXPORT HPX_EXPORT bool locality_pool_counter_discoverer(
+        counter_info const&, discover_counter_func const&,
+        discover_counters_mode, error_code&);
 
     /// Default discoverer function for AGAS performance counters; to be
     /// registered with the counter types. It is suitable to be used for all
@@ -50,8 +53,9 @@ namespace hpx { namespace performance_counters {
     ///
     ///   /<objectname>{locality#0/total}/<instancename>
     ///
-    HPX_EXPORT bool locality0_counter_discoverer(counter_info const&,
-        discover_counter_func const&, discover_counters_mode, error_code&);
+    HPX_CXX_EXPORT HPX_EXPORT bool locality0_counter_discoverer(
+        counter_info const&, discover_counter_func const&,
+        discover_counters_mode, error_code&);
 
     /// Default discoverer function for performance counters; to be registered
     /// with the counter types. It is suitable to be used for all counters
@@ -59,8 +63,9 @@ namespace hpx { namespace performance_counters {
     ///
     ///   /<objectname>(locality#<locality_id>/worker-thread#<threadnum>)/<instancename>
     ///
-    HPX_EXPORT bool locality_thread_counter_discoverer(counter_info const&,
-        discover_counter_func const&, discover_counters_mode, error_code&);
+    HPX_CXX_EXPORT HPX_EXPORT bool locality_thread_counter_discoverer(
+        counter_info const&, discover_counter_func const&,
+        discover_counters_mode, error_code&);
 
     /// Default discoverer function for performance counters; to be registered
     /// with the counter types. It is suitable to be used for all counters
@@ -90,8 +95,9 @@ namespace hpx { namespace performance_counters {
     ///
     ///   /<objectname>(locality#<locality_id>/numa-node#<threadnum>)/<instancename>
     ///
-    HPX_EXPORT bool locality_numa_counter_discoverer(counter_info const&,
-        discover_counter_func const&, discover_counters_mode, error_code&);
+    HPX_CXX_EXPORT HPX_EXPORT bool locality_numa_counter_discoverer(
+        counter_info const&, discover_counter_func const&,
+        discover_counters_mode, error_code&);
 
     ///////////////////////////////////////////////////////////////////////////
     /// Creation function for raw counters. The passed function is encapsulating
@@ -100,12 +106,12 @@ namespace hpx { namespace performance_counters {
     ///
     ///   /<objectname>(locality#<locality_id>/total)/<instancename>
     ///
-    HPX_EXPORT naming::gid_type locality_raw_counter_creator(
+    HPX_CXX_EXPORT HPX_EXPORT naming::gid_type locality_raw_counter_creator(
         counter_info const&, hpx::function<std::int64_t(bool)> const&,
         error_code&);
 
-    HPX_EXPORT naming::gid_type locality_raw_values_counter_creator(
-        counter_info const&,
+    HPX_CXX_EXPORT HPX_EXPORT naming::gid_type
+    locality_raw_values_counter_creator(counter_info const&,
         hpx::function<std::vector<std::int64_t>(bool)> const&, error_code&);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -115,7 +121,7 @@ namespace hpx { namespace performance_counters {
     ///
     ///   /agas(<objectinstance>/total)/<instancename>
     ///
-    HPX_EXPORT naming::gid_type agas_raw_counter_creator(
+    HPX_CXX_EXPORT HPX_EXPORT naming::gid_type agas_raw_counter_creator(
         counter_info const&, error_code&, char const* const);
 
     /// Default discoverer function for performance counters; to be registered
@@ -124,25 +130,25 @@ namespace hpx { namespace performance_counters {
     ///
     ///   /agas(<objectinstance>/total)/<instancename>
     ///
-    HPX_EXPORT bool agas_counter_discoverer(counter_info const&,
+    HPX_CXX_EXPORT HPX_EXPORT bool agas_counter_discoverer(counter_info const&,
         discover_counter_func const&, discover_counters_mode, error_code&);
 
     ///////////////////////////////////////////////////////////////////////////
     // Creation function for action invocation counters.
-    HPX_EXPORT naming::gid_type local_action_invocation_counter_creator(
-        counter_info const&, error_code&);
+    HPX_CXX_EXPORT HPX_EXPORT naming::gid_type
+    local_action_invocation_counter_creator(counter_info const&, error_code&);
 
     // Discoverer function for action invocation counters.
-    HPX_EXPORT bool local_action_invocation_counter_discoverer(
+    HPX_CXX_EXPORT HPX_EXPORT bool local_action_invocation_counter_discoverer(
         counter_info const&, discover_counter_func const&,
         discover_counters_mode, error_code&);
 
 #if defined(HPX_HAVE_NETWORKING)
-    HPX_EXPORT naming::gid_type remote_action_invocation_counter_creator(
-        counter_info const&, error_code&);
+    HPX_CXX_EXPORT HPX_EXPORT naming::gid_type
+    remote_action_invocation_counter_creator(counter_info const&, error_code&);
 
     // Discoverer function for action invocation counters.
-    HPX_EXPORT bool remote_action_invocation_counter_discoverer(
+    HPX_CXX_EXPORT HPX_EXPORT bool remote_action_invocation_counter_discoverer(
         counter_info const&, discover_counter_func const&,
         discover_counters_mode, error_code&);
 
@@ -150,15 +156,15 @@ namespace hpx { namespace performance_counters {
     defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
     ///////////////////////////////////////////////////////////////////////////
     // Creation function for per-action parcel data counters
-    HPX_EXPORT naming::gid_type per_action_data_counter_creator(
+    HPX_CXX_EXPORT HPX_EXPORT naming::gid_type per_action_data_counter_creator(
         counter_info const& info,
         hpx::function<std::int64_t(std::string const&, bool)> const& f,
         error_code& ec);
 
     // Discoverer function for per-action parcel data counters
-    HPX_EXPORT bool per_action_data_counter_discoverer(counter_info const& info,
-        discover_counter_func const& f, discover_counters_mode mode,
-        error_code& ec);
+    HPX_CXX_EXPORT HPX_EXPORT bool per_action_data_counter_discoverer(
+        counter_info const& info, discover_counter_func const& f,
+        discover_counters_mode mode, error_code& ec);
 #endif
 #endif
 }}    // namespace hpx::performance_counters

--- a/libs/full/performance_counters/include/hpx/performance_counters/counter_interface.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/counter_interface.hpp
@@ -15,7 +15,8 @@
 namespace hpx { namespace performance_counters {
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT hpx::future<id_type> create_performance_counter_async(
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future<id_type>
+    create_performance_counter_async(
         id_type target_id, counter_info const& info);
 
     inline id_type create_performance_counter(

--- a/libs/full/performance_counters/include/hpx/performance_counters/counter_parser.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/counter_parser.hpp
@@ -34,6 +34,6 @@ namespace hpx { namespace performance_counters {
         std::string parameters_;
     };
 
-    HPX_EXPORT bool parse_counter_name(
+    HPX_CXX_EXPORT HPX_EXPORT bool parse_counter_name(
         std::string const& name, path_elements& elements);
 }}    // namespace hpx::performance_counters

--- a/libs/full/performance_counters/include/hpx/performance_counters/counters.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/counters.hpp
@@ -178,7 +178,8 @@ namespace hpx { namespace performance_counters {
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Return the readable name of a given counter type
-    HPX_EXPORT char const* get_counter_type_name(counter_type state);
+    HPX_CXX_EXPORT HPX_EXPORT char const* get_counter_type_name(
+        counter_type state);
 
 #if defined(DOXYGEN)
     ///////////////////////////////////////////////////////////////////////////
@@ -232,9 +233,9 @@ namespace hpx { namespace performance_counters {
         // serialization support
         friend class hpx::serialization::access;
 
-        HPX_EXPORT void serialize(
+        HPX_CXX_EXPORT HPX_EXPORT void serialize(
             serialization::output_archive& ar, unsigned int) const;
-        HPX_EXPORT void serialize(
+        HPX_CXX_EXPORT HPX_EXPORT void serialize(
             serialization::input_archive& ar, unsigned int);
     };
 
@@ -308,9 +309,9 @@ namespace hpx { namespace performance_counters {
         // serialization support
         friend class hpx::serialization::access;
 
-        HPX_EXPORT void serialize(
+        HPX_CXX_EXPORT HPX_EXPORT void serialize(
             serialization::output_archive& ar, unsigned int);
-        HPX_EXPORT void serialize(
+        HPX_CXX_EXPORT HPX_EXPORT void serialize(
             serialization::input_archive& ar, unsigned int);
     };
 
@@ -359,9 +360,9 @@ namespace hpx { namespace performance_counters {
         // serialization support
         friend class hpx::serialization::access;
 
-        HPX_EXPORT void serialize(
+        HPX_CXX_EXPORT HPX_EXPORT void serialize(
             serialization::output_archive& ar, unsigned int) const;
-        HPX_EXPORT void serialize(
+        HPX_CXX_EXPORT HPX_EXPORT void serialize(
             serialization::input_archive& ar, unsigned int);
     };
 

--- a/libs/full/performance_counters/include/hpx/performance_counters/counters_fwd.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/counters_fwd.hpp
@@ -189,7 +189,8 @@ namespace hpx { namespace performance_counters {
 
     ///////////////////////////////////////////////////////////////////////////
     // Return the readable name of a given counter type
-    HPX_EXPORT char const* get_counter_type_name(counter_type state);
+    HPX_CXX_EXPORT HPX_EXPORT char const* get_counter_type_name(
+        counter_type state);
 
     ///////////////////////////////////////////////////////////////////////////
     // Status and error codes used by the functions related to
@@ -205,7 +206,8 @@ namespace hpx { namespace performance_counters {
         generic_error            // A unknown error occurred
     };
 
-    HPX_EXPORT std::ostream& operator<<(std::ostream& os, counter_status rhs);
+    HPX_CXX_EXPORT HPX_EXPORT std::ostream& operator<<(
+        std::ostream& os, counter_status rhs);
 
 #define HPX_COUNTER_STATUS_UNSCOPED_ENUM_DEPRECATION_MSG                       \
     "The unscoped counter_status names are deprecated. Please use "            \
@@ -250,49 +252,52 @@ namespace hpx { namespace performance_counters {
     /// \brief Create a full name of a counter type from the contents of the
     ///        given \a counter_type_path_elements instance.The generated
     ///        counter type name will not contain any parameters.
-    HPX_EXPORT counter_status get_counter_type_name(
+    HPX_CXX_EXPORT HPX_EXPORT counter_status get_counter_type_name(
         counter_type_path_elements const& path, std::string& result,
         error_code& ec = throws);
 
     /// \brief Create a full name of a counter type from the contents of the
     ///        given \a counter_type_path_elements instance. The generated
     ///        counter type name will contain all parameters.
-    HPX_EXPORT counter_status get_full_counter_type_name(
+    HPX_CXX_EXPORT HPX_EXPORT counter_status get_full_counter_type_name(
         counter_type_path_elements const& path, std::string& result,
         error_code& ec = throws);
 
     /// \brief Create a full name of a counter from the contents of the given
     ///        \a counter_path_elements instance.
-    HPX_EXPORT counter_status get_counter_name(
+    HPX_CXX_EXPORT HPX_EXPORT counter_status get_counter_name(
         counter_path_elements const& path, std::string& result,
         error_code& ec = throws);
 
     /// \brief Create a name of a counter instance from the contents of the
     ///        given \a counter_path_elements instance.
-    HPX_EXPORT counter_status get_counter_instance_name(
+    HPX_CXX_EXPORT HPX_EXPORT counter_status get_counter_instance_name(
         counter_path_elements const& path, std::string& result,
         error_code& ec = throws);
 
     /// \brief Fill the given \a counter_type_path_elements instance from the
     ///        given full name of a counter type
-    HPX_EXPORT counter_status get_counter_type_path_elements(
+    HPX_CXX_EXPORT HPX_EXPORT counter_status get_counter_type_path_elements(
         std::string const& name, counter_type_path_elements& path,
         error_code& ec = throws);
 
     /// \brief Fill the given \a counter_path_elements instance from the given
     ///        full name of a counter
-    HPX_EXPORT counter_status get_counter_path_elements(std::string const& name,
-        counter_path_elements& path, error_code& ec = throws);
+    HPX_CXX_EXPORT HPX_EXPORT counter_status get_counter_path_elements(
+        std::string const& name, counter_path_elements& path,
+        error_code& ec = throws);
 
     /// \brief Return the canonical counter instance name from a given full
     ///        instance name
-    HPX_EXPORT counter_status get_counter_name(std::string const& name,
-        std::string& countername, error_code& ec = throws);
+    HPX_CXX_EXPORT HPX_EXPORT counter_status get_counter_name(
+        std::string const& name, std::string& countername,
+        error_code& ec = throws);
 
     /// \brief Return the canonical counter type name from a given (full)
     ///        instance name
-    HPX_EXPORT counter_status get_counter_type_name(std::string const& name,
-        std::string& type_name, error_code& ec = throws);
+    HPX_CXX_EXPORT HPX_EXPORT counter_status get_counter_type_name(
+        std::string const& name, std::string& type_name,
+        error_code& ec = throws);
 
     // default version of performance counter structures
 #define HPX_PERFORMANCE_COUNTER_V1 0x01000000
@@ -343,10 +348,11 @@ namespace hpx { namespace performance_counters {
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Complement the counter info if parent instance name is missing
-    HPX_EXPORT counter_status complement_counter_info(counter_info& info,
-        counter_info const& type_info, error_code& ec = throws);
+    HPX_CXX_EXPORT HPX_EXPORT counter_status complement_counter_info(
+        counter_info& info, counter_info const& type_info,
+        error_code& ec = throws);
 
-    HPX_EXPORT counter_status complement_counter_info(
+    HPX_CXX_EXPORT HPX_EXPORT counter_status complement_counter_info(
         counter_info& info, error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -410,9 +416,9 @@ namespace hpx { namespace performance_counters {
         // serialization support
         friend class hpx::serialization::access;
 
-        HPX_EXPORT void serialize(
+        HPX_CXX_EXPORT HPX_EXPORT void serialize(
             serialization::output_archive& ar, unsigned int const) const;
-        HPX_EXPORT void serialize(
+        HPX_CXX_EXPORT HPX_EXPORT void serialize(
             serialization::input_archive& ar, unsigned int const);
     };
 
@@ -506,16 +512,16 @@ namespace hpx { namespace performance_counters {
         // serialization support
         friend class hpx::serialization::access;
 
-        HPX_EXPORT void serialize(
+        HPX_CXX_EXPORT HPX_EXPORT void serialize(
             serialization::output_archive& ar, unsigned int const) const;
-        HPX_EXPORT void serialize(
+        HPX_CXX_EXPORT HPX_EXPORT void serialize(
             serialization::input_archive& ar, unsigned int const);
     };
 
     ///////////////////////////////////////////////////////////////////////
     // Add a new performance counter type to the (local) registry
-    HPX_EXPORT counter_status add_counter_type(counter_info const& info,
-        create_counter_func const& create_counter,
+    HPX_CXX_EXPORT HPX_EXPORT counter_status add_counter_type(
+        counter_info const& info, create_counter_func const& create_counter,
         discover_counters_func const& discover_counters,
         error_code& ec = throws);
 
@@ -524,37 +530,37 @@ namespace hpx { namespace performance_counters {
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Call the supplied function for each registered counter type
-    HPX_EXPORT counter_status discover_counter_types(
+    HPX_CXX_EXPORT HPX_EXPORT counter_status discover_counter_types(
         discover_counter_func const& discover_counter,
         discover_counters_mode mode = discover_counters_mode::minimal,
         error_code& ec = throws);
 
     /// \brief Return a list of all available counter descriptions.
-    HPX_EXPORT counter_status discover_counter_types(
+    HPX_CXX_EXPORT HPX_EXPORT counter_status discover_counter_types(
         std::vector<counter_info>& counters,
         discover_counters_mode mode = discover_counters_mode::minimal,
         error_code& ec = throws);
 
     /// \brief Call the supplied function for the given registered counter type.
-    HPX_EXPORT counter_status discover_counter_type(std::string const& name,
-        discover_counter_func const& discover_counter,
+    HPX_CXX_EXPORT HPX_EXPORT counter_status discover_counter_type(
+        std::string const& name, discover_counter_func const& discover_counter,
         discover_counters_mode mode = discover_counters_mode::minimal,
         error_code& ec = throws);
 
-    HPX_EXPORT counter_status discover_counter_type(counter_info const& info,
-        discover_counter_func const& discover_counter,
+    HPX_CXX_EXPORT HPX_EXPORT counter_status discover_counter_type(
+        counter_info const& info, discover_counter_func const& discover_counter,
         discover_counters_mode mode = discover_counters_mode::minimal,
         error_code& ec = throws);
 
     /// \brief Return a list of matching counter descriptions for the given
     ///        registered counter type.
-    HPX_EXPORT counter_status discover_counter_type(std::string const& name,
-        std::vector<counter_info>& counters,
+    HPX_CXX_EXPORT HPX_EXPORT counter_status discover_counter_type(
+        std::string const& name, std::vector<counter_info>& counters,
         discover_counters_mode mode = discover_counters_mode::minimal,
         error_code& ec = throws);
 
-    HPX_EXPORT counter_status discover_counter_type(counter_info const& info,
-        std::vector<counter_info>& counters,
+    HPX_CXX_EXPORT HPX_EXPORT counter_status discover_counter_type(
+        counter_info const& info, std::vector<counter_info>& counters,
         discover_counters_mode mode = discover_counters_mode::minimal,
         error_code& ec = throws);
 
@@ -563,26 +569,26 @@ namespace hpx { namespace performance_counters {
     ///
     /// This function expands all locality#* and worker-thread#* wild
     /// cards only.
-    HPX_EXPORT bool expand_counter_info(
+    HPX_CXX_EXPORT HPX_EXPORT bool expand_counter_info(
         counter_info const&, discover_counter_func const&, error_code&);
 
     /// \brief Remove an existing counter type from the (local) registry
     ///
     /// \note This doesn't remove existing counters of this type, it just
     ///       inhibits defining new counters using this type.
-    HPX_EXPORT counter_status remove_counter_type(
+    HPX_CXX_EXPORT HPX_EXPORT counter_status remove_counter_type(
         counter_info const& info, error_code& ec = throws);
 
     /// \brief Retrieve the counter type for the given counter name from the
     ///        (local) registry
-    HPX_EXPORT counter_status get_counter_type(
+    HPX_CXX_EXPORT HPX_EXPORT counter_status get_counter_type(
         std::string const& name, counter_info& info, error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Get the global id of an existing performance counter, if the
     ///        counter does not exist yet, the function attempts to create the
     ///        counter based on the given counter name.
-    HPX_EXPORT hpx::future<hpx::id_type> get_counter_async(
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future<hpx::id_type> get_counter_async(
         std::string name, error_code& ec = throws);
 
     inline hpx::id_type get_counter(
@@ -591,7 +597,7 @@ namespace hpx { namespace performance_counters {
     /// \brief Get the global id of an existing performance counter, if the
     ///        counter does not exist yet, the function attempts to create the
     ///        counter based on the given counter info.
-    HPX_EXPORT hpx::future<hpx::id_type> get_counter_async(
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future<hpx::id_type> get_counter_async(
         counter_info const& info, error_code& ec = throws);
 
     inline hpx::id_type get_counter(
@@ -599,103 +605,110 @@ namespace hpx { namespace performance_counters {
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Retrieve the meta data specific for the given counter instance
-    HPX_EXPORT void get_counter_infos(counter_info const& info,
+    HPX_CXX_EXPORT HPX_EXPORT void get_counter_infos(counter_info const& info,
         counter_type& type, std::string& helptext, std::uint32_t& version,
         error_code& ec = throws);
 
     /// \brief Retrieve the meta data specific for the given counter instance
-    HPX_EXPORT void get_counter_infos(std::string name, counter_type& type,
-        std::string& helptext, std::uint32_t& version, error_code& ec = throws);
+    HPX_CXX_EXPORT HPX_EXPORT void get_counter_infos(std::string name,
+        counter_type& type, std::string& helptext, std::uint32_t& version,
+        error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
         /// \brief Add an existing performance counter instance to the registry
-        HPX_EXPORT counter_status add_counter(hpx::id_type const& id,
-            counter_info const& info, error_code& ec = throws);
+        HPX_CXX_EXPORT HPX_EXPORT counter_status add_counter(
+            hpx::id_type const& id, counter_info const& info,
+            error_code& ec = throws);
 
         /// \brief Remove an existing performance counter instance with the
         ///        given id (as returned from \a create_counter)
-        HPX_EXPORT counter_status remove_counter(counter_info const& info,
-            hpx::id_type const& id, error_code& ec = throws);
+        HPX_CXX_EXPORT HPX_EXPORT counter_status remove_counter(
+            counter_info const& info, hpx::id_type const& id,
+            error_code& ec = throws);
 
         ///////////////////////////////////////////////////////////////////////
         // Helper function for creating counters encapsulating a function
         // returning the counter value.
-        HPX_EXPORT naming::gid_type create_raw_counter(counter_info const&,
-            hpx::function<std::int64_t()> const&, error_code&);
+        HPX_CXX_EXPORT HPX_EXPORT naming::gid_type create_raw_counter(
+            counter_info const&, hpx::function<std::int64_t()> const&,
+            error_code&);
 
         // Helper function for creating counters encapsulating a function
         // returning the counter value.
-        HPX_EXPORT naming::gid_type create_raw_counter(counter_info const&,
-            hpx::function<std::int64_t(bool)> const&, error_code&);
+        HPX_CXX_EXPORT HPX_EXPORT naming::gid_type create_raw_counter(
+            counter_info const&, hpx::function<std::int64_t(bool)> const&,
+            error_code&);
 
         // Helper function for creating counters encapsulating a function
         // returning the counter values array.
-        HPX_EXPORT naming::gid_type create_raw_counter(counter_info const&,
+        HPX_CXX_EXPORT HPX_EXPORT naming::gid_type create_raw_counter(
+            counter_info const&,
             hpx::function<std::vector<std::int64_t>()> const&, error_code&);
 
         // Helper function for creating counters encapsulating a function
         // returning the counter values array.
-        HPX_EXPORT naming::gid_type create_raw_counter(counter_info const&,
+        HPX_CXX_EXPORT HPX_EXPORT naming::gid_type create_raw_counter(
+            counter_info const&,
             hpx::function<std::vector<std::int64_t>(bool)> const&, error_code&);
 
         // Helper function for creating a new performance counter instance
         // based on a given counter value.
-        HPX_EXPORT naming::gid_type create_raw_counter_value(
+        HPX_CXX_EXPORT HPX_EXPORT naming::gid_type create_raw_counter_value(
             counter_info const&, std::int64_t*, error_code&);
 
         // Creation function for aggregating performance counters; to be
         // registered with the counter types.
-        HPX_EXPORT naming::gid_type statistics_counter_creator(
+        HPX_CXX_EXPORT HPX_EXPORT naming::gid_type statistics_counter_creator(
             counter_info const&, error_code&);
 
         // Creation function for aggregating performance counters; to be
         // registered with the counter types.
-        HPX_EXPORT naming::gid_type arithmetics_counter_creator(
+        HPX_CXX_EXPORT HPX_EXPORT naming::gid_type arithmetics_counter_creator(
             counter_info const&, error_code&);
 
         // Creation function for extended aggregating performance counters; to
         // be registered with the counter types.
-        HPX_EXPORT naming::gid_type arithmetics_counter_extended_creator(
-            counter_info const&, error_code&);
+        HPX_CXX_EXPORT HPX_EXPORT naming::gid_type
+        arithmetics_counter_extended_creator(counter_info const&, error_code&);
 
         // Creation function for uptime counters.
-        HPX_EXPORT naming::gid_type uptime_counter_creator(
+        HPX_CXX_EXPORT HPX_EXPORT naming::gid_type uptime_counter_creator(
             counter_info const&, error_code&);
 
         // Creation function for instance counters.
-        HPX_EXPORT naming::gid_type component_instance_counter_creator(
-            counter_info const&, error_code&);
+        HPX_CXX_EXPORT HPX_EXPORT naming::gid_type
+        component_instance_counter_creator(counter_info const&, error_code&);
 
         // \brief Create a new statistics performance counter instance based on
         //        the given base counter name and given base time interval
         //        (milliseconds).
-        HPX_EXPORT naming::gid_type create_statistics_counter(
+        HPX_CXX_EXPORT HPX_EXPORT naming::gid_type create_statistics_counter(
             counter_info const& info, std::string const& base_counter_name,
             std::vector<std::size_t> const& parameters,
             error_code& ec = throws);
 
         // \brief Create a new arithmetics performance counter instance based on
         //        the given base counter names
-        HPX_EXPORT naming::gid_type create_arithmetics_counter(
+        HPX_CXX_EXPORT HPX_EXPORT naming::gid_type create_arithmetics_counter(
             counter_info const& info,
             std::vector<std::string> const& base_counter_names,
             error_code& ec = throws);
 
         // \brief Create a new extended arithmetics performance counter instance
         //        based on the given base counter names
-        HPX_EXPORT naming::gid_type create_arithmetics_counter_extended(
-            counter_info const& info,
+        HPX_CXX_EXPORT HPX_EXPORT naming::gid_type
+        create_arithmetics_counter_extended(counter_info const& info,
             std::vector<std::string> const& base_counter_names,
             error_code& ec = throws);
 
         // \brief Create a new performance counter instance based on given
         //        counter info
-        HPX_EXPORT naming::gid_type create_counter(
+        HPX_CXX_EXPORT HPX_EXPORT naming::gid_type create_counter(
             counter_info const& info, error_code& ec = throws);
 
         // \brief Create an arbitrary counter on this locality
-        HPX_EXPORT naming::gid_type create_counter_local(
+        HPX_CXX_EXPORT HPX_EXPORT naming::gid_type create_counter_local(
             counter_info const& info);
     }    // namespace detail
 }}    // namespace hpx::performance_counters

--- a/libs/full/performance_counters/include/hpx/performance_counters/detail/counter_interface_functions.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/detail/counter_interface_functions.hpp
@@ -14,6 +14,7 @@
 namespace hpx { namespace performance_counters { namespace detail {
 
     ///////////////////////////////////////////////////////////////////////////
-    extern HPX_EXPORT hpx::future<id_type> (*create_performance_counter_async)(
+    HPX_CXX_EXPORT extern HPX_EXPORT hpx::future<id_type> (
+        *create_performance_counter_async)(
         id_type target_id, counter_info const& info);
 }}}    // namespace hpx::performance_counters::detail

--- a/libs/full/performance_counters/include/hpx/performance_counters/locality_namespace_counters.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/locality_namespace_counters.hpp
@@ -15,6 +15,6 @@
 namespace hpx { namespace agas {
 
     // Register all performance counter types exposed by the locality_namespace
-    HPX_EXPORT void locality_namespace_register_counter_types(
+    HPX_CXX_EXPORT HPX_EXPORT void locality_namespace_register_counter_types(
         error_code& ec = throws);
 }}    // namespace hpx::agas

--- a/libs/full/performance_counters/include/hpx/performance_counters/manage_counter.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/manage_counter.hpp
@@ -17,6 +17,6 @@
 namespace hpx { namespace performance_counters {
     /// Install a new performance counter in a way, which will uninstall it
     /// automatically during shutdown.
-    HPX_EXPORT void install_counter(hpx::id_type const& id,
+    HPX_CXX_EXPORT HPX_EXPORT void install_counter(hpx::id_type const& id,
         counter_info const& info, error_code& ec = throws);
 }}    // namespace hpx::performance_counters

--- a/libs/full/performance_counters/include/hpx/performance_counters/manage_counter_type.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/manage_counter_type.hpp
@@ -65,7 +65,8 @@ namespace hpx { namespace performance_counters {
     /// \note The counter type registry is a locality based service. You will
     ///       have to register each counter type on every locality where a
     ///       corresponding performance counter will be created.
-    HPX_EXPORT counter_status install_counter_type(std::string const& name,
+    HPX_CXX_EXPORT HPX_EXPORT counter_status install_counter_type(
+        std::string const& name,
         hpx::function<std::int64_t(bool)> const& counter_value,
         std::string const& helptext = "", std::string const& uom = "",
         counter_type type = counter_type::raw, error_code& ec = throws);
@@ -113,7 +114,8 @@ namespace hpx { namespace performance_counters {
     /// \note The counter type registry is a locality based service. You will
     ///       have to register each counter type on every locality where a
     ///       corresponding performance counter will be created.
-    HPX_EXPORT counter_status install_counter_type(std::string const& name,
+    HPX_CXX_EXPORT HPX_EXPORT counter_status install_counter_type(
+        std::string const& name,
         hpx::function<std::vector<std::int64_t>(bool)> const& counter_value,
         std::string const& helptext = "", std::string const& uom = "",
         error_code& ec = throws);
@@ -144,7 +146,7 @@ namespace hpx { namespace performance_counters {
     /// \note As long as \a ec is not pre-initialized to \a hpx#throws this
     ///       function doesn't throw but returns the result code using the
     ///       parameter \a ec. Otherwise it throws an instance of hpx#exception.
-    HPX_EXPORT void install_counter_type(
+    HPX_CXX_EXPORT HPX_EXPORT void install_counter_type(
         std::string const& name, counter_type type, error_code& ec = throws);
 
     /// \brief Install a new performance counter type in a way, which will
@@ -180,8 +182,8 @@ namespace hpx { namespace performance_counters {
     /// \note As long as \a ec is not pre-initialized to \a hpx#throws this
     ///       function doesn't throw but returns the result code using the
     ///       parameter \a ec. Otherwise it throws an instance of hpx#exception.
-    HPX_EXPORT counter_status install_counter_type(std::string const& name,
-        counter_type type, std::string const& helptext,
+    HPX_CXX_EXPORT HPX_EXPORT counter_status install_counter_type(
+        std::string const& name, counter_type type, std::string const& helptext,
         std::string const& uom = "",
         std::uint32_t version = HPX_PERFORMANCE_COUNTER_V1,
         error_code& ec = throws);
@@ -222,8 +224,8 @@ namespace hpx { namespace performance_counters {
     /// \note The counter type registry is a locality based service. You will
     ///       have to register each counter type on every locality where a
     ///       corresponding performance counter will be created.
-    HPX_EXPORT counter_status install_counter_type(std::string const& name,
-        counter_type type, std::string const& helptext,
+    HPX_CXX_EXPORT HPX_EXPORT counter_status install_counter_type(
+        std::string const& name, counter_type type, std::string const& helptext,
         create_counter_func const& create_counter,
         discover_counters_func const& discover_counters,
         std::uint32_t version = HPX_PERFORMANCE_COUNTER_V1,
@@ -253,8 +255,9 @@ namespace hpx { namespace performance_counters {
 
     /// Install several new performance counter types in a way, which will
     /// uninstall them automatically during shutdown.
-    HPX_EXPORT void install_counter_types(generic_counter_type_data const* data,
-        std::size_t count, error_code& ec = throws);
+    HPX_CXX_EXPORT HPX_EXPORT void install_counter_types(
+        generic_counter_type_data const* data, std::size_t count,
+        error_code& ec = throws);
 
     /// \endcond
 }}    // namespace hpx::performance_counters

--- a/libs/full/performance_counters/include/hpx/performance_counters/parcelhandler_counter_types.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/parcelhandler_counter_types.hpp
@@ -13,7 +13,7 @@
 
 namespace hpx::performance_counters {
 
-    HPX_EXPORT void register_parcelhandler_counter_types(
+    HPX_CXX_EXPORT HPX_EXPORT void register_parcelhandler_counter_types(
         parcelset::parcelhandler& ph);
 }    // namespace hpx::performance_counters
 

--- a/libs/full/performance_counters/include/hpx/performance_counters/per_action_data_counter_discoverer.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/per_action_data_counter_discoverer.hpp
@@ -16,7 +16,7 @@
 
 namespace hpx { namespace performance_counters {
 
-    HPX_EXPORT bool per_action_counter_counter_discoverer(
+    HPX_CXX_EXPORT HPX_EXPORT bool per_action_counter_counter_discoverer(
         hpx::actions::detail::per_action_data_counter_registry const& registry,
         performance_counters::counter_info const& info,
         performance_counters::counter_path_elements& p,

--- a/libs/full/performance_counters/include/hpx/performance_counters/performance_counter.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/performance_counter.hpp
@@ -26,7 +26,7 @@
 namespace hpx::performance_counters {
 
     ///////////////////////////////////////////////////////////////////////////
-    struct HPX_EXPORT performance_counter
+    HPX_CXX_EXPORT struct HPX_EXPORT performance_counter
       : components::client_base<performance_counter,
             server::base_performance_counter>
     {
@@ -130,8 +130,8 @@ namespace hpx::performance_counters {
     };
 
     // Return all counters matching the given name (with optional wild cards).
-    HPX_EXPORT std::vector<performance_counter> discover_counters(
-        std::string const& name, error_code& ec = throws);
+    HPX_CXX_EXPORT HPX_EXPORT std::vector<performance_counter>
+    discover_counters(std::string const& name, error_code& ec = throws);
 }    // namespace hpx::performance_counters
 
 #include <hpx/config/warnings_suffix.hpp>

--- a/libs/full/performance_counters/include/hpx/performance_counters/performance_counter_set.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/performance_counter_set.hpp
@@ -26,7 +26,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace performance_counters {
     // Make a collection of performance counters available as a set
-    class HPX_EXPORT performance_counter_set
+    HPX_CXX_EXPORT class HPX_EXPORT performance_counter_set
     {
         using mutex_type = hpx::spinlock;
 

--- a/libs/full/performance_counters/include/hpx/performance_counters/primary_namespace_counters.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/primary_namespace_counters.hpp
@@ -15,6 +15,6 @@
 namespace hpx { namespace agas {
 
     // Register all performance counter types exposed by the primary_namespace
-    HPX_EXPORT void primary_namespace_register_counter_types(
+    HPX_CXX_EXPORT HPX_EXPORT void primary_namespace_register_counter_types(
         error_code& ec = throws);
 }}    // namespace hpx::agas

--- a/libs/full/performance_counters/include/hpx/performance_counters/query_counters.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/query_counters.hpp
@@ -32,7 +32,7 @@
 namespace hpx::util {
 
     ///////////////////////////////////////////////////////////////////////////
-    class HPX_EXPORT query_counters
+    HPX_CXX_EXPORT class HPX_EXPORT query_counters
     {
         // avoid warning about using this in member initializer list
         query_counters* this_()

--- a/libs/full/performance_counters/include/hpx/performance_counters/server/base_performance_counter.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/server/base_performance_counter.hpp
@@ -21,7 +21,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace performance_counters { namespace server {
 
-    class HPX_EXPORT base_performance_counter
+    HPX_CXX_EXPORT class HPX_EXPORT base_performance_counter
       : public hpx::performance_counters::performance_counter_base
       , public hpx::traits::detail::component_tag
     {

--- a/libs/full/performance_counters/include/hpx/performance_counters/server/component_namespace_counters.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/server/component_namespace_counters.hpp
@@ -19,8 +19,8 @@
 namespace hpx { namespace agas {
 
     // Create statistics counter for component namespace on this component
-    HPX_EXPORT naming::gid_type component_namespace_statistics_counter(
-        std::string const& name);
+    HPX_CXX_EXPORT HPX_EXPORT naming::gid_type
+    component_namespace_statistics_counter(std::string const& name);
 
     HPX_DEFINE_PLAIN_ACTION(component_namespace_statistics_counter,
         component_namespace_statistics_counter_action);

--- a/libs/full/performance_counters/include/hpx/performance_counters/server/elapsed_time_counter.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/server/elapsed_time_counter.hpp
@@ -15,7 +15,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx::performance_counters::server {
 
-    class HPX_EXPORT elapsed_time_counter
+    HPX_CXX_EXPORT class HPX_EXPORT elapsed_time_counter
       : public base_performance_counter
       , public components::component_base<elapsed_time_counter>
     {

--- a/libs/full/performance_counters/include/hpx/performance_counters/server/locality_namespace_counters.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/server/locality_namespace_counters.hpp
@@ -19,8 +19,8 @@
 namespace hpx { namespace agas {
 
     // Create statistics counter for locality namespace on this locality
-    HPX_EXPORT naming::gid_type locality_namespace_statistics_counter(
-        std::string const& name);
+    HPX_CXX_EXPORT HPX_EXPORT naming::gid_type
+    locality_namespace_statistics_counter(std::string const& name);
 
     HPX_DEFINE_PLAIN_ACTION(locality_namespace_statistics_counter,
         locality_namespace_statistics_counter_action);

--- a/libs/full/performance_counters/include/hpx/performance_counters/server/primary_namespace_counters.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/server/primary_namespace_counters.hpp
@@ -19,8 +19,8 @@
 namespace hpx { namespace agas {
 
     // Create statistics counter for primary namespace on this locality
-    HPX_EXPORT naming::gid_type primary_namespace_statistics_counter(
-        std::string const& name);
+    HPX_CXX_EXPORT HPX_EXPORT naming::gid_type
+    primary_namespace_statistics_counter(std::string const& name);
 
     HPX_DEFINE_PLAIN_ACTION(primary_namespace_statistics_counter,
         primary_namespace_statistics_counter_action);

--- a/libs/full/performance_counters/include/hpx/performance_counters/server/raw_counter.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/server/raw_counter.hpp
@@ -18,7 +18,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx::performance_counters::server {
 
-    class HPX_EXPORT raw_counter
+    HPX_CXX_EXPORT class HPX_EXPORT raw_counter
       : public base_performance_counter
       , public components::component_base<raw_counter>
     {

--- a/libs/full/performance_counters/include/hpx/performance_counters/server/raw_values_counter.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/server/raw_values_counter.hpp
@@ -19,7 +19,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx::performance_counters::server {
 
-    class HPX_EXPORT raw_values_counter
+    HPX_CXX_EXPORT class HPX_EXPORT raw_values_counter
       : public base_performance_counter
       , public components::component_base<raw_values_counter>
     {

--- a/libs/full/performance_counters/include/hpx/performance_counters/server/symbol_namespace_counters.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/server/symbol_namespace_counters.hpp
@@ -19,8 +19,8 @@
 namespace hpx { namespace agas {
 
     // Create statistics counter for symbol namespace on this locality
-    HPX_EXPORT naming::gid_type symbol_namespace_statistics_counter(
-        std::string const& name);
+    HPX_CXX_EXPORT HPX_EXPORT naming::gid_type
+    symbol_namespace_statistics_counter(std::string const& name);
 
     HPX_DEFINE_PLAIN_ACTION(symbol_namespace_statistics_counter,
         symbol_namespace_statistics_counter_action);

--- a/libs/full/performance_counters/include/hpx/performance_counters/symbol_namespace_counters.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/symbol_namespace_counters.hpp
@@ -15,6 +15,6 @@
 namespace hpx { namespace agas {
 
     // Register all performance counter types exposed by the symbol_namespace
-    HPX_EXPORT void symbol_namespace_register_counter_types(
+    HPX_CXX_EXPORT HPX_EXPORT void symbol_namespace_register_counter_types(
         error_code& ec = throws);
 }}    // namespace hpx::agas

--- a/libs/full/performance_counters/include/hpx/performance_counters/threadmanager_counter_types.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/threadmanager_counter_types.hpp
@@ -13,6 +13,6 @@
 
 namespace hpx { namespace performance_counters {
 
-    HPX_EXPORT void register_threadmanager_counter_types(
+    HPX_CXX_EXPORT HPX_EXPORT void register_threadmanager_counter_types(
         threads::threadmanager& tm);
 }}    // namespace hpx::performance_counters

--- a/libs/full/plugin_factories/CMakeLists.txt
+++ b/libs/full/plugin_factories/CMakeLists.txt
@@ -38,6 +38,7 @@ include(HPX_AddModule)
 add_hpx_module(
   full plugin_factories
   GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_MODULE_GEN ON
   SOURCES ${plugin_factories_sources}
   HEADERS ${plugin_factories_headers}
   COMPAT_HEADERS ${plugin_factories_compat_headers}

--- a/libs/full/plugin_factories/include/hpx/plugin_factories/binary_filter_factory_base.hpp
+++ b/libs/full/plugin_factories/include/hpx/plugin_factories/binary_filter_factory_base.hpp
@@ -18,7 +18,8 @@ namespace hpx::plugins {
     ///////////////////////////////////////////////////////////////////////////
     /// The \a plugin_factory_base has to be used as a base class for all
     /// plugin factories.
-    struct HPX_EXPORT binary_filter_factory_base : plugin_factory_base
+    HPX_CXX_EXPORT struct HPX_EXPORT binary_filter_factory_base
+      : plugin_factory_base
     {
         ~binary_filter_factory_base() override = default;
 
@@ -35,6 +36,6 @@ namespace hpx::plugins {
 /// This macro is used to register the given component factory with
 /// Hpx.Plugin. This macro has to be used for each of the component factories.
 #define HPX_REGISTER_BINARY_FILTER_FACTORY_BASE(FactoryType, pluginname)       \
-    HPX_PLUGIN_EXPORT(HPX_PLUGIN_PLUGIN_PREFIX,                                \
-        hpx::plugins::plugin_factory_base, FactoryType, pluginname, factory)   \
-    /**/
+    HPX_CXX_EXPORT HPX_PLUGIN_EXPORT(HPX_PLUGIN_PLUGIN_PREFIX,                 \
+        hpx::plugins::plugin_factory_base, FactoryType, pluginname,            \
+        factory) /**/

--- a/libs/full/plugin_factories/include/hpx/plugin_factories/message_handler_factory_base.hpp
+++ b/libs/full/plugin_factories/include/hpx/plugin_factories/message_handler_factory_base.hpp
@@ -23,7 +23,8 @@ namespace hpx::plugins {
     ///////////////////////////////////////////////////////////////////////////
     /// The \a plugin_factory_base has to be used as a base class for all
     /// plugin factories.
-    struct HPX_EXPORT message_handler_factory_base : plugin_factory_base
+    HPX_CXX_EXPORT struct HPX_EXPORT message_handler_factory_base
+      : plugin_factory_base
     {
         ~message_handler_factory_base() override = default;
 
@@ -44,8 +45,8 @@ namespace hpx::plugins {
 /// This macro is used to register the given component factory with
 /// Hpx.Plugin. This macro has to be used for each of the component factories.
 #define HPX_REGISTER_MESSAGE_HANDLER_FACTORY_BASE(FactoryType, pluginname)     \
-    HPX_PLUGIN_EXPORT(HPX_PLUGIN_PLUGIN_PREFIX,                                \
-        hpx::plugins::plugin_factory_base, FactoryType, pluginname, factory)   \
-    /**/
+    HPX_CXX_EXPORT HPX_PLUGIN_EXPORT(HPX_PLUGIN_PLUGIN_PREFIX,                 \
+        hpx::plugins::plugin_factory_base, FactoryType, pluginname,            \
+        factory) /**/
 
 #endif

--- a/libs/full/plugin_factories/include/hpx/plugin_factories/parcelport_factory.hpp
+++ b/libs/full/plugin_factories/include/hpx/plugin_factories/parcelport_factory.hpp
@@ -177,8 +177,8 @@ namespace hpx::plugins {
     HPX_DEF_UNIQUE_PLUGIN_NAME(                                                \
         HPX_PP_CAT(pluginname, _plugin_factory_type), pp)                      \
     template struct hpx::plugins::parcelport_factory<Parcelport>;              \
-    HPX_EXPORT hpx::plugins::parcelport_factory_base* HPX_PP_CAT(              \
-        pluginname, _factory_init)(                                            \
+    HPX_CXX_EXPORT HPX_EXPORT hpx::plugins::parcelport_factory_base*           \
+    HPX_PP_CAT(pluginname, _factory_init)(                                     \
         std::vector<hpx::plugins::parcelport_factory_base*> & factories)       \
     {                                                                          \
         static HPX_PP_CAT(pluginname, _plugin_factory_type)                    \

--- a/libs/full/plugin_factories/include/hpx/plugin_factories/parcelport_factory_base.hpp
+++ b/libs/full/plugin_factories/include/hpx/plugin_factories/parcelport_factory_base.hpp
@@ -23,7 +23,7 @@ namespace hpx::plugins {
     ///////////////////////////////////////////////////////////////////////////
     /// The \a plugin_factory_base has to be used as a base class for all
     /// plugin factories.
-    struct HPX_EXPORT parcelport_factory_base
+    HPX_CXX_EXPORT struct HPX_EXPORT parcelport_factory_base
     {
         virtual ~parcelport_factory_base() = default;
 
@@ -43,8 +43,9 @@ namespace hpx::plugins {
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT std::vector<parcelport_factory_base*>&
+    HPX_CXX_EXPORT HPX_EXPORT std::vector<parcelport_factory_base*>&
     get_parcelport_factories();
 
-    HPX_EXPORT void add_parcelport_factory(parcelport_factory_base* factory);
+    HPX_CXX_EXPORT HPX_EXPORT void add_parcelport_factory(
+        parcelport_factory_base* factory);
 }    // namespace hpx::plugins

--- a/libs/full/plugin_factories/include/hpx/plugin_factories/plugin_factory_base.hpp
+++ b/libs/full/plugin_factories/include/hpx/plugin_factories/plugin_factory_base.hpp
@@ -19,7 +19,7 @@ namespace hpx::plugins {
     ///////////////////////////////////////////////////////////////////////////
     /// The \a plugin_factory_base has to be used as a base class for all
     /// plugin factories.
-    struct HPX_EXPORT plugin_factory_base
+    HPX_CXX_EXPORT struct HPX_EXPORT plugin_factory_base
     {
         virtual ~plugin_factory_base() = default;
     };
@@ -53,18 +53,16 @@ struct hpx::util::plugin::virtual_constructor<hpx::plugins::plugin_factory_base>
 /// This macro is used to register the given component factory with
 /// Hpx.Plugin. This macro has to be used for each of the component factories.
 #define HPX_REGISTER_PLUGIN_FACTORY_BASE(FactoryType, pluginname)              \
-    HPX_PLUGIN_EXPORT(HPX_PLUGIN_PLUGIN_PREFIX,                                \
-        hpx::plugins::plugin_factory_base, FactoryType, pluginname, factory)   \
-/**/
+    HPX_CXX_EXPORT HPX_PLUGIN_EXPORT(HPX_PLUGIN_PLUGIN_PREFIX,                 \
+        hpx::plugins::plugin_factory_base, FactoryType, pluginname,            \
+        factory) /**/
 
 /// This macro is used to define the required Hpx.Plugin entry points. This
 /// macro has to be used in exactly one compilation unit of a component module.
 #define HPX_REGISTER_PLUGIN_MODULE()                                           \
-    HPX_PLUGIN_EXPORT_LIST(HPX_PLUGIN_PLUGIN_PREFIX, factory)                  \
-    HPX_REGISTER_PLUGIN_REGISTRY_MODULE()                                      \
-    /**/
+    HPX_CXX_EXPORT HPX_PLUGIN_EXPORT_LIST(HPX_PLUGIN_PLUGIN_PREFIX, factory)   \
+        HPX_REGISTER_PLUGIN_REGISTRY_MODULE() /**/
 
 #define HPX_REGISTER_PLUGIN_MODULE_DYNAMIC()                                   \
-    HPX_PLUGIN_EXPORT_LIST(HPX_PLUGIN_PLUGIN_PREFIX, factory)                  \
-    HPX_REGISTER_PLUGIN_REGISTRY_MODULE_DYNAMIC()                              \
-    /**/
+    HPX_CXX_EXPORT HPX_PLUGIN_EXPORT_LIST(HPX_PLUGIN_PLUGIN_PREFIX, factory)   \
+        HPX_REGISTER_PLUGIN_REGISTRY_MODULE_DYNAMIC() /**/

--- a/libs/full/resiliency_distributed/CMakeLists.txt
+++ b/libs/full/resiliency_distributed/CMakeLists.txt
@@ -20,6 +20,7 @@ include(HPX_AddModule)
 add_hpx_module(
   full resiliency_distributed
   GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_MODULE_GEN OFF
   SOURCES ${resiliency_distributed_sources}
   HEADERS ${resiliency_distributed_headers}
   DEPENDENCIES hpx_core

--- a/libs/full/runtime_components/CMakeLists.txt
+++ b/libs/full/runtime_components/CMakeLists.txt
@@ -56,6 +56,7 @@ include(HPX_AddModule)
 add_hpx_module(
   full runtime_components
   GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_MODULE_GEN ON
   HEADERS ${runtime_components_headers}
   SOURCES ${runtime_components_sources}
   COMPAT_HEADERS ${runtime_components_compat_headers}

--- a/libs/full/runtime_components/include/hpx/runtime_components/component_registry.hpp
+++ b/libs/full/runtime_components/include/hpx/runtime_components/component_registry.hpp
@@ -23,12 +23,12 @@ namespace hpx::components {
 
     namespace detail {
 
-        HPX_EXPORT void get_component_info(std::vector<std::string>& fillini,
-            std::string const& filepath, bool is_static, char const* name,
-            char const* component_string, factory_state state,
-            char const* more);
+        HPX_CXX_EXPORT HPX_EXPORT void get_component_info(
+            std::vector<std::string>& fillini, std::string const& filepath,
+            bool is_static, char const* name, char const* component_string,
+            factory_state state, char const* more);
 
-        HPX_EXPORT bool is_component_enabled(char const* name);
+        HPX_CXX_EXPORT HPX_EXPORT bool is_component_enabled(char const* name);
     }    // namespace detail
 
     ///////////////////////////////////////////////////////////////////////////

--- a/libs/full/runtime_components/include/hpx/runtime_components/components_fwd.hpp
+++ b/libs/full/runtime_components/include/hpx/runtime_components/components_fwd.hpp
@@ -32,10 +32,11 @@ namespace hpx {
 
         namespace server {
 
-            class HPX_EXPORT runtime_support;
+            HPX_CXX_EXPORT class HPX_EXPORT runtime_support;
         }    // namespace server
 
     }    // namespace components
 
-    HPX_EXPORT components::server::runtime_support* get_runtime_support_ptr();
+    HPX_CXX_EXPORT HPX_EXPORT components::server::runtime_support*
+    get_runtime_support_ptr();
 }    // namespace hpx

--- a/libs/full/runtime_components/include/hpx/runtime_components/console_error_sink.hpp
+++ b/libs/full/runtime_components/include/hpx/runtime_components/console_error_sink.hpp
@@ -17,9 +17,10 @@
 namespace hpx { namespace components {
 
     // Stub function which applies the console_error_sink action.
-    HPX_EXPORT void console_error_sink(
+    HPX_CXX_EXPORT HPX_EXPORT void console_error_sink(
         hpx::id_type const& dst, std::exception_ptr const& e);
 
     // Stub function which applies the console_error_sink action.
-    HPX_EXPORT void console_error_sink(std::exception_ptr const& e);
+    HPX_CXX_EXPORT HPX_EXPORT void console_error_sink(
+        std::exception_ptr const& e);
 }}    // namespace hpx::components

--- a/libs/full/runtime_components/include/hpx/runtime_components/console_logging.hpp
+++ b/libs/full/runtime_components/include/hpx/runtime_components/console_logging.hpp
@@ -16,8 +16,8 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx { namespace components {
 
-    HPX_EXPORT void console_logging(
+    HPX_CXX_EXPORT HPX_EXPORT void console_logging(
         logging_destination dest, std::size_t level, std::string const& msg);
-    HPX_EXPORT void cleanup_logging();
-    HPX_EXPORT void activate_logging();
+    HPX_CXX_EXPORT HPX_EXPORT void cleanup_logging();
+    HPX_CXX_EXPORT HPX_EXPORT void activate_logging();
 }}    // namespace hpx::components

--- a/libs/full/runtime_components/include/hpx/runtime_components/server/console_error_sink_singleton.hpp
+++ b/libs/full/runtime_components/include/hpx/runtime_components/server/console_error_sink_singleton.hpp
@@ -55,5 +55,5 @@ namespace hpx { namespace components { namespace server {
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT console_error_dispatcher& get_error_dispatcher();
+    HPX_CXX_EXPORT HPX_EXPORT console_error_dispatcher& get_error_dispatcher();
 }}}    // namespace hpx::components::server

--- a/libs/full/runtime_distributed/CMakeLists.txt
+++ b/libs/full/runtime_distributed/CMakeLists.txt
@@ -59,6 +59,7 @@ include(HPX_AddModule)
 add_hpx_module(
   full runtime_distributed
   GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_MODULE_GEN ON
   SOURCES ${runtime_distributed_sources}
   HEADERS ${runtime_distributed_headers}
   COMPAT_HEADERS ${runtime_distributed_compat_headers}

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed.hpp
@@ -42,7 +42,7 @@ namespace hpx {
     /// The \a runtime class encapsulates the HPX runtime system in a simple to
     /// use way. It makes sure all required parts of the HPX runtime system are
     /// properly initialized.
-    class HPX_EXPORT runtime_distributed : public runtime
+    HPX_CXX_EXPORT class HPX_EXPORT runtime_distributed : public runtime
     {
     public:
         /// Construct a new HPX runtime instance

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/applier.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/applier.hpp
@@ -29,7 +29,7 @@ namespace hpx { namespace applier {
     /// has to be issued on a local or a remote resource. If the target
     /// component is local a new \a thread will be created, if the target is
     /// remote a parcel will be sent.
-    class HPX_EXPORT applier
+    HPX_CXX_EXPORT class HPX_EXPORT applier
     {
     public:
         HPX_NON_COPYABLE(applier);

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/applier_fwd.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/applier_fwd.hpp
@@ -19,16 +19,16 @@ namespace hpx {
     /// class \a hpx#applier#applier and its related functionality. This
     /// namespace is part of the HPX core module.
     namespace applier {
-        class HPX_EXPORT applier;
+        HPX_CXX_EXPORT class HPX_EXPORT applier;
 
         /// The function \a get_applier returns a reference to the (thread
         /// specific) applier instance.
-        HPX_EXPORT applier& get_applier();
+        HPX_CXX_EXPORT HPX_EXPORT applier& get_applier();
 
         /// The function \a get_applier returns a pointer to the (thread
         /// specific) applier instance. The returned pointer is NULL if the
         /// current thread is not known to HPX or if the runtime system is not
         /// active.
-        HPX_EXPORT applier* get_applier_ptr();
+        HPX_CXX_EXPORT HPX_EXPORT applier* get_applier_ptr();
     }    // namespace applier
 }    // namespace hpx

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/big_boot_barrier.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/big_boot_barrier.hpp
@@ -36,7 +36,7 @@ namespace hpx { namespace agas {
 
     struct notification_header;
 
-    struct HPX_EXPORT big_boot_barrier
+    HPX_CXX_EXPORT struct HPX_EXPORT big_boot_barrier
     {
     public:
         HPX_NON_COPYABLE(big_boot_barrier);
@@ -130,13 +130,13 @@ namespace hpx { namespace agas {
             parcelset::endpoints_type const& endpoints);
     };
 
-    HPX_EXPORT void create_big_boot_barrier(parcelset::parcelport* pp_,
-        parcelset::endpoints_type const& endpoints_,
+    HPX_CXX_EXPORT HPX_EXPORT void create_big_boot_barrier(
+        parcelset::parcelport* pp_, parcelset::endpoints_type const& endpoints_,
         util::runtime_configuration const& ini_);
 
-    HPX_EXPORT void destroy_big_boot_barrier();
+    HPX_CXX_EXPORT HPX_EXPORT void destroy_big_boot_barrier();
 
-    HPX_EXPORT big_boot_barrier& get_big_boot_barrier();
+    HPX_CXX_EXPORT HPX_EXPORT big_boot_barrier& get_big_boot_barrier();
 
 }}    // namespace hpx::agas
 

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/find_all_localities.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/find_all_localities.hpp
@@ -47,7 +47,8 @@ namespace hpx {
     ///           otherwise.
     ///
     /// \see      \a hpx::find_all_localities(), \a hpx::find_locality()
-    HPX_EXPORT hpx::id_type find_root_locality(error_code& ec = throws);
+    HPX_CXX_EXPORT HPX_EXPORT hpx::id_type find_root_locality(
+        error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Return the list of global ids representing all localities
@@ -76,7 +77,7 @@ namespace hpx {
     ///           from an HPX-thread. It will return an empty vector otherwise.
     ///
     /// \see      \a hpx::find_here(), \a hpx::find_locality()
-    HPX_EXPORT std::vector<hpx::id_type> find_all_localities(
+    HPX_CXX_EXPORT HPX_EXPORT std::vector<hpx::id_type> find_all_localities(
         error_code& ec = throws);
 
     /// \brief Return the list of locality ids of remote localities supporting
@@ -107,6 +108,6 @@ namespace hpx {
     ///           from an HPX-thread. It will return an empty vector otherwise.
     ///
     /// \see      \a hpx::find_here(), \a hpx::find_locality()
-    HPX_EXPORT std::vector<hpx::id_type> find_remote_localities(
+    HPX_CXX_EXPORT HPX_EXPORT std::vector<hpx::id_type> find_remote_localities(
         error_code& ec = throws);
 }    // namespace hpx

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/find_here.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/find_here.hpp
@@ -42,5 +42,5 @@ namespace hpx {
     ///           otherwise.
     ///
     /// \see      \a hpx::find_all_localities(), \a hpx::find_locality()
-    HPX_EXPORT hpx::id_type find_here(error_code& ec = throws);
+    HPX_CXX_EXPORT HPX_EXPORT hpx::id_type find_here(error_code& ec = throws);
 }    // namespace hpx

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/find_localities.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/find_localities.hpp
@@ -55,7 +55,7 @@ namespace hpx {
     ///           from an HPX-thread. It will return an empty vector otherwise.
     ///
     /// \see      \a hpx::find_here(), \a hpx::find_locality()
-    HPX_EXPORT std::vector<hpx::id_type> find_all_localities(
+    HPX_CXX_EXPORT HPX_EXPORT std::vector<hpx::id_type> find_all_localities(
         components::component_type type, error_code& ec = throws);
 
     /// \brief Return the list of locality ids of remote localities supporting
@@ -89,7 +89,7 @@ namespace hpx {
     ///           from an HPX-thread. It will return an empty vector otherwise.
     ///
     /// \see      \a hpx::find_here(), \a hpx::find_locality()
-    HPX_EXPORT std::vector<hpx::id_type> find_remote_localities(
+    HPX_CXX_EXPORT HPX_EXPORT std::vector<hpx::id_type> find_remote_localities(
         components::component_type type, error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -127,6 +127,6 @@ namespace hpx {
     ///           otherwise.
     ///
     /// \see      \a hpx::find_here(), \a hpx::find_all_localities()
-    HPX_EXPORT hpx::id_type find_locality(
+    HPX_CXX_EXPORT HPX_EXPORT hpx::id_type find_locality(
         components::component_type type, error_code& ec = throws);
 }    // namespace hpx

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/get_locality_name.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/get_locality_name.hpp
@@ -32,5 +32,6 @@ namespace hpx {
     ///           and may be different for different parcel ports.
     ///
     /// \see      \a std::string get_locality_name()
-    HPX_EXPORT future<std::string> get_locality_name(hpx::id_type const& id);
+    HPX_CXX_EXPORT HPX_EXPORT future<std::string> get_locality_name(
+        hpx::id_type const& id);
 }    // namespace hpx

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/get_num_localities.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/get_num_localities.hpp
@@ -35,7 +35,7 @@ namespace hpx {
     ///           from an HPX-thread. It will return 0 otherwise.
     ///
     /// \see      \a hpx::find_all_localities, \a hpx::get_num_localities
-    HPX_EXPORT hpx::future<std::uint32_t> get_num_localities(
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future<std::uint32_t> get_num_localities(
         components::component_type t);
 
     /// \brief Synchronously return the number of localities which are
@@ -55,6 +55,7 @@ namespace hpx {
     ///           from an HPX-thread. It will return 0 otherwise.
     ///
     /// \see      \a hpx::find_all_localities, \a hpx::get_num_localities
-    HPX_EXPORT std::uint32_t get_num_localities(launch::sync_policy,
-        components::component_type t, error_code& ec = throws);
+    HPX_CXX_EXPORT HPX_EXPORT std::uint32_t get_num_localities(
+        launch::sync_policy, components::component_type t,
+        error_code& ec = throws);
 }    // namespace hpx

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/runtime_fwd.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/runtime_fwd.hpp
@@ -24,13 +24,14 @@
 
 namespace hpx {
 
-    class HPX_EXPORT runtime_distributed;
+    HPX_CXX_EXPORT class HPX_EXPORT runtime_distributed;
 
-    HPX_EXPORT runtime_distributed& get_runtime_distributed();
-    HPX_EXPORT runtime_distributed*& get_runtime_distributed_ptr();
+    HPX_CXX_EXPORT HPX_EXPORT runtime_distributed& get_runtime_distributed();
+    HPX_CXX_EXPORT HPX_EXPORT runtime_distributed*&
+    get_runtime_distributed_ptr();
 
     /// The function \a get_locality returns a reference to the locality prefix
-    HPX_EXPORT naming::gid_type const& get_locality();
+    HPX_CXX_EXPORT HPX_EXPORT naming::gid_type const& get_locality();
 
     /// \cond NOINTERNAL
     namespace util {
@@ -54,7 +55,8 @@ namespace hpx {
     /// \note     The active counters are those which have been specified on
     ///           the command line while executing the application (see command
     ///           line option \--hpx:print-counter)
-    HPX_EXPORT void start_active_counters(error_code& ec = throws);
+    HPX_CXX_EXPORT HPX_EXPORT void start_active_counters(
+        error_code& ec = throws);
 
     /// \brief Resets all active performance counters.
     ///
@@ -70,7 +72,8 @@ namespace hpx {
     /// \note     The active counters are those which have been specified on
     ///           the command line while executing the application (see command
     ///           line option \--hpx:print-counter)
-    HPX_EXPORT void reset_active_counters(error_code& ec = throws);
+    HPX_CXX_EXPORT HPX_EXPORT void reset_active_counters(
+        error_code& ec = throws);
 
     /// \brief Re-initialize all active performance counters.
     ///
@@ -88,7 +91,7 @@ namespace hpx {
     /// \note     The active counters are those which have been specified on
     ///           the command line while executing the application (see command
     ///           line option \--hpx:print-counter)
-    HPX_EXPORT void reinit_active_counters(
+    HPX_CXX_EXPORT HPX_EXPORT void reinit_active_counters(
         bool reset = true, error_code& ec = throws);
 
     /// \brief Stop all active performance counters.
@@ -105,7 +108,8 @@ namespace hpx {
     /// \note     The active counters are those which have been specified on
     ///           the command line while executing the application (see command
     ///           line option \--hpx:print-counter)
-    HPX_EXPORT void stop_active_counters(error_code& ec = throws);
+    HPX_CXX_EXPORT HPX_EXPORT void stop_active_counters(
+        error_code& ec = throws);
 
     /// \brief Evaluate and output all active performance counters, optionally
     ///        naming the point in code marked by this function.
@@ -130,7 +134,7 @@ namespace hpx {
     /// \note     The active counters are those which have been specified on
     ///           the command line while executing the application (see command
     ///           line option \--hpx:print-counter)
-    HPX_EXPORT void evaluate_active_counters(bool reset = false,
+    HPX_CXX_EXPORT HPX_EXPORT void evaluate_active_counters(bool reset = false,
         char const* description = nullptr, error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -148,8 +152,8 @@ namespace hpx {
     ///           function doesn't throw but returns the result code using the
     ///           parameter \a ec. Otherwise it throws an instance of
     ///           hpx::exception.
-    HPX_EXPORT serialization::binary_filter* create_binary_filter(
-        char const* binary_filter_type, bool compress,
+    HPX_CXX_EXPORT HPX_EXPORT serialization::binary_filter*
+    create_binary_filter(char const* binary_filter_type, bool compress,
         serialization::binary_filter* next_filter = nullptr,
         error_code& ec = throws);
 }    // namespace hpx

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/runtime_support.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/runtime_support.hpp
@@ -20,7 +20,8 @@ namespace hpx { namespace components {
     ///////////////////////////////////////////////////////////////////////////
     /// The \a runtime_support class is the client side representation of a
     /// \a server#runtime_support component
-    class HPX_EXPORT runtime_support : public stubs::runtime_support
+    HPX_CXX_EXPORT class HPX_EXPORT runtime_support
+      : public stubs::runtime_support
     {
     private:
         typedef stubs::runtime_support base_type;

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/stubs/runtime_support.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/stubs/runtime_support.hpp
@@ -30,7 +30,7 @@ namespace hpx { namespace components { namespace stubs {
     ///////////////////////////////////////////////////////////////////////////
     // The \a runtime_support class is the client side representation of a
     // \a server#runtime_support component
-    struct HPX_EXPORT runtime_support
+    HPX_CXX_EXPORT struct HPX_EXPORT runtime_support
     {
         ///////////////////////////////////////////////////////////////////////
         /// Create a new component \a type using the runtime_support with the

--- a/libs/full/segmented_algorithms/CMakeLists.txt
+++ b/libs/full/segmented_algorithms/CMakeLists.txt
@@ -44,6 +44,7 @@ set(segmented_algorithms_compat_headers
 include(HPX_AddModule)
 add_hpx_module(
   full segmented_algorithms
+  GLOBAL_HEADER_MODULE_GEN OFF
   HEADERS ${segmented_algorithms_headers}
   COMPAT_HEADERS ${segmented_algorithms_compat_headers}
   DEPENDENCIES hpx_core

--- a/libs/full/statistics/CMakeLists.txt
+++ b/libs/full/statistics/CMakeLists.txt
@@ -33,7 +33,7 @@ include(HPX_AddModule)
 add_hpx_module(
   full statistics
   GLOBAL_HEADER_GEN ON
-  GLOBAL_HEADER_MODULE_GEN ON
+  GLOBAL_HEADER_MODULE_GEN OFF
   SOURCES ${statistics_sources}
   HEADERS ${statistics_headers}
   COMPAT_HEADERS ${statistics_compat_headers}

--- a/libs/full/statistics/include/hpx/statistics/histogram.hpp
+++ b/libs/full/statistics/include/hpx/statistics/histogram.hpp
@@ -195,8 +195,8 @@ namespace hpx::util {
 
     namespace tag {
 
-        HPX_CXX_EXPORT using boost::accumulators::tag::histogram;
+        using boost::accumulators::tag::histogram;
     }
 
-    HPX_CXX_EXPORT using boost::accumulators::extract::histogram;
+    using boost::accumulators::extract::histogram;
 }    // namespace hpx::util

--- a/libs/full/statistics/include/hpx/statistics/rolling_max.hpp
+++ b/libs/full/statistics/include/hpx/statistics/rolling_max.hpp
@@ -18,7 +18,7 @@
 
 namespace hpx::util::detail {
 
-    HPX_CXX_EXPORT template <typename Sample>
+    template <typename Sample>
     struct rolling_max_impl : boost::accumulators::accumulator_base
     {
         using float_type = Sample;
@@ -78,7 +78,7 @@ namespace boost::accumulators {
 
     namespace tag {
 
-        HPX_CXX_EXPORT struct rolling_max : depends_on<rolling_window>
+        struct rolling_max : depends_on<rolling_window>
         {
             struct impl
             {
@@ -95,8 +95,7 @@ namespace boost::accumulators {
     // extract::rolling_max
     namespace extract {
 
-        HPX_CXX_EXPORT inline constexpr extractor<tag::rolling_max>
-            rolling_max = {};
+        inline constexpr extractor<tag::rolling_max> rolling_max = {};
     }    // namespace extract
 }    // namespace boost::accumulators
 // namespace boost::accumulators
@@ -105,9 +104,9 @@ namespace hpx::util {
 
     namespace tag {
 
-        HPX_CXX_EXPORT using boost::accumulators::tag::rolling_max;
+        using boost::accumulators::tag::rolling_max;
     }    // namespace tag
 
-    HPX_CXX_EXPORT using boost::accumulators::extract::rolling_max;
+    using boost::accumulators::extract::rolling_max;
 }    // namespace hpx::util
 // namespace hpx::util

--- a/libs/full/statistics/include/hpx/statistics/rolling_min.hpp
+++ b/libs/full/statistics/include/hpx/statistics/rolling_min.hpp
@@ -18,7 +18,7 @@
 
 namespace hpx::util::detail {
 
-    HPX_CXX_EXPORT template <typename Sample>
+    template <typename Sample>
     struct rolling_min_impl : boost::accumulators::accumulator_base
     {
         using float_type = Sample;
@@ -78,7 +78,7 @@ namespace boost::accumulators {
 
     namespace tag {
 
-        HPX_CXX_EXPORT struct rolling_min : depends_on<rolling_window>
+        struct rolling_min : depends_on<rolling_window>
         {
             struct impl
             {
@@ -95,8 +95,7 @@ namespace boost::accumulators {
     // extract::rolling_min
     namespace extract {
 
-        HPX_CXX_EXPORT inline constexpr extractor<tag::rolling_min>
-            rolling_min = {};
+        inline constexpr extractor<tag::rolling_min> rolling_min = {};
     }    // namespace extract
 }    // namespace boost::accumulators
 // namespace boost::accumulators
@@ -105,9 +104,9 @@ namespace hpx::util {
 
     namespace tag {
 
-        HPX_CXX_EXPORT using boost::accumulators::tag::rolling_min;
+        using boost::accumulators::tag::rolling_min;
     }    // namespace tag
 
-    HPX_CXX_EXPORT using boost::accumulators::extract::rolling_min;
+    using boost::accumulators::extract::rolling_min;
 }    // namespace hpx::util
 // namespace hpx::util


### PR DESCRIPTION
## Proposed Changes

- have set `GLOBAL_HEADER_MODULE_GEN ON` for all `libs/full` modules that expose symbols using `HPX_CXX_EXPORT` annotations
- marked all relevant exported symbols with the `HPX_CXX_EXPORT` prefix, following the pattern set in #6925 for core libraries.  
- modules that do not have exported symbols (`checkpoint`, `executors_distributed`, `include`, `lcos_distributed`, `resiliency_distributed`, `segmented_algorithms`, `statistics`) should keep `GLOBAL_HEADER_MODULE_GEN OFF` to prevent unnecessary module interfaces.  
- set `GLOBAL_HEADER_MODULE_GEN ON` and add the `HPX_CXX_CORE_EXPORT` annotation for `lcw_base` in `libs/core`.  

## Any background context you want to provide?

## Checklist

Not all points below apply to all pull requests.

- [x] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
