### PR TITLE
Fix numa allocator test 7027

### DIFF
--- a/libs/core/compute_local/include/hpx/compute_local/host/numa_allocator.hpp
+++ b/libs/core/compute_local/include/hpx/compute_local/host/numa_allocator.hpp
@@ -53,15 +53,14 @@ namespace hpx::parallel::util {
             using other = numa_allocator<U, Executors>;
         };
 
-        numa_allocator(Executors const& executors, hpx::threads::topology& topo)
+        numa_allocator(
+            Executors const& executors, hpx::threads::topology& /* topo */)
           : executors_(executors)
-          , topo_(topo)
         {
         }
 
         numa_allocator(numa_allocator const& rhs)
           : executors_(rhs.executors_)
-          , topo_(rhs.topo_)
         {
         }
 
@@ -70,7 +69,6 @@ namespace hpx::parallel::util {
         template <typename U>
         numa_allocator(numa_allocator<U, Executors> const& rhs)
           : executors_(rhs.executors_)
-          , topo_(rhs.topo_)
         {
         }
 
@@ -87,18 +85,25 @@ namespace hpx::parallel::util {
         // memory allocation
         pointer allocate(size_type cnt, void const* = nullptr)
         {
-            // allocate memory
-            pointer p = static_cast<pointer>(topo_.allocate(cnt * sizeof(T)));
+            // allocate memory using the singleton topology
+            auto& topo = hpx::threads::get_topology();
+            pointer p = static_cast<pointer>(topo.allocate(cnt * sizeof(T)));
 
             // first touch policy, distribute evenly onto executors
-            std::size_t part_size = cnt / executors_.size();
+            // last partition receives any remainder elements to avoid
+            // leaving trailing elements untouched (which would cause
+            // incorrect NUMA domain bindings)
+            std::size_t const num_exec = executors_.size();
+            std::size_t const part_size = cnt / num_exec;
             std::vector<hpx::future<void>> first_touch;
-            first_touch.reserve(executors_.size());
+            first_touch.reserve(num_exec);
 
-            for (std::size_t i = 0; i != executors_.size(); ++i)
+            for (std::size_t i = 0; i != num_exec; ++i)
             {
                 pointer begin = p + i * part_size;
-                pointer end = begin + part_size;
+                // last executor covers any remainder
+                pointer end =
+                    (i + 1 == num_exec) ? (p + cnt) : (begin + part_size);
                 first_touch.push_back(hpx::for_each(
                     hpx::execution::par(hpx::execution::task).on(executors_[i]),
                     begin, end,
@@ -112,6 +117,7 @@ namespace hpx::parallel::util {
                         *reinterpret_cast<char*>(&val) = 0;
 
 #if defined(HPX_DEBUG)
+                        auto& topo_ = hpx::threads::get_topology();
                         // make sure memory was placed appropriately
                         hpx::threads::mask_type const mem_mask =
                             topo_.get_thread_affinity_mask_from_lva(&val);
@@ -143,7 +149,7 @@ namespace hpx::parallel::util {
 
         void deallocate(pointer p, size_type cnt) noexcept
         {
-            topo_.deallocate(p, cnt * sizeof(T));
+            hpx::threads::get_topology().deallocate(p, cnt * sizeof(T));
         }
 
         // size
@@ -179,7 +185,6 @@ namespace hpx::parallel::util {
         friend class numa_allocator;
 
         Executors const& executors_;
-        hpx::threads::topology& topo_;
     };
 }    // namespace hpx::parallel::util
 // namespace hpx::parallel::util

--- a/libs/core/compute_local/include/hpx/compute_local/host/numa_binding_allocator.hpp
+++ b/libs/core/compute_local/include/hpx/compute_local/host/numa_binding_allocator.hpp
@@ -371,7 +371,8 @@ namespace hpx::compute::host {
         // @TODO, move this into hpx::topology for cleanliness
         static int get_numa_domain(void* page)
         {
-            HPX_ASSERT((reinterpret_cast<std::size_t>(page) & 4095) == 0);
+            HPX_ASSERT((reinterpret_cast<std::size_t>(page) &
+                           (threads::get_memory_page_size() - 1)) == 0);
 
 #if defined(NUMA_ALLOCATOR_LINUX)
             // This is an optimized version of the hwloc equivalent
@@ -613,9 +614,11 @@ namespace hpx::compute::host {
                 {
                     HPX_ASSERT((reinterpret_cast<std::size_t>(page_ptr) &
                                    (threads::get_memory_page_size() - 1)) == 0);
-                    // trigger a memory read and rewrite without changing contents
-                    T volatile* vaddr = const_cast<T volatile*>(page_ptr);
-                    *vaddr = *vaddr;
+                    // Write the first byte of the page to trigger first-touch
+                    // without reading uninitialized memory (which would be UB
+                    // for non-trivial T and can be optimized away by the
+                    // compiler even for trivial types).
+                    *reinterpret_cast<char volatile*>(page_ptr) = 0;
 #ifdef NUMA_BINDING_ALLOCATOR_INIT_MEMORY
                     // show which cpu is actually being used
 #if defined(NUMA_ALLOCATOR_LINUX)


### PR DESCRIPTION
Fixes #7027

Changes made:

numa_allocator.hpp

- Integer division truncation fixed — last executor partition now covers cnt % num_executors remainder elements so no pages go untouched
- Dangling topo_ reference removed — now calls hpx::threads::get_topology() directly in allocate() and deallocate(), no more stored reference member

numa_binding_allocator.hpp
 3. UB volatile read eliminated — *vaddr = *vaddr (reading uninitialized memory, optimizable to no-op) replaced with *reinterpret_cast<volatile char*>(page_ptr) = 0 — a guaranteed physical write that triggers first-touch

The <DEB> log lines in the test output are expected (test has #define QUEUE_HOLDER_NUMA_DEBUG true).



## Any background context you want to provide?

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
