### PR TITLE
fix: validate thread_schedule_hint.hint bounds in shared_priority_queue_scheduler

### DIFF
--- a/libs/core/schedulers/include/hpx/schedulers/shared_priority_queue_scheduler.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/shared_priority_queue_scheduler.hpp
@@ -368,9 +368,10 @@ namespace hpx::threads::policies {
             case thread_schedule_hint_mode::thread:
             {
                 spq_deb.set(msg, "HINT_THREAD");
-                // @TODO. We should check that the thread num is valid
                 // Create thread on requested worker thread
-                thread_num = select_active_pu(data.schedulehint.hint);
+                thread_num = select_active_pu(
+                    fast_mod(static_cast<std::size_t>(data.schedulehint.hint),
+                        num_workers_));
                 domain_num = d_lookup_[thread_num];
                 q_index = q_lookup_[thread_num];
                 break;
@@ -775,13 +776,13 @@ namespace hpx::threads::policies {
             }
             case thread_schedule_hint_mode::thread:
             {
-                // @TODO. We should check that the thread num is valid
-                // Create thread on requested worker thread
                 spq_deb.set(msg, "HINT_THREAD");
                 spq_deb.debug(debug::str<>("schedule_thread"),
                     "received HINT_THREAD", debug::dec<3>(schedulehint.hint));
-                thread_num =
-                    select_active_pu(schedulehint.hint, allow_fallback);
+                thread_num = select_active_pu(
+                    fast_mod(static_cast<std::size_t>(schedulehint.hint),
+                        num_workers_),
+                    allow_fallback);
                 domain_num = d_lookup_[thread_num];
                 q_index = q_lookup_[thread_num];
                 break;


### PR DESCRIPTION
Add bounds normalization for thread_schedule_hint_mode::thread path in
create_thread() and schedule_thread() using fast_mod against num_workers_,
consistent with the existing numa hint normalization.

Fixes #6982

## Proposed Changes
- Add `fast_mod(hint, num_workers_)` normalization in `create_thread()` for `thread_schedule_hint_mode::thread` path
- Add `fast_mod(hint, num_workers_)` normalization in `schedule_thread()` for `thread_schedule_hint_mode::thread` path
- Remove stale `@TODO` comments that indicated this validation was missing

## Any background context you want to provide?
The `thread_schedule_hint_mode::thread` path was using the raw `hint` value (typed as `std::int16_t`) directly as a worker index without validating it against the number of available workers. This could lead to out-of-bounds access in `select_active_pu()`, `d_lookup_[]`, and `q_lookup_[]` if the hint exceeded `num_workers_`. The `numa` hint path already applied `fast_mod` normalization, so this fix brings the `thread` path in line with that existing pattern.

## Checklist
- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.