### PR TITLE
`is_sorted`: add independent iterator template parameters to support segmented algorithms

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/algorithms/is_sorted.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/is_sorted.hpp
@@ -299,10 +299,9 @@ namespace hpx::parallel {
 
                 // Note: replacing the invoke() with HPX_INVOKE()
                 // below makes gcc generate errors
-                auto f1 = [tok, last,
-                              pred_projected = HPX_MOVE(pred_projected)](
-                              FwdIter_ part_begin,
-                              std::size_t part_size) mutable
+                auto f1 =
+                    [tok, last, pred_projected = HPX_MOVE(pred_projected)](
+                        FwdIter_ part_begin, std::size_t part_size) mutable
                     -> intermediate_result_t {
                     FwdIter_ trail = part_begin++;
                     util::loop_n<std::decay_t<ExPolicy>>(part_begin,
@@ -354,7 +353,7 @@ namespace hpx::parallel {
               : algorithm<is_sorted_until, FwdIter>("is_sorted_until")
             {
             }
-            
+
             template <typename ExPolicy, typename FwdIter_, typename Sent_,
                 typename Pred, typename Proj>
             static constexpr FwdIter_ sequential(


### PR DESCRIPTION
Fixes #7037 

## Proposed Changes
- Add independent `FwdIter_`/`Sent_` template parameters to `sequential` and `parallel` methods of `is_sorted`
- Add independent `FwdIter_`/`Sent_` template parameters to `sequential` and `parallel` methods of `is_sorted_until`

## Any background context you want to provide?

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
