### PR TITLE
docs: add lifetime warning for create_channel_communicator 

### DIFF
--- a/libs/full/collectives/examples/channel_communicator.cpp
+++ b/libs/full/collectives/examples/channel_communicator.cpp
@@ -34,6 +34,10 @@ int hpx_main()
     std::uint32_t this_locality = hpx::get_locality_id();
 
     // allocate channel communicator
+    // NOTE: The communicator object must be kept alive until all
+    // participating sites have successfully connected. Destroying it
+    // prematurely may cause other sites to hang. Consider using a barrier
+    // after creation if the communicator would otherwise go out of scope.
     auto comm = create_channel_communicator(hpx::launch::sync,
         channel_communicator_name, num_sites_arg(num_localities),
         this_site_arg(this_locality));

--- a/libs/full/collectives/include/hpx/collectives/channel_communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/channel_communicator.hpp
@@ -37,6 +37,16 @@ namespace hpx { namespace collectives {
     /// \returns    This function returns a future to a new communicator object
     ///             usable with the collective operation.
     ///
+    /// \note       The caller must ensure that the communicator object
+    ///             returned by this function is kept alive (i.e., does not go
+    ///             out of scope) until all participating sites have
+    ///             successfully connected. Destroying the communicator before
+    ///             all sites have reached the creation point may cause the
+    ///             remaining sites to hang indefinitely. Consider using a
+    ///             barrier or similar synchronization mechanism after creating
+    ///             the communicator to ensure all sites are connected before
+    ///             allowing it to be destroyed.
+    ///
     hpx::future<channel_communicator> create_channel_communicator(
         char const* basename,
         num_sites_arg num_sites = num_sites_arg(),
@@ -58,6 +68,16 @@ namespace hpx { namespace collectives {
     ///
     /// \returns    This function returns a new communicator object usable
     ///             with the collective operation.
+    ///
+    /// \note       The caller must ensure that the communicator object
+    ///             returned by this function is kept alive (i.e., does not go
+    ///             out of scope) until all participating sites have
+    ///             successfully connected. Destroying the communicator before
+    ///             all sites have reached the creation point may cause the
+    ///             remaining sites to hang indefinitely. Consider using a
+    ///             barrier or similar synchronization mechanism after creating
+    ///             the communicator to ensure all sites are connected before
+    ///             allowing it to be destroyed.
     ///
     channel_communicator create_channel_communicator(
         hpx::launch::sync_policy, char const* basename,


### PR DESCRIPTION
Addresses #6881

## Proposed Changes

  -Added a Doxygen `\note` to the `create_channel_communicator` function in `hpx/collectives/channel_communicator.hpp` to warn users about the object lifetime requirements.
  -Explicitly documented that destroying the communicator prematurely can cause remaining sites to hang indefinitely, and suggested using a barrier or synchronization mechanism.
  -Added a corresponding warning comment to `examples/quickstart/channel_communicator.cpp` to ensure users referencing the tutorial code are aware of this requirement.


## Any background context you want to provide?
As discussed in #6881, a distributed race condition occurs if the local channel_communicator object goes out of scope and is destroyed before all participating localities have successfully connected. By the time the next locality attempts to connect, the channel has already been unregistered, causing an indefinite hang.
## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
