### PR TITLE
async_cuda, async_mpi: replace tuple-based keep_alive capture with C+…

### DIFF
--- a/libs/core/async_cuda/include/hpx/async_cuda/transform_stream.hpp
+++ b/libs/core/async_cuda/include/hpx/async_cuda/transform_stream.hpp
@@ -53,7 +53,7 @@ namespace hpx::cuda::experimental {
             if constexpr (sizeof...(Ts) > 0)
             {
                 detail::add_event_callback(
-                    [keep_alive = hpx::make_tuple(HPX_FORWARD(Ts, ts)...)](
+                    [... keep_alive = HPX_FORWARD(Ts, ts)](
                         cudaError_t const status) {
                         HPX_ASSERT(status != cudaErrorNotReady);
                         HPX_UNUSED(status);
@@ -78,8 +78,7 @@ namespace hpx::cuda::experimental {
             cudaStream_t stream, R&& r, Ts&&... ts)
         {
             detail::add_event_callback(
-                [r = HPX_FORWARD(R, r),
-                    keep_alive = hpx::make_tuple(HPX_FORWARD(Ts, ts)...)](
+                [r = HPX_FORWARD(R, r), ... keep_alive = HPX_FORWARD(Ts, ts)](
                     cudaError_t status) mutable {
                     set_value_event_callback_helper(status, HPX_MOVE(r));
                 },
@@ -105,7 +104,7 @@ namespace hpx::cuda::experimental {
         {
             detail::add_event_callback(
                 [t = HPX_FORWARD(T, t), r = HPX_FORWARD(R, r),
-                    keep_alive = hpx::make_tuple(HPX_FORWARD(Ts, ts)...)](
+                    ... keep_alive = HPX_FORWARD(Ts, ts)](
                     cudaError_t status) mutable {
                     set_value_event_callback_helper(
                         status, HPX_MOVE(r), HPX_MOVE(t));

--- a/libs/core/async_mpi/include/hpx/async_mpi/transform_mpi.hpp
+++ b/libs/core/async_mpi/include/hpx/async_mpi/transform_mpi.hpp
@@ -48,8 +48,7 @@ namespace hpx::mpi::experimental {
             MPI_Request request, R&& r, Ts&&... ts)
         {
             detail::add_request_callback(
-                [r = HPX_FORWARD(R, r),
-                    keep_alive = hpx::make_tuple(HPX_FORWARD(Ts, ts)...)](
+                [r = HPX_FORWARD(R, r), ... keep_alive = HPX_FORWARD(Ts, ts)](
                     int status) mutable {
                     set_value_request_callback_helper(status, HPX_MOVE(r));
                 },
@@ -62,8 +61,7 @@ namespace hpx::mpi::experimental {
         {
             detail::add_request_callback(
                 [r = HPX_FORWARD(R, r), res = HPX_FORWARD(InvokeResult, res),
-                    keep_alive = hpx::make_tuple(HPX_FORWARD(Ts, ts)...)](
-                    int status) mutable {
+                    ... keep_alive = HPX_FORWARD(Ts, ts)](int status) mutable {
                     set_value_request_callback_helper(
                         status, HPX_MOVE(r), HPX_MOVE(res));
                 },


### PR DESCRIPTION
## Description

Replace `hpx::make_tuple(HPX_FORWARD(Ts, ts)...)` used for lifetime
extension in lambda captures with direct C++20 pack capture
(`... keep_alive = HPX_FORWARD(Ts, ts)`) in `transform_stream.hpp`
and `transform_mpi.hpp`.

Since HPX now requires C++20, the tuple workaround is no longer
necessary. Semantics are preserved — captured elements still extend
argument lifetimes for async CUDA/MPI callbacks. `keep_alive` is
never invoked in the lambda body; the capture exists purely for
lifetime extension.


## Proposed Changes

- Replace tuple-based pack capture with C++20 pack capture in
  `libs/core/async_cuda/include/hpx/async_cuda/transform_stream.hpp`
  (3 sites: `extend_argument_lifetimes`, `set_value_event_callback_void`,
  `set_value_event_callback_non_void`)
- Replace tuple-based pack capture with C++20 pack capture in
  `libs/core/async_mpi/include/hpx/async_mpi/transform_mpi.hpp`
  (2 sites: `set_value_request_callback_void`,
  `set_value_request_callback_non_void`)

## Any background context you want to provide?

This is a follow-up to #6965, which replaced the same pattern in
`task_group.hpp` and `async_replicate_executor.hpp`. The CUDA and MPI
files were identified by @hkaiser in the review of that PR as
additional candidates for this cleanup.

## Checklist

Not all points below apply to all pull requests.
- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it
      uses a seed, and that random numbers generated are valid inputs
      for the tests.