### PR TITLE
tests: fix RNG seeding in several sender tests

### DIFF
--- a/libs/core/algorithms/tests/unit/algorithms/destroyn_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/destroyn_sender.cpp
@@ -103,7 +103,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
         seed = vm["seed"].as<unsigned int>();
 
     std::cout << "using seed: " << seed << std::endl;
-    std::srand(seed);
+    gen.seed(seed);
 
     destroy_n_sender_test<std::forward_iterator_tag>();
     destroy_n_sender_test<std::random_access_iterator_tag>();

--- a/libs/core/algorithms/tests/unit/algorithms/includes_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/includes_sender.cpp
@@ -298,7 +298,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
         seed = vm["seed"].as<unsigned int>();
 
     std::cout << "using seed: " << seed << std::endl;
-    std::srand(seed);
+    gen.seed(seed);
 
     includes_sender_test1<std::forward_iterator_tag>();
     includes_sender_test1<std::random_access_iterator_tag>();

--- a/libs/core/algorithms/tests/unit/algorithms/is_partitioned_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/is_partitioned_sender.cpp
@@ -104,7 +104,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
         seed = vm["seed"].as<unsigned int>();
 
     std::cout << "using seed: " << seed << std::endl;
-    std::srand(seed);
+    gen.seed(seed);
 
     is_partitioned_sender_test<std::forward_iterator_tag>();
     is_partitioned_sender_test<std::random_access_iterator_tag>();

--- a/libs/core/algorithms/tests/unit/algorithms/is_sorted_until_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/is_sorted_until_sender.cpp
@@ -96,7 +96,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
         seed = vm["seed"].as<unsigned int>();
 
     std::cout << "using seed: " << seed << std::endl;
-    std::srand(seed);
+    gen.seed(seed);
 
     is_sorted_until_sender_test<std::forward_iterator_tag>();
     is_sorted_until_sender_test<std::random_access_iterator_tag>();

--- a/libs/core/algorithms/tests/unit/algorithms/lexicographical_compare_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/lexicographical_compare_sender.cpp
@@ -117,7 +117,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
         seed = vm["seed"].as<unsigned int>();
 
     std::cout << "using seed: " << seed << std::endl;
-    std::srand(seed);
+    gen.seed(seed);
 
     lexicographical_compare_sender_test<std::forward_iterator_tag>();
     lexicographical_compare_sender_test<std::random_access_iterator_tag>();

--- a/libs/core/algorithms/tests/unit/algorithms/move_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/move_sender.cpp
@@ -77,7 +77,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
         seed = vm["seed"].as<unsigned int>();
 
     std::cout << "using seed: " << seed << std::endl;
-    std::srand(seed);
+    gen.seed(seed);
 
     move_sender_test<std::forward_iterator_tag>();
     move_sender_test<std::random_access_iterator_tag>();

--- a/libs/core/algorithms/tests/unit/algorithms/starts_with_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/starts_with_sender.cpp
@@ -97,7 +97,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
         seed = vm["seed"].as<unsigned int>();
 
     std::cout << "using seed: " << seed << std::endl;
-    std::srand(seed);
+    gen.seed(seed);
 
     starts_with_sender_test<std::forward_iterator_tag>();
     starts_with_sender_test<std::random_access_iterator_tag>();


### PR DESCRIPTION
Some sender tests accepted the --seed flag and printed it, but used std::srand(seed) instead of seeding the global std::mt19937 generator. This meant test failures could not be reproduced using the reported seed.

Replace std::srand(seed) with gen.seed(seed) to correctly seed the generator, following the pattern already used in other sender tests.

Fixes #7000

