### PR TITLE
Add zero-validation for with_processing_units_count

### DIFF
--- a/libs/core/executors/include/hpx/executors/parallel_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/parallel_executor.hpp
@@ -212,8 +212,16 @@ namespace hpx::execution {
             requires(std::is_convertible_v<Executor_, parallel_policy_executor>)
         friend constexpr auto tag_invoke(
             hpx::execution::experimental::with_processing_units_count_t,
-            Executor_ const& exec, std::size_t num_cores) noexcept
+            Executor_ const& exec, std::size_t num_cores)
         {
+            if (num_cores == 0)
+            {
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                    "parallel_policy_executor::"
+                    "with_processing_units_count",
+                    "number of processing units must be greater than "
+                    "zero");
+            }
             auto exec_with_num_cores = exec;
             exec_with_num_cores.num_cores_ = num_cores;
 

--- a/libs/core/executors/include/hpx/executors/parallel_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/parallel_executor.hpp
@@ -210,17 +210,16 @@ namespace hpx::execution {
 
         template <typename Executor_>
             requires(std::is_convertible_v<Executor_, parallel_policy_executor>)
-        friend constexpr auto tag_invoke(
+        friend auto tag_invoke(
             hpx::execution::experimental::with_processing_units_count_t,
             Executor_ const& exec, std::size_t num_cores)
         {
             if (num_cores == 0)
             {
-                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
-                    "parallel_policy_executor::"
-                    "with_processing_units_count",
-                    "number of processing units must be greater than "
-                    "zero");
+                auto pool = exec.pool_ ?
+                    exec.pool_ :
+                    threads::detail::get_self_or_default_pool();
+                num_cores = pool->get_active_os_thread_count();
             }
             auto exec_with_num_cores = exec;
             exec_with_num_cores.num_cores_ = num_cores;

--- a/libs/core/executors/include/hpx/executors/thread_pool_scheduler.hpp
+++ b/libs/core/executors/include/hpx/executors/thread_pool_scheduler.hpp
@@ -98,8 +98,16 @@ namespace hpx::execution::experimental {
                 std::is_convertible_v<Executor_, thread_pool_policy_scheduler>)
         friend constexpr auto tag_invoke(
             hpx::execution::experimental::with_processing_units_count_t,
-            Executor_ const& scheduler, std::size_t num_cores) noexcept
+            Executor_ const& scheduler, std::size_t num_cores)
         {
+            if (num_cores == 0)
+            {
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                    "thread_pool_policy_scheduler::"
+                    "with_processing_units_count",
+                    "number of processing units must be greater than "
+                    "zero");
+            }
             auto scheduler_with_num_cores = scheduler;
             scheduler_with_num_cores.num_cores_ = num_cores;
             return scheduler_with_num_cores;

--- a/libs/core/executors/include/hpx/executors/thread_pool_scheduler.hpp
+++ b/libs/core/executors/include/hpx/executors/thread_pool_scheduler.hpp
@@ -96,17 +96,16 @@ namespace hpx::execution::experimental {
         template <typename Executor_>
             requires(
                 std::is_convertible_v<Executor_, thread_pool_policy_scheduler>)
-        friend constexpr auto tag_invoke(
+        friend auto tag_invoke(
             hpx::execution::experimental::with_processing_units_count_t,
             Executor_ const& scheduler, std::size_t num_cores)
         {
             if (num_cores == 0)
             {
-                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
-                    "thread_pool_policy_scheduler::"
-                    "with_processing_units_count",
-                    "number of processing units must be greater than "
-                    "zero");
+                auto pool = scheduler.pool_ ?
+                    scheduler.pool_ :
+                    threads::detail::get_self_or_default_pool();
+                num_cores = pool->get_active_os_thread_count();
             }
             auto scheduler_with_num_cores = scheduler;
             scheduler_with_num_cores.num_cores_ = num_cores;


### PR DESCRIPTION
## Summary

`with_processing_units_count` silently accepts `0` as valid input, but internally `num_cores_ = 0` means "use all cores." This collision lets user bugs slip through as unintended maximum parallelism. The fix adds validation to both `thread_pool_policy_scheduler` and `parallel_policy_executor`, matching the precedent set in `fork_join_executor` 
## Fix

Added zero-check with `HPX_THROW_EXCEPTION` in both executors. Kept `constexpr`, removed `noexcept`.

```cpp
// thread_pool_scheduler.hpp & parallel_executor.hpp
if (num_cores == 0) {
    HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
        "with_processing_units_count",
        "number of processing units must be greater than zero");
}
```