### PR TITLE
Fix inaccurate comments in 1d_stencil_5 example

### DIFF
--- a/examples/1d_stencil/1d_stencil_5.cpp
+++ b/examples/1d_stencil/1d_stencil_5.cpp
@@ -94,7 +94,7 @@ public:
 
 private:
     // Serialization support: even if all of the code below runs on one
-    // locality only, we need to provide an (empty) implementation for the
+    // locality only, we need to provide an implementation for the
     // serialization as all arguments passed to actions have to support this.
     friend class hpx::serialization::access;
 
@@ -279,10 +279,10 @@ struct stepper
     space do_work(std::size_t np, std::size_t nx, std::size_t nt);
 };
 
-// Global functions can be exposed as actions as well. That allows to invoke
+// Static member functions can be exposed as actions as well. That allows to invoke
 // those remotely. The macro HPX_PLAIN_ACTION() defines a new action type
-// 'heat_part_action' which wraps the global function heat_part(). It can be
-// used to call that function on a given locality.
+// 'heat_part_action' which wraps the static member function
+// stepper::heat_part(). It can be used to call that function on a given locality.
 HPX_PLAIN_ACTION(stepper::heat_part, heat_part_action)
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
This updates two comments in examples/1d_stencil/1d_stencil_5.cpp.

First, the serialization comment referred to an "empty" implementation, but partition_data currently provides real save/load serialization logic.

Second, the action comment referred to heat_part as a global function, but it is actually a static member function of stepper.

No behaviour change.
