### PR TITLE
Re-add iterator traits

### DIFF
--- a/libs/core/iterator_support/include/hpx/iterator_support/boost_iterator_categories.hpp
+++ b/libs/core/iterator_support/include/hpx/iterator_support/boost_iterator_categories.hpp
@@ -55,27 +55,26 @@ namespace hpx::iterators {
         // This is broken out into a separate meta-function to reduce
         // the cost of instantiating iterator_category_to_traversal, below,
         // for new-style types.
+
+        // clang-format off
         template <typename Cat>
         struct std_category_to_traversal
-          : hpx::util::lazy_conditional<
-                std::is_convertible_v<Cat, std::random_access_iterator_tag>,
-                hpx::type_identity<random_access_traversal_tag>,
-                hpx::util::lazy_conditional<
-                    std::is_convertible_v<Cat, std::bidirectional_iterator_tag>,
-                    hpx::type_identity<bidirectional_traversal_tag>,
-                    hpx::util::lazy_conditional<
-                        std::is_convertible_v<Cat, std::forward_iterator_tag>,
-                        hpx::type_identity<forward_traversal_tag>,
-                        hpx::util::lazy_conditional<
-                            std::is_convertible_v<Cat, std::input_iterator_tag>,
-                            hpx::type_identity<single_pass_traversal_tag>,
-                            hpx::util::lazy_conditional<
-                                std::is_convertible_v<Cat,
-                                    std::output_iterator_tag>,
-                                hpx::type_identity<incrementable_traversal_tag>,
-                                hpx::type_identity<no_traversal_tag>>>>>>
+          : hpx::util::select<
+                std::is_convertible<Cat, std::random_access_iterator_tag>,
+                    random_access_traversal_tag,
+                std::is_convertible<Cat, std::bidirectional_iterator_tag>,
+                    bidirectional_traversal_tag,
+                std::is_convertible<Cat, std::forward_iterator_tag>,
+                    forward_traversal_tag,
+                std::is_convertible<Cat, std::input_iterator_tag>,
+                    single_pass_traversal_tag,
+                std::is_convertible<Cat, std::output_iterator_tag>,
+                    incrementable_traversal_tag,
+                hpx::util::else_t,
+                    no_traversal_tag>
         {
         };
+        // clang-format on
     }    // namespace detail
 
     // Convert an iterator category into a traversal tag
@@ -96,27 +95,26 @@ namespace hpx::iterators {
     };
 
     // Convert an iterator traversal to one of the traversal tags.
+
+    // clang-format off
     HPX_CXX_CORE_EXPORT template <typename Traversal>
     struct pure_traversal_tag
-      : hpx::util::lazy_conditional<
-            std::is_convertible_v<Traversal, random_access_traversal_tag>,
-            hpx::type_identity<random_access_traversal_tag>,
-            hpx::util::lazy_conditional<
-                std::is_convertible_v<Traversal, bidirectional_traversal_tag>,
-                hpx::type_identity<bidirectional_traversal_tag>,
-                hpx::util::lazy_conditional<
-                    std::is_convertible_v<Traversal, forward_traversal_tag>,
-                    hpx::type_identity<forward_traversal_tag>,
-                    hpx::util::lazy_conditional<std::is_convertible_v<Traversal,
-                                                    single_pass_traversal_tag>,
-                        hpx::type_identity<single_pass_traversal_tag>,
-                        hpx::util::lazy_conditional<
-                            std::is_convertible_v<Traversal,
-                                incrementable_traversal_tag>,
-                            hpx::type_identity<incrementable_traversal_tag>,
-                            hpx::type_identity<no_traversal_tag>>>>>>
+      : hpx::util::select<
+            std::is_convertible<Traversal, random_access_traversal_tag>,
+                random_access_traversal_tag,
+            std::is_convertible<Traversal, bidirectional_traversal_tag>,
+                bidirectional_traversal_tag,
+            std::is_convertible<Traversal, forward_traversal_tag>,
+                forward_traversal_tag,
+            std::is_convertible<Traversal, single_pass_traversal_tag>,
+                single_pass_traversal_tag,
+            std::is_convertible<Traversal, incrementable_traversal_tag>,
+                incrementable_traversal_tag,
+            hpx::util::else_t,
+                no_traversal_tag>
     {
     };
+    // clang-format on
 
     // Trait to retrieve one of the iterator traversal tags from the
     // iterator category or traversal.
@@ -161,8 +159,7 @@ namespace hpx {
                 Traversal>;
 
         HPX_CXX_CORE_EXPORT template <typename Traversal>
-        using pure_traversal_tag_t =
-            typename pure_traversal_tag<Traversal>::type;
+        using pure_traversal_tag_t = pure_traversal_tag<Traversal>::type;
 
         HPX_CXX_CORE_EXPORT template <typename Iterator>
         using pure_iterator_traversal =
@@ -171,7 +168,7 @@ namespace hpx {
 
         HPX_CXX_CORE_EXPORT template <typename Iterator>
         using pure_iterator_traversal_t =
-            typename pure_iterator_traversal<Iterator>::type;
+            pure_iterator_traversal<Iterator>::type;
 
         ///////////////////////////////////////////////////////////////////////
         HPX_CXX_CORE_EXPORT template <typename Cat>
@@ -180,7 +177,7 @@ namespace hpx {
 
         HPX_CXX_CORE_EXPORT template <typename Cat>
         using iterator_category_to_traversal_t =
-            typename iterator_category_to_traversal<Cat>::type;
+            iterator_category_to_traversal<Cat>::type;
 
         HPX_CXX_CORE_EXPORT template <typename Iterator>
         using iterator_traversal =
@@ -188,8 +185,7 @@ namespace hpx {
                 Iterator>;
 
         HPX_CXX_CORE_EXPORT template <typename Iterator>
-        using iterator_traversal_t =
-            typename iterator_traversal<Iterator>::type;
+        using iterator_traversal_t = iterator_traversal<Iterator>::type;
     }    // namespace traits
 }    // namespace hpx
 

--- a/libs/core/iterator_support/include/hpx/iterator_support/traits/is_iterator.hpp
+++ b/libs/core/iterator_support/include/hpx/iterator_support/traits/is_iterator.hpp
@@ -19,21 +19,19 @@ namespace hpx::traits {
 
     ///////////////////////////////////////////////////////////////////////////
     HPX_CXX_CORE_EXPORT template <typename Iter>
-    using iter_value_t = typename std::iterator_traits<Iter>::value_type;
+    using iter_value_t = std::iterator_traits<Iter>::value_type;
 
     HPX_CXX_CORE_EXPORT template <typename Iter>
-    using iter_difference_t =
-        typename std::iterator_traits<Iter>::difference_type;
+    using iter_difference_t = std::iterator_traits<Iter>::difference_type;
 
     HPX_CXX_CORE_EXPORT template <typename Iter>
-    using iter_pointer_t = typename std::iterator_traits<Iter>::pointer;
+    using iter_pointer_t = std::iterator_traits<Iter>::pointer;
 
     HPX_CXX_CORE_EXPORT template <typename Iter>
-    using iter_reference_t = typename std::iterator_traits<Iter>::reference;
+    using iter_reference_t = std::iterator_traits<Iter>::reference;
 
     HPX_CXX_CORE_EXPORT template <typename Iter>
-    using iter_category_t =
-        typename std::iterator_traits<Iter>::iterator_category;
+    using iter_category_t = std::iterator_traits<Iter>::iterator_category;
 
     ////////////////////////////////////////////////////////////////////////////
     namespace detail {
@@ -163,7 +161,7 @@ namespace hpx::traits {
     };
 
     HPX_CXX_CORE_EXPORT template <typename Iter>
-    using is_iterator_t = typename is_iterator<Iter>::type;
+    using is_iterator_t = is_iterator<Iter>::type;
 
     HPX_CXX_CORE_EXPORT template <typename Iter>
     inline constexpr bool is_iterator_v = is_iterator<Iter>::value;
@@ -295,12 +293,98 @@ namespace hpx::traits {
 
     ///////////////////////////////////////////////////////////////////////////
     HPX_CXX_CORE_EXPORT template <typename Iter, typename Enable = void>
+    struct is_output_iterator
+      : std::integral_constant<bool,
+            belongs_to_iterator_category_v<Iter, std::output_iterator_tag> ||
+                (belongs_to_iterator_traversal_v<Iter,
+                     hpx::incrementable_traversal_tag> &&
+                    !std::is_same_v<iter_category_t<Iter>,
+                        std::input_iterator_tag>)>
+    {
+    };
+
+    HPX_CXX_CORE_EXPORT template <typename Iter>
+    using is_output_iterator_t = is_output_iterator<Iter>::type;
+
+    HPX_CXX_CORE_EXPORT template <typename Iter>
+    inline constexpr bool is_output_iterator_v =
+        is_output_iterator<Iter>::value;
+
+    ///////////////////////////////////////////////////////////////////////////
+    HPX_CXX_CORE_EXPORT template <typename Iter, typename Enable = void>
+    struct is_input_iterator
+      : std::integral_constant<bool,
+            belongs_to_iterator_category_v<Iter, std::input_iterator_tag> ||
+                belongs_to_iterator_traversal_v<Iter,
+                    hpx::single_pass_traversal_tag>>
+    {
+    };
+
+    HPX_CXX_CORE_EXPORT template <typename Iter>
+    using is_input_iterator_t = is_input_iterator<Iter>::type;
+
+    HPX_CXX_CORE_EXPORT template <typename Iter>
+    inline constexpr bool is_input_iterator_v = is_input_iterator<Iter>::value;
+
+    ///////////////////////////////////////////////////////////////////////////
+    HPX_CXX_CORE_EXPORT template <typename Iter, typename Enable = void>
+    struct is_forward_iterator
+      : std::integral_constant<bool,
+            belongs_to_iterator_category_v<Iter, std::forward_iterator_tag> ||
+                belongs_to_iterator_traversal_v<Iter,
+                    hpx::forward_traversal_tag>>
+    {
+    };
+
+    HPX_CXX_CORE_EXPORT template <typename Iter>
+    using is_forward_iterator_t = is_forward_iterator<Iter>::type;
+
+    HPX_CXX_CORE_EXPORT template <typename Iter>
+    inline constexpr bool is_forward_iterator_v =
+        is_forward_iterator<Iter>::value;
+
+    ///////////////////////////////////////////////////////////////////////////
+    HPX_CXX_CORE_EXPORT template <typename Iter, typename Enable = void>
+    struct is_bidirectional_iterator
+      : std::integral_constant<bool,
+            belongs_to_iterator_category_v<Iter,
+                std::bidirectional_iterator_tag> ||
+                belongs_to_iterator_traversal_v<Iter,
+                    hpx::bidirectional_traversal_tag>>
+    {
+    };
+
+    HPX_CXX_CORE_EXPORT template <typename Iter>
+    using is_bidirectional_iterator_t = is_bidirectional_iterator<Iter>::type;
+
+    HPX_CXX_CORE_EXPORT template <typename Iter>
+    inline constexpr bool is_bidirectional_iterator_v =
+        is_bidirectional_iterator<Iter>::value;
+
+    ///////////////////////////////////////////////////////////////////////////
+    HPX_CXX_CORE_EXPORT template <typename Iter, typename Enable = void>
+    struct is_random_access_iterator
+      : std::integral_constant<bool,
+            has_category_v<Iter, std::random_access_iterator_tag> ||
+                has_traversal_v<Iter, hpx::random_access_traversal_tag>>
+    {
+    };
+
+    HPX_CXX_CORE_EXPORT template <typename Iter>
+    using is_random_access_iterator_t = is_random_access_iterator<Iter>::type;
+
+    HPX_CXX_CORE_EXPORT template <typename Iter>
+    inline constexpr bool is_random_access_iterator_v =
+        is_random_access_iterator<Iter>::value;
+
+    ///////////////////////////////////////////////////////////////////////////
+    HPX_CXX_CORE_EXPORT template <typename Iter, typename Enable = void>
     struct is_zip_iterator : std::false_type
     {
     };
 
     HPX_CXX_CORE_EXPORT template <typename Iter>
-    using is_zip_iterator_t = typename is_zip_iterator<Iter>::type;
+    using is_zip_iterator_t = is_zip_iterator<Iter>::type;
 
     HPX_CXX_CORE_EXPORT template <typename Iter>
     inline constexpr bool is_zip_iterator_v = is_zip_iterator<Iter>::value;

--- a/libs/core/iterator_support/tests/unit/is_iterator.cpp
+++ b/libs/core/iterator_support/tests/unit/is_iterator.cpp
@@ -826,75 +826,76 @@ void is_iterator_test()
 
 void is_output_iterator_test()
 {
+    using hpx::traits::is_output_iterator;
+
     {
         using iterator = std::ostream_iterator<int>;
-        HPX_TEST_MSG((std::output_iterator<iterator, int>), "output iterator");
+        HPX_TEST_MSG((is_output_iterator<iterator>::value), "output iterator");
     }
     {
         using iterator = std::istream_iterator<int>;
-        HPX_TEST_MSG((!std::output_iterator<iterator, int>), "input iterator");
+        HPX_TEST_MSG((!is_output_iterator<iterator>::value), "input iterator");
     }
     {
         using iterator = typename std::forward_list<int>::iterator;
-        HPX_TEST_MSG((std::output_iterator<iterator, int>), "forward iterator");
+        HPX_TEST_MSG((is_output_iterator<iterator>::value), "forward iterator");
     }
     {
         using iterator = typename std::list<int>::iterator;
         HPX_TEST_MSG(
-            (std::output_iterator<iterator, int>), "bidirectional iterator");
+            (is_output_iterator<iterator>::value), "bidirectional iterator");
     }
     {
         using iterator = typename std::vector<int>::iterator;
         HPX_TEST_MSG(
-            (std::output_iterator<iterator, int>), "random access iterator");
+            (is_output_iterator<iterator>::value), "random access iterator");
     }
     {
         using iterator = bidirectional_traversal_iterator;
-        // The custom iterator uses 'int' reference, not assignable?
-        // Actually reference is int, so it returns by value. Cannot assign to rvalue.
-        // So this might fail std::output_iterator.
-        // But the previous test passed.
-        // If it fails, we know why.
-        HPX_TEST_MSG((!std::output_iterator<iterator, int>),
-            "bidirectional traversal input iterator (not output)");
+        HPX_TEST_MSG((is_output_iterator<iterator>::value),
+            "bidirectional traversal input iterator");
     }
     {
         using iterator = random_access_traversal_iterator;
-        HPX_TEST_MSG((!std::output_iterator<iterator, int>),
-            "random access traversal input iterator (not output)");
+        HPX_TEST_MSG((is_output_iterator<iterator>::value),
+            "random access traversal input iterator");
     }
 }
 
 void is_input_iterator_test()
 {
+    using hpx::traits::is_input_iterator;
+
     {
         using iterator = std::ostream_iterator<int>;
-        HPX_TEST_MSG((!std::input_iterator<iterator>), "output iterator");
+        HPX_TEST_MSG((!is_input_iterator<iterator>::value), "output iterator");
     }
     {
         using iterator = std::istream_iterator<int>;
-        HPX_TEST_MSG((std::input_iterator<iterator>), "input iterator");
+        HPX_TEST_MSG((is_input_iterator<iterator>::value), "input iterator");
     }
     {
         using iterator = typename std::forward_list<int>::iterator;
-        HPX_TEST_MSG((std::input_iterator<iterator>), "forward iterator");
+        HPX_TEST_MSG((is_input_iterator<iterator>::value), "forward iterator");
     }
     {
         using iterator = typename std::list<int>::iterator;
-        HPX_TEST_MSG((std::input_iterator<iterator>), "bidirectional iterator");
+        HPX_TEST_MSG(
+            (is_input_iterator<iterator>::value), "bidirectional iterator");
     }
     {
         using iterator = typename std::vector<int>::iterator;
-        HPX_TEST_MSG((std::input_iterator<iterator>), "random access iterator");
+        HPX_TEST_MSG(
+            (is_input_iterator<iterator>::value), "random access iterator");
     }
     {
         using iterator = bidirectional_traversal_iterator;
-        HPX_TEST_MSG((std::input_iterator<iterator>),
+        HPX_TEST_MSG((is_input_iterator<iterator>::value),
             "bidirectional traversal input iterator");
     }
     {
         using iterator = random_access_traversal_iterator;
-        HPX_TEST_MSG((std::input_iterator<iterator>),
+        HPX_TEST_MSG((is_input_iterator<iterator>::value),
             "random access traversal input iterator");
     }
     {
@@ -902,63 +903,67 @@ void is_input_iterator_test()
         using iterator =
             test::test_iterator<base_iterator, std::random_access_iterator_tag>;
 
-        HPX_TEST_MSG((std::input_iterator<iterator>), "hpx test iterator");
+        HPX_TEST_MSG((is_input_iterator<iterator>::value), "hpx test iterator");
     }
     {
         using base_iterator = std::vector<std::size_t>::iterator;
         using iterator =
             test::test_iterator<base_iterator, std::bidirectional_iterator_tag>;
 
-        HPX_TEST_MSG((std::input_iterator<iterator>), "hpx test iterator");
+        HPX_TEST_MSG((is_input_iterator<iterator>::value), "hpx test iterator");
     }
     {
         using base_iterator = std::vector<std::size_t>::iterator;
         using iterator =
             test::test_iterator<base_iterator, std::forward_iterator_tag>;
 
-        HPX_TEST_MSG((std::input_iterator<iterator>), "hpx test iterator");
+        HPX_TEST_MSG((is_input_iterator<iterator>::value), "hpx test iterator");
     }
     {
         using base_iterator = std::vector<std::size_t>::iterator;
         using iterator =
             test::test_iterator<base_iterator, std::input_iterator_tag>;
 
-        HPX_TEST_MSG((std::input_iterator<iterator>), "hpx test iterator");
+        HPX_TEST_MSG((is_input_iterator<iterator>::value), "hpx test iterator");
     }
 }
 
 void is_forward_iterator_test()
 {
+    using hpx::traits::is_forward_iterator;
+
     {
         using iterator = std::ostream_iterator<int>;
-        HPX_TEST_MSG((!std::forward_iterator<iterator>), "output iterator");
+        HPX_TEST_MSG(
+            (!is_forward_iterator<iterator>::value), "output iterator");
     }
     {
         using iterator = std::istream_iterator<int>;
-        HPX_TEST_MSG((!std::forward_iterator<iterator>), "input iterator");
+        HPX_TEST_MSG((!is_forward_iterator<iterator>::value), "input iterator");
     }
     {
         using iterator = typename std::forward_list<int>::iterator;
-        HPX_TEST_MSG((std::forward_iterator<iterator>), "forward iterator");
+        HPX_TEST_MSG(
+            (is_forward_iterator<iterator>::value), "forward iterator");
     }
     {
         using iterator = typename std::list<int>::iterator;
         HPX_TEST_MSG(
-            (std::forward_iterator<iterator>), "bidirectional iterator");
+            (is_forward_iterator<iterator>::value), "bidirectional iterator");
     }
     {
         using iterator = typename std::vector<int>::iterator;
         HPX_TEST_MSG(
-            (std::forward_iterator<iterator>), "random access iterator");
+            (is_forward_iterator<iterator>::value), "random access iterator");
     }
     {
         using iterator = bidirectional_traversal_iterator;
-        HPX_TEST_MSG((std::forward_iterator<iterator>),
+        HPX_TEST_MSG((is_forward_iterator<iterator>::value),
             "bidirectional traversal input iterator");
     }
     {
         using iterator = random_access_traversal_iterator;
-        HPX_TEST_MSG((std::forward_iterator<iterator>),
+        HPX_TEST_MSG((is_forward_iterator<iterator>::value),
             "random access traversal input iterator");
     }
     {
@@ -966,66 +971,72 @@ void is_forward_iterator_test()
         using iterator =
             test::test_iterator<base_iterator, std::random_access_iterator_tag>;
 
-        HPX_TEST_MSG((std::forward_iterator<iterator>), "hpx test iterator");
+        HPX_TEST_MSG(
+            (is_forward_iterator<iterator>::value), "hpx test iterator");
     }
     {
         using base_iterator = std::vector<std::size_t>::iterator;
         using iterator =
             test::test_iterator<base_iterator, std::bidirectional_iterator_tag>;
 
-        HPX_TEST_MSG((std::forward_iterator<iterator>), "hpx test iterator");
+        HPX_TEST_MSG(
+            (is_forward_iterator<iterator>::value), "hpx test iterator");
     }
     {
         using base_iterator = std::vector<std::size_t>::iterator;
         using iterator =
             test::test_iterator<base_iterator, std::forward_iterator_tag>;
 
-        HPX_TEST_MSG((std::forward_iterator<iterator>), "hpx test iterator");
+        HPX_TEST_MSG(
+            (is_forward_iterator<iterator>::value), "hpx test iterator");
     }
     {
         using base_iterator = std::vector<std::size_t>::iterator;
         using iterator =
             test::test_iterator<base_iterator, std::input_iterator_tag>;
 
-        HPX_TEST_MSG((!std::forward_iterator<iterator>), "hpx test iterator");
+        HPX_TEST_MSG(
+            (!is_forward_iterator<iterator>::value), "hpx test iterator");
     }
 }
 
 void is_bidirectional_iterator_test()
 {
+    using hpx::traits::is_bidirectional_iterator;
+
     {
         using iterator = std::ostream_iterator<int>;
         HPX_TEST_MSG(
-            (!std::bidirectional_iterator<iterator>), "output iterator");
+            (!is_bidirectional_iterator<iterator>::value), "output iterator");
     }
     {
         using iterator = std::istream_iterator<int>;
         HPX_TEST_MSG(
-            (!std::bidirectional_iterator<iterator>), "input iterator");
+            (!is_bidirectional_iterator<iterator>::value), "input iterator");
     }
     {
         using iterator = typename std::forward_list<int>::iterator;
         HPX_TEST_MSG(
-            (!std::bidirectional_iterator<iterator>), "forward iterator");
+            (!is_bidirectional_iterator<iterator>::value), "forward iterator");
     }
     {
         using iterator = typename std::list<int>::iterator;
-        HPX_TEST_MSG(
-            (std::bidirectional_iterator<iterator>), "bidirectional iterator");
+        HPX_TEST_MSG((is_bidirectional_iterator<iterator>::value),
+            "bidirectional iterator");
     }
     {
         using iterator = typename std::vector<int>::iterator;
-        HPX_TEST_MSG(
-            (std::bidirectional_iterator<iterator>), "random access iterator");
+        HPX_TEST_MSG((is_bidirectional_iterator<iterator>::value),
+            "random access iterator");
     }
     {
         using iterator = bidirectional_traversal_iterator;
-        HPX_TEST_MSG((std::bidirectional_iterator<iterator>),
+        HPX_TEST_MSG((is_bidirectional_iterator<iterator>::value),
             "bidirectional traversal input iterator");
     }
     {
         using iterator = random_access_traversal_iterator;
-        HPX_TEST_MSG((std::bidirectional_iterator<iterator>),
+        HPX_TEST_MSG((is_bidirectional_iterator<iterator>::value),
             "random access traversal input iterator");
     }
     {
@@ -1034,7 +1045,7 @@ void is_bidirectional_iterator_test()
             test::test_iterator<base_iterator, std::random_access_iterator_tag>;
 
         HPX_TEST_MSG(
-            (std::bidirectional_iterator<iterator>), "hpx test iterator");
+            (is_bidirectional_iterator<iterator>::value), "hpx test iterator");
     }
     {
         using base_iterator = std::vector<std::size_t>::iterator;
@@ -1042,7 +1053,7 @@ void is_bidirectional_iterator_test()
             test::test_iterator<base_iterator, std::bidirectional_iterator_tag>;
 
         HPX_TEST_MSG(
-            (std::bidirectional_iterator<iterator>), "hpx test iterator");
+            (is_bidirectional_iterator<iterator>::value), "hpx test iterator");
     }
     {
         using base_iterator = std::vector<std::size_t>::iterator;
@@ -1050,7 +1061,7 @@ void is_bidirectional_iterator_test()
             test::test_iterator<base_iterator, std::forward_iterator_tag>;
 
         HPX_TEST_MSG(
-            (!std::bidirectional_iterator<iterator>), "hpx test iterator");
+            (!is_bidirectional_iterator<iterator>::value), "hpx test iterator");
     }
     {
         using base_iterator = std::vector<std::size_t>::iterator;
@@ -1058,45 +1069,47 @@ void is_bidirectional_iterator_test()
             test::test_iterator<base_iterator, std::input_iterator_tag>;
 
         HPX_TEST_MSG(
-            (!std::bidirectional_iterator<iterator>), "hpx test iterator");
+            (!is_bidirectional_iterator<iterator>::value), "hpx test iterator");
     }
 }
 
 void is_random_access_iterator_test()
 {
+    using hpx::traits::is_random_access_iterator;
+
     {
         using iterator = std::ostream_iterator<int>;
         HPX_TEST_MSG(
-            (!std::random_access_iterator<iterator>), "output iterator");
+            (!is_random_access_iterator<iterator>::value), "output iterator");
     }
     {
         using iterator = std::istream_iterator<int>;
         HPX_TEST_MSG(
-            (!std::random_access_iterator<iterator>), "input iterator");
+            (!is_random_access_iterator<iterator>::value), "input iterator");
     }
     {
         using iterator = typename std::forward_list<int>::iterator;
         HPX_TEST_MSG(
-            (!std::random_access_iterator<iterator>), "forward iterator");
+            (!is_random_access_iterator<iterator>::value), "forward iterator");
     }
     {
         using iterator = typename std::list<int>::iterator;
-        HPX_TEST_MSG(
-            (!std::random_access_iterator<iterator>), "bidirectional iterator");
+        HPX_TEST_MSG((!is_random_access_iterator<iterator>::value),
+            "bidirectional iterator");
     }
     {
         using iterator = typename std::vector<int>::iterator;
-        HPX_TEST_MSG(
-            (std::random_access_iterator<iterator>), "random access iterator");
+        HPX_TEST_MSG((is_random_access_iterator<iterator>::value),
+            "random access iterator");
     }
     {
         using iterator = bidirectional_traversal_iterator;
-        HPX_TEST_MSG((!std::random_access_iterator<iterator>),
+        HPX_TEST_MSG((!is_random_access_iterator<iterator>::value),
             "bidirectional traversal input iterator");
     }
     {
         using iterator = random_access_traversal_iterator;
-        HPX_TEST_MSG((std::random_access_iterator<iterator>),
+        HPX_TEST_MSG((is_random_access_iterator<iterator>::value),
             "random access traversal input iterator");
     }
     {
@@ -1105,7 +1118,7 @@ void is_random_access_iterator_test()
             test::test_iterator<base_iterator, std::random_access_iterator_tag>;
 
         HPX_TEST_MSG(
-            (std::random_access_iterator<iterator>), "hpx test iterator");
+            (is_random_access_iterator<iterator>::value), "hpx test iterator");
     }
     {
         using base_iterator = std::vector<std::size_t>::iterator;
@@ -1113,7 +1126,7 @@ void is_random_access_iterator_test()
             test::test_iterator<base_iterator, std::bidirectional_iterator_tag>;
 
         HPX_TEST_MSG(
-            (!std::random_access_iterator<iterator>), "hpx test iterator");
+            (!is_random_access_iterator<iterator>::value), "hpx test iterator");
     }
     {
         using base_iterator = std::vector<std::size_t>::iterator;
@@ -1121,7 +1134,7 @@ void is_random_access_iterator_test()
             test::test_iterator<base_iterator, std::forward_iterator_tag>;
 
         HPX_TEST_MSG(
-            (!std::random_access_iterator<iterator>), "hpx test iterator");
+            (!is_random_access_iterator<iterator>::value), "hpx test iterator");
     }
     {
         using base_iterator = std::vector<std::size_t>::iterator;
@@ -1129,7 +1142,7 @@ void is_random_access_iterator_test()
             test::test_iterator<base_iterator, std::input_iterator_tag>;
 
         HPX_TEST_MSG(
-            (!std::random_access_iterator<iterator>), "hpx test iterator");
+            (!is_random_access_iterator<iterator>::value), "hpx test iterator");
     }
 }
 


### PR DESCRIPTION
- This is necessary for backwards compatibility with external code depending on those traits. We may later deprecate the use of those traits.
