### PR TITLE
Fix incorrect Doxygen for hpx::search_n: "last" -> "first" subsequence

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/algorithms/search.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/search.hpp
@@ -252,7 +252,7 @@ namespace hpx {
     ///
     /// \returns  The \a search_n algorithm returns \a FwdIter.
     ///           The \a search_n algorithm returns an iterator to the beginning of
-    ///           the last subsequence [s_first, s_last) in range [first, first+count).
+    ///           the first subsequence [s_first, s_last) in range [first, first+count).
     ///           If the length of the subsequence [s_first, s_last) is greater
     ///           than the length of the range [first, first+count),
     ///           \a first is returned.
@@ -327,7 +327,7 @@ namespace hpx {
     ///           execution policy is of type \a task_execution_policy and
     ///           returns \a FwdIter otherwise.
     ///           The \a search_n algorithm returns an iterator to the beginning of
-    ///           the last subsequence [s_first, s_last) in range [first, first+count).
+    ///           the first subsequence [s_first, s_last) in range [first, first+count).
     ///           If the length of the subsequence [s_first, s_last) is greater
     ///           than the length of the range [first, first+count),
     ///           \a first is returned.


### PR DESCRIPTION
While reading through the `search.hpp` docs I noticed the `\returns` section for `hpx::search_n` says it returns an iterator to the beginning of the **last** subsequence - but that's actually how `find_end` works, not `search_n`. `search_n` (like `std::search_n`) returns the **first** match.

Looks like the wording got copy-pasted from `find_end`'s docs at some point. This is just a two-word comment fix, no code changes at all.

**Changed:** `search.hpp` - two instances of `"last"` -> `"first"` in the `\returns` Doxygen comment for both overloads of `search_n`.