### PR TITLE
Fix heap corruption and out-of-bounds access in sort_thread partitioning

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/algorithms/sort.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/sort.hpp
@@ -211,17 +211,17 @@ namespace hpx::parallel {
             // pivot selections
             pivot9(first, last, comp);
 
-            using reference =
-                typename std::iterator_traits<RandomIt>::reference;
+            using value_type =
+                typename std::iterator_traits<RandomIt>::value_type;
 
-            reference val = *first;
+            value_type val = *first;
             RandomIt c_first = first + 1, c_last = last - 1;
 
-            while (comp(*c_first, val))
+            while (c_first < last && comp(*c_first, val))
             {
                 ++c_first;
             }
-            while (comp(val, *c_last))
+            while (c_last > first && comp(val, *c_last))
             {
                 --c_last;
             }
@@ -232,11 +232,11 @@ namespace hpx::parallel {
 #else
                 std::iter_swap(c_first++, c_last--);
 #endif
-                while (comp(*c_first, val))
+                while (c_first < last && comp(*c_first, val))
                 {
                     ++c_first;
                 }
-                while (comp(val, *c_last))
+                while (c_last > first && comp(val, *c_last))
                 {
                     --c_last;
                 }


### PR DESCRIPTION
Fixes #6974

Two bugs in the quicksort partitioning loop inside sort_thread():

1. Pivot stored as reference instead of value_type: 'reference val = *first' silently changes after iter_swap(first, c_last) executes, corrupting all subsequent comparisons and potentially producing overlapping recursive sub-ranges that write to the same heap memory.

   Fix: use value_type val = *first to take a stable copy of the pivot.

2. Unbounded while-loops during partitioning: the four scanning loops had no bounds checks, relying solely on the pivot value as a sentinel. When duplicate elements cause the pivot to appear multiple times (or not at all in a sub-range), c_first can advance past 'last' or c_last can decrement before 'first', causing out-of-bounds reads and writes that corrupt heap metadata.

   Fix: add bounds guards (c_first < last, c_last > first) to all four scanning loops.

Together these produce the 'malloc_consolidate(): unaligned fastbin chunk detected' heap corruption followed by SIGSEGV (exit 139) observed on the sort_range_test with parallel_task_policy and float/std::greater<float>.
