### PR TITLE
add slash command

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -8,6 +8,7 @@ name: Build and Test
 
 on:
   pull_request:
+    types: [labeled]
   push:
     branches:
       - master
@@ -16,6 +17,11 @@ on:
 
 jobs:
     configure-core-core_local-components:
+        # On PRs, only run if the 'ok-to-test' label is present.
+        # On pushes to master/release, always run.
+        if: >-
+          github.event_name != 'pull_request' ||
+          contains(github.event.pull_request.labels.*.name, 'ok-to-test')
         runs-on: ubuntu-latest
         container: stellargroup/build_env:17
 

--- a/.github/workflows/pr_welcome.yml
+++ b/.github/workflows/pr_welcome.yml
@@ -1,0 +1,48 @@
+name: PR Welcome
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  welcome-message:
+    name: "Post Welcome Message"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add Welcome Comment
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const prAuthor = context.payload.pull_request.user.login;
+            
+            // Check if the PR author is a repository member/collaborator
+            try {
+              const { data: permissionLvl } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: prAuthor,
+              });
+
+              // If they have admin, write, or maintain, they are not an external contributor.
+              // We only want to notify external contributors about the /ok to test workflow.
+              const level = permissionLvl.permission.toLowerCase();
+              const internalPermissions = ['admin', 'maintain', 'write'];
+              if (internalPermissions.includes(level)) {
+                console.log(`User ${prAuthor} is an internal contributor (Permission: ${level}). Skipping welcome message.`);
+                return;
+              }
+            } catch (error) {
+              console.log("Could not fetch permission level, assuming external contributor.", error);
+            }
+
+            const body = `Hi @${prAuthor}! Thanks for the PR.\n\nA maintainer will trigger the full tests once they've had a quick look at your changes. In the meantime, please check the results below!`;
+
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            });

--- a/.github/workflows/pr_welcome.yml
+++ b/.github/workflows/pr_welcome.yml
@@ -1,3 +1,9 @@
+# Copyright (c) 2026 Sai Charan Arvapally
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
 name: PR Welcome
 
 on:

--- a/.github/workflows/slash_commands.yml
+++ b/.github/workflows/slash_commands.yml
@@ -1,0 +1,105 @@
+name: Slash Command Dispatch
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  pull-requests: write
+  issues: write
+  contents: read
+
+jobs:
+  ok-to-test:
+    name: "Check for /ok to test command"
+    # Only run on pull requests and if the comment contains '/ok to test'
+    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '/ok to test') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify permissions and react
+        uses: actions/github-script@v6
+        env:
+          CIRCLE_CI_TOKEN: ${{ secrets.CIRCLECI_TOKEN }}
+        with:
+          script: |
+            // 1. Get the pull request author and the commenter
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number,
+            });
+            const prAuthor = pr.data.user.login;
+            const commenter = context.actor;
+
+            // 2. Check commenter permissions first
+            let permissionLvl;
+            try {
+              const response = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                username: commenter,
+              });
+              permissionLvl = response.data;
+            } catch (error) {
+              console.error("Error checking permissions:", error);
+              core.setFailed("Failed to verify permissions.");
+              return;
+            }
+
+            // 3. Allow if they are a maintainer (even on their own PR)
+            // Block only if they are NOT a maintainer
+            const level = permissionLvl.permission.toLowerCase();
+            const isMaintainer = ['admin', 'maintain', 'write'].includes(level);
+
+            if (!isMaintainer) {
+                console.log(`User ${commenter} is not a maintainer (Permission: ${level}). Rejecting.`);
+                await github.rest.reactions.createForIssueComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    comment_id: context.payload.comment.id,
+                    content: 'confused'
+                });
+                core.setFailed(`Insufficient permissions to run /ok to test. User has: ${level}`);
+                return;
+            }
+
+            console.log(`Permissions verified for ${commenter}. Triggering heavy tests.`);
+
+            // 4. Add +1 (thumbs up) reaction to acknowledge the command
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: '+1',
+            });
+
+            // 5. Add 'ok-to-test' label to the PR so GitHub Actions heavy workflows can trigger
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['ok-to-test']
+            });
+            // 6. Trigger CircleCI pipeline via API (with run_heavy_tests=true parameter)
+            // NOTE: CIRCLE_CI_TOKEN must be a Personal API Token from CircleCI, not just a project token,
+            // in order to trigger pipelines via the v2 API.
+            const response = await fetch(`https://circleci.com/api/v2/project/gh/${context.repo.owner}/${context.repo.repo}/pipeline`, {
+              method: 'POST',
+              headers: {
+                'Content-Type': 'application/json',
+                'Circle-Token': process.env.CIRCLE_CI_TOKEN
+              },
+              body: JSON.stringify({
+                branch: pr.data.head.ref,
+                parameters: {
+                  run_heavy_tests: true
+                }
+              })
+            });
+
+            if (!response.ok) {
+              console.error("Failed to trigger CircleCI:", await response.text());
+              core.setFailed("Failed to trigger CircleCI pipeline.");
+            } else {
+              console.log("Successfully triggered CircleCI pipeline.");
+            }

--- a/.github/workflows/slash_commands.yml
+++ b/.github/workflows/slash_commands.yml
@@ -1,3 +1,9 @@
+# Copyright (c) 2026 Sai Charan Arvapally
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
 name: Slash Command Dispatch
 
 on:
@@ -18,8 +24,6 @@ jobs:
     steps:
       - name: Verify permissions and react
         uses: actions/github-script@v6
-        env:
-          CIRCLE_CI_TOKEN: ${{ secrets.CIRCLECI_TOKEN }}
         with:
           script: |
             // 1. Get the pull request author and the commenter
@@ -80,26 +84,3 @@ jobs:
               issue_number: context.issue.number,
               labels: ['ok-to-test']
             });
-            // 6. Trigger CircleCI pipeline via API (with run_heavy_tests=true parameter)
-            // NOTE: CIRCLE_CI_TOKEN must be a Personal API Token from CircleCI, not just a project token,
-            // in order to trigger pipelines via the v2 API.
-            const response = await fetch(`https://circleci.com/api/v2/project/gh/${context.repo.owner}/${context.repo.repo}/pipeline`, {
-              method: 'POST',
-              headers: {
-                'Content-Type': 'application/json',
-                'Circle-Token': process.env.CIRCLE_CI_TOKEN
-              },
-              body: JSON.stringify({
-                branch: pr.data.head.ref,
-                parameters: {
-                  run_heavy_tests: true
-                }
-              })
-            });
-
-            if (!response.ok) {
-              console.error("Failed to trigger CircleCI:", await response.text());
-              core.setFailed("Failed to trigger CircleCI pipeline.");
-            } else {
-              console.log("Successfully triggered CircleCI pipeline.");
-            }


### PR DESCRIPTION
Fixes #7075

Adds `/ok to test` to CI actions to save CI resources.

- Light checks (formatting, deps) run automatically on every PR push
- Heavy tests only run when a maintainer comments `/ok to test`
