### PR TITLE
Replace BLOCK_SIZE with different name to avoid clashes with Linux-defined macro

### DIFF
--- a/libs/core/concurrency/include/hpx/concurrency/concurrentqueue.hpp
+++ b/libs/core/concurrency/include/hpx/concurrency/concurrentqueue.hpp
@@ -301,7 +301,7 @@ HPX_CXX_CORE_EXPORT struct ConcurrentQueueDefaultTraits
     // but many producers, a smaller block size should be favoured. For few producers
     // and/or many elements, a larger block size is preferred. A sane default
     // is provided. Must be a power of 2.
-    static const size_t BLOCK_SIZE = 32;
+    static const size_t QUEUE_BLOCK_SIZE = 32;
 
     // For explicit producers (i.e. when using a producer token), the block is
     // checked for being empty by iterating through a list of flags, one per element.
@@ -708,7 +708,7 @@ public:
     typedef typename Traits::index_t index_t;
     typedef typename Traits::size_t size_t;
 
-    static const size_t BLOCK_SIZE = static_cast<size_t>(Traits::BLOCK_SIZE);
+    static const size_t QUEUE_BLOCK_SIZE = static_cast<size_t>(Traits::QUEUE_BLOCK_SIZE);
     static const size_t EXPLICIT_BLOCK_EMPTY_COUNTER_THRESHOLD = static_cast<size_t>(Traits::EXPLICIT_BLOCK_EMPTY_COUNTER_THRESHOLD);
     static const size_t EXPLICIT_INITIAL_INDEX_SIZE = static_cast<size_t>(Traits::EXPLICIT_INITIAL_INDEX_SIZE);
     static const size_t IMPLICIT_INITIAL_INDEX_SIZE = static_cast<size_t>(Traits::IMPLICIT_INITIAL_INDEX_SIZE);
@@ -719,7 +719,7 @@ public:
 #pragma warning(disable: 4307)    // + integral constant overflow (that's what the ternary expression is for!)
 #pragma warning(disable: 4309)    // static_cast: Truncation of constant value
 #endif
-    static const size_t MAX_SUBQUEUE_SIZE = (details::const_numeric_max<size_t>::value - static_cast<size_t>(Traits::MAX_SUBQUEUE_SIZE) < BLOCK_SIZE) ? details::const_numeric_max<size_t>::value : ((static_cast<size_t>(Traits::MAX_SUBQUEUE_SIZE) + (BLOCK_SIZE - 1)) / BLOCK_SIZE * BLOCK_SIZE);
+    static const size_t MAX_SUBQUEUE_SIZE = (details::const_numeric_max<size_t>::value - static_cast<size_t>(Traits::MAX_SUBQUEUE_SIZE) < QUEUE_BLOCK_SIZE) ? details::const_numeric_max<size_t>::value : ((static_cast<size_t>(Traits::MAX_SUBQUEUE_SIZE) + (QUEUE_BLOCK_SIZE - 1)) / QUEUE_BLOCK_SIZE * QUEUE_BLOCK_SIZE);
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
@@ -727,7 +727,7 @@ public:
     static_assert(!std::numeric_limits<size_t>::is_signed && std::is_integral<size_t>::value, "Traits::size_t must be an unsigned integral type");
     static_assert(!std::numeric_limits<index_t>::is_signed && std::is_integral<index_t>::value, "Traits::index_t must be an unsigned integral type");
     static_assert(sizeof(index_t) >= sizeof(size_t), "Traits::index_t must be at least as wide as Traits::size_t");
-    static_assert((BLOCK_SIZE > 1) && !(BLOCK_SIZE & (BLOCK_SIZE - 1)), "Traits::BLOCK_SIZE must be a power of 2 (and at least 2)");
+    static_assert((QUEUE_BLOCK_SIZE > 1) && !(QUEUE_BLOCK_SIZE & (QUEUE_BLOCK_SIZE - 1)), "Traits::QUEUE_BLOCK_SIZE must be a power of 2 (and at least 2)");
     static_assert((EXPLICIT_BLOCK_EMPTY_COUNTER_THRESHOLD > 1) && !(EXPLICIT_BLOCK_EMPTY_COUNTER_THRESHOLD & (EXPLICIT_BLOCK_EMPTY_COUNTER_THRESHOLD - 1)), "Traits::EXPLICIT_BLOCK_EMPTY_COUNTER_THRESHOLD must be a power of 2 (and greater than 1)");
     static_assert((EXPLICIT_INITIAL_INDEX_SIZE > 1) && !(EXPLICIT_INITIAL_INDEX_SIZE & (EXPLICIT_INITIAL_INDEX_SIZE - 1)), "Traits::EXPLICIT_INITIAL_INDEX_SIZE must be a power of 2 (and greater than 1)");
     static_assert((IMPLICIT_INITIAL_INDEX_SIZE > 1) && !(IMPLICIT_INITIAL_INDEX_SIZE & (IMPLICIT_INITIAL_INDEX_SIZE - 1)), "Traits::IMPLICIT_INITIAL_INDEX_SIZE must be a power of 2 (and greater than 1)");
@@ -745,7 +745,7 @@ public:
     // queue is fully constructed before it starts being used by other threads (this
     // includes making the memory effects of construction visible, possibly with a
     // memory barrier).
-    explicit ConcurrentQueue(size_t capacity = 6 * BLOCK_SIZE)
+    explicit ConcurrentQueue(size_t capacity = 6 * QUEUE_BLOCK_SIZE)
         : producerListTail(nullptr),
         producerCount(0),
         initialBlockPoolIndex(0),
@@ -754,7 +754,7 @@ public:
     {
         implicitProducerHashResizeInProgress.clear(std::memory_order_relaxed);
         populate_initial_implicit_producer_hash();
-        populate_initial_block_list(capacity / BLOCK_SIZE + ((capacity & (BLOCK_SIZE - 1)) == 0 ? 0 : 1));
+        populate_initial_block_list(capacity / QUEUE_BLOCK_SIZE + ((capacity & (QUEUE_BLOCK_SIZE - 1)) == 0 ? 0 : 1));
 
 #ifdef MOODYCAMEL_QUEUE_INTERNAL_DEBUG
         // Track all the producers using a fully-resolved typed list for
@@ -778,7 +778,7 @@ public:
     {
         implicitProducerHashResizeInProgress.clear(std::memory_order_relaxed);
         populate_initial_implicit_producer_hash();
-        size_t blocks = (((minCapacity + BLOCK_SIZE - 1) / BLOCK_SIZE) - 1) * (maxExplicitProducers + 1) + 2 * (maxExplicitProducers + maxImplicitProducers);
+        size_t blocks = (((minCapacity + QUEUE_BLOCK_SIZE - 1) / QUEUE_BLOCK_SIZE) - 1) * (maxExplicitProducers + 1) + 2 * (maxExplicitProducers + maxImplicitProducers);
         populate_initial_block_list(blocks);
 
 #ifdef MOODYCAMEL_QUEUE_INTERNAL_DEBUG
@@ -1505,9 +1505,9 @@ private:
         template<InnerQueueContext context>
         inline bool is_empty() const
         {
-            if (context == explicit_context && BLOCK_SIZE <= EXPLICIT_BLOCK_EMPTY_COUNTER_THRESHOLD) {
+            if (context == explicit_context && QUEUE_BLOCK_SIZE <= EXPLICIT_BLOCK_EMPTY_COUNTER_THRESHOLD) {
                 // Check flags
-                for (size_t i = 0; i < BLOCK_SIZE; ++i) {
+                for (size_t i = 0; i < QUEUE_BLOCK_SIZE; ++i) {
                     if (!emptyFlags[i].load(std::memory_order_relaxed)) {
                         return false;
                     }
@@ -1519,11 +1519,11 @@ private:
             }
             else {
                 // Check counter
-                if (elementsCompletelyDequeued.load(std::memory_order_relaxed) == BLOCK_SIZE) {
+                if (elementsCompletelyDequeued.load(std::memory_order_relaxed) == QUEUE_BLOCK_SIZE) {
                     std::atomic_thread_fence(std::memory_order_acquire);
                     return true;
                 }
-                assert(elementsCompletelyDequeued.load(std::memory_order_relaxed) <= BLOCK_SIZE);
+                assert(elementsCompletelyDequeued.load(std::memory_order_relaxed) <= QUEUE_BLOCK_SIZE);
                 return false;
             }
         }
@@ -1532,17 +1532,17 @@ private:
         template<InnerQueueContext context>
         inline bool set_empty(index_t i)
         {
-            if (context == explicit_context && BLOCK_SIZE <= EXPLICIT_BLOCK_EMPTY_COUNTER_THRESHOLD) {
+            if (context == explicit_context && QUEUE_BLOCK_SIZE <= EXPLICIT_BLOCK_EMPTY_COUNTER_THRESHOLD) {
                 // Set flag
-                assert(!emptyFlags[BLOCK_SIZE - 1 - static_cast<size_t>(i & static_cast<index_t>(BLOCK_SIZE - 1))].load(std::memory_order_relaxed));
-                emptyFlags[BLOCK_SIZE - 1 - static_cast<size_t>(i & static_cast<index_t>(BLOCK_SIZE - 1))].store(true, std::memory_order_release);
+                assert(!emptyFlags[QUEUE_BLOCK_SIZE - 1 - static_cast<size_t>(i & static_cast<index_t>(QUEUE_BLOCK_SIZE - 1))].load(std::memory_order_relaxed));
+                emptyFlags[QUEUE_BLOCK_SIZE - 1 - static_cast<size_t>(i & static_cast<index_t>(QUEUE_BLOCK_SIZE - 1))].store(true, std::memory_order_release);
                 return false;
             }
             else {
                 // Increment counter
                 auto prevVal = elementsCompletelyDequeued.fetch_add(1, std::memory_order_release);
-                assert(prevVal < BLOCK_SIZE);
-                return prevVal == BLOCK_SIZE - 1;
+                assert(prevVal < QUEUE_BLOCK_SIZE);
+                return prevVal == QUEUE_BLOCK_SIZE - 1;
             }
         }
 
@@ -1551,10 +1551,10 @@ private:
         template<InnerQueueContext context>
         inline bool set_many_empty(index_t i, size_t count)
         {
-            if (context == explicit_context && BLOCK_SIZE <= EXPLICIT_BLOCK_EMPTY_COUNTER_THRESHOLD) {
+            if (context == explicit_context && QUEUE_BLOCK_SIZE <= EXPLICIT_BLOCK_EMPTY_COUNTER_THRESHOLD) {
                 // Set flags
                 std::atomic_thread_fence(std::memory_order_release);
-                i = BLOCK_SIZE - 1 - static_cast<size_t>(i & static_cast<index_t>(BLOCK_SIZE - 1)) - count + 1;
+                i = QUEUE_BLOCK_SIZE - 1 - static_cast<size_t>(i & static_cast<index_t>(QUEUE_BLOCK_SIZE - 1)) - count + 1;
                 for (size_t j = 0; j != count; ++j) {
                     assert(!emptyFlags[i + j].load(std::memory_order_relaxed));
                     emptyFlags[i + j].store(true, std::memory_order_relaxed);
@@ -1564,32 +1564,32 @@ private:
             else {
                 // Increment counter
                 auto prevVal = elementsCompletelyDequeued.fetch_add(count, std::memory_order_release);
-                assert(prevVal + count <= BLOCK_SIZE);
-                return prevVal + count == BLOCK_SIZE;
+                assert(prevVal + count <= QUEUE_BLOCK_SIZE);
+                return prevVal + count == QUEUE_BLOCK_SIZE;
             }
         }
 
         template<InnerQueueContext context>
         inline void set_all_empty()
         {
-            if (context == explicit_context && BLOCK_SIZE <= EXPLICIT_BLOCK_EMPTY_COUNTER_THRESHOLD) {
+            if (context == explicit_context && QUEUE_BLOCK_SIZE <= EXPLICIT_BLOCK_EMPTY_COUNTER_THRESHOLD) {
                 // Set all flags
-                for (size_t i = 0; i != BLOCK_SIZE; ++i) {
+                for (size_t i = 0; i != QUEUE_BLOCK_SIZE; ++i) {
                     emptyFlags[i].store(true, std::memory_order_relaxed);
                 }
             }
             else {
                 // Reset counter
-                elementsCompletelyDequeued.store(BLOCK_SIZE, std::memory_order_relaxed);
+                elementsCompletelyDequeued.store(QUEUE_BLOCK_SIZE, std::memory_order_relaxed);
             }
         }
 
         template<InnerQueueContext context>
         inline void reset_empty()
         {
-            if (context == explicit_context && BLOCK_SIZE <= EXPLICIT_BLOCK_EMPTY_COUNTER_THRESHOLD) {
+            if (context == explicit_context && QUEUE_BLOCK_SIZE <= EXPLICIT_BLOCK_EMPTY_COUNTER_THRESHOLD) {
                 // Reset flags
-                for (size_t i = 0; i != BLOCK_SIZE; ++i) {
+                for (size_t i = 0; i != QUEUE_BLOCK_SIZE; ++i) {
                     emptyFlags[i].store(false, std::memory_order_relaxed);
                 }
             }
@@ -1600,8 +1600,8 @@ private:
         }
 
         // NOLINTBEGIN(bugprone-casting-through-void)
-        inline T* operator[](index_t idx) MOODYCAMEL_NOEXCEPT { return static_cast<T*>(static_cast<void*>(elements)) + static_cast<size_t>(idx & static_cast<index_t>(BLOCK_SIZE - 1)); }
-        inline T const* operator[](index_t idx) const MOODYCAMEL_NOEXCEPT { return static_cast<T const*>(static_cast<void const*>(elements)) + static_cast<size_t>(idx & static_cast<index_t>(BLOCK_SIZE - 1)); }
+        inline T* operator[](index_t idx) MOODYCAMEL_NOEXCEPT { return static_cast<T*>(static_cast<void*>(elements)) + static_cast<size_t>(idx & static_cast<index_t>(QUEUE_BLOCK_SIZE - 1)); }
+        inline T const* operator[](index_t idx) const MOODYCAMEL_NOEXCEPT { return static_cast<T const*>(static_cast<void const*>(elements)) + static_cast<size_t>(idx & static_cast<index_t>(QUEUE_BLOCK_SIZE - 1)); }
         // NOLINTEND(bugprone-casting-through-void)
 
     private:
@@ -1617,13 +1617,13 @@ private:
         // this.
         union {
             // NOLINTNEXTLINE(bugprone-sizeof-expression)
-            char elements[sizeof(T) * BLOCK_SIZE];
+            char elements[sizeof(T) * QUEUE_BLOCK_SIZE];
             details::max_align_t dummy;
         };
     public:
         Block* next;
         std::atomic<size_t> elementsCompletelyDequeued;
-        std::atomic<bool> emptyFlags[BLOCK_SIZE <= EXPLICIT_BLOCK_EMPTY_COUNTER_THRESHOLD ? BLOCK_SIZE : 1];
+        std::atomic<bool> emptyFlags[QUEUE_BLOCK_SIZE <= EXPLICIT_BLOCK_EMPTY_COUNTER_THRESHOLD ? QUEUE_BLOCK_SIZE : 1];
     public:
         std::atomic<std::uint32_t> freeListRefs;
         std::atomic<Block*> freeListNext;
@@ -1745,11 +1745,11 @@ private:
             if (this->tailBlock != nullptr) {    // Note this means there must be a block index too
                 // First find the block that's partially dequeued, if any
                 Block* halfDequeuedBlock = nullptr;
-                if ((this->headIndex.load(std::memory_order_relaxed) & static_cast<index_t>(BLOCK_SIZE - 1)) != 0) {
+                if ((this->headIndex.load(std::memory_order_relaxed) & static_cast<index_t>(QUEUE_BLOCK_SIZE - 1)) != 0) {
                     // The head's not on a block boundary, meaning a block somewhere is partially dequeued
                     // (or the head block is the tail block and was fully dequeued, but the head/tail are still not on a boundary)
                     size_t i = (pr_blockIndexFront - pr_blockIndexSlotsUsed) & (pr_blockIndexSize - 1);
-                    while (details::circular_less_than<index_t>(pr_blockIndexEntries[i].base + BLOCK_SIZE, this->headIndex.load(std::memory_order_relaxed))) {
+                    while (details::circular_less_than<index_t>(pr_blockIndexEntries[i].base + QUEUE_BLOCK_SIZE, this->headIndex.load(std::memory_order_relaxed))) {
                         i = (i + 1) & (pr_blockIndexSize - 1);
                     }
                     assert(details::circular_less_than<index_t>(pr_blockIndexEntries[i].base, this->headIndex.load(std::memory_order_relaxed)));
@@ -1766,12 +1766,12 @@ private:
 
                     size_t i = 0;  // Offset into block
                     if (block == halfDequeuedBlock) {
-                        i = static_cast<size_t>(this->headIndex.load(std::memory_order_relaxed) & static_cast<index_t>(BLOCK_SIZE - 1));
+                        i = static_cast<size_t>(this->headIndex.load(std::memory_order_relaxed) & static_cast<index_t>(QUEUE_BLOCK_SIZE - 1));
                     }
 
                     // Walk through all the items in the block; if this is the tail block, we need to stop when we reach the tail index
-                    auto lastValidIndex = (this->tailIndex.load(std::memory_order_relaxed) & static_cast<index_t>(BLOCK_SIZE - 1)) == 0 ? BLOCK_SIZE : static_cast<size_t>(this->tailIndex.load(std::memory_order_relaxed) & static_cast<index_t>(BLOCK_SIZE - 1));
-                    while (i != BLOCK_SIZE && (block != this->tailBlock || i != lastValidIndex)) {
+                    auto lastValidIndex = (this->tailIndex.load(std::memory_order_relaxed) & static_cast<index_t>(QUEUE_BLOCK_SIZE - 1)) == 0 ? QUEUE_BLOCK_SIZE : static_cast<size_t>(this->tailIndex.load(std::memory_order_relaxed) & static_cast<index_t>(QUEUE_BLOCK_SIZE - 1));
+                    while (i != QUEUE_BLOCK_SIZE && (block != this->tailBlock || i != lastValidIndex)) {
                         (*block)[i++]->~T();
                     }
                 } while (block != this->tailBlock);
@@ -1807,7 +1807,7 @@ private:
         {
             index_t currentTailIndex = this->tailIndex.load(std::memory_order_relaxed);
             index_t newTailIndex = 1 + currentTailIndex;
-            if ((currentTailIndex & static_cast<index_t>(BLOCK_SIZE - 1)) == 0) {
+            if ((currentTailIndex & static_cast<index_t>(QUEUE_BLOCK_SIZE - 1)) == 0) {
                 // We reached the end of a block, start a new one
                 auto startBlock = this->tailBlock;
                 auto originalBlockIndexSlotsUsed = pr_blockIndexSlotsUsed;
@@ -1828,8 +1828,8 @@ private:
                     // <= to it.
                     auto head = this->headIndex.load(std::memory_order_relaxed);
                     assert(!details::circular_less_than<index_t>(currentTailIndex, head));
-                    if (!details::circular_less_than<index_t>(head, currentTailIndex + BLOCK_SIZE)
-                        || (MAX_SUBQUEUE_SIZE != details::const_numeric_max<size_t>::value && (MAX_SUBQUEUE_SIZE == 0 || MAX_SUBQUEUE_SIZE - BLOCK_SIZE < currentTailIndex - head))) {
+                    if (!details::circular_less_than<index_t>(head, currentTailIndex + QUEUE_BLOCK_SIZE)
+                        || (MAX_SUBQUEUE_SIZE != details::const_numeric_max<size_t>::value && (MAX_SUBQUEUE_SIZE == 0 || MAX_SUBQUEUE_SIZE - QUEUE_BLOCK_SIZE < currentTailIndex - head))) {
                         // We can't enqueue in another block because there's not enough leeway -- the
                         // tail could surpass the head by the time the block fills up! (Or we'll exceed
                         // the size limit, if the second part of the condition was true.)
@@ -1966,8 +1966,8 @@ private:
                     // When an index wraps, we need to preserve the sign of the offset when dividing it by the
                     // block size (in order to get a correct signed block count offset in all cases):
                     auto headBase = localBlockIndex->entries[localBlockIndexHead].base;
-                    auto blockBaseIndex = index & ~static_cast<index_t>(BLOCK_SIZE - 1);
-                    auto offset = static_cast<size_t>(static_cast<typename std::make_signed<index_t>::type>(blockBaseIndex - headBase) / BLOCK_SIZE);
+                    auto blockBaseIndex = index & ~static_cast<index_t>(QUEUE_BLOCK_SIZE - 1);
+                    auto offset = static_cast<size_t>(static_cast<typename std::make_signed<index_t>::type>(blockBaseIndex - headBase) / QUEUE_BLOCK_SIZE);
                     auto block = localBlockIndex->entries[(localBlockIndexHead + offset) & (localBlockIndex->size - 1)].block;
 
                     // Dequeue
@@ -2020,13 +2020,13 @@ private:
             Block* firstAllocatedBlock = nullptr;
 
             // Figure out how many blocks we'll need to allocate, and do so
-            size_t blockBaseDiff = ((startTailIndex + count - 1) & ~static_cast<index_t>(BLOCK_SIZE - 1)) - ((startTailIndex - 1) & ~static_cast<index_t>(BLOCK_SIZE - 1));
-            index_t currentTailIndex = (startTailIndex - 1) & ~static_cast<index_t>(BLOCK_SIZE - 1);
+            size_t blockBaseDiff = ((startTailIndex + count - 1) & ~static_cast<index_t>(QUEUE_BLOCK_SIZE - 1)) - ((startTailIndex - 1) & ~static_cast<index_t>(QUEUE_BLOCK_SIZE - 1));
+            index_t currentTailIndex = (startTailIndex - 1) & ~static_cast<index_t>(QUEUE_BLOCK_SIZE - 1);
             if (blockBaseDiff > 0) {
                 // Allocate as many blocks as possible from ahead
                 while (blockBaseDiff > 0 && this->tailBlock != nullptr && this->tailBlock->next != firstAllocatedBlock && this->tailBlock->next->ConcurrentQueue::Block::template is_empty<explicit_context>()) {
-                    blockBaseDiff -= static_cast<index_t>(BLOCK_SIZE);
-                    currentTailIndex += static_cast<index_t>(BLOCK_SIZE);
+                    blockBaseDiff -= static_cast<index_t>(QUEUE_BLOCK_SIZE);
+                    currentTailIndex += static_cast<index_t>(QUEUE_BLOCK_SIZE);
 
                     this->tailBlock = this->tailBlock->next;
                     firstAllocatedBlock = firstAllocatedBlock == nullptr ? this->tailBlock : firstAllocatedBlock;
@@ -2039,12 +2039,12 @@ private:
 
                 // Now allocate as many blocks as necessary from the block pool
                 while (blockBaseDiff > 0) {
-                    blockBaseDiff -= static_cast<index_t>(BLOCK_SIZE);
-                    currentTailIndex += static_cast<index_t>(BLOCK_SIZE);
+                    blockBaseDiff -= static_cast<index_t>(QUEUE_BLOCK_SIZE);
+                    currentTailIndex += static_cast<index_t>(QUEUE_BLOCK_SIZE);
 
                     auto head = this->headIndex.load(std::memory_order_relaxed);
                     assert(!details::circular_less_than<index_t>(currentTailIndex, head));
-                    bool full = !details::circular_less_than<index_t>(head, currentTailIndex + BLOCK_SIZE) || (MAX_SUBQUEUE_SIZE != details::const_numeric_max<size_t>::value && (MAX_SUBQUEUE_SIZE == 0 || MAX_SUBQUEUE_SIZE - BLOCK_SIZE < currentTailIndex - head));
+                    bool full = !details::circular_less_than<index_t>(head, currentTailIndex + QUEUE_BLOCK_SIZE) || (MAX_SUBQUEUE_SIZE != details::const_numeric_max<size_t>::value && (MAX_SUBQUEUE_SIZE == 0 || MAX_SUBQUEUE_SIZE - QUEUE_BLOCK_SIZE < currentTailIndex - head));
                     if (pr_blockIndexRaw == nullptr || pr_blockIndexSlotsUsed == pr_blockIndexSize || full) {
                         if (allocMode == CannotAlloc || full || !new_block_index(originalBlockIndexSlotsUsed)) {
                             // Failed to allocate, undo changes (but keep injected blocks)
@@ -2112,12 +2112,12 @@ private:
             currentTailIndex = startTailIndex;
             auto endBlock = this->tailBlock;
             this->tailBlock = startBlock;
-            assert((startTailIndex & static_cast<index_t>(BLOCK_SIZE - 1)) != 0 || firstAllocatedBlock != nullptr || count == 0);
-            if ((startTailIndex & static_cast<index_t>(BLOCK_SIZE - 1)) == 0 && firstAllocatedBlock != nullptr) {
+            assert((startTailIndex & static_cast<index_t>(QUEUE_BLOCK_SIZE - 1)) != 0 || firstAllocatedBlock != nullptr || count == 0);
+            if ((startTailIndex & static_cast<index_t>(QUEUE_BLOCK_SIZE - 1)) == 0 && firstAllocatedBlock != nullptr) {
                 this->tailBlock = firstAllocatedBlock;
             }
             while (true) {
-                auto stopIndex = (currentTailIndex & ~static_cast<index_t>(BLOCK_SIZE - 1)) + static_cast<index_t>(BLOCK_SIZE);
+                auto stopIndex = (currentTailIndex & ~static_cast<index_t>(QUEUE_BLOCK_SIZE - 1)) + static_cast<index_t>(QUEUE_BLOCK_SIZE);
                 if (details::circular_less_than<index_t>(newTailIndex, stopIndex)) {
                     stopIndex = newTailIndex;
                 }
@@ -2154,12 +2154,12 @@ private:
 
                         if (!details::is_trivially_destructible<T>::value) {
                             auto block = startBlock;
-                            if ((startTailIndex & static_cast<index_t>(BLOCK_SIZE - 1)) == 0) {
+                            if ((startTailIndex & static_cast<index_t>(QUEUE_BLOCK_SIZE - 1)) == 0) {
                                 block = firstAllocatedBlock;
                             }
                             currentTailIndex = startTailIndex;
                             while (true) {
-                                stopIndex = (currentTailIndex & ~static_cast<index_t>(BLOCK_SIZE - 1)) + static_cast<index_t>(BLOCK_SIZE);
+                                stopIndex = (currentTailIndex & ~static_cast<index_t>(QUEUE_BLOCK_SIZE - 1)) + static_cast<index_t>(QUEUE_BLOCK_SIZE);
                                 if (details::circular_less_than<index_t>(constructedStopIndex, stopIndex)) {
                                     stopIndex = constructedStopIndex;
                                 }
@@ -2220,15 +2220,15 @@ private:
                     auto localBlockIndexHead = localBlockIndex->front.load(std::memory_order_acquire);
 
                     auto headBase = localBlockIndex->entries[localBlockIndexHead].base;
-                    auto firstBlockBaseIndex = firstIndex & ~static_cast<index_t>(BLOCK_SIZE - 1);
-                    auto offset = static_cast<size_t>(static_cast<typename std::make_signed<index_t>::type>(firstBlockBaseIndex - headBase) / BLOCK_SIZE);
+                    auto firstBlockBaseIndex = firstIndex & ~static_cast<index_t>(QUEUE_BLOCK_SIZE - 1);
+                    auto offset = static_cast<size_t>(static_cast<typename std::make_signed<index_t>::type>(firstBlockBaseIndex - headBase) / QUEUE_BLOCK_SIZE);
                     auto indexIndex = (localBlockIndexHead + offset) & (localBlockIndex->size - 1);
 
                     // Iterate the blocks and dequeue
                     auto index = firstIndex;
                     do {
                         auto firstIndexInBlock = index;
-                        auto endIndex = (index & ~static_cast<index_t>(BLOCK_SIZE - 1)) + static_cast<index_t>(BLOCK_SIZE);
+                        auto endIndex = (index & ~static_cast<index_t>(QUEUE_BLOCK_SIZE - 1)) + static_cast<index_t>(QUEUE_BLOCK_SIZE);
                         endIndex = details::circular_less_than<index_t>(firstIndex + static_cast<index_t>(actualCount), endIndex) ? firstIndex + static_cast<index_t>(actualCount) : endIndex;
                         auto block = localBlockIndex->entries[indexIndex].block;
                         // NOLINTNEXTLINE(bugprone-assignment-in-if-condition)
@@ -2263,7 +2263,7 @@ private:
                                     indexIndex = (indexIndex + 1) & (localBlockIndex->size - 1);
 
                                     firstIndexInBlock = index;
-                                    endIndex = (index & ~static_cast<index_t>(BLOCK_SIZE - 1)) + static_cast<index_t>(BLOCK_SIZE);
+                                    endIndex = (index & ~static_cast<index_t>(QUEUE_BLOCK_SIZE - 1)) + static_cast<index_t>(QUEUE_BLOCK_SIZE);
                                     endIndex = details::circular_less_than<index_t>(firstIndex + static_cast<index_t>(actualCount), endIndex) ? firstIndex + static_cast<index_t>(actualCount) : endIndex;
                                 } while (index != firstIndex + actualCount);
 
@@ -2397,7 +2397,7 @@ private:
             assert(index == tail || details::circular_less_than(index, tail));
             bool forceFreeLastBlock = index != tail;    // If we enter the loop, then the last (tail) block will not be freed
             while (index != tail) {
-                if ((index & static_cast<index_t>(BLOCK_SIZE - 1)) == 0 || block == nullptr) {
+                if ((index & static_cast<index_t>(QUEUE_BLOCK_SIZE - 1)) == 0 || block == nullptr) {
                     if (block != nullptr) {
                         // Free the old block
                         this->parent->add_block_to_free_list(block);
@@ -2412,7 +2412,7 @@ private:
             // Even if the queue is empty, there's still one block that's not on the free list
             // (unless the head index reached the end of it, in which case the tail will be poised
             // to create a new block).
-            if (this->tailBlock != nullptr && (forceFreeLastBlock || (tail & static_cast<index_t>(BLOCK_SIZE - 1)) != 0)) {
+            if (this->tailBlock != nullptr && (forceFreeLastBlock || (tail & static_cast<index_t>(QUEUE_BLOCK_SIZE - 1)) != 0)) {
                 this->parent->add_block_to_free_list(this->tailBlock);
             }
 
@@ -2436,11 +2436,11 @@ private:
         {
             index_t currentTailIndex = this->tailIndex.load(std::memory_order_relaxed);
             index_t newTailIndex = 1 + currentTailIndex;
-            if ((currentTailIndex & static_cast<index_t>(BLOCK_SIZE - 1)) == 0) {
+            if ((currentTailIndex & static_cast<index_t>(QUEUE_BLOCK_SIZE - 1)) == 0) {
                 // We reached the end of a block, start a new one
                 auto head = this->headIndex.load(std::memory_order_relaxed);
                 assert(!details::circular_less_than<index_t>(currentTailIndex, head));
-                if (!details::circular_less_than<index_t>(head, currentTailIndex + BLOCK_SIZE) || (MAX_SUBQUEUE_SIZE != details::const_numeric_max<size_t>::value && (MAX_SUBQUEUE_SIZE == 0 || MAX_SUBQUEUE_SIZE - BLOCK_SIZE < currentTailIndex - head))) {
+                if (!details::circular_less_than<index_t>(head, currentTailIndex + QUEUE_BLOCK_SIZE) || (MAX_SUBQUEUE_SIZE != details::const_numeric_max<size_t>::value && (MAX_SUBQUEUE_SIZE == 0 || MAX_SUBQUEUE_SIZE - QUEUE_BLOCK_SIZE < currentTailIndex - head))) {
                     return false;
                 }
 #if MCDBGQ_NOLOCKFREE_IMPLICITPRODBLOCKINDEX
@@ -2587,15 +2587,15 @@ private:
             auto endBlock = this->tailBlock;
 
             // Figure out how many blocks we'll need to allocate, and do so
-            size_t blockBaseDiff = ((startTailIndex + count - 1) & ~static_cast<index_t>(BLOCK_SIZE - 1)) - ((startTailIndex - 1) & ~static_cast<index_t>(BLOCK_SIZE - 1));
-            index_t currentTailIndex = (startTailIndex - 1) & ~static_cast<index_t>(BLOCK_SIZE - 1);
+            size_t blockBaseDiff = ((startTailIndex + count - 1) & ~static_cast<index_t>(QUEUE_BLOCK_SIZE - 1)) - ((startTailIndex - 1) & ~static_cast<index_t>(QUEUE_BLOCK_SIZE - 1));
+            index_t currentTailIndex = (startTailIndex - 1) & ~static_cast<index_t>(QUEUE_BLOCK_SIZE - 1);
             if (blockBaseDiff > 0) {
 #if MCDBGQ_NOLOCKFREE_IMPLICITPRODBLOCKINDEX
                 debug::DebugLock lock(mutex);
 #endif
                 do {
-                    blockBaseDiff -= static_cast<index_t>(BLOCK_SIZE);
-                    currentTailIndex += static_cast<index_t>(BLOCK_SIZE);
+                    blockBaseDiff -= static_cast<index_t>(QUEUE_BLOCK_SIZE);
+                    currentTailIndex += static_cast<index_t>(QUEUE_BLOCK_SIZE);
 
                     // Find out where we'll be inserting this block in the block index
                     BlockIndexEntry* idxEntry = nullptr;  // initialization here unnecessary but compiler can't always tell
@@ -2603,7 +2603,7 @@ private:
                     bool indexInserted = false;
                     auto head = this->headIndex.load(std::memory_order_relaxed);
                     assert(!details::circular_less_than<index_t>(currentTailIndex, head));
-                    bool full = !details::circular_less_than<index_t>(head, currentTailIndex + BLOCK_SIZE) || (MAX_SUBQUEUE_SIZE != details::const_numeric_max<size_t>::value && (MAX_SUBQUEUE_SIZE == 0 || MAX_SUBQUEUE_SIZE - BLOCK_SIZE < currentTailIndex - head));
+                    bool full = !details::circular_less_than<index_t>(head, currentTailIndex + QUEUE_BLOCK_SIZE) || (MAX_SUBQUEUE_SIZE != details::const_numeric_max<size_t>::value && (MAX_SUBQUEUE_SIZE == 0 || MAX_SUBQUEUE_SIZE - QUEUE_BLOCK_SIZE < currentTailIndex - head));
                     // NOLINTNEXTLINE(bugprone-assignment-in-if-condition)
                     if (full || !(indexInserted = insert_block_index_entry<allocMode>(idxEntry, currentTailIndex)) || (newBlock = this->parent->ConcurrentQueue::template requisition_block<allocMode>()) == nullptr) {
                         // Index allocation or block allocation failed; revert any other allocations
@@ -2612,9 +2612,9 @@ private:
                             rewind_block_index_tail();
                             idxEntry->value.store(nullptr, std::memory_order_relaxed);
                         }
-                        currentTailIndex = (startTailIndex - 1) & ~static_cast<index_t>(BLOCK_SIZE - 1);
+                        currentTailIndex = (startTailIndex - 1) & ~static_cast<index_t>(QUEUE_BLOCK_SIZE - 1);
                         for (auto block = firstAllocatedBlock; block != nullptr; block = block->next) {
-                            currentTailIndex += static_cast<index_t>(BLOCK_SIZE);
+                            currentTailIndex += static_cast<index_t>(QUEUE_BLOCK_SIZE);
                             idxEntry = get_block_index_entry_for_index(currentTailIndex);
                             idxEntry->value.store(nullptr, std::memory_order_relaxed);
                             rewind_block_index_tail();
@@ -2636,7 +2636,7 @@ private:
 
                     // Store the chain of blocks so that we can undo if later allocations fail,
                     // and so that we can find the blocks when we do the actual enqueueing
-                    if ((startTailIndex & static_cast<index_t>(BLOCK_SIZE - 1)) != 0 || firstAllocatedBlock != nullptr) {
+                    if ((startTailIndex & static_cast<index_t>(QUEUE_BLOCK_SIZE - 1)) != 0 || firstAllocatedBlock != nullptr) {
                         assert(this->tailBlock != nullptr);
                         this->tailBlock->next = newBlock;
                     }
@@ -2650,12 +2650,12 @@ private:
             index_t newTailIndex = startTailIndex + static_cast<index_t>(count);
             currentTailIndex = startTailIndex;
             this->tailBlock = startBlock;
-            assert((startTailIndex & static_cast<index_t>(BLOCK_SIZE - 1)) != 0 || firstAllocatedBlock != nullptr || count == 0);
-            if ((startTailIndex & static_cast<index_t>(BLOCK_SIZE - 1)) == 0 && firstAllocatedBlock != nullptr) {
+            assert((startTailIndex & static_cast<index_t>(QUEUE_BLOCK_SIZE - 1)) != 0 || firstAllocatedBlock != nullptr || count == 0);
+            if ((startTailIndex & static_cast<index_t>(QUEUE_BLOCK_SIZE - 1)) == 0 && firstAllocatedBlock != nullptr) {
                 this->tailBlock = firstAllocatedBlock;
             }
             while (true) {
-                auto stopIndex = (currentTailIndex & ~static_cast<index_t>(BLOCK_SIZE - 1)) + static_cast<index_t>(BLOCK_SIZE);
+                auto stopIndex = (currentTailIndex & ~static_cast<index_t>(QUEUE_BLOCK_SIZE - 1)) + static_cast<index_t>(QUEUE_BLOCK_SIZE);
                 if (details::circular_less_than<index_t>(newTailIndex, stopIndex)) {
                     stopIndex = newTailIndex;
                 }
@@ -2678,12 +2678,12 @@ private:
 
                         if (!details::is_trivially_destructible<T>::value) {
                             auto block = startBlock;
-                            if ((startTailIndex & static_cast<index_t>(BLOCK_SIZE - 1)) == 0) {
+                            if ((startTailIndex & static_cast<index_t>(QUEUE_BLOCK_SIZE - 1)) == 0) {
                                 block = firstAllocatedBlock;
                             }
                             currentTailIndex = startTailIndex;
                             while (true) {
-                                stopIndex = (currentTailIndex & ~static_cast<index_t>(BLOCK_SIZE - 1)) + static_cast<index_t>(BLOCK_SIZE);
+                                stopIndex = (currentTailIndex & ~static_cast<index_t>(QUEUE_BLOCK_SIZE - 1)) + static_cast<index_t>(QUEUE_BLOCK_SIZE);
                                 if (details::circular_less_than<index_t>(constructedStopIndex, stopIndex)) {
                                     stopIndex = constructedStopIndex;
                                 }
@@ -2697,9 +2697,9 @@ private:
                             }
                         }
 
-                        currentTailIndex = (startTailIndex - 1) & ~static_cast<index_t>(BLOCK_SIZE - 1);
+                        currentTailIndex = (startTailIndex - 1) & ~static_cast<index_t>(QUEUE_BLOCK_SIZE - 1);
                         for (auto block = firstAllocatedBlock; block != nullptr; block = block->next) {
-                            currentTailIndex += static_cast<index_t>(BLOCK_SIZE);
+                            currentTailIndex += static_cast<index_t>(QUEUE_BLOCK_SIZE);
                             auto idxEntry = get_block_index_entry_for_index(currentTailIndex);
                             idxEntry->value.store(nullptr, std::memory_order_relaxed);
                             rewind_block_index_tail();
@@ -2750,7 +2750,7 @@ private:
                     auto indexIndex = get_block_index_index_for_index(index, localBlockIndex);
                     do {
                         auto blockStartIndex = index;
-                        auto endIndex = (index & ~static_cast<index_t>(BLOCK_SIZE - 1)) + static_cast<index_t>(BLOCK_SIZE);
+                        auto endIndex = (index & ~static_cast<index_t>(QUEUE_BLOCK_SIZE - 1)) + static_cast<index_t>(QUEUE_BLOCK_SIZE);
                         endIndex = details::circular_less_than<index_t>(firstIndex + static_cast<index_t>(actualCount), endIndex) ? firstIndex + static_cast<index_t>(actualCount) : endIndex;
 
                         auto entry = localBlockIndex->index[indexIndex];
@@ -2792,7 +2792,7 @@ private:
                                     indexIndex = (indexIndex + 1) & (localBlockIndex->capacity - 1);
 
                                     blockStartIndex = index;
-                                    endIndex = (index & ~static_cast<index_t>(BLOCK_SIZE - 1)) + static_cast<index_t>(BLOCK_SIZE);
+                                    endIndex = (index & ~static_cast<index_t>(QUEUE_BLOCK_SIZE - 1)) + static_cast<index_t>(QUEUE_BLOCK_SIZE);
                                     endIndex = details::circular_less_than<index_t>(firstIndex + static_cast<index_t>(actualCount), endIndex) ? firstIndex + static_cast<index_t>(actualCount) : endIndex;
                                 } while (index != firstIndex + actualCount);
 
@@ -2890,14 +2890,14 @@ private:
 #if MCDBGQ_NOLOCKFREE_IMPLICITPRODBLOCKINDEX
             debug::DebugLock lock(mutex);
 #endif
-            index &= ~static_cast<index_t>(BLOCK_SIZE - 1);
+            index &= ~static_cast<index_t>(QUEUE_BLOCK_SIZE - 1);
             localBlockIndex = blockIndex.load(std::memory_order_acquire);
             auto tail = localBlockIndex->tail.load(std::memory_order_acquire);
             auto tailBase = localBlockIndex->index[tail]->key.load(std::memory_order_relaxed);
             assert(tailBase != INVALID_BLOCK_BASE);
             // Note: Must use division instead of shift because the index may wrap around, causing a negative
             // offset, whose negativity we want to preserve
-            auto offset = static_cast<size_t>(static_cast<typename std::make_signed<index_t>::type>(index - tailBase) / BLOCK_SIZE);
+            auto offset = static_cast<size_t>(static_cast<typename std::make_signed<index_t>::type>(index - tailBase) / QUEUE_BLOCK_SIZE);
             size_t idx = (tail + offset) & (localBlockIndex->capacity - 1);
             assert(localBlockIndex->index[idx]->key.load(std::memory_order_relaxed) == index && localBlockIndex->index[idx]->value.load(std::memory_order_relaxed) != nullptr);
             return idx;
@@ -3104,7 +3104,7 @@ private:
                                 stats.implicitBlockIndexBytes += sizeof(typename ImplicitProducer::BlockIndexHeader) + hash->capacity * sizeof(typename ImplicitProducer::BlockIndexEntry*);
                             }
                         }
-                        for (; details::circular_less_than<index_t>(head, tail); head += BLOCK_SIZE) {
+                        for (; details::circular_less_than<index_t>(head, tail); head += QUEUE_BLOCK_SIZE) {
                             //auto block = prod->get_block_index_entry_for_index(head);
                             ++stats.usedBlocks;
                         }


### PR DESCRIPTION
@stevenrbrandt This should resolve your issue. This change can also be back-applied to V1.11.0.