### PR TITLE
Improve hpx_wrap error message with explicit linker flags for non-CMa…

### DIFF
--- a/libs/core/threading_base/src/get_default_pool.cpp
+++ b/libs/core/threading_base/src/get_default_pool.cpp
@@ -65,12 +65,13 @@ namespace hpx::threads::detail {
                     "hpx::threads::detail::get_self_or_default_pool",
                     "Attempting to use hpx_main.hpp functionality "
                     "without linking to libhpx_wrap. If you're using "
-                    "CMakeLists, make sure to add HPX::wrap_main to "
-                    "target_link_libraries. "
-                    "If you're using Makefile, make sure to link to "
-                    "libhpx_wrap when generating the executable. If "
-                    "you're linking explicitly, consult the HPX docs "
-                    "for library link order and other subtle nuances.");
+                    "CMake, make sure to add HPX::wrap_main to "
+                    "target_link_libraries. If you're linking "
+                    "manually (e.g., via Makefiles or Godbolt), "
+                    "ensure you pass '-Wl,-wrap=main' to the linker "
+                    "on Linux or '-Wl,-e,_initialize_main' on macOS. "
+                    "Consult the HPX documentation for the full "
+                    "library link order and other subtle nuances.");
             }
 #endif
             HPX_THROW_EXCEPTION(hpx::error::invalid_status,


### PR DESCRIPTION
Fixes # — N/A (usability improvement)

## Proposed Changes

  - Improve the runtime error message in [get_default_pool.cpp](cci:7://file:///home/shivanshsingh/Desktop/compiler-explorer/hpx-godbolt-build/hpx-src/libs/core/threading_base/src/get_default_pool.cpp:0:0-0:0) when `hpx_main.hpp` is used without properly linking to `libhpx_wrap`.
  - The updated message now explicitly mentions the required linker flags: `-Wl,-wrap=main` on Linux and `-Wl,-e,_initialize_main` on macOS.
  - This helps non-CMake users (e.g., those using Makefiles, Godbolt/Compiler Explorer, or direct compiler invocations) resolve the issue without needing to search the documentation.

## Any background context you want to provide?

During the integration of HPX into [Compiler Explorer (Godbolt)](https://godbolt.org/) as part of GSoC 2026, we discovered that users linking HPX statically without CMake consistently hit this error with no actionable guidance on how to fix it. The existing message mentions CMake and Makefiles but does not specify the actual platform-specific linker flag required (`-Wl,-wrap=main` on Linux, `-Wl,-e,_initialize_main` on macOS). This change reduces debugging time by providing the exact flag in the error output itself.

The CMake build system correctly propagates this flag via `INTERFACE_LINK_LIBRARIES` on the `hpx_wrap` target (set in `wrap/CMakeLists.txt:128`), but this mechanism is invisible to users who invoke the compiler directly. The pkgconfig `.pc` file also includes the flag, but many users do not use pkgconfig either.

## Checklist

- [ ] ~~I have added a new feature and have added tests to go along with it.~~ — N/A
- [x] I have fixed a bug and have added a regression test.
  - _This is a string-only change to an error message with no behavioral change. The existing `auto_wrap_main` unit test in `tests/unit/init/` covers this code path._
- [ ] ~~I have added a test using random numbers~~ — N/A
