### PR TITLE
tests: fix self-copy UB in move algorithm tests causing occasional segfault

### DIFF
--- a/libs/core/algorithms/tests/unit/algorithms/move.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/move.cpp
@@ -33,8 +33,8 @@ void test_move(IteratorTag)
     std::iota(std::begin(c), std::end(c), gen());
     hpx::move(iterator(std::begin(c)), iterator(std::end(c)), std::begin(d));
 
-    //copy contents of d back into c for testing
-    std::copy(std::begin(d), std::end(d), std::begin(d));
+    // copy contents of d back into c for testing
+    std::copy(std::begin(d), std::end(d), std::begin(c));
 
     std::size_t count = 0;
     HPX_TEST(std::equal(std::begin(c), std::end(c), std::begin(d),
@@ -61,8 +61,8 @@ void test_move(ExPolicy policy, IteratorTag)
     hpx::move(
         policy, iterator(std::begin(c)), iterator(std::end(c)), std::begin(d));
 
-    //copy contents of d back into c for testing
-    std::copy(std::begin(d), std::end(d), std::begin(d));
+    // copy contents of d back into c for testing
+    std::copy(std::begin(d), std::end(d), std::begin(c));
 
     std::size_t count = 0;
     HPX_TEST(std::equal(std::begin(c), std::end(c), std::begin(d),

--- a/libs/core/algorithms/tests/unit/algorithms/move_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/move_sender.cpp
@@ -46,8 +46,8 @@ void test_move_sender(LnPolicy ln_policy, ExPolicy&& ex_policy, IteratorTag)
                       std::begin(d)) |
         hpx::move(ex_policy.on(exec)));
 
-    //copy contents of d back into c for testing
-    std::copy(std::begin(d), std::end(d), std::begin(d));
+    // copy contents of d back into c for testing
+    std::copy(std::begin(d), std::end(d), std::begin(c));
 
     std::size_t count = 0;
     HPX_TEST(std::equal(std::begin(c), std::end(c), std::begin(d),

--- a/libs/core/algorithms/tests/unit/container_algorithms/move_range.cpp
+++ b/libs/core/algorithms/tests/unit/container_algorithms/move_range.cpp
@@ -32,8 +32,8 @@ void test_move(IteratorTag)
     std::iota(std::begin(c), std::end(c), std::rand());
     hpx::ranges::move(c, std::begin(d));
 
-    //copy contents of d back into c for testing
-    std::copy(std::begin(d), std::end(d), std::begin(d));
+    // copy contents of d back into c for testing
+    std::copy(std::begin(d), std::end(d), std::begin(c));
 
     std::size_t count = 0;
     HPX_TEST(std::equal(std::begin(c), std::end(c), std::begin(d),
@@ -60,8 +60,8 @@ void test_move(ExPolicy policy, IteratorTag)
     std::iota(std::begin(c), std::end(c), std::rand());
     hpx::ranges::move(policy, c, std::begin(d));
 
-    //copy contents of d back into c for testing
-    std::copy(std::begin(d), std::end(d), std::begin(d));
+    // copy contents of d back into c for testing
+    std::copy(std::begin(d), std::end(d), std::begin(c));
 
     std::size_t count = 0;
     HPX_TEST(std::equal(std::begin(c), std::end(c), std::begin(d),


### PR DESCRIPTION
Fixes #6975

## Problem

The move algorithm tests contained a self-copy undefined behavior:
```cpp
//copy contents of d back into c for testing
std::copy(std::begin(d), std::end(d), std::begin(d));  // d into d, not c
```

The comment says "copy d back into **c**" but the destination is
`std::begin(d)`. This is undefined behavior — `std::copy` does not
permit the destination to overlap with the source range.

Under gcc-13 release builds, the compiler lowers `std::copy` on
trivially copyable types to `memcpy` (which forbids overlap), producing
the observed segfault with seed `1772660164` and `--hpx:threads=4`.

The async variants also copied `d` into `c` then checked `c == d` —
tautological since `c` was just set equal to `d`. Stale lambda
captures `[&d, &c]` are cleaned up as well.

All `hpx::copy` test files were checked and are not affected.

## Files Changed
- `libs/core/algorithms/tests/unit/algorithms/move.cpp`
- `libs/core/algorithms/tests/unit/algorithms/move_sender.cpp`
- `libs/core/algorithms/tests/unit/container_algorithms/move_range.cpp`