### PR TITLE
replace 'return false' with 'return 0'

### DIFF
--- a/libs/core/schedulers/include/hpx/schedulers/thread_queue.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/thread_queue.hpp
@@ -893,7 +893,7 @@ namespace hpx::threads::policies {
             return false;
         }
 
-        // Return the next thread to be executed, return false if none is
+        // Return the next threads to be executed, return 0 if none are
         // available
         template <typename Iterator>
         std::size_t get_next_threads(Iterator it, std::int64_t max_items,
@@ -906,13 +906,13 @@ namespace hpx::threads::policies {
 
             if (work_items_count == 0)
             {
-                return false;
+                return 0;
             }
 
             if (allow_stealing &&
                 parameters_.min_tasks_to_steal_pending_ > work_items_count)
             {
-                return false;
+                return 0;
             }
 
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME


### PR DESCRIPTION
Fixes  #7025


## Proposed Changes

  - Replace `return false` with `return 0` in the first early-exit guard
    of `thread_queue::get_next_threads` (when `work_items_count == 0`)
  - Replace `return false` with `return 0` in the second early-exit guard
    (when stealing is blocked due to insufficient task count)
  - Update the stale function comment from "return false if none is" to
    "return 0 if none are" to accurately reflect the `std::size_t` return type

## Any background context you want to provide?

[get_next_threads](cci:1://file:///home/arpit/Desktop/Gsoc/hpx/libs/core/schedulers/include/hpx/schedulers/thread_queue.hpp:895:8-970:9) has a return type of `std::size_t` (a count of threads
retrieved), but two early-exit guard clauses returned the boolean literal
`false` instead of the integer `0`. While `bool` implicitly converts to
`std::size_t` and is functionally equivalent, this is:

- **Semantically misleading** the function returns a count, not a boolean
- **A source of compiler/static-analysis warnings**  tools like clang-tidy
  (`readability-implicit-bool-conversion`) and `-Wconversion` will flag this
- **A latent risk**  if the return type ever changes, `return false` would
  silently compile to incorrect behavior

The comment above the function was also stale  it was copied from the
`bool`-returning [get_next_thread](cci:1://file:///home/arpit/Desktop/Gsoc/hpx/libs/core/schedulers/include/hpx/schedulers/thread_queue.hpp:845:8-893:9) (singular) immediately above it.

This is a pure correctness/readability fix with no behavioral change.

## Checklist

- [ ] I have added a new feature and have added tests to go along with it.
- [x] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
