### PR TITLE
Add godbolt-minimal CMake preset for browser-based compiler environments

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -271,6 +271,23 @@
                 "HPX_WITH_TESTS": "ON",
                 "HPX_WITH_EXAMPLES": "ON"
             }
+        },
+        {
+            "name": "godbolt-minimal",
+            "displayName": "Godbolt / Sandboxed Environment",
+            "description": "Minimal single-node static build optimized for browser-based compilers (Compiler Explorer / Godbolt). Uses system malloc, disables networking, tests, examples, and documentation to minimize binary size and build time.",
+            "generator": "Ninja",
+            "binaryDir": "${sourceDir}/build/godbolt-minimal",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "HPX_WITH_MALLOC": "system",
+                "HPX_WITH_NETWORKING": "OFF",
+                "HPX_WITH_TESTS": "OFF",
+                "HPX_WITH_EXAMPLES": "OFF",
+                "HPX_WITH_DOCUMENTATION": "OFF",
+                "HPX_WITH_STATIC_LINKING": "ON",
+                "HPX_WITH_FETCH_ASIO": "ON"
+            }
         }
     ],
     "buildPresets": [
@@ -394,6 +411,12 @@
             "name": "no-distributed-runtime",
             "displayName": "No Distributed Runtime Build",
             "configurePreset": "no-distributed-runtime",
+            "jobs": 0
+        },
+        {
+            "name": "godbolt-minimal",
+            "displayName": "Godbolt / Sandboxed Environment Build",
+            "configurePreset": "godbolt-minimal",
             "jobs": 0
         }
     ],


### PR DESCRIPTION
Fixes # — N/A (new feature)

## Proposed Changes

  - Add `godbolt-minimal` configure preset to [CMakePresets.json](cci:7://file:///home/shivanshsingh/Desktop/compiler-explorer/hpx-godbolt-build/hpx-src/CMakePresets.json:0:0-0:0) with 8 cache variables optimized for browser-based sandboxed environments (Compiler Explorer / Godbolt): `HPX_WITH_MALLOC=system`, `HPX_WITH_NETWORKING=OFF`, `HPX_WITH_TESTS=OFF`, `HPX_WITH_EXAMPLES=OFF`, `HPX_WITH_DOCUMENTATION=OFF`, `HPX_WITH_STATIC_LINKING=ON`, `HPX_WITH_FETCH_ASIO=ON`, `CMAKE_BUILD_TYPE=Release`.
  - Add corresponding `godbolt-minimal` build preset.
  - This enables a one-command reproducible build (`cmake --preset godbolt-minimal`) that produces the minimal static HPX libraries required for integration with [Compiler Explorer](https://godbolt.org/).

## Any background context you want to provide?

As part of the GSoC 2026 effort to integrate HPX into Compiler Explorer, we identified a specific combination of CMake flags required to produce a minimal, single-node static build suitable for sandboxed web execution. This preset encodes the exact configuration that was verified locally against HPX 2.0.0 with GCC 13.3.0 (C++20), producing all 12 expected static libraries (`libhpx_wrap.a`, `libhpx.a`, `libhpx_init.a`, `libhpx_core.a`, etc.) and the critical `hpx/hpx_main.hpp` header.

**Key design decisions:**
- **`HPX_WITH_MALLOC=system`** — Removes the tcmalloc/jemalloc dependency to reduce binary size and avoid allocator collisions in the Godbolt sandbox.
- **`HPX_WITH_NETWORKING=OFF`** — Godbolt is single-node; all parcelport code (MPI, LCI, libfabric, GASNet) is unnecessary.
- **`HPX_WITH_STATIC_LINKING=ON`** — Required by Compiler Explorer's Conan-based per-compiler binary distribution pipeline.
- **`HPX_WITH_FETCH_ASIO=ON`** — Auto-fetches Asio, removing one external dependency for sandboxed builders.
- **`HPX_WITH_DISTRIBUTED_RUNTIME=OFF` was deliberately NOT set** to avoid the `HPX_WITH_APEX` conflict; `HPX_WITH_NETWORKING=OFF` already disables all parcelports.

This preset follows the existing conventions in [CMakePresets.json](cci:7://file:///home/shivanshsingh/Desktop/compiler-explorer/hpx-godbolt-build/hpx-src/CMakePresets.json:0:0-0:0) (schema v4, Ninja generator, kebab-case naming, `${sourceDir}/build/<name>` binary directory pattern).

## Checklist

- [x] I have added a new feature and have added tests to go along with it.
  - _No test preset was added because `HPX_WITH_TESTS=OFF` in this configuration. The preset was verified by a successful local build producing all expected artifacts._
- [ ] ~~I have fixed a bug and have added a regression test.~~ — N/A
- [ ] ~~I have added a test using random numbers~~ — N/A
