### PR TITLE
tests: add sender/receiver for hpx::copy_if

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/algorithms/copy.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/copy.hpp
@@ -789,10 +789,9 @@ namespace hpx {
                 >
             )
         // clang-format on
-        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
-            FwdIter2>::type
-        tag_fallback_invoke(hpx::copy_if_t, ExPolicy&& policy, FwdIter1 first,
-            FwdIter1 last, FwdIter2 dest, Pred pred)
+        friend decltype(auto) tag_fallback_invoke(hpx::copy_if_t,
+            ExPolicy&& policy, FwdIter1 first, FwdIter1 last, FwdIter2 dest,
+            Pred&& pred)
         {
             static_assert(std::forward_iterator<FwdIter1>,
                 "Required at least forward iterator.");
@@ -806,7 +805,7 @@ namespace hpx {
                 hpx::parallel::detail::copy_if<
                     hpx::parallel::util::in_out_result<FwdIter1, FwdIter2>>()
                     .call(HPX_FORWARD(ExPolicy, policy), first, last, dest,
-                        HPX_MOVE(pred), hpx::identity_v));
+                        HPX_FORWARD(Pred, pred), hpx::identity_v));
         }
 
         template <typename FwdIter1, typename FwdIter2, typename Pred>

--- a/libs/core/algorithms/tests/unit/algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/tests/unit/algorithms/CMakeLists.txt
@@ -168,6 +168,7 @@ if(HPX_WITH_STDEXEC)
       all_of_sender
       any_of_sender
       copy_sender
+      copyif_sender
       copyn_sender
       count_sender
       countif_sender

--- a/libs/core/algorithms/tests/unit/algorithms/copyif_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/copyif_sender.cpp
@@ -1,0 +1,107 @@
+//  Copyright (c) 2026 Kashy Namboothiri
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/algorithm.hpp>
+#include <hpx/execution.hpp>
+#include <hpx/init.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <cstddef>
+#include <iostream>
+#include <iterator>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include "test_utils.hpp"
+
+template <typename LnPolicy, typename ExPolicy, typename IteratorTag>
+void test_copy_if_sender(LnPolicy ln_policy, ExPolicy&& ex_policy, IteratorTag)
+{
+    static_assert(hpx::is_async_execution_policy_v<ExPolicy>,
+        "hpx::is_async_execution_policy_v<ExPolicy>");
+
+    using base_iterator = std::vector<std::size_t>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
+
+    namespace ex = hpx::execution::experimental;
+    namespace tt = hpx::this_thread::experimental;
+    using scheduler_t = ex::thread_pool_policy_scheduler<LnPolicy>;
+
+    std::vector<std::size_t> c(10007);
+    std::vector<std::size_t> d1(c.size());
+    std::vector<std::size_t> d2(c.size());
+
+    std::iota(std::begin(c), std::end(c), std::rand());
+
+    auto exec = ex::explicit_scheduler_executor(scheduler_t(ln_policy));
+
+    auto pred = [](std::size_t i) { return i % 2 == 0; };
+    tt::sync_wait(ex::just(iterator(std::begin(c)), iterator(std::end(c)),
+                      std::begin(d1), pred) |
+        hpx::copy_if(ex_policy.on(exec)));
+
+    std::copy_if(std::begin(c), std::end(c), std::begin(d2), pred);
+
+    std::size_t count = 0;
+    HPX_TEST(std::equal(std::begin(d1), std::end(d1), std::begin(d2),
+        [&count](std::size_t v1, std::size_t v2) -> bool {
+            HPX_TEST_EQ(v1, v2);
+            ++count;
+            return v1 == v2;
+        }));
+    HPX_TEST_EQ(count, d1.size());
+}
+
+template <typename IteratorTag>
+void copy_if_sender_test()
+{
+    using namespace hpx::execution;
+
+    test_copy_if_sender(hpx::launch::sync, seq(task), IteratorTag());
+    test_copy_if_sender(hpx::launch::sync, unseq(task), IteratorTag());
+    // par, par_unseq require scan_partitioner to gain
+    // scheduler-executor support before they can be tested here
+}
+
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    copy_if_sender_test<std::forward_iterator_tag>();
+    copy_if_sender_test<std::random_access_iterator_tag>();
+
+    return hpx::local::finalize();
+}
+
+// add command line option which controls the random number generator seed
+// By default this test should run on all available cores
+// Initialize and run HPX
+int main(int argc, char* argv[])
+{
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
## Proposed Changes                                                         
                                                                              
  - Add `copyif_sender.cpp` testing `hpx::copy_if` with the P2300             
  sender/receiver pipeline API using `seq(task)` and `unseq(task)` policies   
  with `explicit_scheduler_executor`                                          
  - Fix `copy_if` `tag_fallback_invoke` return type to `decltype(auto)` to    
  match the `copy` algorithm, resolving a type mismatch in the sender         
  execution path                                                              
                       
  ## Any background context you want to provide?                              
                                          
  Contributes to #6535                                                        
                                                                              
  ## Checklist                                
                                                                              
  - [x] I have added a new feature and have added tests to go along with it.
  - [x] I have added a test using random numbers; I have made sure it uses a seed.
