### PR TITLE
Add segmented replace & replace_if

### DIFF
--- a/libs/full/include/include/hpx/include/parallel_replace.hpp
+++ b/libs/full/include/include/hpx/include/parallel_replace.hpp
@@ -8,3 +8,4 @@
 #pragma once
 
 #include <hpx/modules/algorithms.hpp>
+#include <hpx/parallel/segmented_algorithms/replace.hpp>

--- a/libs/full/segmented_algorithms/CMakeLists.txt
+++ b/libs/full/segmented_algorithms/CMakeLists.txt
@@ -26,6 +26,7 @@ set(segmented_algorithms_headers
     hpx/parallel/segmented_algorithms/generate.hpp
     hpx/parallel/segmented_algorithms/inclusive_scan.hpp
     hpx/parallel/segmented_algorithms/minmax.hpp
+    hpx/parallel/segmented_algorithms/replace.hpp
     hpx/parallel/segmented_algorithms/reduce.hpp
     hpx/parallel/segmented_algorithms/traits/zip_iterator.hpp
     hpx/parallel/segmented_algorithms/transform_exclusive_scan.hpp

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithm.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithm.hpp
@@ -21,6 +21,7 @@
 #include <hpx/parallel/segmented_algorithms/inclusive_scan.hpp>
 #include <hpx/parallel/segmented_algorithms/minmax.hpp>
 #include <hpx/parallel/segmented_algorithms/reduce.hpp>
+#include <hpx/parallel/segmented_algorithms/replace.hpp>
 #include <hpx/parallel/segmented_algorithms/transform.hpp>
 #include <hpx/parallel/segmented_algorithms/transform_exclusive_scan.hpp>
 #include <hpx/parallel/segmented_algorithms/transform_inclusive_scan.hpp>

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/replace.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/replace.hpp
@@ -1,0 +1,228 @@
+//  Copyright (c) 2026 Mo'men Samir
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/modules/algorithms.hpp>
+#include <hpx/modules/executors.hpp>
+#include <hpx/modules/type_support.hpp>
+#include <hpx/parallel/segmented_algorithms/for_each.hpp>
+
+#include <algorithm>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace hpx::parallel {
+
+    ///////////////////////////////////////////////////////////////////////////
+    // segmented_replace, segmented_replace_if
+    namespace detail {
+
+        ///////////////////////////////////////////////////////////////////////
+        /// \cond NOINTERNAL
+
+        template <typename T>
+        struct replace_function
+        {
+            replace_function(T old_value = T(), T new_value = T())
+              : old_value_(old_value)
+              , new_value_(new_value)
+            {
+            }
+
+            T old_value_;
+            T new_value_;
+
+            void operator()(T& value) const
+            {
+                if (value == old_value_)
+                {
+                    value = new_value_;
+                }
+            }
+
+            template <typename Archive>
+            void serialize(Archive& ar, unsigned int /* version */)
+            {
+                // clang-format off
+                ar & old_value_ & new_value_;
+                // clang-format on
+            }
+        };
+
+        template <typename Pred, typename T>
+        struct replace_if_function
+        {
+            replace_if_function(Pred pred = Pred(), T new_value = T())
+              : pred_(HPX_MOVE(pred))
+              , new_value_(new_value)
+            {
+            }
+
+            Pred pred_;
+            T new_value_;
+
+            void operator()(T& value) const
+            {
+                if (HPX_INVOKE(pred_, value))
+                {
+                    value = new_value_;
+                }
+            }
+
+            template <typename Archive>
+            void serialize(Archive& ar, unsigned int /* version */)
+            {
+                // clang-format off
+                ar & pred_ & new_value_;
+                // clang-format on
+            }
+        };
+
+        /// \endcond
+    }    // namespace detail
+}    // namespace hpx::parallel
+
+namespace hpx::segmented {
+
+    ///////////////////////////////////////////////////////////////////////////
+    // hpx::replace
+
+    template <typename SegIter,
+        typename T = typename std::iterator_traits<SegIter>::value_type>
+        requires(hpx::traits::is_iterator_v<SegIter> &&
+            hpx::traits::is_segmented_iterator_v<SegIter>)
+    void tag_invoke(hpx::replace_t, SegIter first, SegIter last,
+        T const& old_value, T const& new_value)
+    {
+        static_assert(std::forward_iterator<SegIter>,
+            "Requires at least forward iterator.");
+
+        if (first == last)
+        {
+            return;
+        }
+
+        using iterator_traits = hpx::traits::segmented_iterator_traits<SegIter>;
+        using value_type = typename std::iterator_traits<SegIter>::value_type;
+
+        hpx::parallel::detail::segmented_for_each(
+            hpx::parallel::detail::for_each<
+                typename iterator_traits::local_iterator>(),
+            hpx::execution::seq, first, last,
+            hpx::parallel::detail::replace_function<value_type>(
+                old_value, new_value),
+            hpx::identity_v, std::true_type{});
+    }
+
+    template <typename ExPolicy, typename SegIter,
+        typename T = typename std::iterator_traits<SegIter>::value_type>
+        requires(hpx::is_execution_policy_v<ExPolicy> &&
+            hpx::traits::is_iterator_v<SegIter> &&
+            hpx::traits::is_segmented_iterator_v<SegIter>)
+    typename parallel::util::detail::algorithm_result<ExPolicy, void>::type
+    tag_invoke(hpx::replace_t, ExPolicy&& policy, SegIter first, SegIter last,
+        T const& old_value, T const& new_value)
+    {
+        static_assert(std::forward_iterator<SegIter>,
+            "Requires at least forward iterator.");
+
+        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
+        using result =
+            hpx::parallel::util::detail::algorithm_result<ExPolicy, void>;
+        using result_type = typename result::type;
+
+        if (first == last)
+        {
+            return result::get();
+        }
+
+        using iterator_traits = hpx::traits::segmented_iterator_traits<SegIter>;
+        using value_type = typename std::iterator_traits<SegIter>::value_type;
+
+        return hpx::util::void_guard<result_type>(),
+               hpx::parallel::detail::segmented_for_each(
+                   hpx::parallel::detail::for_each<
+                       typename iterator_traits::local_iterator>(),
+                   HPX_FORWARD(ExPolicy, policy), first, last,
+                   hpx::parallel::detail::replace_function<value_type>(
+                       old_value, new_value),
+                   hpx::identity_v, is_seq());
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // hpx::replace_if
+
+    template <typename SegIter, typename Pred,
+        typename T = typename std::iterator_traits<SegIter>::value_type>
+        requires(hpx::traits::is_iterator_v<SegIter> &&
+            hpx::traits::is_segmented_iterator_v<SegIter> &&
+            hpx::is_invocable_v<Pred,
+                typename std::iterator_traits<SegIter>::value_type>)
+    void tag_invoke(hpx::replace_if_t, SegIter first, SegIter last, Pred pred,
+        T const& new_value)
+    {
+        static_assert(std::forward_iterator<SegIter>,
+            "Requires at least forward iterator.");
+
+        if (first == last)
+        {
+            return;
+        }
+
+        using iterator_traits = hpx::traits::segmented_iterator_traits<SegIter>;
+        using value_type = typename std::iterator_traits<SegIter>::value_type;
+
+        hpx::parallel::detail::segmented_for_each(
+            hpx::parallel::detail::for_each<
+                typename iterator_traits::local_iterator>(),
+            hpx::execution::seq, first, last,
+            hpx::parallel::detail::replace_if_function<Pred, value_type>(
+                HPX_MOVE(pred), new_value),
+            hpx::identity_v, std::true_type{});
+    }
+
+    template <typename ExPolicy, typename SegIter, typename Pred,
+        typename T = typename std::iterator_traits<SegIter>::value_type>
+        requires(hpx::is_execution_policy_v<ExPolicy> &&
+            hpx::traits::is_iterator_v<SegIter> &&
+            hpx::traits::is_segmented_iterator_v<SegIter> &&
+            hpx::is_invocable_v<Pred,
+                typename std::iterator_traits<SegIter>::value_type>)
+    typename parallel::util::detail::algorithm_result<ExPolicy, void>::type
+    tag_invoke(hpx::replace_if_t, ExPolicy&& policy, SegIter first,
+        SegIter last, Pred pred, T const& new_value)
+    {
+        static_assert(std::forward_iterator<SegIter>,
+            "Requires at least forward iterator.");
+
+        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
+        using result =
+            hpx::parallel::util::detail::algorithm_result<ExPolicy, void>;
+        using result_type = typename result::type;
+
+        if (first == last)
+        {
+            return result::get();
+        }
+
+        using iterator_traits = hpx::traits::segmented_iterator_traits<SegIter>;
+        using value_type = typename std::iterator_traits<SegIter>::value_type;
+
+        return hpx::util::void_guard<result_type>(),
+               hpx::parallel::detail::segmented_for_each(
+                   hpx::parallel::detail::for_each<
+                       typename iterator_traits::local_iterator>(),
+                   HPX_FORWARD(ExPolicy, policy), first, last,
+                   hpx::parallel::detail::replace_if_function<Pred, value_type>(
+                       HPX_MOVE(pred), new_value),
+                   hpx::identity_v, is_seq());
+    }
+
+}    // namespace hpx::segmented

--- a/libs/full/segmented_algorithms/tests/unit/CMakeLists.txt
+++ b/libs/full/segmented_algorithms/tests/unit/CMakeLists.txt
@@ -50,6 +50,8 @@ set(tests
     partitioned_vector_transform_scan
     partitioned_vector_transform_scan2
     partitioned_vector_reduce
+    partitioned_vector_replace
+    partitioned_vector_replace_if
 )
 
 set(partitioned_vector_inclusive_scan_PARAMETERS RUN_SERIAL)

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_replace.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_replace.cpp
@@ -1,0 +1,149 @@
+//  Copyright (c) 2026 Mo'men Samir
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/parallel_replace.hpp>
+#include <hpx/include/partitioned_vector_predef.hpp>
+#include <hpx/include/runtime.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <cstddef>
+#include <vector>
+
+template <typename T>
+void initialize(hpx::partitioned_vector<T>& v)
+{
+    std::size_t index = 0;
+
+    typename hpx::partitioned_vector<T>::iterator end = v.end();
+    for (typename hpx::partitioned_vector<T>::iterator it = v.begin();
+        it != end; ++it, ++index)
+    {
+        *it = T(index % 5);
+    }
+}
+
+template <typename T>
+void verify_replace(hpx::partitioned_vector<T> const& v, std::size_t first,
+    std::size_t last, T const& old_value, T const& new_value)
+{
+    std::size_t index = 0;
+
+    typename hpx::partitioned_vector<T>::const_iterator end = v.end();
+    for (typename hpx::partitioned_vector<T>::const_iterator it = v.begin();
+        it != end; ++it, ++index)
+    {
+        T expected = T(index % 5);
+        if (index >= first && index < last && expected == old_value)
+        {
+            expected = new_value;
+        }
+        HPX_TEST_EQ(*it, expected);
+    }
+}
+
+template <typename T, typename ExPolicy>
+void replace_empty_range_test(ExPolicy const& replace_policy)
+{
+    hpx::partitioned_vector<T> c(10, hpx::container_layout);
+    initialize(c);
+
+    hpx::replace(replace_policy, c.begin(), c.begin(), T(2), T(9));
+    verify_replace(c, 0, 0, T(2), T(9));
+}
+
+template <typename T, typename ExPolicy>
+void replace_single_element_test(ExPolicy const& replace_policy)
+{
+    hpx::partitioned_vector<T> c(1, hpx::container_layout);
+
+    c[0] = T(2);
+    hpx::replace(replace_policy, c.begin(), c.end(), T(2), T(9));
+    HPX_TEST_EQ(c[0], T(9));
+
+    c[0] = T(4);
+    hpx::replace(replace_policy, c.begin(), c.end(), T(2), T(9));
+    HPX_TEST_EQ(c[0], T(4));
+}
+
+template <typename T, typename DistPolicy, typename ExPolicy>
+void replace_tests_with_policy(
+    std::size_t size, DistPolicy const& policy, ExPolicy const& replace_policy)
+{
+    hpx::partitioned_vector<T> c(size, policy);
+
+    initialize(c);
+    hpx::replace(replace_policy, c.begin(), c.end(), T(2), T(9));
+    verify_replace(c, 0, size, T(2), T(9));
+
+    initialize(c);
+    hpx::replace(replace_policy, c.begin() + 1, c.end() - 1, T(3), T(7));
+    verify_replace(c, 1, size - 1, T(3), T(7));
+}
+
+template <typename T, typename DistPolicy, typename ExPolicy>
+void replace_tests_with_policy_async(
+    std::size_t size, DistPolicy const& policy, ExPolicy const& replace_policy)
+{
+    hpx::partitioned_vector<T> c(size, policy);
+
+    initialize(c);
+    hpx::future<void> f =
+        hpx::replace(replace_policy, c.begin(), c.end(), T(2), T(9));
+    f.wait();
+    verify_replace(c, 0, size, T(2), T(9));
+
+    initialize(c);
+    hpx::future<void> f1 =
+        hpx::replace(replace_policy, c.begin() + 1, c.end() - 1, T(3), T(7));
+    f1.wait();
+    verify_replace(c, 1, size - 1, T(3), T(7));
+}
+
+template <typename T, typename DistPolicy>
+void test_replace_with_policy(
+    std::size_t size, std::size_t /* localities */, DistPolicy const& policy)
+{
+    using namespace hpx::execution;
+
+    replace_tests_with_policy<T>(size, policy, seq);
+    replace_tests_with_policy<T>(size, policy, par);
+
+    replace_tests_with_policy_async<T>(size, policy, seq(task));
+    replace_tests_with_policy_async<T>(size, policy, par(task));
+}
+
+template <typename T>
+void replace_tests()
+{
+    std::size_t const length = 30;
+    std::vector<hpx::id_type> localities = hpx::find_all_localities();
+
+    test_replace_with_policy<T>(length, 1, hpx::container_layout);
+    test_replace_with_policy<T>(length, 3, hpx::container_layout(3));
+    test_replace_with_policy<T>(
+        length, 3, hpx::container_layout(3, localities));
+    test_replace_with_policy<T>(
+        length, localities.size(), hpx::container_layout(localities));
+
+    using namespace hpx::execution;
+    replace_empty_range_test<T>(seq);
+    replace_empty_range_test<T>(par);
+
+    replace_single_element_test<T>(seq);
+    replace_single_element_test<T>(par);
+}
+
+int main()
+{
+    replace_tests<double>();
+    replace_tests<int>();
+
+    return hpx::util::report_errors();
+}
+#endif

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_replace_if.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_replace_if.cpp
@@ -1,0 +1,169 @@
+//  Copyright (c) 2026 Mo'men Samir
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/parallel_replace.hpp>
+#include <hpx/include/partitioned_vector_predef.hpp>
+#include <hpx/include/runtime.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <cstddef>
+#include <vector>
+
+template <typename T>
+void initialize(hpx::partitioned_vector<T>& v)
+{
+    std::size_t index = 0;
+
+    typename hpx::partitioned_vector<T>::iterator end = v.end();
+    for (typename hpx::partitioned_vector<T>::iterator it = v.begin();
+        it != end; ++it, ++index)
+    {
+        *it = T(index % 5);
+    }
+}
+
+template <typename T>
+struct less_than_three
+{
+    bool operator()(T const& value) const
+    {
+        return value < T(3);
+    }
+
+    template <typename Archive>
+    void serialize(Archive& ar, unsigned int /* version */)
+    {
+        (void) ar;
+    }
+};
+
+template <typename T>
+void verify_replace_if(hpx::partitioned_vector<T> const& v, std::size_t first,
+    std::size_t last, T const& new_value)
+{
+    std::size_t index = 0;
+
+    typename hpx::partitioned_vector<T>::const_iterator end = v.end();
+    for (typename hpx::partitioned_vector<T>::const_iterator it = v.begin();
+        it != end; ++it, ++index)
+    {
+        T expected = T(index % 5);
+        if (index >= first && index < last && expected < T(3))
+        {
+            expected = new_value;
+        }
+        HPX_TEST_EQ(*it, expected);
+    }
+}
+
+template <typename T, typename ExPolicy>
+void replace_if_empty_range_test(ExPolicy const& replace_policy)
+{
+    hpx::partitioned_vector<T> c(10, hpx::container_layout);
+    initialize(c);
+
+    hpx::replace_if(
+        replace_policy, c.begin(), c.begin(), less_than_three<T>(), T(8));
+    verify_replace_if(c, 0, 0, T(8));
+}
+
+template <typename T, typename ExPolicy>
+void replace_if_single_element_test(ExPolicy const& replace_policy)
+{
+    hpx::partitioned_vector<T> c(1, hpx::container_layout);
+
+    c[0] = T(1);
+    hpx::replace_if(
+        replace_policy, c.begin(), c.end(), less_than_three<T>(), T(8));
+    HPX_TEST_EQ(c[0], T(8));
+
+    c[0] = T(4);
+    hpx::replace_if(
+        replace_policy, c.begin(), c.end(), less_than_three<T>(), T(8));
+    HPX_TEST_EQ(c[0], T(4));
+}
+
+template <typename T, typename DistPolicy, typename ExPolicy>
+void replace_if_tests_with_policy(
+    std::size_t size, DistPolicy const& policy, ExPolicy const& replace_policy)
+{
+    hpx::partitioned_vector<T> c(size, policy);
+
+    initialize(c);
+    hpx::replace_if(
+        replace_policy, c.begin(), c.end(), less_than_three<T>(), T(8));
+    verify_replace_if(c, 0, size, T(8));
+
+    initialize(c);
+    hpx::replace_if(
+        replace_policy, c.begin() + 2, c.end() - 2, less_than_three<T>(), T(6));
+    verify_replace_if(c, 2, size - 2, T(6));
+}
+
+template <typename T, typename DistPolicy, typename ExPolicy>
+void replace_if_tests_with_policy_async(
+    std::size_t size, DistPolicy const& policy, ExPolicy const& replace_policy)
+{
+    hpx::partitioned_vector<T> c(size, policy);
+
+    initialize(c);
+    hpx::future<void> f2 = hpx::replace_if(
+        replace_policy, c.begin(), c.end(), less_than_three<T>(), T(8));
+    f2.wait();
+    verify_replace_if(c, 0, size, T(8));
+
+    initialize(c);
+    hpx::future<void> f3 = hpx::replace_if(
+        replace_policy, c.begin() + 2, c.end() - 2, less_than_three<T>(), T(6));
+    f3.wait();
+    verify_replace_if(c, 2, size - 2, T(6));
+}
+
+template <typename T, typename DistPolicy>
+void test_replace_if_with_policy(
+    std::size_t size, std::size_t /* localities */, DistPolicy const& policy)
+{
+    using namespace hpx::execution;
+
+    replace_if_tests_with_policy<T>(size, policy, seq);
+    replace_if_tests_with_policy<T>(size, policy, par);
+
+    replace_if_tests_with_policy_async<T>(size, policy, seq(task));
+    replace_if_tests_with_policy_async<T>(size, policy, par(task));
+}
+
+template <typename T>
+void replace_if_tests()
+{
+    std::size_t const length = 30;
+    std::vector<hpx::id_type> localities = hpx::find_all_localities();
+
+    test_replace_if_with_policy<T>(length, 1, hpx::container_layout);
+    test_replace_if_with_policy<T>(length, 3, hpx::container_layout(3));
+    test_replace_if_with_policy<T>(
+        length, 3, hpx::container_layout(3, localities));
+    test_replace_if_with_policy<T>(
+        length, localities.size(), hpx::container_layout(localities));
+
+    using namespace hpx::execution;
+    replace_if_empty_range_test<T>(seq);
+    replace_if_empty_range_test<T>(par);
+
+    replace_if_single_element_test<T>(seq);
+    replace_if_single_element_test<T>(par);
+}
+
+int main()
+{
+    replace_if_tests<double>();
+    replace_if_tests<int>();
+
+    return hpx::util::report_errors();
+}
+#endif


### PR DESCRIPTION
Partially Fixes #1338 

## Proposed Changes

  - Add segmented version of `replace`, `replace_if` that uses `segmented_for_each` internally.
 

## Any background context you want to provide?

## Checklist

Not all points below apply to all pull requests.

- [x] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
