### PR TITLE
cmake: Improve error messages for missing optional dependencies Improve dependency errors

### DIFF
--- a/cmake/HPX_SetupAsio.cmake
+++ b/cmake/HPX_SetupAsio.cmake
@@ -17,7 +17,12 @@ if(NOT HPX_WITH_FETCH_ASIO)
   find_package(Asio 1.12.0)
   if(NOT Asio_FOUND)
     hpx_error(
-      "Could not find Asio. Set Asio_ROOT as a CMake or environment variable to point to the Asio root install directory. Alternatively, set HPX_WITH_FETCH_ASIO=ON to fetch Asio using CMake's FetchContent (when using this option Asio will be installed together with HPX, be careful about conflicts with separately installed versions of Asio)."
+      "Could not find Asio. Set Asio_ROOT as a CMake or environment variable to "
+      "point to the Asio root install directory. Alternatively, set "
+      "HPX_WITH_FETCH_ASIO=ON to fetch Asio using CMake's FetchContent (this is "
+      "currently the default, but might have failed or been disabled). Note that "
+      "Asio is installed together with HPX, be careful about conflicts with "
+      "separately installed versions of Asio."
     )
   endif()
 elseif(NOT TARGET Asio::asio AND NOT HPX_FIND_PACKAGE)

--- a/cmake/HPX_SetupBoost.cmake
+++ b/cmake/HPX_SetupBoost.cmake
@@ -62,7 +62,11 @@ if(NOT TARGET hpx_dependencies_boost)
     endif()
 
     if(NOT Boost_FOUND)
-      hpx_error("Could not find Boost. Please check your configuration.")
+      hpx_error(
+        "Boost could not be found. Please either specify Boost_ROOT to point to the correct location, "
+        "install it using your system's package manager, or configure CMake with -DHPX_WITH_FETCH_BOOST=ON "
+        "to download it automatically."
+      )
     endif()
 
     add_library(hpx_dependencies_boost INTERFACE IMPORTED)

--- a/cmake/HPX_SetupHwloc.cmake
+++ b/cmake/HPX_SetupHwloc.cmake
@@ -18,7 +18,9 @@ if(NOT HPX_WITH_FETCH_HWLOC)
   find_package(Hwloc)
   if(NOT Hwloc_FOUND)
     hpx_error(
-      "Hwloc could not be found, please specify Hwloc_ROOT to point to the correct location"
+      "Hwloc could not be found. Please either specify Hwloc_ROOT to point to the correct location, "
+      "install it using your system's package manager, or configure CMake with -DHPX_WITH_FETCH_HWLOC=ON "
+      "to download it automatically."
     )
   endif()
 else()


### PR DESCRIPTION
### Description
As discussed with @hkaiser in Issue #7059, this PR improves the CMake configuration experience for new users who encounter missing optional dependencies. 

Specifically, this PR:
1. Updates `HPX_WITH_ASIO_TAG` to use a newer, stable release (`asio-1-30-2`).
2. Refines the `hpx_error` messages in `HPX_SetupAsio.cmake`, `HPX_SetupBoost.cmake`, and `HPX_SetupHwloc.cmake` to explicitly explain the required CMake flags (e.g., `-DHPX_WITH_FETCH_BOOST=ON`) and fallback options when the system fails to find them.

### Related Issue
Anything else can be followed up in the discussion section.