### PR TITLE
Add segmented is_sorted_until , is_sorted

### DIFF
--- a/.circleci/tests.unit1.segmented_algorithms
+++ b/.circleci/tests.unit1.segmented_algorithms
@@ -19,6 +19,7 @@ tests.unit.modules.segmented_algorithms.partitioned_vector_for_each_n
 tests.unit.modules.segmented_algorithms.partitioned_vector_generate
 tests.unit.modules.segmented_algorithms.partitioned_vector_handle_values
 tests.unit.modules.segmented_algorithms.partitioned_vector_iter
+tests.unit.modules.segmented_algorithms.partitioned_vector_is_sorted
 tests.unit.modules.segmented_algorithms.partitioned_vector_max_element1
 tests.unit.modules.segmented_algorithms.partitioned_vector_max_element2
 tests.unit.modules.segmented_algorithms.partitioned_vector_min_element1

--- a/.github/test-targets/tests.unit1.segmented_algorithms
+++ b/.github/test-targets/tests.unit1.segmented_algorithms
@@ -19,6 +19,7 @@ tests.unit.modules.segmented_algorithms.partitioned_vector_for_each_n
 tests.unit.modules.segmented_algorithms.partitioned_vector_generate
 tests.unit.modules.segmented_algorithms.partitioned_vector_handle_values
 tests.unit.modules.segmented_algorithms.partitioned_vector_iter
+tests.unit.modules.segmented_algorithms.partitioned_vector_is_sorted
 tests.unit.modules.segmented_algorithms.partitioned_vector_max_element1
 tests.unit.modules.segmented_algorithms.partitioned_vector_max_element2
 tests.unit.modules.segmented_algorithms.partitioned_vector_min_element1

--- a/libs/full/include/include/hpx/include/parallel_is_sorted.hpp
+++ b/libs/full/include/include/hpx/include/parallel_is_sorted.hpp
@@ -7,3 +7,4 @@
 #pragma once
 
 #include <hpx/modules/algorithms.hpp>
+#include <hpx/parallel/segmented_algorithms/is_sorted.hpp>

--- a/libs/full/segmented_algorithms/CMakeLists.txt
+++ b/libs/full/segmented_algorithms/CMakeLists.txt
@@ -25,6 +25,7 @@ set(segmented_algorithms_headers
     hpx/parallel/segmented_algorithms/for_each.hpp
     hpx/parallel/segmented_algorithms/generate.hpp
     hpx/parallel/segmented_algorithms/inclusive_scan.hpp
+    hpx/parallel/segmented_algorithms/is_sorted.hpp
     hpx/parallel/segmented_algorithms/minmax.hpp
     hpx/parallel/segmented_algorithms/reduce.hpp
     hpx/parallel/segmented_algorithms/replace.hpp

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithm.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithm.hpp
@@ -19,6 +19,7 @@
 #include <hpx/parallel/segmented_algorithms/for_each.hpp>
 #include <hpx/parallel/segmented_algorithms/generate.hpp>
 #include <hpx/parallel/segmented_algorithms/inclusive_scan.hpp>
+#include <hpx/parallel/segmented_algorithms/is_sorted.hpp>
 #include <hpx/parallel/segmented_algorithms/minmax.hpp>
 #include <hpx/parallel/segmented_algorithms/reduce.hpp>
 #include <hpx/parallel/segmented_algorithms/replace.hpp>

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/is_sorted.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/is_sorted.hpp
@@ -1,0 +1,398 @@
+//  Copyright (c) 2026 Mo'men Samir
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/modules/algorithms.hpp>
+#include <hpx/modules/executors.hpp>
+#include <hpx/modules/functional.hpp>
+#include <hpx/modules/type_support.hpp>
+#include <hpx/parallel/segmented_algorithms/detail/dispatch.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <exception>
+#include <iterator>
+#include <list>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace hpx::parallel { namespace detail {
+
+    ///////////////////////////////////////////////////////////////////////////
+    // segmented_is_sorted_until
+
+    ///////////////////////////////////////////////////////////////////////
+    /// \cond NOINTERNAL
+
+    // sequential remote implementation
+    template <typename Algo, typename ExPolicy, typename SegIter, typename Pred,
+        typename Proj>
+    static util::detail::algorithm_result_t<ExPolicy, SegIter>
+    segmented_is_sorted_until(Algo&& algo, ExPolicy const& policy,
+        SegIter first, SegIter last, Pred&& pred, Proj&& proj, std::true_type)
+    {
+        using traits = hpx::traits::segmented_iterator_traits<SegIter>;
+        using segment_iterator = typename traits::segment_iterator;
+        using local_iterator_type = typename traits::local_iterator;
+        using result = util::detail::algorithm_result<ExPolicy, SegIter>;
+
+        util::invoke_projected<Pred, Proj> pred_projected{pred, proj};
+
+        segment_iterator sit = traits::segment(first);
+        segment_iterator send = traits::segment(last);
+
+        if (sit == send)
+        {
+            // all elements are on the same partition
+            local_iterator_type beg = traits::local(first);
+            local_iterator_type end = traits::local(last);
+            if (beg != end)
+            {
+                local_iterator_type out = dispatch(traits::get_id(sit), algo,
+                    policy, std::true_type(), beg, end, pred, proj);
+                last = traits::compose(sit, out);
+            }
+        }
+        else
+        {
+            bool last_found = false;
+
+            // handle the remaining part of the first partition
+            local_iterator_type beg = traits::local(first);
+            local_iterator_type end = traits::end(sit);
+
+            if (beg != end)
+            {
+                local_iterator_type out = dispatch(traits::get_id(sit), algo,
+                    policy, std::true_type(), beg, end, pred, proj);
+
+                if (out != end)
+                {
+                    last_found = true;
+                    last = traits::compose(sit, out);
+                }
+
+                if (!last_found)
+                {
+                    SegIter boundary = traits::compose(sit, std::prev(end));
+                    SegIter next_elem = std::next(boundary);
+                    if (next_elem != last &&
+                        HPX_INVOKE(pred_projected, *next_elem, *boundary))
+                    {
+                        last_found = true;
+                        last = next_elem;
+                    }
+                }
+            }
+
+            // handle all the full partitions
+            for (++sit; sit != send && !last_found; ++sit)
+            {
+                beg = traits::begin(sit);
+                end = traits::end(sit);
+
+                if (beg != end)
+                {
+                    local_iterator_type out = dispatch(traits::get_id(sit),
+                        algo, policy, std::true_type(), beg, end, pred, proj);
+
+                    if (out != end)
+                    {
+                        last_found = true;
+                        last = traits::compose(sit, out);
+                        break;
+                    }
+
+                    SegIter boundary = traits::compose(sit, std::prev(end));
+                    SegIter next_elem = std::next(boundary);
+                    if (next_elem != last &&
+                        HPX_INVOKE(pred_projected, *next_elem, *boundary))
+                    {
+                        last_found = true;
+                        last = next_elem;
+                        break;
+                    }
+                }
+            }
+            // handle the beginning of the last partition
+            beg = traits::begin(sit);
+            end = traits::local(last);
+            if (beg != end && !last_found)
+            {
+                local_iterator_type out = dispatch(traits::get_id(sit), algo,
+                    policy, std::true_type(), beg, end, pred, proj);
+                if (out != end)
+                {
+                    last = traits::compose(sit, out);
+                }
+            }
+        }
+
+        return result::get(HPX_MOVE(last));
+    }
+
+    // parallel remote implementation
+    template <typename Algo, typename ExPolicy, typename SegIter, typename Pred,
+        typename Proj>
+    static util::detail::algorithm_result_t<ExPolicy, SegIter>
+    segmented_is_sorted_until(Algo&& algo, ExPolicy const& policy,
+        SegIter first, SegIter last, Pred&& pred, Proj&& proj, std::false_type)
+    {
+        using traits = hpx::traits::segmented_iterator_traits<SegIter>;
+        using segment_iterator = typename traits::segment_iterator;
+        using local_iterator_type = typename traits::local_iterator;
+        using result = util::detail::algorithm_result<ExPolicy, SegIter>;
+
+        using forced_seq =
+            std::integral_constant<bool, !std::forward_iterator<SegIter>>;
+
+        using segment_type = std::vector<hpx::future<SegIter>>;
+
+        util::invoke_projected<Pred, Proj> pred_projected{pred, proj};
+
+        segment_iterator sit = traits::segment(first);
+        segment_iterator send = traits::segment(last);
+
+        auto const size = std::distance(sit, send);
+
+        segment_type segments;
+        segments.reserve(size);
+
+        std::vector<SegIter> between_segments;
+        between_segments.reserve(size);
+
+        if (sit == send)
+        {
+            // all elements are on the same partition
+            local_iterator_type beg = traits::local(first);
+            local_iterator_type end = traits::local(last);
+            if (beg != end)
+            {
+                segments.push_back(hpx::make_future<SegIter>(
+                    dispatch_async(traits::get_id(sit), algo, policy,
+                        forced_seq(), beg, end, pred, proj),
+                    [sit, end, last](
+                        local_iterator_type const& out) -> SegIter {
+                        if (out != end)
+                            return traits::compose(sit, out);
+                        return last;
+                    }));
+            }
+        }
+        else
+        {
+            // handle the remaining part of the first partition
+            local_iterator_type beg = traits::local(first);
+            local_iterator_type end = traits::end(sit);
+
+            if (beg != end)
+            {
+                segments.push_back(hpx::make_future<SegIter>(
+                    dispatch_async(traits::get_id(sit), algo, policy,
+                        forced_seq(), beg, end, pred, proj),
+                    [sit, end, last](
+                        local_iterator_type const& out) -> SegIter {
+                        if (out != end)
+                            return traits::compose(sit, out);
+                        return last;
+                    }));
+            }
+
+            // handle all the full partitions
+            for (++sit; sit != send; ++sit)
+            {
+                beg = traits::begin(sit);
+                end = traits::end(sit);
+
+                if (beg != end)
+                {
+                    between_segments.push_back(traits::compose(sit, beg));
+                    segments.push_back(hpx::make_future<SegIter>(
+                        dispatch_async(traits::get_id(sit), algo, policy,
+                            forced_seq(), beg, end, pred, proj),
+                        [sit, end, last](
+                            local_iterator_type const& out) -> SegIter {
+                            if (out != end)
+                                return traits::compose(sit, out);
+                            return last;
+                        }));
+                }
+            }
+
+            // handle the beginning of the last partition
+            beg = traits::begin(sit);
+            end = traits::local(last);
+            if (beg != end)
+            {
+                between_segments.push_back(traits::compose(sit, beg));
+                segments.push_back(hpx::make_future<SegIter>(
+                    dispatch_async(traits::get_id(sit), algo, policy,
+                        forced_seq(), beg, end, HPX_FORWARD(Pred, pred),
+                        HPX_FORWARD(Proj, proj)),
+                    [sit, end, last](
+                        local_iterator_type const& out) -> SegIter {
+                        if (out != end)
+                            return traits::compose(sit, out);
+                        return last;
+                    }));
+            }
+        }
+
+        return result::get(dataflow(
+            [=](segment_type&& r) mutable -> SegIter {
+                std::list<std::exception_ptr> errors;
+                parallel::util::detail::handle_remote_exceptions<
+                    ExPolicy>::call(r, errors);
+                std::vector<SegIter> res = hpx::unwrap(HPX_MOVE(r));
+
+                auto it = res.begin();
+                std::size_t i = 0;
+                while (it != res.end())
+                {
+                    if (*it != last)
+                        return *it;
+
+                    if (i < between_segments.size())
+                    {
+                        if (HPX_INVOKE(pred_projected, *between_segments[i],
+                                *std::prev(between_segments[i])))
+                        {
+                            return between_segments[i];
+                        }
+                    }
+                    ++it;
+                    ++i;
+                }
+                return last;
+            },
+            HPX_MOVE(segments)));
+    }
+
+    /// \endcond
+}}    // namespace hpx::parallel::detail
+
+// The segmented iterators we support all live in namespace hpx::segmented
+namespace hpx::segmented {
+
+    template <typename InIter, typename Pred = hpx::parallel::detail::less>
+        requires(hpx::traits::is_iterator_v<InIter> &&
+            hpx::traits::is_segmented_iterator_v<InIter>)
+    InIter tag_invoke(
+        hpx::is_sorted_until_t, InIter first, InIter last, Pred&& pred = Pred())
+    {
+        static_assert(std::forward_iterator<InIter>,
+            "Requires at least forward iterator.");
+
+        if (first == last)
+            return first;
+
+        using iterator_traits = hpx::traits::segmented_iterator_traits<InIter>;
+
+        return hpx::parallel::detail::segmented_is_sorted_until(
+            hpx::parallel::detail::is_sorted_until<
+                typename iterator_traits::local_iterator,
+                typename iterator_traits::local_iterator>(),
+            hpx::execution::seq, first, last, HPX_FORWARD(Pred, pred),
+            hpx::identity_v, std::true_type());
+    }
+
+    template <typename ExPolicy, typename SegIter,
+        typename Pred = hpx::parallel::detail::less>
+        requires(hpx::is_execution_policy_v<ExPolicy> &&
+            hpx::traits::is_iterator_v<SegIter> &&
+            hpx::traits::is_segmented_iterator_v<SegIter>)
+    hpx::parallel::util::detail::algorithm_result_t<ExPolicy, SegIter>
+    tag_invoke(hpx::is_sorted_until_t, ExPolicy&& policy, SegIter first,
+        SegIter last, Pred&& pred = Pred())
+    {
+        static_assert(std::forward_iterator<SegIter>,
+            "Requires at least forward iterator.");
+
+        if (first == last)
+        {
+            using result =
+                hpx::parallel::util::detail::algorithm_result<ExPolicy,
+                    SegIter>;
+            return result::get(HPX_MOVE(first));
+        }
+
+        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
+        using iterator_traits = hpx::traits::segmented_iterator_traits<SegIter>;
+
+        return hpx::parallel::detail::segmented_is_sorted_until(
+            hpx::parallel::detail::is_sorted_until<
+                typename iterator_traits::local_iterator,
+                typename iterator_traits::local_iterator>(),
+            HPX_FORWARD(ExPolicy, policy), first, last, HPX_FORWARD(Pred, pred),
+            hpx::identity_v, is_seq());
+    }
+
+    template <typename InIter, typename Pred = hpx::parallel::detail::less>
+        requires(hpx::traits::is_iterator_v<InIter> &&
+            hpx::traits::is_segmented_iterator_v<InIter>)
+    bool tag_invoke(
+        hpx::is_sorted_t, InIter first, InIter last, Pred&& pred = Pred())
+    {
+        static_assert(std::forward_iterator<InIter>,
+            "Requires at least forward iterator.");
+
+        if (first == last)
+            return true;
+
+        using iterator_traits = hpx::traits::segmented_iterator_traits<InIter>;
+
+        return hpx::parallel::detail::segmented_is_sorted_until(
+                   hpx::parallel::detail::is_sorted_until<
+                       typename iterator_traits::local_iterator,
+                       typename iterator_traits::local_iterator>(),
+                   hpx::execution::seq, first, last, HPX_FORWARD(Pred, pred),
+                   hpx::identity_v, std::true_type()) == last;
+    }
+
+    template <typename ExPolicy, typename SegIter,
+        typename Pred = hpx::parallel::detail::less>
+        requires(hpx::is_execution_policy_v<ExPolicy> &&
+            hpx::traits::is_iterator_v<SegIter> &&
+            hpx::traits::is_segmented_iterator_v<SegIter>)
+    hpx::parallel::util::detail::algorithm_result_t<ExPolicy, bool> tag_invoke(
+        hpx::is_sorted_t, ExPolicy&& policy, SegIter first, SegIter last,
+        Pred&& pred = Pred())
+    {
+        static_assert(std::forward_iterator<SegIter>,
+            "Requires at least forward iterator.");
+
+        if (first == last)
+        {
+            using result =
+                hpx::parallel::util::detail::algorithm_result<ExPolicy, bool>;
+            return result::get(true);
+        }
+
+        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
+        using iterator_traits = hpx::traits::segmented_iterator_traits<SegIter>;
+        using local_iter = typename iterator_traits::local_iterator;
+
+        auto until_result = hpx::parallel::detail::segmented_is_sorted_until(
+            hpx::parallel::detail::is_sorted_until<local_iter, local_iter>(),
+            HPX_FORWARD(ExPolicy, policy), first, last, HPX_FORWARD(Pred, pred),
+            hpx::identity_v, is_seq());
+
+        if constexpr (hpx::traits::is_future_v<decltype(until_result)>)
+        {
+            return until_result.then(
+                [last](auto&& f) -> bool { return f.get() == last; });
+        }
+        else
+        {
+            using result =
+                hpx::parallel::util::detail::algorithm_result<ExPolicy, bool>;
+            return result::get(until_result == last);
+        }
+    }
+}    // namespace hpx::segmented

--- a/libs/full/segmented_algorithms/tests/unit/CMakeLists.txt
+++ b/libs/full/segmented_algorithms/tests/unit/CMakeLists.txt
@@ -43,6 +43,7 @@ set(tests
     partitioned_vector_find2
     partitioned_vector_inclusive_scan
     partitioned_vector_inclusive_scan2
+    partitioned_vector_is_sorted
     partitioned_vector_exclusive_scan
     partitioned_vector_exclusive_scan2
     partitioned_vector_none1

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_is_sorted.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_is_sorted.cpp
@@ -1,0 +1,173 @@
+//  Copyright (c) 2026 Mo'men Samir
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/parallel_is_sorted.hpp>
+
+#include <hpx/include/partitioned_vector_predef.hpp>
+#include <hpx/include/runtime.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <cstddef>
+#include <functional>
+#include <iostream>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+#define SIZE 64
+
+template <typename T>
+void initialize_sorted(hpx::partitioned_vector<T>& xvalues)
+{
+    typename hpx::partitioned_vector<T>::iterator it = xvalues.begin();
+    for (int i = 0; i < SIZE; ++i, ++it)
+        *it = T(i + 1);
+}
+
+template <typename T>
+void initialize_unsorted(hpx::partitioned_vector<T>& xvalues)
+{
+    typename hpx::partitioned_vector<T>::iterator it = xvalues.begin();
+    for (int i = 0; i < SIZE; ++i, ++it)
+    {
+        *it = T(i + 1);
+        if (i == 32)
+            *it = T(30);
+    }
+}
+
+template <typename T>
+void test_is_sorted(hpx::partitioned_vector<T>& sorted_vals,
+    hpx::partitioned_vector<T>& unsorted_vals)
+{
+    HPX_TEST(hpx::is_sorted(sorted_vals.begin(), sorted_vals.end()));
+    HPX_TEST(!hpx::is_sorted(unsorted_vals.begin(), unsorted_vals.end()));
+    HPX_TEST(!hpx::is_sorted(
+        sorted_vals.begin(), sorted_vals.end(), std::greater<T>()));
+}
+
+// Policy overload
+template <typename ExPolicy, typename T>
+void test_is_sorted(ExPolicy&& policy, hpx::partitioned_vector<T>& sorted_vals,
+    hpx::partitioned_vector<T>& unsorted_vals)
+{
+    HPX_TEST(hpx::is_sorted(policy, sorted_vals.begin(), sorted_vals.end()));
+    HPX_TEST(
+        !hpx::is_sorted(policy, unsorted_vals.begin(), unsorted_vals.end()));
+    HPX_TEST(!hpx::is_sorted(
+        policy, sorted_vals.begin(), sorted_vals.end(), std::greater<T>()));
+}
+
+template <typename ExPolicy, typename T>
+void test_is_sorted_async(ExPolicy&& policy,
+    hpx::partitioned_vector<T>& sorted_vals,
+    hpx::partitioned_vector<T>& unsorted_vals)
+{
+    HPX_TEST(
+        hpx::is_sorted(policy, sorted_vals.begin(), sorted_vals.end()).get());
+    HPX_TEST(!hpx::is_sorted(policy, unsorted_vals.begin(), unsorted_vals.end())
+            .get());
+    HPX_TEST(!hpx::is_sorted(
+        policy, sorted_vals.begin(), sorted_vals.end(), std::greater<T>())
+            .get());
+}
+
+template <typename T>
+void test_is_sorted_until(hpx::partitioned_vector<T>& sorted_vals,
+    hpx::partitioned_vector<T>& unsorted_vals)
+{
+    auto result = hpx::is_sorted_until(sorted_vals.begin(), sorted_vals.end());
+    HPX_TEST(result == sorted_vals.end());
+
+    result = hpx::is_sorted_until(unsorted_vals.begin(), unsorted_vals.end());
+    HPX_TEST_EQ(std::distance(unsorted_vals.begin(), result), 32L);
+
+    result = hpx::is_sorted_until(
+        sorted_vals.begin(), sorted_vals.end(), std::greater<T>());
+    HPX_TEST_EQ(std::distance(sorted_vals.begin(), result), 1L);
+}
+
+template <typename ExPolicy, typename T>
+void test_is_sorted_until(ExPolicy&& policy,
+    hpx::partitioned_vector<T>& sorted_vals,
+    hpx::partitioned_vector<T>& unsorted_vals)
+{
+    auto result =
+        hpx::is_sorted_until(policy, sorted_vals.begin(), sorted_vals.end());
+    HPX_TEST(result == sorted_vals.end());
+
+    result = hpx::is_sorted_until(
+        policy, unsorted_vals.begin(), unsorted_vals.end());
+    HPX_TEST_EQ(std::distance(unsorted_vals.begin(), result), 32L);
+
+    result = hpx::is_sorted_until(
+        policy, sorted_vals.begin(), sorted_vals.end(), std::greater<T>());
+    HPX_TEST_EQ(std::distance(sorted_vals.begin(), result), 1L);
+}
+
+template <typename ExPolicy, typename T>
+void test_is_sorted_until_async(ExPolicy&& policy,
+    hpx::partitioned_vector<T>& sorted_vals,
+    hpx::partitioned_vector<T>& unsorted_vals)
+{
+    auto result =
+        hpx::is_sorted_until(policy, sorted_vals.begin(), sorted_vals.end())
+            .get();
+    HPX_TEST(result == sorted_vals.end());
+
+    result =
+        hpx::is_sorted_until(policy, unsorted_vals.begin(), unsorted_vals.end())
+            .get();
+    HPX_TEST_EQ(std::distance(unsorted_vals.begin(), result), 32L);
+
+    result = hpx::is_sorted_until(
+        policy, sorted_vals.begin(), sorted_vals.end(), std::greater<T>())
+                 .get();
+    HPX_TEST_EQ(std::distance(sorted_vals.begin(), result), 1L);
+}
+
+template <typename T>
+void is_sorted_tests(std::vector<hpx::id_type>& localities)
+{
+    hpx::partitioned_vector<T> sorted_vals(
+        SIZE, T(0), hpx::container_layout(localities));
+    hpx::partitioned_vector<T> unsorted_vals(
+        SIZE, T(0), hpx::container_layout(localities));
+
+    initialize_sorted(sorted_vals);
+    initialize_unsorted(unsorted_vals);
+
+    test_is_sorted(sorted_vals, unsorted_vals);
+
+    test_is_sorted(hpx::execution::seq, sorted_vals, unsorted_vals);
+    test_is_sorted(hpx::execution::par, sorted_vals, unsorted_vals);
+
+    test_is_sorted_async(
+        hpx::execution::seq(hpx::execution::task), sorted_vals, unsorted_vals);
+    test_is_sorted_async(
+        hpx::execution::par(hpx::execution::task), sorted_vals, unsorted_vals);
+
+    test_is_sorted_until(sorted_vals, unsorted_vals);
+
+    test_is_sorted_until(hpx::execution::seq, sorted_vals, unsorted_vals);
+    test_is_sorted_until(hpx::execution::par, sorted_vals, unsorted_vals);
+
+    test_is_sorted_until_async(
+        hpx::execution::seq(hpx::execution::task), sorted_vals, unsorted_vals);
+    test_is_sorted_until_async(
+        hpx::execution::par(hpx::execution::task), sorted_vals, unsorted_vals);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int main()
+{
+    std::vector<hpx::id_type> localities = hpx::find_all_localities();
+    is_sorted_tests<int>(localities);
+    return hpx::util::report_errors();
+}
+#endif


### PR DESCRIPTION
#1338 

## Proposed Changes

  - Add segmented version of `is_sorted_until` & `is_sorted`.
  - `is_sorted` delegates to `is_sorted_until` and compares result against `last` iterator.
  
## Any background context you want to provide?

## Checklist

Not all points below apply to all pull requests.

- [x] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
