### PR TITLE
use optimised image for reflection ci

### DIFF
--- a/.github/workflows/linux_release_clang_p2996_reflection.yml
+++ b/.github/workflows/linux_release_clang_p2996_reflection.yml
@@ -11,7 +11,7 @@ on: [pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: sleepingeight/clang-cpp-refl:latest
+    container: stellargroup/clang_p2996_build_env:1
 
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
Optimised the docker image being used for reflection CI.

```
IMAGE                                                                                  ID             DISK USAGE   CONTENT SIZE   EXTRA
sleepingeight/clang-cpp-refl:latest                                                    f30c6fec6572       8.88GB         2.12GB    U   
ujjwalshekhar2503/hpx-clang-ci:latest                                                  ed5431cfd199       45.6GB         11.4GB    U   
```

(I think that the previous docker image was not deleting left over build files causing the bloat)