### PR TITLE
[datapar] Fix sentinel compatibility in SIMD algorithms

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/datapar/adjacent_find.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/datapar/adjacent_find.hpp
@@ -12,6 +12,7 @@
 #include <hpx/modules/concepts.hpp>
 #include <hpx/modules/execution.hpp>
 #include <hpx/parallel/algorithms/detail/adjacent_find.hpp>
+#include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/datapar/iterator_helpers.hpp>
 #include <hpx/parallel/datapar/loop.hpp>
 #include <hpx/parallel/datapar/zip_iterator.hpp>
@@ -37,7 +38,8 @@ namespace hpx::parallel::detail {
             ++next;
 
             auto zip_iter = hpx::util::zip_iterator(first, next);
-            std::size_t const count = std::distance(first, last);
+            std::size_t const count =
+                hpx::parallel::detail::distance(first, last);
             util::cancellation_token<std::size_t> tok(count);
 
             call(0, zip_iter, count - 1, tok,

--- a/libs/core/algorithms/include/hpx/parallel/datapar/find.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/datapar/find.hpp
@@ -12,6 +12,7 @@
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/executors.hpp>
 #include <hpx/modules/tag_invoke.hpp>
+#include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/algorithms/detail/find.hpp>
 #include <hpx/parallel/datapar/handle_local_exceptions.hpp>
 #include <hpx/parallel/datapar/iterator_helpers.hpp>
@@ -402,7 +403,7 @@ namespace hpx::parallel::detail {
             if (first == last)
                 return last;
 
-            std::size_t count = std::distance(first, last);
+            std::size_t count = hpx::parallel::detail::distance(first, last);
             util::cancellation_token<std::size_t> tok(count);
 
             call(first, s_first, s_last, 0, count, tok, HPX_FORWARD(Pred, op),
@@ -433,8 +434,8 @@ namespace hpx::parallel::detail {
 
                     util::cancellation_token<> local_tok;
                     util::loop_n<hpx::execution::simd_policy>(s_first,
-                        std::distance(s_first, s_last), local_tok,
-                        [&local_tok, &proj2, &op, &val](auto curr) {
+                        hpx::parallel::detail::distance(s_first, s_last),
+                        local_tok, [&local_tok, &proj2, &op, &val](auto curr) {
                             auto msk =
                                 HPX_INVOKE(op, val, HPX_INVOKE(proj2, *curr));
                             if (hpx::parallel::traits::any_of(msk))

--- a/libs/core/algorithms/include/hpx/parallel/datapar/generate.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/datapar/generate.hpp
@@ -11,6 +11,7 @@
 #if defined(HPX_HAVE_DATAPAR)
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/tag_invoke.hpp>
+#include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/algorithms/detail/generate.hpp>
 #include <hpx/parallel/datapar/handle_local_exceptions.hpp>
 #include <hpx/parallel/datapar/iterator_helpers.hpp>
@@ -87,7 +88,7 @@ namespace hpx::parallel::detail {
         HPX_HOST_DEVICE HPX_FORCEINLINE static Iter call(
             ExPolicy&&, Iter first, Sent last, F&& f)
         {
-            std::size_t count = std::distance(first, last);
+            std::size_t count = hpx::parallel::detail::distance(first, last);
             return datapar_generate_helper<Iter>::call(
                 first, count, HPX_FORWARD(F, f));
         }

--- a/libs/core/algorithms/include/hpx/parallel/datapar/transform_loop.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/datapar/transform_loop.hpp
@@ -13,6 +13,7 @@
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/executors.hpp>
 #include <hpx/modules/functional.hpp>
+#include <hpx/parallel/algorithms/detail/distance.hpp>
 #include <hpx/parallel/datapar/iterator_helpers.hpp>
 #include <hpx/parallel/util/transform_loop.hpp>
 
@@ -195,8 +196,8 @@ namespace hpx::parallel::util {
                 if constexpr (datapar_compatible)
                 {
                     return util::transform_loop_n<hpx::execution::simd_policy>(
-                        first, std::distance(first, last), dest,
-                        HPX_FORWARD(F, f));
+                        first, hpx::parallel::detail::distance(first, last),
+                        dest, HPX_FORWARD(F, f));
                 }
                 else
                 {
@@ -264,7 +265,8 @@ namespace hpx::parallel::util {
                 {
                     return util::transform_loop_n_ind<
                         hpx::execution::simd_policy>(first,
-                        std::distance(first, last), dest, HPX_FORWARD(F, f));
+                        hpx::parallel::detail::distance(first, last), dest,
+                        HPX_FORWARD(F, f));
                 }
                 else
                 {
@@ -428,8 +430,8 @@ namespace hpx::parallel::util {
                 {
                     auto ret = util::transform_binary_loop_n<
                         hpx::execution::par_simd_policy>(first1,
-                        std::distance(first1, last1), first2, dest,
-                        HPX_FORWARD(F, f));
+                        hpx::parallel::detail::distance(first1, last1), first2,
+                        dest, HPX_FORWARD(F, f));
 
                     return util::in_in_out_result<InIter1, InIter2, OutIter>{
                         hpx::get<0>(ret), hpx::get<1>(ret), hpx::get<2>(ret)};
@@ -462,8 +464,8 @@ namespace hpx::parallel::util {
                     // different versions of clang-format do different things
                     // clang-format off
                     std::size_t count = (std::min)(
-                        std::distance(first1, last1),
-                        std::distance(first2, last2));
+                        hpx::parallel::detail::distance(first1, last1),
+                        hpx::parallel::detail::distance(first2, last2));
                     // clang-format on
 
                     auto ret = util::transform_binary_loop_n<
@@ -624,8 +626,8 @@ namespace hpx::parallel::util {
             {
                 auto ret = util::transform_binary_loop_ind_n<
                     hpx::execution::par_simd_policy>(first1,
-                    std::distance(first1, last1), first2, dest,
-                    HPX_FORWARD(F, f));
+                    hpx::parallel::detail::distance(first1, last1), first2,
+                    dest, HPX_FORWARD(F, f));
 
                 return util::in_in_out_result<InIter1, InIter2, OutIter>{
                     hpx::get<0>(ret), hpx::get<1>(ret), hpx::get<2>(ret)};
@@ -660,8 +662,9 @@ namespace hpx::parallel::util {
             call(InIter1 first1, InIter1 last1, InIter2 first2, InIter2 last2,
                 OutIter dest, F&& f)
             {
-                std::size_t count = (std::min) (std::distance(first1, last1),
-                    std::distance(first2, last2));
+                std::size_t count =
+                    (std::min) (hpx::parallel::detail::distance(first1, last1),
+                        hpx::parallel::detail::distance(first2, last2));
 
                 auto ret = util::transform_binary_loop_ind_n<
                     hpx::execution::par_simd_policy>(


### PR DESCRIPTION
Hi! I'm a student learning about how HPX handles different iterator types. While looking through the `datapar` (SIMD) module, I found a few spots where we were using `std::distance`.

I realized that `std::distance` (the old version) only works if the iterator and the sentinel are exactly the same type. This meant that if someone tried to use a newer C++20-style sentinel with our SIMD algorithms, it would actually crash the compiler! 

To fix this, I've swapped those calls with our own `hpx::parallel::detail::distance`. It's much smarter and already knows how to handle these modern C++ features. This change brings the SIMD algorithms up to speed with the rest of the library and makes them much more robust for users.

I've applied this to `adjacent_find`, `find`, `generate`, `replace`, and `transform_loop`. I'm really excited to see this module get updated! 

Thanks a lot for the help and for reviewing my PR!