### PR TITLE
Fix exception safety risk in options_description_easy_init

### DIFF
--- a/libs/core/program_options/include/hpx/program_options/options_description.hpp
+++ b/libs/core/program_options/include/hpx/program_options/options_description.hpp
@@ -40,22 +40,11 @@ namespace hpx::program_options {
 
         /** Initializes the object with the passed data.
 
-            Note: it would be nice to make the second parameter auto_ptr,
-            to explicitly pass ownership. Unfortunately, it's often needed to
-            create objects of types derived from 'value_semantic':
-               options_description d;
-               d.add_options()("a", parameter<int>("n")->default_value(1));
-            Here, the static type returned by 'parameter' should be derived
-            from value_semantic.
-
-            Alas, derived->base conversion for auto_ptr does not really work,
-            see
-            http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2000/n1232.pdf
-            http://www.open-std.org/jtc1/sc22/wg21/docs/cwg_defects.html#84
-
-            So, we have to use plain old pointers. Besides, users are not
-            expected to use the constructor directly.
-
+            Note: it is generally preferred to use the std::unique_ptr
+            overloads to explicitly pass ownership. We retain the raw pointer
+            overloads for backward compatibility with legacy code that
+            relies on implicit derived-to-base conversions which were historically
+            problematic with std::auto_ptr.
 
             The 'name' parameter is interpreted by the following rules:
             - if there's no "," character in 'name', it specifies long name
@@ -66,8 +55,8 @@ namespace hpx::program_options {
 
         /** Initializes the class with the passed data.
          */
-        option_description(char const* name,
-            std::shared_ptr<value_semantic const> s);
+        option_description(
+            char const* name, std::unique_ptr<value_semantic const> s);
 
         /** Initializes the class with the passed data.
          */
@@ -77,7 +66,7 @@ namespace hpx::program_options {
         /** Initializes the class with the passed data.
          */
         option_description(char const* name,
-            std::shared_ptr<value_semantic const> s, char const* description);
+            std::unique_ptr<value_semantic const> s, char const* description);
 
         virtual ~option_description();
 

--- a/libs/core/program_options/include/hpx/program_options/options_description.hpp
+++ b/libs/core/program_options/include/hpx/program_options/options_description.hpp
@@ -66,8 +66,18 @@ namespace hpx::program_options {
 
         /** Initializes the class with the passed data.
          */
+        option_description(char const* name,
+            std::shared_ptr<value_semantic const> s);
+
+        /** Initializes the class with the passed data.
+         */
         option_description(
             char const* name, value_semantic const* s, char const* description);
+
+        /** Initializes the class with the passed data.
+         */
+        option_description(char const* name,
+            std::shared_ptr<value_semantic const> s, char const* description);
 
         virtual ~option_description();
 

--- a/libs/core/program_options/src/options_description.cpp
+++ b/libs/core/program_options/src/options_description.cpp
@@ -50,9 +50,9 @@ namespace hpx::program_options {
         this->set_names(names);
     }
 
-    option_description::option_description(char const* name,
-        std::shared_ptr<value_semantic const> s)
-      : m_value_semantic(HPX_MOVE(s))
+    option_description::option_description(
+        char const* name, std::unique_ptr<value_semantic const> s)
+      : m_value_semantic(s.release())
     {
         this->set_names(name);
     }
@@ -66,9 +66,9 @@ namespace hpx::program_options {
     }
 
     option_description::option_description(char const* names,
-        std::shared_ptr<value_semantic const> s, char const* description)
+        std::unique_ptr<value_semantic const> s, char const* description)
       : m_description(description)
-      , m_value_semantic(HPX_MOVE(s))
+      , m_value_semantic(s.release())
     {
         this->set_names(names);
     }
@@ -269,11 +269,10 @@ namespace hpx::program_options {
         // Create untyped semantic which accepts zero tokens: i.e.
         // no value can be specified on command line.
         //
-        // By creating a shared_ptr first, and passing it to the new
-        // option_description constructor that accepts a shared_ptr, we avoid
+        // By creating a unique_ptr first, and passing it to the new
+        // option_description constructor that accepts a unique_ptr, we avoid
         // any possibility of a memory leak if allocation fails.
-        std::shared_ptr<value_semantic const> semantic =
-            std::make_shared<untyped_value>(true);
+        std::unique_ptr<value_semantic const> semantic(new untyped_value(true));
         std::shared_ptr<option_description> d =
             std::make_shared<option_description>(
                 name, HPX_MOVE(semantic), description);

--- a/libs/core/program_options/src/options_description.cpp
+++ b/libs/core/program_options/src/options_description.cpp
@@ -253,13 +253,14 @@ namespace hpx::program_options {
     {
         // Create untyped semantic which accepts zero tokens: i.e.
         // no value can be specified on command line.
-        // Store the semantic in a shared_ptr first to ensure exception safety:
-        // if make_shared<option_description> fails, the semantic won't leak.
-        std::shared_ptr<value_semantic const> semantic =
-            std::make_shared<untyped_value>(true);
-        std::shared_ptr<option_description> d =
-            std::make_shared<option_description>(
-                name, semantic.get(), description);
+        //
+        // Use unique_ptr to hold the semantic temporarily. If the
+        // option_description constructor or its allocation throws, the semantic
+        // is automatically freed. We only release() ownership after the
+        // option_description has been successfully constructed.
+        std::unique_ptr<untyped_value> semantic(new untyped_value(true));
+        std::shared_ptr<option_description> d(
+            new option_description(name, semantic.release(), description));
 
         owner->add(HPX_MOVE(d));
         return *this;

--- a/libs/core/program_options/src/options_description.cpp
+++ b/libs/core/program_options/src/options_description.cpp
@@ -253,10 +253,13 @@ namespace hpx::program_options {
     {
         // Create untyped semantic which accepts zero tokens: i.e.
         // no value can be specified on command line.
-        // FIXME: does not look exception-safe
+        // Store the semantic in a shared_ptr first to ensure exception safety:
+        // if make_shared<option_description> fails, the semantic won't leak.
+        std::shared_ptr<value_semantic const> semantic =
+            std::make_shared<untyped_value>(true);
         std::shared_ptr<option_description> d =
             std::make_shared<option_description>(
-                name, new untyped_value(true), description);
+                name, semantic.get(), description);
 
         owner->add(HPX_MOVE(d));
         return *this;

--- a/libs/core/program_options/src/options_description.cpp
+++ b/libs/core/program_options/src/options_description.cpp
@@ -50,10 +50,25 @@ namespace hpx::program_options {
         this->set_names(names);
     }
 
+    option_description::option_description(char const* name,
+        std::shared_ptr<value_semantic const> s)
+      : m_value_semantic(HPX_MOVE(s))
+    {
+        this->set_names(name);
+    }
+
     option_description::option_description(
         char const* names, value_semantic const* s, char const* description)
       : m_description(description)
       , m_value_semantic(s)
+    {
+        this->set_names(names);
+    }
+
+    option_description::option_description(char const* names,
+        std::shared_ptr<value_semantic const> s, char const* description)
+      : m_description(description)
+      , m_value_semantic(HPX_MOVE(s))
     {
         this->set_names(names);
     }
@@ -254,13 +269,14 @@ namespace hpx::program_options {
         // Create untyped semantic which accepts zero tokens: i.e.
         // no value can be specified on command line.
         //
-        // Use unique_ptr to hold the semantic temporarily. If the
-        // option_description constructor or its allocation throws, the semantic
-        // is automatically freed. We only release() ownership after the
-        // option_description has been successfully constructed.
-        std::unique_ptr<untyped_value> semantic(new untyped_value(true));
-        std::shared_ptr<option_description> d(
-            new option_description(name, semantic.release(), description));
+        // By creating a shared_ptr first, and passing it to the new
+        // option_description constructor that accepts a shared_ptr, we avoid
+        // any possibility of a memory leak if allocation fails.
+        std::shared_ptr<value_semantic const> semantic =
+            std::make_shared<untyped_value>(true);
+        std::shared_ptr<option_description> d =
+            std::make_shared<option_description>(
+                name, HPX_MOVE(semantic), description);
 
         owner->add(HPX_MOVE(d));
         return *this;

--- a/libs/core/program_options/src/options_description.cpp
+++ b/libs/core/program_options/src/options_description.cpp
@@ -272,7 +272,8 @@ namespace hpx::program_options {
         // By creating a unique_ptr first, and passing it to the new
         // option_description constructor that accepts a unique_ptr, we avoid
         // any possibility of a memory leak if allocation fails.
-        std::unique_ptr<value_semantic const> semantic(new untyped_value(true));
+        std::unique_ptr<value_semantic const> semantic =
+            std::make_unique<untyped_value>(true);
         std::shared_ptr<option_description> d =
             std::make_shared<option_description>(
                 name, HPX_MOVE(semantic), description);


### PR DESCRIPTION
## Proposed Changes

In `libs/core/program_options/src/options_description.cpp`, the `operator()` overload that takes just `name` and `description` contained a raw `new` expression passed directly as a constructor argument:

### Before (unsafe)

```cpp
// FIXME: does not look exception-safe
std::shared_ptr<option_description> d =
    std::make_shared<option_description>(
        name, new untyped_value(true), description);
```

## Fix
this PR fixes the issue by wrapping the semantic object in a std::shared_ptr first:
After (exception-safe)
```cpp
std::shared_ptr<value_semantic const> semantic =
    std::make_shared<untyped_value>(true);

std::shared_ptr<option_description> d =
    std::make_shared<option_description>(
        name, semantic.get(), description);
```
This ensures that if make_shared<option_description> fails, the untyped_value object is properly cleaned up when the semantic smart pointer goes out of scope.

fix #7040