### PR TITLE
examples: add sender_diamond quickstart example

### DIFF
--- a/examples/quickstart/CMakeLists.txt
+++ b/examples/quickstart/CMakeLists.txt
@@ -42,6 +42,10 @@ if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD" AND NOT HPX_WITH_STATIC_LINKING)
   set(example_programs ${example_programs} init_globally)
 endif()
 
+if(NOT (MSVC AND HPX_WITH_CXX_MODULES))
+  list(APPEND example_programs sender_diamond)
+endif()
+
 if(HPX_WITH_DISTRIBUTED_RUNTIME)
   set(example_programs
       ${example_programs}
@@ -134,6 +138,7 @@ set(hello_world_2_PARAMETERS THREADS_PER_LOCALITY 4)
 set(hello_world_distributed_PARAMETERS THREADS_PER_LOCALITY 4)
 set(interval_timer_PARAMETERS THREADS_PER_LOCALITY 4)
 set(local_channel_PARAMETERS THREADS_PER_LOCALITY 4)
+set(sender_diamond_PARAMETERS THREADS_PER_LOCALITY 4)
 set(sierpinski_PARAMETERS THREADS_PER_LOCALITY 4)
 set(partitioned_vector_spmd_foreach_PARAMETERS THREADS_PER_LOCALITY 4)
 set(pingpong_PARAMETERS THREADS_PER_LOCALITY 4)

--- a/examples/quickstart/sender_diamond.cpp
+++ b/examples/quickstart/sender_diamond.cpp
@@ -1,0 +1,82 @@
+//  Copyright (c) 2026 Kashy Namboothiri
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Note: This example is excluded from MSVC builds with C++ modules enabled
+// due to a compiler ICE. See CMakeLists.txt for the build guard.
+
+// Demonstrates a diamond dependency pattern using HPX sender/receiver
+// primitives. A single sender (A) is shared between two independent continuations
+// (B and C) using split. Their results are then joined by when_all and merged
+// in a final step (D).
+//
+// Dependency structure:
+//
+//         A  (produce initial value)
+//        / \
+//       B   C  (independent transforms, dispatched to thread pool)
+//        \ /
+//         D  (merge)
+
+#include <hpx/assert.hpp>
+#include <hpx/execution.hpp>
+#include <hpx/init.hpp>
+
+#include <iostream>
+#include <utility>
+
+namespace ex = hpx::execution::experimental;
+namespace tt = hpx::this_thread::experimental;
+
+int hpx_main()
+{
+    // A. Produces an initial value
+    auto a = ex::just(10) | ex::then([](int x) {
+        std::cout << "A: produced " << x << "\n";
+        return x;
+    });
+
+    // split makes the sender A safe to connect more than once
+    auto a_shared = ex::split(std::move(a));
+
+    auto sched = ex::thread_pool_scheduler{};
+
+    // B. Double the value from A
+    auto b = a_shared | ex::transfer(sched) | ex::then([](int x) {
+        int result = x * 2;
+        std::cout << "B: " << x << " * 2 = " << result << "\n";
+        return result;
+    });
+
+    // C. Triple the value from A
+    auto c = a_shared | ex::transfer(sched) | ex::then([](int x) {
+        int result = x * 3;
+        std::cout << "C: " << x << " * 3 = " << result << "\n";
+        return result;
+    });
+
+    // D. Join B and C, then sum their results
+    auto d = ex::then(
+        ex::when_all(std::move(b), std::move(c)), [](int from_b, int from_c) {
+            int result = from_b + from_c;
+            std::cout << "D: " << from_b << " + " << from_c << " = " << result
+                      << "\n";
+            return result;
+        });
+
+    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+    auto result = hpx::get<0>(*tt::sync_wait(std::move(d)));
+    std::cout << "Final Result: " << result << "\n";
+
+    // expected: A=10, B=20, C=30, D=50
+    HPX_ASSERT(result == 50);
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    return hpx::local::init(hpx_main, argc, argv);
+}


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - Add `sender_diamond.cpp` to `examples/quickstart` demonstrating a diamond dependency pattern using HPX sender/receiver primitives
  - Add corresponding `CMakeLists.txt` entry

## Any background context you want to provide?

The example shows split for safe multi-consumer reuse, then for branch continuations, when_all for joining dependencies, and sync_wait for extracting the final result. Intended as a minimal educational example of a common fork-join pattern in sender/receiver composition.

Built and ran locally:
A: produced 10
B: 10 * 2 = 20
C: 10 * 3 = 30
D: 20 + 30 = 50
Final Result: 50

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
