### PR TITLE
contracts: add violation handler infrastructure and annotated hpx::future

### DIFF
--- a/.github/workflows/linux_release_gcc_trunk_reflection.yml
+++ b/.github/workflows/linux_release_gcc_trunk_reflection.yml
@@ -31,7 +31,7 @@ jobs:
           -DHPX_WITH_CXX_STANDARD=26 \
           -DCMAKE_C_COMPILER=gcc \
           -DCMAKE_CXX_COMPILER=g++ \
-          -DCMAKE_CXX_FLAGS="-freflection -std=c++26 -latomic -fcontracts" \
+          -DCMAKE_CXX_FLAGS="-freflection -std=c++26 -latomic -fcontracts -fcontract-evaluation-semantic=enforce" \
           -DCMAKE_EXE_LINKER_FLAGS="-latomic" \
           -DCMAKE_SHARED_LINKER_FLAGS="-latomic" \
           -DCMAKE_REQUIRED_LIBRARIES="atomic" \
@@ -40,17 +40,16 @@ jobs:
           -DHPX_WITH_EXAMPLES=OFF \
           -DHPX_WITH_TESTS=ON \
           -DHPX_WITH_TESTS_MAX_THREADS_PER_LOCALITY=2 \
-          -DHPX_WITH_CHECK_MODULE_DEPENDENCIES=On \
-          -DHPX_CMAKE_LOGLEVEL=Debug
+          -DHPX_WITH_CHECK_MODULE_DEPENDENCIES=On
     - name: Build
       shell: bash
       run: |
           cmake --build build --target all
           cmake --build build --target tests.unit.modules.serialization
+          cmake --build build --target tests.unit.modules.contracts
     - name: Test
       shell: bash
       run: |
           cd build
-          ctest \
-            --output-on-failure \
-            --tests-regex "tests.unit.modules.serialization"
+          ctest --output-on-failure --tests-regex "tests.unit.modules.serialization"
+          ctest --output-on-failure --tests-regex "tests.unit.modules.contracts"

--- a/.github/workflows/linux_release_gcc_trunk_reflection.yml
+++ b/.github/workflows/linux_release_gcc_trunk_reflection.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: stellargroup/gcc_trunk_build_env:1
+    container: stellargroup/gcc_trunk_build_env:2
 
     steps:
     - uses: actions/checkout@v7
@@ -40,7 +40,6 @@ jobs:
           -DHPX_WITH_EXAMPLES=OFF \
           -DHPX_WITH_TESTS=ON \
           -DHPX_WITH_TESTS_MAX_THREADS_PER_LOCALITY=2 \
-          -DHPX_SERIALIZATION_WITH_ALLOW_AUTO_GENERATE=ON \
           -DHPX_WITH_CHECK_MODULE_DEPENDENCIES=On
     - name: Build
       shell: bash

--- a/.github/workflows/linux_release_gcc_trunk_reflection.yml
+++ b/.github/workflows/linux_release_gcc_trunk_reflection.yml
@@ -31,7 +31,7 @@ jobs:
           -DHPX_WITH_CXX_STANDARD=26 \
           -DCMAKE_C_COMPILER=gcc \
           -DCMAKE_CXX_COMPILER=g++ \
-          -DCMAKE_CXX_FLAGS="-freflection -std=c++26 -latomic" \
+          -DCMAKE_CXX_FLAGS="-freflection -std=c++26 -latomic -fcontracts" \
           -DCMAKE_EXE_LINKER_FLAGS="-latomic" \
           -DCMAKE_SHARED_LINKER_FLAGS="-latomic" \
           -DCMAKE_REQUIRED_LIBRARIES="atomic" \
@@ -40,7 +40,8 @@ jobs:
           -DHPX_WITH_EXAMPLES=OFF \
           -DHPX_WITH_TESTS=ON \
           -DHPX_WITH_TESTS_MAX_THREADS_PER_LOCALITY=2 \
-          -DHPX_WITH_CHECK_MODULE_DEPENDENCIES=On
+          -DHPX_WITH_CHECK_MODULE_DEPENDENCIES=On \
+          -DHPX_CMAKE_LOGLEVEL=Debug
     - name: Build
       shell: bash
       run: |

--- a/.github/workflows/macos_debug.yml
+++ b/.github/workflows/macos_debug.yml
@@ -39,7 +39,8 @@ jobs:
               -DHPX_WITH_TESTS_MAX_THREADS_PER_LOCALITY=3 \
               -DHPX_WITH_VERIFY_LOCKS=OFF \
               -DHPX_WITH_VERIFY_LOCKS_BACKTRACE=OFF \
-              -DHPX_WITH_CHECK_MODULE_DEPENDENCIES=ON
+              -DHPX_WITH_CHECK_MODULE_DEPENDENCIES=ON \
+              -DHPX_WITH_CONTRACTS_MODE=OBSERVE
     - name: Build
       shell: bash
       run: |

--- a/.github/workflows/macos_debug_fetch_boost.yml
+++ b/.github/workflows/macos_debug_fetch_boost.yml
@@ -37,7 +37,8 @@ jobs:
               -DHPX_WITH_TESTS=ON \
               -DHPX_WITH_TESTS_MAX_THREADS_PER_LOCALITY=2 \
               -DHPX_WITH_CHECK_MODULE_DEPENDENCIES=On \
-              -DHPX_WITH_TESTS_EXTERNAL_BUILD=Off
+              -DHPX_WITH_TESTS_EXTERNAL_BUILD=Off \
+              -DHPX_WITH_CONTRACTS_MODE=IGNORE
     - name: Build
       shell: bash
       run: |

--- a/.github/workflows/macos_debug_fetch_hwloc.yml
+++ b/.github/workflows/macos_debug_fetch_hwloc.yml
@@ -43,7 +43,8 @@ jobs:
               -DHPX_WITH_TESTS_MAX_THREADS_PER_LOCALITY=3 \
               -DHPX_WITH_VERIFY_LOCKS=OFF \
               -DHPX_WITH_VERIFY_LOCKS_BACKTRACE=OFF \
-              -DHPX_WITH_CHECK_MODULE_DEPENDENCIES=ON
+              -DHPX_WITH_CHECK_MODULE_DEPENDENCIES=ON \
+              -DHPX_WITH_CONTRACTS_MODE=ENFORCE
     - name: Build
       shell: bash
       run: |

--- a/cmake/HPX_AddTest.cmake
+++ b/cmake/HPX_AddTest.cmake
@@ -22,6 +22,8 @@ function(add_hpx_test category name)
     ${name} "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN}
   )
 
+  hpx_debug("add_hpx_test.${category}.${name}" "args: ${ARGN}")
+
   if(NOT ${name}_LOCALITIES)
     set(${name}_LOCALITIES 1)
   endif()
@@ -126,6 +128,8 @@ function(add_hpx_test category name)
   else()
     set(${name}_LOCALITIES "1")
   endif()
+
+  hpx_debug("add_hpx_test.${category}.${name}" "cmd: ${cmd} ${args}")
 
   if(${name}_LOCALITIES STREQUAL "1")
     set(_full_name "${category}.${name}")

--- a/cmake/tests/cxx26_contracts.cpp
+++ b/cmake/tests/cxx26_contracts.cpp
@@ -6,6 +6,9 @@
 
 // test for availability of C++26 contracts (compiler and library support)
 
+#include <version>
+#include <contracts>
+
 #if !defined(__cpp_contracts)
 #error "__cpp_contracts not defined, assume contracts are not supported"
 #endif
@@ -13,8 +16,6 @@
 #if !defined(__cpp_lib_contracts)
 #error "__cpp_lib_contracts not defined, assume contracts are not supported"
 #endif
-
-#include <contracts>
 
 // Test actual contract syntax support (for experimental implementations)
 int main() pre(true) post(r : r == 0)

--- a/cmake/tests/cxx26_contracts.cpp
+++ b/cmake/tests/cxx26_contracts.cpp
@@ -1,13 +1,17 @@
-//  Copyright (c) 2025 Hartmut Kaiser
+//  Copyright (c) 2025-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// test for availability of C++26 contracts
+// test for availability of C++26 contracts (compiler and library support)
 
 #if !defined(__cpp_contracts)
 #error "__cpp_contracts not defined, assume contracts are not supported"
+#endif
+
+#if !defined(__cpp_lib_contracts)
+#error "__cpp_lib_contracts not defined, assume contracts are not supported"
 #endif
 
 #include <contracts>

--- a/components/process/include/hpx/components/process/util/posix/initializers/run_exe.hpp
+++ b/components/process/include/hpx/components/process/util/posix/initializers/run_exe.hpp
@@ -80,7 +80,7 @@ namespace hpx::components::process::posix::initializers {
 
     inline run_exe_ run_exe(filesystem::path const& p)
     {
-        return run_exe_(filesystem::to_string(p);
+        return run_exe_(hpx::filesystem::to_string(p));
     }
 
 }    // namespace hpx::components::process::posix::initializers

--- a/components/process/include/hpx/components/process/util/posix/initializers/run_exe.hpp
+++ b/components/process/include/hpx/components/process/util/posix/initializers/run_exe.hpp
@@ -80,7 +80,7 @@ namespace hpx::components::process::posix::initializers {
 
     inline run_exe_ run_exe(filesystem::path const& p)
     {
-        return run_exe_(p.string());
+        return run_exe_(filesystem::to_string(p);
     }
 
 }    // namespace hpx::components::process::posix::initializers

--- a/components/process/include/hpx/components/process/util/windows/initializers/run_exe.hpp
+++ b/components/process/include/hpx/components/process/util/windows/initializers/run_exe.hpp
@@ -81,7 +81,7 @@ namespace hpx::components::process::windows::initializers {
 
     inline auto run_exe(filesystem::path const& p)
     {
-        return run_exe_<std::string>(filesystem::to_string(p));
+        return run_exe_<std::string>(hpx::filesystem::to_string(p));
     }
 }    // namespace hpx::components::process::windows::initializers
 

--- a/components/process/include/hpx/components/process/util/windows/initializers/run_exe.hpp
+++ b/components/process/include/hpx/components/process/util/windows/initializers/run_exe.hpp
@@ -81,7 +81,7 @@ namespace hpx::components::process::windows::initializers {
 
     inline auto run_exe(filesystem::path const& p)
     {
-        return run_exe_<std::string>(p.string());
+        return run_exe_<std::string>(filesystem::to_string(p));
     }
 }    // namespace hpx::components::process::windows::initializers
 

--- a/components/process/include/hpx/components/process/util/windows/initializers/start_in_dir.hpp
+++ b/components/process/include/hpx/components/process/util/windows/initializers/start_in_dir.hpp
@@ -81,7 +81,7 @@ namespace hpx::components::process::windows::initializers {
 
     inline auto start_in_dir(filesystem::path const& p)
     {
-        return start_in_dir_<std::string>(filesystem::to_string(p));
+        return start_in_dir_<std::string>(hpx::filesystem::to_string(p));
     }
 }    // namespace hpx::components::process::windows::initializers
 

--- a/components/process/include/hpx/components/process/util/windows/initializers/start_in_dir.hpp
+++ b/components/process/include/hpx/components/process/util/windows/initializers/start_in_dir.hpp
@@ -81,7 +81,7 @@ namespace hpx::components::process::windows::initializers {
 
     inline auto start_in_dir(filesystem::path const& p)
     {
-        return start_in_dir_<std::string>(p.string());
+        return start_in_dir_<std::string>(filesystem::to_string(p));
     }
 }    // namespace hpx::components::process::windows::initializers
 

--- a/components/process/src/util/posix/search_path_u.cpp
+++ b/components/process/src/util/posix/search_path_u.cpp
@@ -49,7 +49,7 @@ namespace hpx { namespace components { namespace process { namespace posix {
             p /= filename;
             if (!::access(p.c_str(), X_OK))
             {
-                result = filesystem::to_string(p);
+                result = hpx::filesystem::to_string(p);
                 break;
             }
         }

--- a/components/process/src/util/posix/search_path_u.cpp
+++ b/components/process/src/util/posix/search_path_u.cpp
@@ -49,7 +49,7 @@ namespace hpx { namespace components { namespace process { namespace posix {
             p /= filename;
             if (!::access(p.c_str(), X_OK))
             {
-                result = p.string();
+                result = filesystem::to_string(p);
                 break;
             }
         }

--- a/components/process/src/util/windows/search_path_w.cpp
+++ b/components/process/src/util/windows/search_path_w.cpp
@@ -106,11 +106,11 @@ namespace hpx::components::process::windows {
                 std::error_code ec;
                 bool file = filesystem::is_regular_file(p2, ec);
                 if (!ec && file &&
-                    SHGetFileInfoA(filesystem::to_string(p2).c_str(), 0,
+                    SHGetFileInfoA(hpx::filesystem::to_string(p2).c_str(), 0,
                         nullptr,    //-V575
                         0, SHGFI_EXETYPE))
                 {
-                    return filesystem::to_string(p2);
+                    return hpx::filesystem::to_string(p2);
                 }
             }
         }

--- a/components/process/src/util/windows/search_path_w.cpp
+++ b/components/process/src/util/windows/search_path_w.cpp
@@ -106,10 +106,11 @@ namespace hpx::components::process::windows {
                 std::error_code ec;
                 bool file = filesystem::is_regular_file(p2, ec);
                 if (!ec && file &&
-                    SHGetFileInfoA(p2.string().c_str(), 0, nullptr,    //-V575
+                    SHGetFileInfoA(filesystem::to_string(p2).c_str(), 0,
+                        nullptr,    //-V575
                         0, SHGFI_EXETYPE))
                 {
-                    return p2.string();
+                    return filesystem::to_string(p2);
                 }
             }
         }

--- a/libs/core/algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/CMakeLists.txt
@@ -280,6 +280,7 @@ add_hpx_module(
     hpx_concepts
     hpx_concurrency
     hpx_config
+    hpx_contracts
     hpx_coroutines
     hpx_datastructures
     hpx_errors

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/sort.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/sort.hpp
@@ -152,6 +152,7 @@ namespace hpx {
 #include <hpx/config.hpp>
 #include <hpx/algorithms/traits/projected.hpp>
 #include <hpx/assert.hpp>
+#include <hpx/contracts.hpp>
 #include <hpx/modules/async_local.hpp>
 #include <hpx/modules/concepts.hpp>
 #include <hpx/modules/execution.hpp>
@@ -392,8 +393,8 @@ namespace hpx {
                 >
             )
         // clang-format on
-        friend void tag_fallback_invoke(
-            hpx::sort_t, RandomIt first, RandomIt last, Comp comp = Comp())
+        friend void tag_fallback_invoke(hpx::sort_t, RandomIt first,
+            RandomIt last, Comp comp = Comp()) HPX_PRE(first <= last)
         {
             static_assert(std::random_access_iterator<RandomIt>,
                 "Requires a random access iterator.");
@@ -416,7 +417,7 @@ namespace hpx {
         // clang-format on
         friend parallel::util::detail::algorithm_result_t<ExPolicy>
         tag_fallback_invoke(hpx::sort_t, ExPolicy&& policy, RandomIt first,
-            RandomIt last, Comp comp = Comp())
+            RandomIt last, Comp comp = Comp()) HPX_PRE(first <= last)
         {
             static_assert(std::random_access_iterator<RandomIt>,
                 "Requires a random access iterator.");

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/stable_sort.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/stable_sort.hpp
@@ -150,6 +150,7 @@ namespace hpx {
 
 #include <hpx/config.hpp>
 #include <hpx/algorithms/traits/projected.hpp>
+#include <hpx/contracts.hpp>
 #include <hpx/modules/concepts.hpp>
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/executors.hpp>
@@ -285,7 +286,7 @@ namespace hpx {
             )
         // clang-format on
         friend void tag_fallback_invoke(hpx::stable_sort_t, RandomIt first,
-            RandomIt last, Comp comp = Comp())
+            RandomIt last, Comp comp = Comp()) HPX_PRE(first <= last)
         {
             static_assert(std::random_access_iterator<RandomIt>,
                 "Requires a random access iterator.");
@@ -310,6 +311,7 @@ namespace hpx {
         friend hpx::parallel::util::detail::algorithm_result_t<ExPolicy>
         tag_fallback_invoke(hpx::stable_sort_t, ExPolicy&& policy,
             RandomIt first, RandomIt last, Comp comp = Comp())
+            HPX_PRE(first <= last)
         {
             static_assert(std::random_access_iterator<RandomIt>,
                 "Requires a random access iterator.");

--- a/libs/core/assertion/include/hpx/assertion/api.hpp
+++ b/libs/core/assertion/include/hpx/assertion/api.hpp
@@ -22,6 +22,6 @@ namespace hpx::assertion {
     /// Set the assertion handler to be used within a program. If the handler has been
     /// set already once, the call to this function will be ignored.
     /// \note This function is not thread safe
-    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void set_assertion_handler(
+    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT assertion_handler set_assertion_handler(
         assertion_handler handler);
 }    // namespace hpx::assertion

--- a/libs/core/assertion/src/assertion.cpp
+++ b/libs/core/assertion/src/assertion.cpp
@@ -14,21 +14,20 @@
 
 namespace hpx::assertion {
 
-    namespace detail {
+    namespace {
 
         [[nodiscard]] assertion_handler& get_handler()
         {
             static assertion_handler handler = nullptr;
             return handler;
         }
-    }    // namespace detail
+    }    // namespace
 
-    void set_assertion_handler(assertion_handler handler)
+    assertion_handler set_assertion_handler(assertion_handler const handler)
     {
-        if (detail::get_handler() == nullptr)
-        {
-            detail::get_handler() = handler;
-        }
+        assertion_handler const old = get_handler();
+        get_handler() = handler;
+        return old;
     }
 
     namespace detail {

--- a/libs/core/assertion/tests/unit/CMakeLists.txt
+++ b/libs/core/assertion/tests/unit/CMakeLists.txt
@@ -1,10 +1,12 @@
-# Copyright (c) 2019-2025 The STE||AR-Group
+# Copyright (c) 2019-2026 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 set(tests assert_fail assert_succeed)
+
+set(assert_fail_PARAMETERS FAILURE_EXPECTED)
 
 foreach(test ${tests})
   set(sources ${test}.cpp)
@@ -19,10 +21,4 @@ foreach(test ${tests})
   )
 
   add_hpx_unit_test("modules.assertion" ${test} ${${test}_PARAMETERS})
-
 endforeach()
-
-set_tests_properties(
-  tests.unit.modules.assertion.assert_fail PROPERTIES WILL_FAIL
-                                                      $<$<CONFIG:Debug>:true>
-)

--- a/libs/core/command_line_handling_local/src/parse_command_line_local.cpp
+++ b/libs/core/command_line_handling_local/src/parse_command_line_local.cpp
@@ -270,8 +270,8 @@ namespace hpx::local::detail {
             util::commandline_error_mode const mode = error_mode &
                 ~util::commandline_error_mode::report_missing_config_file;
 
-            std::vector<std::string> options =
-                read_config_file_options(filesystem::to_string(filename), mode);
+            std::vector<std::string> options = read_config_file_options(
+                hpx::filesystem::to_string(filename), mode);
 
             if (handle_config_file_options(
                     options, desc_cfgfile, vm, ini, mode))

--- a/libs/core/command_line_handling_local/src/parse_command_line_local.cpp
+++ b/libs/core/command_line_handling_local/src/parse_command_line_local.cpp
@@ -271,7 +271,7 @@ namespace hpx::local::detail {
                 ~util::commandline_error_mode::report_missing_config_file;
 
             std::vector<std::string> options =
-                read_config_file_options(filename.string(), mode);
+                read_config_file_options(filesystem::to_string(filename), mode);
 
             if (handle_config_file_options(
                     options, desc_cfgfile, vm, ini, mode))

--- a/libs/core/concurrency/include/hpx/concurrency/detail/freelist_stack.hpp
+++ b/libs/core/concurrency/include/hpx/concurrency/detail/freelist_stack.hpp
@@ -150,7 +150,7 @@ namespace hpx::lockfree::detail {
         template <bool Bounded>
         T* allocate_impl()
         {
-            tagged_node_ptr old_pool = pool_.load(std::memory_order_consume);
+            tagged_node_ptr old_pool = pool_.load(std::memory_order_acquire);
 
             for (;;)
             {
@@ -224,7 +224,7 @@ namespace hpx::lockfree::detail {
         void deallocate_impl(T* n) noexcept
         {
             void* node = n;
-            tagged_node_ptr old_pool = pool_.load(std::memory_order_consume);
+            tagged_node_ptr old_pool = pool_.load(std::memory_order_acquire);
             auto* new_pool_ptr = static_cast<freelist_node*>(node);
 
             for (;;)
@@ -543,7 +543,7 @@ namespace hpx::lockfree::detail {
     private:
         index_t allocate_impl()
         {
-            tagged_index old_pool = pool_.load(std::memory_order_consume);
+            tagged_index old_pool = pool_.load(std::memory_order_acquire);
 
             for (;;)
             {
@@ -565,7 +565,7 @@ namespace hpx::lockfree::detail {
 
         index_t allocate_impl_unsafe()
         {
-            tagged_index const old_pool = pool_.load(std::memory_order_consume);
+            tagged_index const old_pool = pool_.load(std::memory_order_acquire);
 
             index_t index = old_pool.get_index();
             if (index == null_handle())
@@ -599,7 +599,7 @@ namespace hpx::lockfree::detail {
         {
             freelist_node* new_pool_node =
                 reinterpret_cast<freelist_node*>(NodeStorage::nodes() + index);
-            tagged_index old_pool = pool_.load(std::memory_order_consume);
+            tagged_index old_pool = pool_.load(std::memory_order_acquire);
 
             for (;;)
             {
@@ -615,7 +615,7 @@ namespace hpx::lockfree::detail {
         {
             freelist_node* new_pool_node =
                 reinterpret_cast<freelist_node*>(NodeStorage::nodes() + index);
-            tagged_index const old_pool = pool_.load(std::memory_order_consume);
+            tagged_index const old_pool = pool_.load(std::memory_order_acquire);
 
             tagged_index const new_pool(index, old_pool.get_tag());
             new_pool_node->next.set_index(old_pool.get_index());

--- a/libs/core/concurrency/include/hpx/concurrency/stack.hpp
+++ b/libs/core/concurrency/include/hpx/concurrency/stack.hpp
@@ -583,7 +583,7 @@ namespace hpx::lockfree {
         template <typename F>
         bool consume_one(F&& f)
         {
-            tagged_node_handle old_tos = tos.load(std::memory_order_consume);
+            tagged_node_handle old_tos = tos.load(std::memory_order_acquire);
 
             for (;;)
             {
@@ -639,7 +639,7 @@ namespace hpx::lockfree {
         std::size_t consume_all_atomic(F&& f)
         {
             std::size_t element_count = 0;
-            tagged_node_handle old_tos = tos.load(std::memory_order_consume);
+            tagged_node_handle old_tos = tos.load(std::memory_order_acquire);
 
             for (;;)
             {
@@ -693,7 +693,7 @@ namespace hpx::lockfree {
         std::size_t consume_all_atomic_reversed(F&& f)
         {
             std::size_t element_count = 0;
-            tagged_node_handle old_tos = tos.load(std::memory_order_consume);
+            tagged_node_handle old_tos = tos.load(std::memory_order_acquire);
 
             for (;;)
             {

--- a/libs/core/contracts/CMakeLists.txt
+++ b/libs/core/contracts/CMakeLists.txt
@@ -21,13 +21,35 @@ if(HPX_WITH_CXX26_CONTRACTS)
       DEFINE HPX_CONTRACTS_HAVE_ASSERTS_AS_CONTRACT_ASSERTS NAMESPACE CONTRACTS
     )
   endif()
+else()
+  # Contract evaluation mode for pre-C++26 compilers
+  hpx_option(
+    HPX_WITH_CONTRACTS_MODE STRING
+    "Contract evaluation mode for pre-C++26 compilers (ENFORCE, OBSERVE, IGNORE). (default: ENFORCE)"
+    "ENFORCE"
+    STRINGS "ENFORCE;OBSERVE;IGNORE"
+    CATEGORY "Modules"
+    MODULE CONTRACTS
+  )
+
+  if(HPX_WITH_CONTRACTS_MODE STREQUAL "ENFORCE")
+    hpx_add_config_define_namespace(
+      DEFINE HPX_CONTRACTS_MODE VALUE 0 NAMESPACE CONTRACTS
+    )
+  elseif(HPX_WITH_CONTRACTS_MODE STREQUAL "OBSERVE")
+    hpx_add_config_define_namespace(
+      DEFINE HPX_CONTRACTS_MODE VALUE 1 NAMESPACE CONTRACTS
+    )
+  elseif(HPX_WITH_CONTRACTS_MODE STREQUAL "IGNORE")
+    hpx_add_config_define_namespace(
+      DEFINE HPX_CONTRACTS_MODE VALUE 2 NAMESPACE CONTRACTS
+    )
+  endif()
 endif()
 
 # Default location is $HPX_ROOT/libs/contracts/include
-set(contracts_headers
-  hpx/contracts.hpp
-  hpx/contracts/macros.hpp
-  hpx/contracts/violation_handler.hpp
+set(contracts_headers hpx/contracts.hpp hpx/contracts/macros.hpp
+                      hpx/contracts/violation_handler.hpp
 )
 set(contracts_macro_headers hpx/contracts/macros.hpp)
 

--- a/libs/core/contracts/CMakeLists.txt
+++ b/libs/core/contracts/CMakeLists.txt
@@ -22,27 +22,35 @@ if(HPX_WITH_CXX26_CONTRACTS)
     )
   endif()
 else()
-  # Contract evaluation mode for pre-C++26 compilers
-  hpx_option(
-    HPX_WITH_CONTRACTS_MODE STRING
-    "Contract evaluation mode for pre-C++26 compilers (ENFORCE, OBSERVE, IGNORE). (default: ENFORCE)"
-    "ENFORCE"
-    STRINGS "ENFORCE;OBSERVE;IGNORE"
-    CATEGORY "Modules"
-    MODULE CONTRACTS
+  # Contract evaluation mode for pre-C++26 compilers. Not registered via
+  # hpx_option(MODULE CONTRACTS) to avoid triggering the config_entries.cpp
+  # generation mechanism before add_hpx_module creates the build directory.
+  set(HPX_WITH_CONTRACTS_MODE
+      "ENFORCE"
+      CACHE STRING
+            "Contract evaluation mode for pre-C++26 compilers (ENFORCE, OBSERVE, IGNORE)."
+  )
+  set_property(
+    CACHE HPX_WITH_CONTRACTS_MODE PROPERTY STRINGS "ENFORCE;OBSERVE;IGNORE"
   )
 
   if(HPX_WITH_CONTRACTS_MODE STREQUAL "ENFORCE")
     hpx_add_config_define_namespace(
-      DEFINE HPX_CONTRACTS_MODE VALUE 0 NAMESPACE CONTRACTS
+      DEFINE HPX_CONTRACTS_MODE
+      VALUE 0
+      NAMESPACE CONTRACTS
     )
   elseif(HPX_WITH_CONTRACTS_MODE STREQUAL "OBSERVE")
     hpx_add_config_define_namespace(
-      DEFINE HPX_CONTRACTS_MODE VALUE 1 NAMESPACE CONTRACTS
+      DEFINE HPX_CONTRACTS_MODE
+      VALUE 1
+      NAMESPACE CONTRACTS
     )
   elseif(HPX_WITH_CONTRACTS_MODE STREQUAL "IGNORE")
     hpx_add_config_define_namespace(
-      DEFINE HPX_CONTRACTS_MODE VALUE 2 NAMESPACE CONTRACTS
+      DEFINE HPX_CONTRACTS_MODE
+      VALUE 2
+      NAMESPACE CONTRACTS
     )
   endif()
 endif()

--- a/libs/core/contracts/CMakeLists.txt
+++ b/libs/core/contracts/CMakeLists.txt
@@ -30,22 +30,24 @@ else()
     STRINGS "ENFORCE;OBSERVE;IGNORE"
   )
 
+  # Note: values start at 1 because hpx_add_config_define_namespace treats a
+  # numeric "0" as falsy and would emit a valueless #define.
   if(HPX_WITH_CONTRACTS_MODE STREQUAL "ENFORCE")
-    hpx_add_config_define_namespace(
-      DEFINE HPX_HAVE_CONTRACTS_MODE
-      VALUE 0
-      NAMESPACE CONTRACTS
-    )
-  elseif(HPX_WITH_CONTRACTS_MODE STREQUAL "OBSERVE")
     hpx_add_config_define_namespace(
       DEFINE HPX_HAVE_CONTRACTS_MODE
       VALUE 1
       NAMESPACE CONTRACTS
     )
-  elseif(HPX_WITH_CONTRACTS_MODE STREQUAL "IGNORE")
+  elseif(HPX_WITH_CONTRACTS_MODE STREQUAL "OBSERVE")
     hpx_add_config_define_namespace(
       DEFINE HPX_HAVE_CONTRACTS_MODE
       VALUE 2
+      NAMESPACE CONTRACTS
+    )
+  elseif(HPX_WITH_CONTRACTS_MODE STREQUAL "IGNORE")
+    hpx_add_config_define_namespace(
+      DEFINE HPX_HAVE_CONTRACTS_MODE
+      VALUE 3
       NAMESPACE CONTRACTS
     )
   endif()

--- a/libs/core/contracts/CMakeLists.txt
+++ b/libs/core/contracts/CMakeLists.txt
@@ -24,11 +24,15 @@ if(HPX_WITH_CXX26_CONTRACTS)
 endif()
 
 # Default location is $HPX_ROOT/libs/contracts/include
-set(contracts_headers hpx/contracts.hpp hpx/contracts/macros.hpp)
+set(contracts_headers
+  hpx/contracts.hpp
+  hpx/contracts/macros.hpp
+  hpx/contracts/violation_handler.hpp
+)
 set(contracts_macro_headers hpx/contracts/macros.hpp)
 
 # Default location is $HPX_ROOT/libs/contracts/src
-set(contracts_sources)
+set(contracts_sources violation_handler.cpp)
 
 include(HPX_AddModule)
 add_hpx_module(

--- a/libs/core/contracts/CMakeLists.txt
+++ b/libs/core/contracts/CMakeLists.txt
@@ -22,34 +22,29 @@ if(HPX_WITH_CXX26_CONTRACTS)
     )
   endif()
 else()
-  # Contract evaluation mode for pre-C++26 compilers. Not registered via
-  # hpx_option(MODULE CONTRACTS) to avoid triggering the config_entries.cpp
-  # generation mechanism before add_hpx_module creates the build directory.
-  set(HPX_WITH_CONTRACTS_MODE
-      "ENFORCE"
-      CACHE
-        STRING
-        "Contract evaluation mode for pre-C++26 compilers (ENFORCE, OBSERVE, IGNORE)."
-  )
-  set_property(
-    CACHE HPX_WITH_CONTRACTS_MODE PROPERTY STRINGS "ENFORCE;OBSERVE;IGNORE"
+  hpx_option(
+    HPX_WITH_CONTRACTS_MODE
+    STRING
+    "Contract evaluation mode for pre-C++26 compilers, options are: ENFORCE, OBSERVE, IGNORE"
+    "ENFORCE"
+    STRINGS "ENFORCE;OBSERVE;IGNORE"
   )
 
   if(HPX_WITH_CONTRACTS_MODE STREQUAL "ENFORCE")
     hpx_add_config_define_namespace(
-      DEFINE HPX_CONTRACTS_MODE
+      DEFINE HPX_HAVE_CONTRACTS_MODE
       VALUE 0
       NAMESPACE CONTRACTS
     )
   elseif(HPX_WITH_CONTRACTS_MODE STREQUAL "OBSERVE")
     hpx_add_config_define_namespace(
-      DEFINE HPX_CONTRACTS_MODE
+      DEFINE HPX_HAVE_CONTRACTS_MODE
       VALUE 1
       NAMESPACE CONTRACTS
     )
   elseif(HPX_WITH_CONTRACTS_MODE STREQUAL "IGNORE")
     hpx_add_config_define_namespace(
-      DEFINE HPX_CONTRACTS_MODE
+      DEFINE HPX_HAVE_CONTRACTS_MODE
       VALUE 2
       NAMESPACE CONTRACTS
     )

--- a/libs/core/contracts/CMakeLists.txt
+++ b/libs/core/contracts/CMakeLists.txt
@@ -27,8 +27,9 @@ else()
   # generation mechanism before add_hpx_module creates the build directory.
   set(HPX_WITH_CONTRACTS_MODE
       "ENFORCE"
-      CACHE STRING
-            "Contract evaluation mode for pre-C++26 compilers (ENFORCE, OBSERVE, IGNORE)."
+      CACHE
+        STRING
+        "Contract evaluation mode for pre-C++26 compilers (ENFORCE, OBSERVE, IGNORE)."
   )
   set_property(
     CACHE HPX_WITH_CONTRACTS_MODE PROPERTY STRINGS "ENFORCE;OBSERVE;IGNORE"

--- a/libs/core/contracts/CMakeLists.txt
+++ b/libs/core/contracts/CMakeLists.txt
@@ -57,6 +57,7 @@ endif()
 set(contracts_headers hpx/contracts.hpp hpx/contracts/macros.hpp
                       hpx/contracts/violation_handler.hpp
 )
+set(contracts_exclude_global_header hpx/contracts.hpp)
 set(contracts_macro_headers hpx/contracts/macros.hpp)
 
 # Default location is $HPX_ROOT/libs/contracts/src
@@ -67,10 +68,11 @@ add_hpx_module(
   core contracts
   GLOBAL_HEADER_GEN ON
   GLOBAL_HEADER_MODULE_GEN ON
+  EXCLUDE_FROM_GLOBAL_HEADER ${contracts_exclude_global_header}
   SOURCES ${contracts_sources}
   HEADERS ${contracts_headers}
   MACRO_HEADERS ${contracts_macro_headers}
   COMPAT_HEADERS ${contracts_compat_headers}
-  MODULE_DEPENDENCIES hpx_config hpx_preprocessor hpx_assertion
+  MODULE_DEPENDENCIES hpx_config hpx_format hpx_preprocessor hpx_assertion
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/core/contracts/CMakeLists.txt
+++ b/libs/core/contracts/CMakeLists.txt
@@ -32,23 +32,45 @@ else()
 
   # Note: values start at 1 because hpx_add_config_define_namespace treats a
   # numeric "0" as falsy and would emit a valueless #define.
+
+  # define readable contract mode constants
+  hpx_add_config_define_namespace(
+    DEFINE HPX_HAVE_CONTRACTS_MODE_ENFORCE
+    VALUE 1
+    NAMESPACE CONTRACTS
+  )
+  hpx_add_config_define_namespace(
+    DEFINE HPX_HAVE_CONTRACTS_MODE_OBSERVE
+    VALUE 2
+    NAMESPACE CONTRACTS
+  )
+  hpx_add_config_define_namespace(
+    DEFINE HPX_HAVE_CONTRACTS_MODE_IGNORE
+    VALUE 3
+    NAMESPACE CONTRACTS
+  )
+
   if(HPX_WITH_CONTRACTS_MODE STREQUAL "ENFORCE")
     hpx_add_config_define_namespace(
       DEFINE HPX_HAVE_CONTRACTS_MODE
-      VALUE 1
+      VALUE HPX_HAVE_CONTRACTS_MODE_ENFORCE
       NAMESPACE CONTRACTS
     )
   elseif(HPX_WITH_CONTRACTS_MODE STREQUAL "OBSERVE")
     hpx_add_config_define_namespace(
       DEFINE HPX_HAVE_CONTRACTS_MODE
-      VALUE 2
+      VALUE HPX_HAVE_CONTRACTS_MODE_OBSERVE
       NAMESPACE CONTRACTS
     )
   elseif(HPX_WITH_CONTRACTS_MODE STREQUAL "IGNORE")
     hpx_add_config_define_namespace(
       DEFINE HPX_HAVE_CONTRACTS_MODE
-      VALUE 3
+      VALUE HPX_HAVE_CONTRACTS_MODE_IGNORE
       NAMESPACE CONTRACTS
+    )
+  else()
+    hpx_error(
+      "HPX_WITH_CONTRACTS_MODE must be one of ENFORCE, OBSERVE, or IGNORE"
     )
   endif()
 endif()

--- a/libs/core/contracts/CMakeLists.txt
+++ b/libs/core/contracts/CMakeLists.txt
@@ -25,9 +25,9 @@ else()
   hpx_option(
     HPX_WITH_CONTRACTS_MODE
     STRING
-    "Contract evaluation mode for pre-C++26 compilers, options are: ENFORCE, OBSERVE, IGNORE"
+    "Contract evaluation mode for pre-C++26 compilers, options are: ENFORCE, QUICK_ENFORCE, OBSERVE, IGNORE"
     "ENFORCE"
-    STRINGS "ENFORCE;OBSERVE;IGNORE"
+    STRINGS "ENFORCE;QUICK_ENFORCE;OBSERVE;IGNORE"
   )
 
   # Note: values start at 1 because hpx_add_config_define_namespace treats a
@@ -35,7 +35,7 @@ else()
 
   # define readable contract mode constants
   hpx_add_config_define_namespace(
-    DEFINE HPX_HAVE_CONTRACTS_MODE_ENFORCE
+    DEFINE HPX_HAVE_CONTRACTS_MODE_IGNORE
     VALUE 1
     NAMESPACE CONTRACTS
   )
@@ -45,8 +45,13 @@ else()
     NAMESPACE CONTRACTS
   )
   hpx_add_config_define_namespace(
-    DEFINE HPX_HAVE_CONTRACTS_MODE_IGNORE
+    DEFINE HPX_HAVE_CONTRACTS_MODE_ENFORCE
     VALUE 3
+    NAMESPACE CONTRACTS
+  )
+  hpx_add_config_define_namespace(
+    DEFINE HPX_HAVE_CONTRACTS_MODE_QUICK_ENFORCE
+    VALUE 4
     NAMESPACE CONTRACTS
   )
 
@@ -54,6 +59,12 @@ else()
     hpx_add_config_define_namespace(
       DEFINE HPX_HAVE_CONTRACTS_MODE
       VALUE HPX_HAVE_CONTRACTS_MODE_ENFORCE
+      NAMESPACE CONTRACTS
+    )
+  elseif(HPX_WITH_CONTRACTS_MODE STREQUAL "QUICK_ENFORCE")
+    hpx_add_config_define_namespace(
+      DEFINE HPX_HAVE_CONTRACTS_MODE
+      VALUE HPX_HAVE_CONTRACTS_MODE_QUICK_ENFORCE
       NAMESPACE CONTRACTS
     )
   elseif(HPX_WITH_CONTRACTS_MODE STREQUAL "OBSERVE")
@@ -70,7 +81,7 @@ else()
     )
   else()
     hpx_error(
-      "HPX_WITH_CONTRACTS_MODE must be one of ENFORCE, OBSERVE, or IGNORE"
+      "HPX_WITH_CONTRACTS_MODE must be one of ENFORCE, QUICK_ENFORCE, OBSERVE, or IGNORE"
     )
   endif()
 endif()

--- a/libs/core/contracts/include/hpx/contracts.hpp
+++ b/libs/core/contracts/include/hpx/contracts.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2025 The STE||AR-Group
+//  Copyright (c) 2025-2026 The STE||AR-Group
 //  Copyright (c) 2025 Alexandros Papadakis
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -7,4 +7,5 @@
 
 #pragma once
 
+#include <hpx/config.hpp>
 #include <hpx/modules/contracts.hpp>

--- a/libs/core/contracts/include/hpx/contracts/macros.hpp
+++ b/libs/core/contracts/include/hpx/contracts/macros.hpp
@@ -53,7 +53,8 @@
 #define HPX_PRE(x)
 #define HPX_POST(x)
 
-#if defined(HPX_HAVE_CONTRACTS_MODE) && HPX_HAVE_CONTRACTS_MODE == 3    // IGNORE
+#if defined(HPX_HAVE_CONTRACTS_MODE) &&                                        \
+    HPX_HAVE_CONTRACTS_MODE == 3    // IGNORE
 
 #define HPX_CONTRACT_ASSERT(x)
 

--- a/libs/core/contracts/include/hpx/contracts/macros.hpp
+++ b/libs/core/contracts/include/hpx/contracts/macros.hpp
@@ -53,7 +53,7 @@
 #define HPX_PRE(x)
 #define HPX_POST(x)
 
-#if HPX_HAVE_CONTRACTS_MODE == 2    // IGNORE
+#if defined(HPX_HAVE_CONTRACTS_MODE) && HPX_HAVE_CONTRACTS_MODE == 3    // IGNORE
 
 #define HPX_CONTRACT_ASSERT(x)
 

--- a/libs/core/contracts/include/hpx/contracts/macros.hpp
+++ b/libs/core/contracts/include/hpx/contracts/macros.hpp
@@ -1,6 +1,5 @@
-//  Copyright (c) 2025 The STE||AR-Group
+//  Copyright (c) 2025-2026 The STE||AR-Group
 //  Copyright (c) 2025 Alexandros Papadakis
-//  Copyright (c) 2026 The STE||AR-Group
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -54,7 +53,7 @@
 #define HPX_PRE(x)
 #define HPX_POST(x)
 
-#if HPX_CONTRACTS_MODE == 2    // IGNORE
+#if HPX_HAVE_CONTRACTS_MODE == 2    // IGNORE
 
 #define HPX_CONTRACT_ASSERT(x)
 
@@ -72,6 +71,6 @@
     } while (false)
 // clang-format on
 
-#endif    // HPX_CONTRACTS_MODE
+#endif    // HPX_HAVE_CONTRACTS_MODE
 
 #endif    // HPX_HAVE_CXX26_CONTRACTS

--- a/libs/core/contracts/include/hpx/contracts/macros.hpp
+++ b/libs/core/contracts/include/hpx/contracts/macros.hpp
@@ -1,5 +1,6 @@
 //  Copyright (c) 2025 The STE||AR-Group
 //  Copyright (c) 2025 Alexandros Papadakis
+//  Copyright (c) 2026 The STE||AR-Group
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -13,22 +14,22 @@
 /// behavior when contracts are not available.
 ///
 /// ## API Reference:
-/// - **HPX_PRE(condition)**: Precondition contracts (no-op in fallback mode)
-/// - **HPX_POST(condition)**: Postcondition contracts (no-op in fallback mode)
-/// - **HPX_CONTRACT_ASSERT(condition)**: Contract assertions (always available, maps to HPX_ASSERT)
+/// - **HPX_PRE(condition)**: Precondition contracts
+/// - **HPX_POST(condition)**: Postcondition contracts
+/// - **HPX_CONTRACT_ASSERT(condition)**: Contract assertions
 ///
 /// ## Configuration:
-/// Enable with: `cmake -DHPX_WITH_CONTRACTS=ON -DCMAKE_CXX_STANDARD=26`
+/// Enable native contracts with: `cmake -DHPX_WITH_CONTRACTS=ON -DCMAKE_CXX_STANDARD=26`
+/// Set fallback mode with: `cmake -DHPX_WITH_CONTRACTS_MODE=ENFORCE|OBSERVE|IGNORE`
 ///
 /// See docs/index.rst for comprehensive usage guide.
 
 #pragma once
 
-#include <hpx/config.hpp>
 #include <hpx/assert.hpp>
+#include <hpx/config.hpp>
+#include <hpx/contracts/config/defines.hpp>
 
-// Contract implementation: automatically selects native C++26 contracts
-// or provides appropriate fallback behavior based on compiler capabilities
 #if defined(HPX_HAVE_CXX26_CONTRACTS)
 
 // Native C++26 contracts mode
@@ -42,12 +43,40 @@
 #define HPX_ASSERT(x) contract_assert(x)
 #endif
 
-#else
+#elif HPX_CONTRACTS_MODE == 2    // IGNORE: all contracts are no-ops
 
-// Fallback mode: PRE/POST become no-ops for forward compatibility,
-// CONTRACT_ASSERT maps to HPX_ASSERT for runtime validation
 #define HPX_PRE(x)
-#define HPX_CONTRACT_ASSERT(x) HPX_ASSERT((x))
 #define HPX_POST(x)
+#define HPX_CONTRACT_ASSERT(x)
+
+#else    // ENFORCE (0) or OBSERVE (1): runtime checking via violation handler
+
+#include <hpx/contracts/violation_handler.hpp>
+
+// clang-format off
+#define HPX_PRE(x)                                                             \
+    do {                                                                       \
+        if (!(x))                                                              \
+            ::hpx::contracts::invoke_violation_handler(                       \
+                {::hpx::contracts::contract_kind::pre, #x,                    \
+                    HPX_CURRENT_SOURCE_LOCATION()});                           \
+    } while (false)
+
+#define HPX_POST(x)                                                            \
+    do {                                                                       \
+        if (!(x))                                                              \
+            ::hpx::contracts::invoke_violation_handler(                       \
+                {::hpx::contracts::contract_kind::post, #x,                   \
+                    HPX_CURRENT_SOURCE_LOCATION()});                           \
+    } while (false)
+
+#define HPX_CONTRACT_ASSERT(x)                                                 \
+    do {                                                                       \
+        if (!(x))                                                              \
+            ::hpx::contracts::invoke_violation_handler(                       \
+                {::hpx::contracts::contract_kind::assertion, #x,              \
+                    HPX_CURRENT_SOURCE_LOCATION()});                           \
+    } while (false)
+// clang-format on
 
 #endif

--- a/libs/core/contracts/include/hpx/contracts/macros.hpp
+++ b/libs/core/contracts/include/hpx/contracts/macros.hpp
@@ -14,9 +14,12 @@
 /// behavior when contracts are not available.
 ///
 /// ## API Reference:
-/// - **HPX_PRE(condition)**: Precondition contracts
-/// - **HPX_POST(condition)**: Postcondition contracts
-/// - **HPX_CONTRACT_ASSERT(condition)**: Contract assertions
+/// - **HPX_PRE(condition)**: Precondition contracts (declaration specifier in
+///   C++26; no-op in fallback mode)
+/// - **HPX_POST(condition)**: Postcondition contracts (declaration specifier
+///   in C++26; no-op in fallback mode)
+/// - **HPX_CONTRACT_ASSERT(condition)**: Contract assertions (always active;
+///   dispatches on HPX_WITH_CONTRACTS_MODE in fallback mode)
 ///
 /// ## Configuration:
 /// Enable native contracts with: `cmake -DHPX_WITH_CONTRACTS=ON -DCMAKE_CXX_STANDARD=26`
@@ -26,9 +29,9 @@
 
 #pragma once
 
-#include <hpx/assert.hpp>
 #include <hpx/config.hpp>
 #include <hpx/contracts/config/defines.hpp>
+#include <hpx/assert.hpp>
 
 #if defined(HPX_HAVE_CXX26_CONTRACTS)
 
@@ -43,10 +46,16 @@
 #define HPX_ASSERT(x) contract_assert(x)
 #endif
 
-#elif HPX_CONTRACTS_MODE == 2    // IGNORE: all contracts are no-ops
+#else    // fallback mode
 
+// HPX_PRE and HPX_POST are declaration specifiers in C++26 and cannot be
+// replicated as statement macros without changing call sites. Keep them as
+// no-ops in fallback regardless of mode.
 #define HPX_PRE(x)
 #define HPX_POST(x)
+
+#if HPX_CONTRACTS_MODE == 2    // IGNORE
+
 #define HPX_CONTRACT_ASSERT(x)
 
 #else    // ENFORCE (0) or OBSERVE (1): runtime checking via violation handler
@@ -54,22 +63,6 @@
 #include <hpx/contracts/violation_handler.hpp>
 
 // clang-format off
-#define HPX_PRE(x)                                                             \
-    do {                                                                       \
-        if (!(x))                                                              \
-            ::hpx::contracts::invoke_violation_handler(                       \
-                {::hpx::contracts::contract_kind::pre, #x,                    \
-                    HPX_CURRENT_SOURCE_LOCATION()});                           \
-    } while (false)
-
-#define HPX_POST(x)                                                            \
-    do {                                                                       \
-        if (!(x))                                                              \
-            ::hpx::contracts::invoke_violation_handler(                       \
-                {::hpx::contracts::contract_kind::post, #x,                   \
-                    HPX_CURRENT_SOURCE_LOCATION()});                           \
-    } while (false)
-
 #define HPX_CONTRACT_ASSERT(x)                                                 \
     do {                                                                       \
         if (!(x))                                                              \
@@ -79,4 +72,6 @@
     } while (false)
 // clang-format on
 
-#endif
+#endif    // HPX_CONTRACTS_MODE
+
+#endif    // HPX_HAVE_CXX26_CONTRACTS

--- a/libs/core/contracts/include/hpx/contracts/macros.hpp
+++ b/libs/core/contracts/include/hpx/contracts/macros.hpp
@@ -21,16 +21,21 @@
 ///   dispatches on HPX_WITH_CONTRACTS_MODE in fallback mode)
 ///
 /// ## Configuration:
-/// Enable native contracts with: `cmake -DHPX_WITH_CONTRACTS=ON -DCMAKE_CXX_STANDARD=26`
-/// Set fallback mode with: `cmake -DHPX_WITH_CONTRACTS_MODE=ENFORCE|OBSERVE|IGNORE`
+/// Enable native contracts with:
+///     `cmake -DHPX_WITH_CONTRACTS=ON -DCMAKE_CXX_STANDARD=26`
+/// Set fallback mode with:
+///     `cmake -DHPX_WITH_CONTRACTS_MODE=ENFORCE|OBSERVE|IGNORE`
 ///
 /// See docs/index.rst for comprehensive usage guide.
+
+// Don't report missing #include for HPX_ASSERT macro
+// hpxinspect:noinclude:HPX_ASSERT
 
 #pragma once
 
 #include <hpx/config.hpp>
 #include <hpx/contracts/config/defines.hpp>
-#include <hpx/assert.hpp>
+#include <hpx/assertion/macros.hpp>
 
 #if defined(HPX_HAVE_CXX26_CONTRACTS)
 
@@ -61,16 +66,14 @@
 #else    // ENFORCE (0) or OBSERVE (1): runtime checking via violation handler
 
 #include <hpx/contracts/violation_handler.hpp>
+#include <hpx/modules/preprocessor.hpp>
 
-// clang-format off
-#define HPX_CONTRACT_ASSERT(x)                                                 \
-    do {                                                                       \
-        if (!(x))                                                              \
-            ::hpx::contracts::invoke_violation_handler(                       \
-                {::hpx::contracts::contract_kind::assertion, #x,              \
-                    HPX_CURRENT_SOURCE_LOCATION()});                           \
-    } while (false)
-// clang-format on
+#define HPX_CONTRACT_ASSERT(expr, ...)                                         \
+    (!!(expr) ? void() :                                                       \
+                ::hpx::contracts::handle_contract_violation(                   \
+                    {::hpx::contracts::contract_kind::assertion,               \
+                        HPX_PP_STRINGIZE(expr), HPX_CURRENT_SOURCE_LOCATION(), \
+                        hpx::util::format(__VA_ARGS__)})) /**/
 
 #endif    // HPX_HAVE_CONTRACTS_MODE
 

--- a/libs/core/contracts/include/hpx/contracts/macros.hpp
+++ b/libs/core/contracts/include/hpx/contracts/macros.hpp
@@ -24,9 +24,7 @@
 /// Enable native contracts with:
 ///     `cmake -DHPX_WITH_CONTRACTS=ON -DCMAKE_CXX_STANDARD=26`
 /// Set fallback mode with:
-///     `cmake -DHPX_WITH_CONTRACTS_MODE=ENFORCE|OBSERVE|IGNORE`
-///
-/// See docs/index.rst for comprehensive usage guide.
+///     `cmake -DHPX_WITH_CONTRACTS_MODE=ENFORCE|QUICK_ENFORCE|OBSERVE|IGNORE`
 
 // Don't report missing #include for HPX_ASSERT macro
 // hpxinspect:noinclude:HPX_ASSERT
@@ -63,17 +61,38 @@
 
 #define HPX_CONTRACT_ASSERT(x)
 
-#else    // ENFORCE (0) or OBSERVE (1): runtime checking via violation handler
+#else    // ENFORCE, QUICK_ENFORCE or OBSERVE: runtime checking
 
-#include <hpx/contracts/violation_handler.hpp>
 #include <hpx/modules/preprocessor.hpp>
 
-#define HPX_CONTRACT_ASSERT(expr, ...)                                         \
-    (!!(expr) ? void() :                                                       \
-                ::hpx::contracts::handle_contract_violation(                   \
-                    {::hpx::contracts::contract_kind::assertion,               \
-                        HPX_PP_STRINGIZE(expr), HPX_CURRENT_SOURCE_LOCATION(), \
-                        hpx::util::format(__VA_ARGS__)})) /**/
+// https://eel.is/c%2B%2Bdraft/basic.contract.eval#7 states:
+//
+// A contract violation occurs when:
+// - (7.1) expr is false,
+// - (7.2) the evaluation of the predicate exits via an exception,
+// - ...
+
+#define HPX_CONTRACT_ASSERT(expr)                                              \
+    do                                                                         \
+    {                                                                          \
+        ::hpx::contracts::detection_mode mode =                                \
+            ::hpx::contracts::detection_mode::unknown;                         \
+        try                                                                    \
+        {                                                                      \
+            if (!!(expr))                                                      \
+                break;                                                         \
+            mode = ::hpx::contracts::detection_mode::predicate_false;          \
+        }                                                                      \
+        catch (...)                                                            \
+        {                                                                      \
+            mode = ::hpx::contracts::detection_mode::evaluation_exception;     \
+        }                                                                      \
+                                                                               \
+        ::hpx::contracts::invoke_contract_violation_handler(                   \
+            ::hpx::contracts::detail::construct_contract_violation(            \
+                mode, HPX_PP_STRINGIZE(expr)));                                \
+                                                                               \
+    } while (false) /**/
 
 #endif    // HPX_HAVE_CONTRACTS_MODE
 

--- a/libs/core/contracts/include/hpx/contracts/macros.hpp
+++ b/libs/core/contracts/include/hpx/contracts/macros.hpp
@@ -59,7 +59,7 @@
 #define HPX_POST(x)
 
 #if defined(HPX_HAVE_CONTRACTS_MODE) &&                                        \
-    HPX_HAVE_CONTRACTS_MODE == 3    // IGNORE
+    HPX_HAVE_CONTRACTS_MODE == HPX_HAVE_CONTRACTS_MODE_IGNORE
 
 #define HPX_CONTRACT_ASSERT(x)
 

--- a/libs/core/contracts/include/hpx/contracts/violation_handler.hpp
+++ b/libs/core/contracts/include/hpx/contracts/violation_handler.hpp
@@ -11,12 +11,7 @@
 
 namespace hpx::contracts {
 
-    HPX_CXX_CORE_EXPORT enum class contract_kind
-    {
-        pre,
-        post,
-        assertion
-    };
+    HPX_CXX_CORE_EXPORT enum class contract_kind { pre, post, assertion };
 
     HPX_CXX_CORE_EXPORT struct violation_info
     {

--- a/libs/core/contracts/include/hpx/contracts/violation_handler.hpp
+++ b/libs/core/contracts/include/hpx/contracts/violation_handler.hpp
@@ -11,14 +11,14 @@
 
 namespace hpx::contracts {
 
-    enum class contract_kind
+    HPX_CXX_CORE_EXPORT enum class contract_kind
     {
         pre,
         post,
         assertion
     };
 
-    struct violation_info
+    HPX_CXX_CORE_EXPORT struct violation_info
     {
         contract_kind kind;
         char const* condition;
@@ -28,11 +28,14 @@ namespace hpx::contracts {
     HPX_CXX_CORE_EXPORT using violation_handler_t =
         void (*)(violation_info const&);
 
-    HPX_CORE_EXPORT void set_violation_handler(
-        violation_handler_t handler) noexcept;
-    HPX_CORE_EXPORT violation_handler_t get_violation_handler() noexcept;
+    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT violation_handler_t
+    set_violation_handler(violation_handler_t handler) noexcept;
+    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT violation_handler_t
+    get_violation_handler() noexcept;
 
-    HPX_CORE_EXPORT void default_violation_handler(violation_info const& info);
-    HPX_CORE_EXPORT void invoke_violation_handler(violation_info const& info);
+    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void default_violation_handler(
+        violation_info const& info);
+    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void invoke_violation_handler(
+        violation_info const& info);
 
 }    // namespace hpx::contracts

--- a/libs/core/contracts/include/hpx/contracts/violation_handler.hpp
+++ b/libs/core/contracts/include/hpx/contracts/violation_handler.hpp
@@ -25,9 +25,11 @@ namespace hpx::contracts {
         hpx::source_location location;
     };
 
-    HPX_CXX_CORE_EXPORT using violation_handler_t = void (*)(violation_info const&);
+    HPX_CXX_CORE_EXPORT using violation_handler_t =
+        void (*)(violation_info const&);
 
-    HPX_CORE_EXPORT void set_violation_handler(violation_handler_t handler) noexcept;
+    HPX_CORE_EXPORT void set_violation_handler(
+        violation_handler_t handler) noexcept;
     HPX_CORE_EXPORT violation_handler_t get_violation_handler() noexcept;
 
     HPX_CORE_EXPORT void default_violation_handler(violation_info const& info);

--- a/libs/core/contracts/include/hpx/contracts/violation_handler.hpp
+++ b/libs/core/contracts/include/hpx/contracts/violation_handler.hpp
@@ -1,0 +1,36 @@
+//  Copyright (c) 2026 The STE||AR-Group
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/assertion/source_location.hpp>
+
+namespace hpx::contracts {
+
+    enum class contract_kind
+    {
+        pre,
+        post,
+        assertion
+    };
+
+    struct violation_info
+    {
+        contract_kind kind;
+        char const* condition;
+        hpx::source_location location;
+    };
+
+    HPX_CXX_CORE_EXPORT using violation_handler_t = void (*)(violation_info const&);
+
+    HPX_CORE_EXPORT void set_violation_handler(violation_handler_t handler) noexcept;
+    HPX_CORE_EXPORT violation_handler_t get_violation_handler() noexcept;
+
+    HPX_CORE_EXPORT void default_violation_handler(violation_info const& info);
+    HPX_CORE_EXPORT void invoke_violation_handler(violation_info const& info);
+
+}    // namespace hpx::contracts

--- a/libs/core/contracts/include/hpx/contracts/violation_handler.hpp
+++ b/libs/core/contracts/include/hpx/contracts/violation_handler.hpp
@@ -20,6 +20,7 @@
 namespace hpx::contracts {
 
     HPX_CXX_CORE_EXPORT enum class contract_kind : std::uint8_t {
+        unknown,
         pre,
         post,
         assertion
@@ -27,10 +28,10 @@ namespace hpx::contracts {
 
     HPX_CXX_CORE_EXPORT struct contract_violation
     {
-        contract_kind kind;
-        char const* condition;
-        hpx::source_location location;
-        std::string message;
+        contract_kind kind = contract_kind::unknown;
+        char const* condition = nullptr;
+        hpx::source_location location = {};
+        std::string message = {};
     };
 
     HPX_CXX_CORE_EXPORT using violation_handler_t =

--- a/libs/core/contracts/include/hpx/contracts/violation_handler.hpp
+++ b/libs/core/contracts/include/hpx/contracts/violation_handler.hpp
@@ -7,30 +7,43 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/assertion/source_location.hpp>
+#include <hpx/contracts/config/defines.hpp>
+
+// Compile contracts fallback support if C++26 contracts are not available.
+#if !defined(HPX_HAVE_CXX26_CONTRACTS)
+
+#include <hpx/assert.hpp>
+
+#include <cstdint>
+#include <string>
 
 namespace hpx::contracts {
 
-    HPX_CXX_CORE_EXPORT enum class contract_kind { pre, post, assertion };
+    HPX_CXX_CORE_EXPORT enum class contract_kind : std::uint8_t {
+        pre,
+        post,
+        assertion
+    };
 
-    HPX_CXX_CORE_EXPORT struct violation_info
+    HPX_CXX_CORE_EXPORT struct contract_violation
     {
         contract_kind kind;
         char const* condition;
         hpx::source_location location;
+        std::string message;
     };
 
     HPX_CXX_CORE_EXPORT using violation_handler_t =
-        void (*)(violation_info const&);
+        void (*)(contract_violation const&);
 
     HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT violation_handler_t
     set_violation_handler(violation_handler_t handler) noexcept;
     HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT violation_handler_t
     get_violation_handler() noexcept;
 
-    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void default_violation_handler(
-        violation_info const& info);
-    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void invoke_violation_handler(
-        violation_info const& info);
+    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void handle_contract_violation(
+        contract_violation const& info);
 
 }    // namespace hpx::contracts
+
+#endif

--- a/libs/core/contracts/include/hpx/contracts/violation_handler.hpp
+++ b/libs/core/contracts/include/hpx/contracts/violation_handler.hpp
@@ -9,29 +9,117 @@
 #include <hpx/config.hpp>
 #include <hpx/contracts/config/defines.hpp>
 
-// Compile contracts fallback support if C++26 contracts are not available.
-#if !defined(HPX_HAVE_CXX26_CONTRACTS)
+#if defined(HPX_HAVE_CXX26_CONTRACTS)
 
-#include <hpx/assert.hpp>
-
-#include <cstdint>
-#include <string>
+#include <contracts>
 
 namespace hpx::contracts {
 
-    HPX_CXX_CORE_EXPORT enum class contract_kind : std::uint8_t {
-        unknown,
-        pre,
-        post,
-        assertion
+    using assertion_kind = std::contracts::assertion_kind;
+    using evaluation_semantic = std::contracts::evaluation_semantic;
+    using detection_mode = std::contracts::detection_mode;
+    using contract_violation = std::contracts::contract_violation;
+}    // namespace hpx::contracts
+
+#else
+// Compile contracts fallback support if C++26 contracts are not available.
+
+#include <hpx/assert.hpp>
+#include <hpx/contracts/macros.hpp>
+
+#include <cstdint>
+
+namespace hpx::contracts {
+
+    ////////////////////////////////////////////////////////////////////////////
+    HPX_CXX_CORE_EXPORT enum class assertion_kind : std::uint8_t {
+        unknown = 0,
+        pre = 1,
+        post = 2,
+        assertion = 3
     };
 
-    HPX_CXX_CORE_EXPORT struct contract_violation
+    HPX_CXX_CORE_EXPORT enum class evaluation_semantic : std::uint8_t {
+        unknown = 0,
+        ignore = HPX_HAVE_CONTRACTS_MODE_IGNORE,
+        observe = HPX_HAVE_CONTRACTS_MODE_OBSERVE,
+        enforce = HPX_HAVE_CONTRACTS_MODE_ENFORCE,
+        quick_enforce = HPX_HAVE_CONTRACTS_MODE_QUICK_ENFORCE
+    };
+
+    HPX_CXX_CORE_EXPORT enum class detection_mode : std::uint8_t {
+        unknown = 0,
+        predicate_false = 1,
+        evaluation_exception = 2
+    };
+
+    ////////////////////////////////////////////////////////////////////////////
+    HPX_CXX_CORE_EXPORT struct contract_violation;
+
+    namespace detail {
+
+        HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT contract_violation
+        construct_contract_violation(detection_mode mode, char const* condition,
+            hpx::source_location const& location =
+                HPX_CURRENT_SOURCE_LOCATION()) noexcept;
+    }    // namespace detail
+
+    struct contract_violation
     {
-        contract_kind kind = contract_kind::unknown;
-        char const* condition = nullptr;
-        hpx::source_location location = {};
-        std::string message = {};
+        contract_violation() = default;
+        ~contract_violation() = default;
+
+        contract_violation(contract_violation const&) = delete;
+        contract_violation& operator=(contract_violation const&) = delete;
+
+        assertion_kind kind() const noexcept
+        {
+            return kind_;
+        }
+
+        source_location location() const noexcept
+        {
+            return location_;
+        }
+
+        static evaluation_semantic semantic() noexcept
+        {
+            return static_cast<evaluation_semantic>(HPX_HAVE_CONTRACTS_MODE);
+        }
+
+        contracts::detection_mode detection_mode() const noexcept
+        {
+            return mode_;
+        }
+
+        static bool is_terminating() noexcept
+        {
+            return semantic() == evaluation_semantic::enforce ||
+                semantic() == evaluation_semantic::quick_enforce;
+        }
+
+        HPX_CORE_EXPORT char const* comment() const noexcept;
+
+        char const* condition() const noexcept
+        {
+            return condition_;
+        }
+
+    private:
+        friend HPX_CORE_EXPORT contract_violation
+        detail::construct_contract_violation(contracts::detection_mode mode,
+            char const* condition,
+            hpx::source_location const& location) noexcept;
+
+        HPX_CORE_EXPORT contract_violation(contracts::detection_mode mode,
+            char const* condition,
+            hpx::source_location const& location) noexcept;
+
+    private:
+        assertion_kind kind_ = assertion_kind::unknown;
+        contracts::detection_mode mode_ = contracts::detection_mode::unknown;
+        char const* condition_ = nullptr;
+        hpx::source_location location_ = {};
     };
 
     HPX_CXX_CORE_EXPORT using violation_handler_t =
@@ -42,9 +130,8 @@ namespace hpx::contracts {
     HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT violation_handler_t
     get_violation_handler() noexcept;
 
-    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void handle_contract_violation(
+    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void invoke_contract_violation_handler(
         contract_violation const& info);
-
 }    // namespace hpx::contracts
 
 #endif

--- a/libs/core/contracts/src/violation_handler.cpp
+++ b/libs/core/contracts/src/violation_handler.cpp
@@ -1,0 +1,64 @@
+//  Copyright (c) 2026 The STE||AR-Group
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/contracts/violation_handler.hpp>
+
+#include <cstdlib>
+#include <iostream>
+
+namespace hpx::contracts {
+
+    namespace detail {
+
+        [[nodiscard]] violation_handler_t& get_handler() noexcept
+        {
+            static violation_handler_t handler = nullptr;
+            return handler;
+        }
+
+    }    // namespace detail
+
+    void set_violation_handler(violation_handler_t handler) noexcept
+    {
+        detail::get_handler() = handler;
+    }
+
+    violation_handler_t get_violation_handler() noexcept
+    {
+        return detail::get_handler();
+    }
+
+    void default_violation_handler(violation_info const& info)
+    {
+        char const* kind_str = nullptr;
+        switch (info.kind)
+        {
+        case contract_kind::pre:
+            kind_str = "precondition";
+            break;
+        case contract_kind::post:
+            kind_str = "postcondition";
+            break;
+        case contract_kind::assertion:
+            kind_str = "assertion";
+            break;
+        }
+
+        std::cerr << info.location << ": Contract " << kind_str << " '"
+                  << info.condition << "' violated\n";
+        std::abort();
+    }
+
+    void invoke_violation_handler(violation_info const& info)
+    {
+        violation_handler_t handler = detail::get_handler();
+        if (handler == nullptr)
+            default_violation_handler(info);
+        else
+            handler(info);
+    }
+
+}    // namespace hpx::contracts

--- a/libs/core/contracts/src/violation_handler.cpp
+++ b/libs/core/contracts/src/violation_handler.cpp
@@ -55,7 +55,8 @@ namespace hpx::contracts {
         std::cerr << info.location << ": Contract " << kind_str << " '"
                   << info.condition << "' violated\n";
 
-#if HPX_HAVE_CONTRACTS_MODE != 1    // abort in ENFORCE; continue in OBSERVE
+#if !defined(HPX_HAVE_CONTRACTS_MODE) || HPX_HAVE_CONTRACTS_MODE != 2
+        // abort in ENFORCE (and by default); continue in OBSERVE
         std::abort();
 #endif
     }

--- a/libs/core/contracts/src/violation_handler.cpp
+++ b/libs/core/contracts/src/violation_handler.cpp
@@ -4,6 +4,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/config.hpp>
 #include <hpx/contracts/config/defines.hpp>
 #include <hpx/contracts/violation_handler.hpp>
 
@@ -22,9 +23,12 @@ namespace hpx::contracts {
 
     }    // namespace detail
 
-    void set_violation_handler(violation_handler_t handler) noexcept
+    violation_handler_t set_violation_handler(
+        violation_handler_t handler) noexcept
     {
+        violation_handler_t old = detail::get_handler();
         detail::get_handler() = handler;
+        return old;
     }
 
     violation_handler_t get_violation_handler() noexcept
@@ -51,7 +55,7 @@ namespace hpx::contracts {
         std::cerr << info.location << ": Contract " << kind_str << " '"
                   << info.condition << "' violated\n";
 
-#if HPX_CONTRACTS_MODE != 1    // abort in ENFORCE; continue in OBSERVE
+#if HPX_HAVE_CONTRACTS_MODE != 1    // abort in ENFORCE; continue in OBSERVE
         std::abort();
 #endif
     }

--- a/libs/core/contracts/src/violation_handler.cpp
+++ b/libs/core/contracts/src/violation_handler.cpp
@@ -4,6 +4,7 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/contracts/config/defines.hpp>
 #include <hpx/contracts/violation_handler.hpp>
 
 #include <cstdlib>
@@ -49,7 +50,10 @@ namespace hpx::contracts {
 
         std::cerr << info.location << ": Contract " << kind_str << " '"
                   << info.condition << "' violated\n";
+
+#if HPX_CONTRACTS_MODE != 1    // abort in ENFORCE; continue in OBSERVE
         std::abort();
+#endif
     }
 
     void invoke_violation_handler(violation_info const& info)

--- a/libs/core/contracts/src/violation_handler.cpp
+++ b/libs/core/contracts/src/violation_handler.cpp
@@ -6,14 +6,44 @@
 
 #include <hpx/config.hpp>
 #include <hpx/contracts/config/defines.hpp>
+
+// Compile contracts fallback support if C++26 contracts are not available.
+#if !defined(HPX_HAVE_CXX26_CONTRACTS)
+
+#include <hpx/assert.hpp>
 #include <hpx/contracts/violation_handler.hpp>
 
 #include <cstdlib>
 #include <iostream>
+#include <sstream>
 
 namespace hpx::contracts {
 
-    namespace detail {
+    namespace {
+
+        char const* get_contract_violation_name(contract_kind kind) noexcept
+        {
+            char const* kind_str = "unknown";
+            switch (kind)
+            {
+            case contract_kind::pre:
+                kind_str = "precondition";
+                break;
+
+            case contract_kind::post:
+                kind_str = "postcondition";
+                break;
+
+            case contract_kind::assertion:
+                kind_str = "assertion";
+                break;
+
+            default:
+                HPX_ASSERT(false);
+            }
+
+            return kind_str;
+        }
 
         [[nodiscard]] violation_handler_t& get_handler() noexcept
         {
@@ -21,53 +51,66 @@ namespace hpx::contracts {
             return handler;
         }
 
-    }    // namespace detail
+#if !defined(HPX_HAVE_CONTRACTS_MODE) || HPX_HAVE_CONTRACTS_MODE != 2
+        [[noreturn]]
+#endif
+        void default_violation_handler(contract_violation const& info)
+        {
+            thread_local bool handling_violation = false;
+
+            std::ostringstream strm;
+            if (handling_violation)
+            {
+                strm << "Trying to handle contracts violation while handling "
+                        "another contracts violation!\n";
+            }
+
+            handling_violation = true;
+
+            char const* kind_str = get_contract_violation_name(info.kind);
+            strm << info.location << ": Contract " << kind_str << " '"
+                 << info.condition << "' violated";
+            if (!info.message.empty())
+            {
+                strm << " (" << info.message << ")";
+            }
+            strm << ".\n";
+
+            std::cerr << strm.str() << std::flush;
+
+#if !defined(HPX_HAVE_CONTRACTS_MODE) || HPX_HAVE_CONTRACTS_MODE != 2
+            // abort in ENFORCE (and by default); continue in OBSERVE
+            std::abort();
+#endif
+        }
+    }    // namespace
 
     violation_handler_t set_violation_handler(
-        violation_handler_t handler) noexcept
+        violation_handler_t const handler) noexcept
     {
-        violation_handler_t old = detail::get_handler();
-        detail::get_handler() = handler;
+        violation_handler_t const old = get_handler();
+        get_handler() = handler;
         return old;
     }
 
     violation_handler_t get_violation_handler() noexcept
     {
-        return detail::get_handler();
+        return get_handler();
     }
 
-    void default_violation_handler(violation_info const& info)
+    void handle_contract_violation(contract_violation const& info)
     {
-        char const* kind_str = nullptr;
-        switch (info.kind)
+        if (violation_handler_t const handler = get_handler();
+            handler == nullptr)
         {
-        case contract_kind::pre:
-            kind_str = "precondition";
-            break;
-        case contract_kind::post:
-            kind_str = "postcondition";
-            break;
-        case contract_kind::assertion:
-            kind_str = "assertion";
-            break;
-        }
-
-        std::cerr << info.location << ": Contract " << kind_str << " '"
-                  << info.condition << "' violated\n";
-
-#if !defined(HPX_HAVE_CONTRACTS_MODE) || HPX_HAVE_CONTRACTS_MODE != 2
-        // abort in ENFORCE (and by default); continue in OBSERVE
-        std::abort();
-#endif
-    }
-
-    void invoke_violation_handler(violation_info const& info)
-    {
-        violation_handler_t handler = detail::get_handler();
-        if (handler == nullptr)
             default_violation_handler(info);
+        }
         else
+        {
             handler(info);
+        }
     }
 
 }    // namespace hpx::contracts
+
+#endif

--- a/libs/core/contracts/src/violation_handler.cpp
+++ b/libs/core/contracts/src/violation_handler.cpp
@@ -16,57 +16,82 @@
 #include <cstdlib>
 #include <iostream>
 #include <sstream>
+#include <string>
 
 namespace hpx::contracts {
 
     namespace {
 
         char const* get_contract_violation_kind_name(
-            contract_kind kind) noexcept
+            assertion_kind const kind) noexcept
         {
-            char const* kind_str = "unknown";
+            auto* kind_str = "unknown";
             switch (kind)
             {
-            case contract_kind::pre:
+            case assertion_kind::pre:
                 kind_str = "precondition";
                 break;
 
-            case contract_kind::post:
+            case assertion_kind::post:
                 kind_str = "postcondition";
                 break;
 
-            case contract_kind::assertion:
+            case assertion_kind::assertion:
                 kind_str = "assertion";
                 break;
 
-            default:
+            case assertion_kind::unknown:
                 HPX_ASSERT(false);
             }
             return kind_str;
         }
 
-        constexpr char const* get_contracts_violation_mode_name() noexcept
+        char const* get_contracts_violation_semantic_name(
+            evaluation_semantic const semantic) noexcept
         {
-            char const* semantic_str = nullptr;
-            switch (HPX_HAVE_CONTRACTS_MODE)
+            auto* semantic_str = "unknown";
+            switch (semantic)
             {
-            case HPX_HAVE_CONTRACTS_MODE_ENFORCE:
+            case evaluation_semantic::enforce:
                 semantic_str = "enforce";
                 break;
 
-            case HPX_HAVE_CONTRACTS_MODE_OBSERVE:
+            case evaluation_semantic::quick_enforce:
+                semantic_str = "quick_enforce";
+                break;
+
+            case evaluation_semantic::observe:
                 semantic_str = "observe";
                 break;
 
-            case HPX_HAVE_CONTRACTS_MODE_IGNORE:
+            case evaluation_semantic::ignore:
                 semantic_str = "ignore";
                 break;
 
-            default:
-                semantic_str = "unknown";
-                break;
+            case evaluation_semantic::unknown:
+                HPX_ASSERT(false);
             }
             return semantic_str;
+        }
+
+        char const* get_contracts_violation_detection_mode_name(
+            contracts::detection_mode const mode) noexcept
+        {
+            auto* detection_mode_str = "unknown";
+            switch (mode)
+            {
+            case contracts::detection_mode::predicate_false:
+                detection_mode_str = "predicate_false";
+                break;
+
+            case contracts::detection_mode::evaluation_exception:
+                detection_mode_str = "evaluation_exception";
+                break;
+
+            case contracts::detection_mode::unknown:
+                HPX_ASSERT(false);
+            }
+            return detection_mode_str;
         }
 
         [[nodiscard]] violation_handler_t& get_handler() noexcept
@@ -79,7 +104,31 @@ namespace hpx::contracts {
     HPX_HAVE_CONTRACTS_MODE != HPX_HAVE_CONTRACTS_MODE_OBSERVE
         [[noreturn]]
 #endif
-        void default_violation_handler(contract_violation const& info)
+        void default_violation_handler(
+            [[maybe_unused]] contract_violation const& info)
+        {
+            // no diagnostics are generated in quick_enforce mode
+#if !defined(HPX_HAVE_CONTRACTS_MODE) ||                                       \
+    HPX_HAVE_CONTRACTS_MODE != HPX_HAVE_CONTRACTS_MODE_QUICK_ENFORCE
+            std::cerr << info.comment() << std::flush;
+#endif
+
+            // abort in ENFORCE, QUICK_ENFORCE (and by default); continue in
+            // OBSERVE
+#if !defined(HPX_HAVE_CONTRACTS_MODE) ||                                       \
+    HPX_HAVE_CONTRACTS_MODE != HPX_HAVE_CONTRACTS_MODE_OBSERVE
+            // abort in ENFORCE (and by default); continue in OBSERVE
+            std::abort();
+#endif
+        }
+    }    // namespace
+
+    ///////////////////////////////////////////////////////////////////////////
+    char const* contract_violation::comment() const noexcept
+    {
+        thread_local std::string comment;
+
+        try
         {
             thread_local bool handling_violation = false;
 
@@ -92,27 +141,26 @@ namespace hpx::contracts {
 
             handling_violation = true;
 
-            char const* kind_str = get_contract_violation_kind_name(info.kind);
-            constexpr char const* semantic_str =
-                get_contracts_violation_mode_name();
+            char const* kind_str = get_contract_violation_kind_name(kind());
+            char const* semantic_str =
+                get_contracts_violation_semantic_name(semantic());
+            char const* detection_mode_str =
+                get_contracts_violation_detection_mode_name(detection_mode());
 
-            strm << info.location << ": Contract " << kind_str << " '"
-                 << info.condition << "' violated, semantic: " << semantic_str;
-            if (!info.message.empty())
-            {
-                strm << " (" << info.message << ")";
-            }
-            strm << ".\n";
+            strm << location() << ": Contract " << kind_str << " '"
+                 << condition_ << "' violated, semantic: " << semantic_str
+                 << "detection mode: " << detection_mode_str << ".\n";
 
-            std::cerr << strm.str() << std::flush;
-
-#if !defined(HPX_HAVE_CONTRACTS_MODE) ||                                       \
-    HPX_HAVE_CONTRACTS_MODE != HPX_HAVE_CONTRACTS_MODE_OBSERVE
-            // abort in ENFORCE (and by default); continue in OBSERVE
-            std::abort();
-#endif
+            comment = strm.str();
         }
-    }    // namespace
+        catch (...)
+        {
+            return "Exception caught while generating diagnostics for "
+                   "contracts violation!\n";
+        }
+
+        return comment.c_str();
+    }
 
     violation_handler_t set_violation_handler(
         violation_handler_t const handler) noexcept
@@ -127,7 +175,7 @@ namespace hpx::contracts {
         return get_handler();
     }
 
-    void handle_contract_violation(contract_violation const& info)
+    void invoke_contract_violation_handler(contract_violation const& info)
     {
         if (violation_handler_t const handler = get_handler();
             handler == nullptr)
@@ -140,6 +188,25 @@ namespace hpx::contracts {
         }
     }
 
+    ////////////////////////////////////////////////////////////////////////////
+    contract_violation::contract_violation(contracts::detection_mode const mode,
+        char const* condition, hpx::source_location const& location) noexcept
+      : kind_(assertion_kind::assertion)
+      , mode_(mode)
+      , condition_(condition)
+      , location_(location)
+    {
+    }
+
+    namespace detail {
+
+        contract_violation construct_contract_violation(
+            contracts::detection_mode const mode, char const* condition,
+            hpx::source_location const& location) noexcept
+        {
+            return {mode, condition, location};
+        }
+    }    // namespace detail
 }    // namespace hpx::contracts
 
 #endif

--- a/libs/core/contracts/src/violation_handler.cpp
+++ b/libs/core/contracts/src/violation_handler.cpp
@@ -21,7 +21,8 @@ namespace hpx::contracts {
 
     namespace {
 
-        char const* get_contract_violation_name(contract_kind kind) noexcept
+        char const* get_contract_violation_kind_name(
+            contract_kind kind) noexcept
         {
             char const* kind_str = "unknown";
             switch (kind)
@@ -41,8 +42,31 @@ namespace hpx::contracts {
             default:
                 HPX_ASSERT(false);
             }
-
             return kind_str;
+        }
+
+        constexpr char const* get_contracts_violation_mode_name() noexcept
+        {
+            char const* semantic_str = nullptr;
+            switch (HPX_HAVE_CONTRACTS_MODE)
+            {
+            case HPX_HAVE_CONTRACTS_MODE_ENFORCE:
+                semantic_str = "enforce";
+                break;
+
+            case HPX_HAVE_CONTRACTS_MODE_OBSERVE:
+                semantic_str = "observe";
+                break;
+
+            case HPX_HAVE_CONTRACTS_MODE_IGNORE:
+                semantic_str = "ignore";
+                break;
+
+            default:
+                semantic_str = "unknown";
+                break;
+            }
+            return semantic_str;
         }
 
         [[nodiscard]] violation_handler_t& get_handler() noexcept
@@ -51,7 +75,8 @@ namespace hpx::contracts {
             return handler;
         }
 
-#if !defined(HPX_HAVE_CONTRACTS_MODE) || HPX_HAVE_CONTRACTS_MODE != 2
+#if !defined(HPX_HAVE_CONTRACTS_MODE) ||                                       \
+    HPX_HAVE_CONTRACTS_MODE != HPX_HAVE_CONTRACTS_MODE_OBSERVE
         [[noreturn]]
 #endif
         void default_violation_handler(contract_violation const& info)
@@ -67,9 +92,12 @@ namespace hpx::contracts {
 
             handling_violation = true;
 
-            char const* kind_str = get_contract_violation_name(info.kind);
+            char const* kind_str = get_contract_violation_kind_name(info.kind);
+            constexpr char const* semantic_str =
+                get_contracts_violation_mode_name();
+
             strm << info.location << ": Contract " << kind_str << " '"
-                 << info.condition << "' violated";
+                 << info.condition << "' violated, semantic: " << semantic_str;
             if (!info.message.empty())
             {
                 strm << " (" << info.message << ")";
@@ -78,7 +106,8 @@ namespace hpx::contracts {
 
             std::cerr << strm.str() << std::flush;
 
-#if !defined(HPX_HAVE_CONTRACTS_MODE) || HPX_HAVE_CONTRACTS_MODE != 2
+#if !defined(HPX_HAVE_CONTRACTS_MODE) ||                                       \
+    HPX_HAVE_CONTRACTS_MODE != HPX_HAVE_CONTRACTS_MODE_OBSERVE
             // abort in ENFORCE (and by default); continue in OBSERVE
             std::abort();
 #endif

--- a/libs/core/contracts/tests/unit/CMakeLists.txt
+++ b/libs/core/contracts/tests/unit/CMakeLists.txt
@@ -33,16 +33,8 @@ foreach(test ${contract_tests})
   add_hpx_unit_test("modules.contracts" ${test})
 endforeach()
 
-# Set failure expectation for fallback failure test Fallback only fails in Debug
-# mode (HPX_ASSERT or HPX_CONTRACT_ASSERT behavior)
-set_tests_properties(
-  tests.unit.modules.contracts.declaration_contracts_fail_contract_assert
-  PROPERTIES WILL_FAIL $<$<CONFIG:Debug>:ON>
-)
-
 if(HPX_HAVE_CXX26_CONTRACTS)
-  # Set failure expectations for declaration contract failure tests Native
-  # contracts should fail when violated
+  # Native C++26 contracts always fail when violated, regardless of build config
   set_tests_properties(
     tests.unit.modules.contracts.declaration_contracts_fail_pre
     PROPERTIES WILL_FAIL ON
@@ -51,20 +43,32 @@ if(HPX_HAVE_CXX26_CONTRACTS)
     tests.unit.modules.contracts.declaration_contracts_fail_post
     PROPERTIES WILL_FAIL ON
   )
-else()
-  # Set failure expectation for fallback failure test Fallback only fails in
-  # Debug mode (HPX_ASSERT behavior)
+  # HPX_CONTRACT_ASSERT still routes through HPX_ASSERT in native mode — Debug
+  # only
   set_tests_properties(
-    tests.unit.modules.contracts.fallback_contracts_fail
+    tests.unit.modules.contracts.declaration_contracts_fail_contract_assert
     PROPERTIES WILL_FAIL $<$<CONFIG:Debug>:ON>
   )
-
-  # default_handler_aborts calls HPX_CONTRACT_ASSERT(false) with no custom
-  # handler; the default handler aborts in ENFORCE mode
-  if(HPX_WITH_CONTRACTS_MODE STREQUAL "ENFORCE" OR NOT HPX_WITH_CONTRACTS_MODE)
+else()
+  # Fallback mode: HPX_PRE / HPX_POST are no-ops so fail_pre / fail_post succeed.
+  # HPX_CONTRACT_ASSERT routes through invoke_violation_handler, whose default
+  # handler aborts unless HPX_WITH_CONTRACTS_MODE=OBSERVE.
+  if(NOT HPX_WITH_CONTRACTS_MODE STREQUAL "OBSERVE"
+     AND NOT HPX_WITH_CONTRACTS_MODE STREQUAL "IGNORE"
+  )
+    set_tests_properties(
+      tests.unit.modules.contracts.declaration_contracts_fail_contract_assert
+      PROPERTIES WILL_FAIL ON
+    )
     set_tests_properties(
       tests.unit.modules.contracts.default_handler_aborts PROPERTIES WILL_FAIL
                                                                      ON
     )
   endif()
+
+  # fallback_contracts_fail uses HPX_ASSERT directly, so it only fails in Debug
+  set_tests_properties(
+    tests.unit.modules.contracts.fallback_contracts_fail
+    PROPERTIES WILL_FAIL $<$<CONFIG:Debug>:ON>
+  )
 endif()

--- a/libs/core/contracts/tests/unit/CMakeLists.txt
+++ b/libs/core/contracts/tests/unit/CMakeLists.txt
@@ -1,4 +1,5 @@
 # Copyright (c) 2025 Alexandros Papadakis
+# Copyright (c) 2026 The STE||AR-Group
 # HPX Contracts Module Unit Tests
 #
 # SPDX-License-Identifier: BSL-1.0
@@ -15,6 +16,9 @@ set(contract_tests
     fallback_contracts_succeed
     fallback_contracts_fail
     disabled_contracts
+    violation_handler_invoked
+    default_handler_aborts
+    handler_receives_correct_info
 )
 
 foreach(test ${contract_tests})
@@ -54,4 +58,13 @@ else()
     tests.unit.modules.contracts.fallback_contracts_fail
     PROPERTIES WILL_FAIL $<$<CONFIG:Debug>:ON>
   )
+
+  # default_handler_aborts calls HPX_CONTRACT_ASSERT(false) with no custom
+  # handler; the default handler aborts in ENFORCE mode
+  if(HPX_WITH_CONTRACTS_MODE STREQUAL "ENFORCE" OR NOT HPX_WITH_CONTRACTS_MODE)
+    set_tests_properties(
+      tests.unit.modules.contracts.default_handler_aborts PROPERTIES WILL_FAIL
+                                                                      ON
+    )
+  endif()
 endif()

--- a/libs/core/contracts/tests/unit/CMakeLists.txt
+++ b/libs/core/contracts/tests/unit/CMakeLists.txt
@@ -50,9 +50,9 @@ if(HPX_HAVE_CXX26_CONTRACTS)
     PROPERTIES WILL_FAIL $<$<CONFIG:Debug>:ON>
   )
 else()
-  # Fallback mode: HPX_PRE / HPX_POST are no-ops so fail_pre / fail_post succeed.
-  # HPX_CONTRACT_ASSERT routes through invoke_violation_handler, whose default
-  # handler aborts unless HPX_WITH_CONTRACTS_MODE=OBSERVE.
+  # Fallback mode: HPX_PRE / HPX_POST are no-ops so fail_pre / fail_post
+  # succeed. HPX_CONTRACT_ASSERT routes through invoke_violation_handler, whose
+  # default handler aborts unless HPX_WITH_CONTRACTS_MODE=OBSERVE.
   if(NOT HPX_WITH_CONTRACTS_MODE STREQUAL "OBSERVE"
      AND NOT HPX_WITH_CONTRACTS_MODE STREQUAL "IGNORE"
   )

--- a/libs/core/contracts/tests/unit/CMakeLists.txt
+++ b/libs/core/contracts/tests/unit/CMakeLists.txt
@@ -64,7 +64,7 @@ else()
   if(HPX_WITH_CONTRACTS_MODE STREQUAL "ENFORCE" OR NOT HPX_WITH_CONTRACTS_MODE)
     set_tests_properties(
       tests.unit.modules.contracts.default_handler_aborts PROPERTIES WILL_FAIL
-                                                                      ON
+                                                                     ON
     )
   endif()
 endif()

--- a/libs/core/contracts/tests/unit/CMakeLists.txt
+++ b/libs/core/contracts/tests/unit/CMakeLists.txt
@@ -13,13 +13,43 @@ set(contract_tests
     declaration_contracts_fail_pre
     declaration_contracts_fail_post
     declaration_contracts_fail_contract_assert
-    fallback_contracts_succeed
-    fallback_contracts_fail
-    disabled_contracts
-    violation_handler_invoked
     default_handler_aborts
+    fallback_contracts_succeed
     handler_receives_correct_info
+    violation_handler_invoked
 )
+
+if(HPX_WITH_CXX26_CONTRACTS)
+  # Native C++26 contracts always fail when violated, regardless of build config
+  set(default_handler_aborts_PARAMETERS FAILURE_EXPECTED)
+  set(declaration_contracts_fail_pre_PARAMETERS FAILURE_EXPECTED)
+  set(declaration_contracts_fail_post_PARAMETERS FAILURE_EXPECTED)
+  set(declaration_contracts_fail_contract_assert_PARAMETERS FAILURE_EXPECTED)
+else()
+  # some of the tests should run only of contracts are disabled
+  set(contract_tests ${contract_tests} disabled_contracts
+                     fallback_contracts_fail
+  )
+
+  # Fallback mode: HPX_PRE / HPX_POST are no-ops so fail_pre / fail_post
+  # succeed.
+  #
+  # HPX_CONTRACT_ASSERT routes through invoke_violation_handler, whose default
+  # handler aborts unless HPX_WITH_CONTRACTS_MODE=OBSERVE.
+  if(HPX_WITH_CONTRACTS_MODE STREQUAL "ENFORCE")
+    set(default_handler_aborts_PARAMETERS FAILURE_EXPECTED)
+    set(fallback_contracts_fail_PARAMETERS FAILURE_EXPECTED)
+  endif()
+
+  # violation handlers will not be called
+  if(HPX_WITH_CONTRACTS_MODE STREQUAL "IGNORE")
+    set(handler_receives_correct_info_PARAMETERS FAILURE_EXPECTED)
+    set(violation_handler_invoked_PARAMETERS FAILURE_EXPECTED)
+  endif()
+
+  # This test should always fail (albeight for different reasons)
+  set(declaration_contracts_fail_contract_assert_PARAMETERS FAILURE_EXPECTED)
+endif()
 
 foreach(test ${contract_tests})
   add_hpx_executable(
@@ -30,45 +60,5 @@ foreach(test ${contract_tests})
     EXCLUDE_FROM_ALL
     FOLDER "Tests/Unit/Modules/Core/Contracts/"
   )
-  add_hpx_unit_test("modules.contracts" ${test})
+  add_hpx_unit_test("modules.contracts" ${test} ${${test}_PARAMETERS})
 endforeach()
-
-if(HPX_HAVE_CXX26_CONTRACTS)
-  # Native C++26 contracts always fail when violated, regardless of build config
-  set_tests_properties(
-    tests.unit.modules.contracts.declaration_contracts_fail_pre
-    PROPERTIES WILL_FAIL ON
-  )
-  set_tests_properties(
-    tests.unit.modules.contracts.declaration_contracts_fail_post
-    PROPERTIES WILL_FAIL ON
-  )
-  # HPX_CONTRACT_ASSERT still routes through HPX_ASSERT in native mode — Debug
-  # only
-  set_tests_properties(
-    tests.unit.modules.contracts.declaration_contracts_fail_contract_assert
-    PROPERTIES WILL_FAIL $<$<CONFIG:Debug>:ON>
-  )
-else()
-  # Fallback mode: HPX_PRE / HPX_POST are no-ops so fail_pre / fail_post
-  # succeed. HPX_CONTRACT_ASSERT routes through invoke_violation_handler, whose
-  # default handler aborts unless HPX_WITH_CONTRACTS_MODE=OBSERVE.
-  if(NOT HPX_WITH_CONTRACTS_MODE STREQUAL "OBSERVE"
-     AND NOT HPX_WITH_CONTRACTS_MODE STREQUAL "IGNORE"
-  )
-    set_tests_properties(
-      tests.unit.modules.contracts.declaration_contracts_fail_contract_assert
-      PROPERTIES WILL_FAIL ON
-    )
-    set_tests_properties(
-      tests.unit.modules.contracts.default_handler_aborts PROPERTIES WILL_FAIL
-                                                                     ON
-    )
-  endif()
-
-  # fallback_contracts_fail uses HPX_ASSERT directly, so it only fails in Debug
-  set_tests_properties(
-    tests.unit.modules.contracts.fallback_contracts_fail
-    PROPERTIES WILL_FAIL $<$<CONFIG:Debug>:ON>
-  )
-endif()

--- a/libs/core/contracts/tests/unit/CMakeLists.txt
+++ b/libs/core/contracts/tests/unit/CMakeLists.txt
@@ -36,7 +36,8 @@ else()
   #
   # HPX_CONTRACT_ASSERT routes through invoke_violation_handler, whose default
   # handler aborts unless HPX_WITH_CONTRACTS_MODE=OBSERVE.
-  if(HPX_WITH_CONTRACTS_MODE STREQUAL "ENFORCE")
+  string(FIND "${HPX_WITH_CONTRACTS_MODE}" "ENFORCE" _is_enforce)
+  if(NOT (_is_enforce EQUAL -1))
     set(default_handler_aborts_PARAMETERS FAILURE_EXPECTED)
     set(fallback_contracts_fail_PARAMETERS FAILURE_EXPECTED)
   endif()

--- a/libs/core/contracts/tests/unit/declaration_contracts_fail_contract_assert.cpp
+++ b/libs/core/contracts/tests/unit/declaration_contracts_fail_contract_assert.cpp
@@ -16,12 +16,14 @@ int process_data(int const x) HPX_PRE(x >= 0)
 {
     // Internal contract check that always fails
     HPX_CONTRACT_ASSERT(false);
+
+    // The test should fail even in cases where the contracts are being ignored.
     return x + 1;
 }
 
 int main()
 {
-    // This should trigger CONTRACT_ASSERT failure
-    [[maybe_unused]] int result = process_data(5);
-    return 0;
+    // This should trigger CONTRACT_ASSERT failure or return 1 to make the test
+    // fail.
+    return process_data(5);
 }

--- a/libs/core/contracts/tests/unit/declaration_contracts_succeed.cpp
+++ b/libs/core/contracts/tests/unit/declaration_contracts_succeed.cpp
@@ -11,6 +11,7 @@
 
 #include <hpx/contracts.hpp>
 #include <hpx/modules/testing.hpp>
+
 #include <iostream>
 
 // This test runs when __cpp_contracts is available

--- a/libs/core/contracts/tests/unit/default_handler_aborts.cpp
+++ b/libs/core/contracts/tests/unit/default_handler_aborts.cpp
@@ -1,0 +1,13 @@
+//  Copyright (c) 2026 The STE||AR-Group
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/contracts.hpp>
+
+int main()
+{
+    HPX_CONTRACT_ASSERT(false);    // default handler should abort here
+    return 0;
+}

--- a/libs/core/contracts/tests/unit/fallback_contracts_fail.cpp
+++ b/libs/core/contracts/tests/unit/fallback_contracts_fail.cpp
@@ -11,12 +11,14 @@
 
 #include <hpx/contracts.hpp>
 #include <hpx/modules/testing.hpp>
+
 #include <iostream>
 
 int main() HPX_PRE(false)    // This precondition is ignored in fallback mode
     HPX_POST(false)          // This postcondition is ignored in fallback mode
 {
     HPX_CONTRACT_ASSERT(true);
+
     // Add a failing assertion to test WILL_FAIL behavior.
     HPX_CONTRACT_ASSERT(false);    // This should abort in Debug mode
     HPX_TEST(true);

--- a/libs/core/contracts/tests/unit/handler_receives_correct_info.cpp
+++ b/libs/core/contracts/tests/unit/handler_receives_correct_info.cpp
@@ -1,0 +1,46 @@
+//  Copyright (c) 2026 The STE||AR-Group
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/contracts.hpp>
+#include <hpx/contracts/violation_handler.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <cstring>
+
+#if !defined(HPX_HAVE_CXX26_CONTRACTS) && HPX_CONTRACTS_MODE == 2
+
+int main()
+{
+    return 0;
+}
+
+#else
+
+namespace {
+    hpx::contracts::violation_info captured{
+        hpx::contracts::contract_kind::assertion, nullptr, {}};
+
+    void capturing_handler(hpx::contracts::violation_info const& info)
+    {
+        captured = info;
+    }
+}    // namespace
+
+int main()
+{
+    hpx::contracts::set_violation_handler(capturing_handler);
+
+    HPX_CONTRACT_ASSERT(1 == 2);    // NOLINT: intentional false assertion
+
+    HPX_TEST(captured.condition != nullptr);
+    HPX_TEST(std::strstr(captured.condition, "1 == 2") != nullptr);
+    HPX_TEST(captured.kind == hpx::contracts::contract_kind::assertion);
+    HPX_TEST(captured.location.line() > 0);
+
+    return hpx::util::report_errors();
+}
+
+#endif

--- a/libs/core/contracts/tests/unit/handler_receives_correct_info.cpp
+++ b/libs/core/contracts/tests/unit/handler_receives_correct_info.cpp
@@ -4,13 +4,9 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/contracts.hpp>
-#include <hpx/contracts/violation_handler.hpp>
-#include <hpx/modules/testing.hpp>
+#include <hpx/config.hpp>
 
-#include <cstring>
-
-#if !defined(HPX_HAVE_CXX26_CONTRACTS) && HPX_CONTRACTS_MODE == 2
+#if defined(HPX_HAVE_CXX26_CONTRACTS)
 
 int main()
 {
@@ -19,9 +15,14 @@ int main()
 
 #else
 
+#include <hpx/contracts.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <cstring>
+
 namespace {
     hpx::contracts::contract_violation captured{
-        hpx::contracts::contract_kind::assertion, nullptr, {}, {}};
+        hpx::contracts::contract_kind::assertion, nullptr, {}};
 
     void capturing_handler(hpx::contracts::contract_violation const& info)
     {

--- a/libs/core/contracts/tests/unit/handler_receives_correct_info.cpp
+++ b/libs/core/contracts/tests/unit/handler_receives_correct_info.cpp
@@ -18,15 +18,24 @@ int main()
 #include <hpx/contracts.hpp>
 #include <hpx/modules/testing.hpp>
 
-#include <cstring>
+#include <atomic>
+#include <string>
 
 namespace {
-    hpx::contracts::contract_violation captured{
-        hpx::contracts::contract_kind::assertion, nullptr, {}};
+
+    std::atomic<int> handler_call_count = 0;
 
     void capturing_handler(hpx::contracts::contract_violation const& info)
     {
-        captured = info;
+        HPX_TEST(info.condition() != nullptr);
+        HPX_TEST_EQ(std::string(info.condition()), std::string("1 == 2"));
+
+        HPX_TEST(info.kind() == hpx::contracts::assertion_kind::assertion);
+        HPX_TEST(info.location().line() > 0);
+
+        ++handler_call_count;
+
+        // deliberately does not abort so the test can continue
     }
 }    // namespace
 
@@ -36,10 +45,7 @@ int main()
 
     HPX_CONTRACT_ASSERT(1 == 2);    // NOLINT: intentional false assertion
 
-    HPX_TEST(captured.condition != nullptr);
-    HPX_TEST(std::strstr(captured.condition, "1 == 2") != nullptr);
-    HPX_TEST(captured.kind == hpx::contracts::contract_kind::assertion);
-    HPX_TEST(captured.location.line() > 0);
+    HPX_TEST_EQ(handler_call_count.load(), 1);
 
     return hpx::util::report_errors();
 }

--- a/libs/core/contracts/tests/unit/handler_receives_correct_info.cpp
+++ b/libs/core/contracts/tests/unit/handler_receives_correct_info.cpp
@@ -20,10 +20,10 @@ int main()
 #else
 
 namespace {
-    hpx::contracts::violation_info captured{
-        hpx::contracts::contract_kind::assertion, nullptr, {}};
+    hpx::contracts::contract_violation captured{
+        hpx::contracts::contract_kind::assertion, nullptr, {}, {}};
 
-    void capturing_handler(hpx::contracts::violation_info const& info)
+    void capturing_handler(hpx::contracts::contract_violation const& info)
     {
         captured = info;
     }

--- a/libs/core/contracts/tests/unit/violation_handler_invoked.cpp
+++ b/libs/core/contracts/tests/unit/violation_handler_invoked.cpp
@@ -1,0 +1,46 @@
+//  Copyright (c) 2026 The STE||AR-Group
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/contracts.hpp>
+#include <hpx/contracts/violation_handler.hpp>
+#include <hpx/modules/testing.hpp>
+
+#if !defined(HPX_HAVE_CXX26_CONTRACTS) && HPX_CONTRACTS_MODE == 2
+
+// IGNORE mode: contracts are no-ops, nothing to test here.
+int main()
+{
+    return 0;
+}
+
+#else
+
+namespace {
+    int handler_call_count = 0;
+    hpx::contracts::contract_kind last_kind =
+        hpx::contracts::contract_kind::assertion;
+
+    void recording_handler(hpx::contracts::violation_info const& info)
+    {
+        ++handler_call_count;
+        last_kind = info.kind;
+        // deliberately does not abort so the test can continue
+    }
+}    // namespace
+
+int main()
+{
+    hpx::contracts::set_violation_handler(recording_handler);
+
+    HPX_CONTRACT_ASSERT(false);    // should invoke recording_handler
+
+    HPX_TEST_EQ(handler_call_count, 1);
+    HPX_TEST(last_kind == hpx::contracts::contract_kind::assertion);
+
+    return hpx::util::report_errors();
+}
+
+#endif

--- a/libs/core/contracts/tests/unit/violation_handler_invoked.cpp
+++ b/libs/core/contracts/tests/unit/violation_handler_invoked.cpp
@@ -4,13 +4,10 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#include <hpx/contracts.hpp>
-#include <hpx/contracts/violation_handler.hpp>
-#include <hpx/modules/testing.hpp>
+#include <hpx/config.hpp>
 
-#if !defined(HPX_HAVE_CXX26_CONTRACTS) && HPX_CONTRACTS_MODE == 2
+#if defined(HPX_HAVE_CXX26_CONTRACTS)
 
-// IGNORE mode: contracts are no-ops, nothing to test here.
 int main()
 {
     return 0;
@@ -18,7 +15,11 @@ int main()
 
 #else
 
+#include <hpx/contracts.hpp>
+#include <hpx/modules/testing.hpp>
+
 namespace {
+
     int handler_call_count = 0;
     hpx::contracts::contract_kind last_kind =
         hpx::contracts::contract_kind::assertion;

--- a/libs/core/contracts/tests/unit/violation_handler_invoked.cpp
+++ b/libs/core/contracts/tests/unit/violation_handler_invoked.cpp
@@ -23,7 +23,7 @@ namespace {
     hpx::contracts::contract_kind last_kind =
         hpx::contracts::contract_kind::assertion;
 
-    void recording_handler(hpx::contracts::violation_info const& info)
+    void recording_handler(hpx::contracts::contract_violation const& info)
     {
         ++handler_call_count;
         last_kind = info.kind;

--- a/libs/core/contracts/tests/unit/violation_handler_invoked.cpp
+++ b/libs/core/contracts/tests/unit/violation_handler_invoked.cpp
@@ -18,16 +18,18 @@ int main()
 #include <hpx/contracts.hpp>
 #include <hpx/modules/testing.hpp>
 
+#include <atomic>
+
 namespace {
 
-    int handler_call_count = 0;
-    hpx::contracts::contract_kind last_kind =
-        hpx::contracts::contract_kind::assertion;
+    std::atomic<int> handler_call_count = 0;
+    auto last_kind = hpx::contracts::assertion_kind::unknown;
 
     void recording_handler(hpx::contracts::contract_violation const& info)
     {
         ++handler_call_count;
-        last_kind = info.kind;
+        last_kind = info.kind();
+
         // deliberately does not abort so the test can continue
     }
 }    // namespace
@@ -39,7 +41,7 @@ int main()
     HPX_CONTRACT_ASSERT(false);    // should invoke recording_handler
 
     HPX_TEST_EQ(handler_call_count, 1);
-    HPX_TEST(last_kind == hpx::contracts::contract_kind::assertion);
+    HPX_TEST(last_kind == hpx::contracts::assertion_kind::assertion);
 
     return hpx::util::report_errors();
 }

--- a/libs/core/datastructures/CMakeLists.txt
+++ b/libs/core/datastructures/CMakeLists.txt
@@ -101,7 +101,7 @@ add_hpx_module(
     "hpx/datastructures/detail/flat_set.hpp"
     "hpx/datastructures/detail/intrusive_list.hpp"
     "hpx/datastructures/detail/small_vector.hpp"
-  MODULE_DEPENDENCIES hpx_assertion hpx_config hpx_concepts hpx_errors
-                      hpx_serialization hpx_type_support
+  MODULE_DEPENDENCIES hpx_assertion hpx_config hpx_concepts hpx_contracts
+                      hpx_errors hpx_serialization hpx_type_support
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/core/datastructures/CMakeLists.txt
+++ b/libs/core/datastructures/CMakeLists.txt
@@ -101,7 +101,13 @@ add_hpx_module(
     "hpx/datastructures/detail/flat_set.hpp"
     "hpx/datastructures/detail/intrusive_list.hpp"
     "hpx/datastructures/detail/small_vector.hpp"
-  MODULE_DEPENDENCIES hpx_assertion hpx_config hpx_concepts hpx_contracts
-                      hpx_errors hpx_serialization hpx_type_support
+  MODULE_DEPENDENCIES
+    hpx_assertion
+    hpx_config
+    hpx_concepts
+    hpx_contracts
+    hpx_errors
+    hpx_serialization
+    hpx_type_support
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/core/datastructures/include/hpx/datastructures/detail/small_vector.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/detail/small_vector.hpp
@@ -1036,8 +1036,8 @@ namespace hpx::detail {
             return const_reverse_iterator{begin()};
         }
 
-        [[nodiscard]] auto front() const noexcept
-            HPX_PRE(!this->empty()) -> T const&
+        [[nodiscard]] auto front() const noexcept HPX_PRE(!this->empty())
+            -> T const&
         {
             return *data();
         }
@@ -1047,8 +1047,8 @@ namespace hpx::detail {
             return *data();
         }
 
-        [[nodiscard]] auto back() const noexcept
-            HPX_PRE(!this->empty()) -> T const&
+        [[nodiscard]] auto back() const noexcept HPX_PRE(!this->empty())
+            -> T const&
         {
             if (is_direct())
             {

--- a/libs/core/datastructures/include/hpx/datastructures/detail/small_vector.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/detail/small_vector.hpp
@@ -33,6 +33,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
+#include <hpx/contracts.hpp>
 #include <hpx/modules/type_support.hpp>
 
 #include <algorithm>
@@ -938,12 +939,13 @@ namespace hpx::detail {
         }
 
         [[nodiscard]] auto operator[](std::size_t idx) const noexcept
-            -> T const&
+            HPX_PRE(idx < this->size()) -> T const&
         {
             return *(data() + idx);
         }
 
-        [[nodiscard]] auto operator[](std::size_t idx) noexcept -> T&
+        [[nodiscard]] auto operator[](std::size_t idx) noexcept
+            HPX_PRE(idx < this->size()) -> T&
         {
             return *(data() + idx);
         }
@@ -1034,17 +1036,19 @@ namespace hpx::detail {
             return const_reverse_iterator{begin()};
         }
 
-        [[nodiscard]] auto front() const noexcept -> T const&
+        [[nodiscard]] auto front() const noexcept
+            HPX_PRE(!this->empty()) -> T const&
         {
             return *data();
         }
 
-        [[nodiscard]] auto front() noexcept -> T&
+        [[nodiscard]] auto front() noexcept HPX_PRE(!this->empty()) -> T&
         {
             return *data();
         }
 
-        [[nodiscard]] auto back() const noexcept -> T const&
+        [[nodiscard]] auto back() const noexcept
+            HPX_PRE(!this->empty()) -> T const&
         {
             if (is_direct())
             {
@@ -1055,7 +1059,7 @@ namespace hpx::detail {
                 data<direction::indirect>() + size<direction::indirect>() - 1);
         }
 
-        [[nodiscard]] auto back() noexcept -> T&
+        [[nodiscard]] auto back() noexcept HPX_PRE(!this->empty()) -> T&
         {
             if (is_direct())
             {

--- a/libs/core/datastructures/include/hpx/datastructures/detail/small_vector.hpp
+++ b/libs/core/datastructures/include/hpx/datastructures/detail/small_vector.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2022-2025 Hartmut Kaiser
+//  Copyright (c) 2022-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -939,13 +939,13 @@ namespace hpx::detail {
         }
 
         [[nodiscard]] auto operator[](std::size_t idx) const noexcept
-            HPX_PRE(idx < this->size()) -> T const&
+            -> T const& HPX_PRE(idx < this->size())
         {
             return *(data() + idx);
         }
 
         [[nodiscard]] auto operator[](std::size_t idx) noexcept
-            HPX_PRE(idx < this->size()) -> T&
+            -> T& HPX_PRE(idx < this->size())
         {
             return *(data() + idx);
         }
@@ -1036,19 +1036,21 @@ namespace hpx::detail {
             return const_reverse_iterator{begin()};
         }
 
-        [[nodiscard]] auto front() const noexcept HPX_PRE(!this->empty())
-            -> T const&
+        [[nodiscard]] auto front() const noexcept
+            -> T const& HPX_PRE(!this->empty())
+
         {
             return *data();
         }
 
-        [[nodiscard]] auto front() noexcept HPX_PRE(!this->empty()) -> T&
+        [[nodiscard]] auto front() noexcept -> T& HPX_PRE(!this->empty())
         {
             return *data();
         }
 
-        [[nodiscard]] auto back() const noexcept HPX_PRE(!this->empty())
-            -> T const&
+        [[nodiscard]] auto back() const noexcept
+            -> T const& HPX_PRE(!this->empty())
+
         {
             if (is_direct())
             {
@@ -1059,7 +1061,7 @@ namespace hpx::detail {
                 data<direction::indirect>() + size<direction::indirect>() - 1);
         }
 
-        [[nodiscard]] auto back() noexcept HPX_PRE(!this->empty()) -> T&
+        [[nodiscard]] auto back() noexcept -> T& HPX_PRE(!this->empty())
         {
             if (is_direct())
             {

--- a/libs/core/datastructures/tests/unit/dynamic_bitset4.cpp
+++ b/libs/core/datastructures/tests/unit/dynamic_bitset4.cpp
@@ -12,6 +12,7 @@
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/modules/datastructures.hpp>
+#include <hpx/modules/filesystem.hpp>
 
 #include <cstddef>    // for std::size_t
 #include <fstream>
@@ -113,12 +114,13 @@ void run_test_cases()
                             scoped_temp_file stf;
                             bitset_type b(strings[si]);
                             std::ofstream file(
-                                stf.path().string().c_str(), std::ios::trunc);
+                                hpx::filesystem::to_string(stf.path()).c_str(),
+                                std::ios::trunc);
                             file.width(w);
                             file.fill(fill_chars[ci]);
                             file.exceptions(masks[mi]);
-                            Tests::stream_inserter(
-                                b, file, stf.path().string().c_str());
+                            Tests::stream_inserter(b, file,
+                                hpx::filesystem::to_string(stf.path()).c_str());
                         }
                         {
                             //NOTE: there are NO string stream tests
@@ -127,12 +129,13 @@ void run_test_cases()
                             // test 1b - wide file stream
                             scoped_temp_file stf;
                             bitset_type b(strings[si]);
-                            std::wofstream file(stf.path().string().c_str());
+                            std::wofstream file(
+                                hpx::filesystem::to_string(stf.path()).c_str());
                             file.width(w);
                             file.fill(fill_chars[ci]);
                             file.exceptions(masks[mi]);
-                            Tests::stream_inserter(
-                                b, file, stf.path().string().c_str());
+                            Tests::stream_inserter(b, file,
+                                hpx::filesystem::to_string(stf.path()).c_str());
                         }
 #endif
                     }
@@ -235,11 +238,13 @@ void run_test_cases()
                         scoped_temp_file stf;
                         bitset_type b(1, 255ul);
                         {
-                            std::ofstream f(stf.path().string().c_str());
+                            std::ofstream f(
+                                hpx::filesystem::to_string(stf.path()).c_str());
                             f << strings[si];
                         }
 
-                        std::ifstream f(stf.path().string().c_str());
+                        std::ifstream f(
+                            hpx::filesystem::to_string(stf.path()).c_str());
                         f.width(w);
                         f.exceptions(masks[mi]);
                         Tests::stream_extractor(b, f, strings[si]);
@@ -260,12 +265,12 @@ void run_test_cases()
                         bitset_type b(1, 255ul);
                         {
                             std::basic_ofstream<wchar_t> of(
-                                stf.path().string().c_str());
+                                hpx::filesystem::to_string(stf.path()).c_str());
                             of << wstr;
                         }
 
                         std::basic_ifstream<wchar_t> f(
-                            stf.path().string().c_str());
+                            hpx::filesystem::to_string(stf.path()).c_str());
                         f.width(w);
                         f.exceptions(masks[mi]);
                         Tests::stream_extractor(b, f, wstr);

--- a/libs/core/errors/src/throw_exception.cpp
+++ b/libs/core/errors/src/throw_exception.cpp
@@ -22,7 +22,7 @@ namespace hpx::detail {
         filesystem::path const p(file);
         hpx::detail::throw_exception(
             hpx::exception(errcode, msg, hpx::throwmode::plain), func,
-            filesystem::to_string(p), line);
+            hpx::filesystem::to_string(p), line);
     }
 
     [[noreturn]] void rethrow_exception(
@@ -39,7 +39,7 @@ namespace hpx::detail {
     {
         filesystem::path const p(file);
         return hpx::detail::get_exception(hpx::exception(errcode, msg, mode),
-            filesystem::to_string(p), file, line, auxinfo);
+            hpx::filesystem::to_string(p), file, line, auxinfo);
     }
 
     std::exception_ptr get_exception(std::error_code const& ec,

--- a/libs/core/errors/src/throw_exception.cpp
+++ b/libs/core/errors/src/throw_exception.cpp
@@ -22,7 +22,7 @@ namespace hpx::detail {
         filesystem::path const p(file);
         hpx::detail::throw_exception(
             hpx::exception(errcode, msg, hpx::throwmode::plain), func,
-            p.string(), line);
+            filesystem::to_string(p), line);
     }
 
     [[noreturn]] void rethrow_exception(
@@ -39,7 +39,7 @@ namespace hpx::detail {
     {
         filesystem::path const p(file);
         return hpx::detail::get_exception(hpx::exception(errcode, msg, mode),
-            p.string(), file, line, auxinfo);
+            filesystem::to_string(p), file, line, auxinfo);
     }
 
     std::exception_ptr get_exception(std::error_code const& ec,

--- a/libs/core/execution_base/include/hpx/execution_base/stdexec_forward.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/stdexec_forward.hpp
@@ -35,16 +35,6 @@
 #pragma warning(disable : 4244)    // conversion warnings
 #endif
 
-// GCC advertises constexpr exceptions in C++26, but current stdexec main
-// selects a code path that is not accepted by GCC yet. Hide the feature-test
-// macro while including stdexec so it falls back to the pre-C++26 path.
-#if defined(HPX_GCC_VERSION) && defined(__cpp_constexpr_exceptions) &&         \
-    (__cpp_constexpr_exceptions >= 202411L)
-#define HPX_STDEXEC_RESTORE___cpp_constexpr_exceptions                         \
-    __cpp_constexpr_exceptions
-#undef __cpp_constexpr_exceptions
-#endif
-
 // NOLINTBEGIN(bugprone-crtp-constructor-accessibility)
 // NOLINTBEGIN(bugprone-unhandled-exception-at-new)
 #include <exec/completion_signatures.hpp>
@@ -57,12 +47,6 @@
 #include <stdexec/execution.hpp>
 // NOLINTEND(bugprone-unhandled-exception-at-new)
 // NOLINTEND(bugprone-crtp-constructor-accessibility)
-
-#if defined(HPX_STDEXEC_RESTORE___cpp_constexpr_exceptions)
-#define __cpp_constexpr_exceptions                                             \
-    HPX_STDEXEC_RESTORE___cpp_constexpr_exceptions
-#undef HPX_STDEXEC_RESTORE___cpp_constexpr_exceptions
-#endif
 
 #if defined(HPX_GCC_VERSION)
 #pragma GCC diagnostic pop

--- a/libs/core/filesystem/include/hpx/filesystem/api.hpp
+++ b/libs/core/filesystem/include/hpx/filesystem/api.hpp
@@ -36,9 +36,19 @@ namespace hpx::filesystem {
         return ip;
     }
 
+    HPX_CXX_CORE_EXPORT [[nodiscard]] inline std::string to_string(
+        path const& p)
+    {
+#if defined(__GLIBCXX__) && __cplusplus >= 202400L
+        return p.display_string();
+#else
+        return p.string();
+#endif
+    }
+
     HPX_CXX_CORE_EXPORT [[nodiscard]] inline std::string basename(path const& p)
     {
-        return p.stem().string();
+        return to_string(p.stem());
     }
 
     HPX_CXX_CORE_EXPORT [[nodiscard]] inline path canonical(
@@ -85,6 +95,12 @@ namespace hpx::filesystem {
     HPX_CXX_CORE_EXPORT using namespace boost::filesystem;
 
     HPX_CXX_CORE_EXPORT using boost::filesystem::canonical;
+
+    HPX_CXX_CORE_EXPORT [[nodiscard]] inline std::string to_string(
+        path const& p)
+    {
+        return p.string();
+    }
 
     HPX_CXX_CORE_EXPORT [[nodiscard]] inline path canonical(
         path const& p, path const& base, std::error_code& ec)

--- a/libs/core/futures/CMakeLists.txt
+++ b/libs/core/futures/CMakeLists.txt
@@ -77,6 +77,7 @@ add_hpx_module(
     hpx_concepts
     hpx_concurrency
     hpx_config
+    hpx_contracts
     hpx_coroutines
     hpx_datastructures
     hpx_errors

--- a/libs/core/futures/include/hpx/futures/future.hpp
+++ b/libs/core/futures/include/hpx/futures/future.hpp
@@ -13,6 +13,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
+#include <hpx/contracts.hpp>
 #include <hpx/futures/detail/future_data.hpp>
 #include <hpx/futures/future_fwd.hpp>
 #include <hpx/futures/traits/acquire_shared_state.hpp>
@@ -662,6 +663,7 @@ namespace hpx {
         //         shared state.
         // Postcondition: valid() == false.
         typename hpx::traits::future_traits<future>::result_type get()
+            HPX_PRE(this->valid())
         {
             if (!this->shared_state_)
             {
@@ -1012,7 +1014,7 @@ namespace hpx {
         //         shared state.
         // Postcondition: valid() == false.
         typename hpx::traits::future_traits<shared_future>::result_type get()
-            const    //-V659
+            const HPX_PRE(this->valid())    //-V659
         {
             if (!this->shared_state_)
             {

--- a/libs/core/futures/include/hpx/futures/future.hpp
+++ b/libs/core/futures/include/hpx/futures/future.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2025 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c) 2013 Agustin Berge
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -756,7 +756,7 @@ namespace hpx {
         ///                          after it returns.
         template <typename F>
         decltype(auto) then(F&& f, error_code& ec = throws)
-            HPX_PRE(this->valid()) HPX_POST(!this->valid())
+        // HPX_PRE(this->valid()) HPX_POST(!this->valid())
         {
 #if defined(HPX_COMPUTE_DEVICE_CODE)
             // This and the similar ifdefs below for future::then and
@@ -800,7 +800,7 @@ namespace hpx {
         ///                          after it returns.
         template <typename T0, typename F>
         decltype(auto) then(T0&& t0, F&& f, error_code& ec = throws)
-            HPX_PRE(this->valid()) HPX_POST(!this->valid())
+        // HPX_PRE(this->valid()) HPX_POST(!this->valid())
         {
 #if defined(HPX_COMPUTE_DEVICE_CODE)
             HPX_ASSERT(false);
@@ -820,7 +820,7 @@ namespace hpx {
         auto then_alloc(Allocator const& alloc, F&& f, error_code& ec = throws)
             -> decltype(base_type::then_alloc(
                 alloc, std::move(*this), std::forward<F>(f), ec))
-                HPX_PRE(this->valid()) HPX_POST(!this->valid())
+        // HPX_PRE(this->valid()) HPX_POST(!this->valid())
         {
 #if defined(HPX_COMPUTE_DEVICE_CODE)
             HPX_ASSERT(false);
@@ -1067,7 +1067,7 @@ namespace hpx {
         /// \copydoc hpx::future::then(F&& f, error_code& ec = throws)
         template <typename F>
         decltype(auto) then(F&& f, error_code& ec = throws) const
-            HPX_PRE(this->valid())
+        //HPX_PRE(this->valid())
         {
 #if defined(HPX_COMPUTE_DEVICE_CODE)
             HPX_ASSERT(false);
@@ -1084,7 +1084,7 @@ namespace hpx {
         /// \copydoc hpx::future::then(T0&& t0, F&& f, error_code& ec = throws)
         template <typename T0, typename F>
         decltype(auto) then(T0&& t0, F&& f, error_code& ec = throws) const
-            HPX_PRE(this->valid())
+        // HPX_PRE(this->valid())
         {
 #if defined(HPX_COMPUTE_DEVICE_CODE)
             HPX_ASSERT(false);
@@ -1100,7 +1100,7 @@ namespace hpx {
         template <typename Allocator, typename F>
         auto then_alloc(Allocator const& alloc, F&& f, error_code& ec = throws)
             -> decltype(base_type::then_alloc(alloc, std::move(*this),
-                std::forward<F>(f), ec)) HPX_PRE(this->valid())
+                std::forward<F>(f), ec))    // HPX_PRE(this->valid())
         {
 #if defined(HPX_COMPUTE_DEVICE_CODE)
             HPX_ASSERT(false);

--- a/libs/core/futures/include/hpx/futures/future.hpp
+++ b/libs/core/futures/include/hpx/futures/future.hpp
@@ -69,7 +69,7 @@ namespace hpx::lcos::detail {
     };
 
     HPX_CXX_CORE_EXPORT template <typename Future>
-    using future_unwrap_result_t = typename future_unwrap_result<Future>::type;
+    using future_unwrap_result_t = future_unwrap_result<Future>::type;
 
     ///////////////////////////////////////////////////////////////////////////
     HPX_CXX_CORE_EXPORT template <typename T>
@@ -148,8 +148,7 @@ namespace hpx::lcos::detail {
     };
 
     HPX_CXX_CORE_EXPORT template <typename ContResult>
-    using continuation_result_t =
-        typename continuation_result<ContResult>::type;
+    using continuation_result_t = continuation_result<ContResult>::type;
 
     template <typename ContResult>
     struct continuation_result<hpx::future<ContResult>>
@@ -330,7 +329,7 @@ namespace hpx::lcos::detail {
                     "this future has no valid shared state");
             }
 
-            using result_type = typename shared_state_type::result_type;
+            using result_type = shared_state_type::result_type;
 
             error_code ec(throwmode::lightweight);
             lcos::detail::future_get_result<result_type>::call(
@@ -544,7 +543,7 @@ namespace hpx {
 
     public:
         using result_type = R;
-        using shared_state_type = typename base_type::shared_state_type;
+        using shared_state_type = base_type::shared_state_type;
 
     private:
         template <typename Future>
@@ -662,7 +661,7 @@ namespace hpx {
         // Throws: the stored exception, if an exception was stored in the
         //         shared state.
         // Postcondition: valid() == false.
-        typename hpx::traits::future_traits<future>::result_type get()
+        hpx::traits::future_traits<future>::result_type get()
             HPX_PRE(this->valid())
         {
             if (!this->shared_state_)
@@ -674,7 +673,7 @@ namespace hpx {
             auto on_exit = hpx::experimental::scope_exit(
                 [this] { this->shared_state_.reset(); });
 
-            using result_type = typename shared_state_type::result_type;
+            using result_type = shared_state_type::result_type;
             auto* result = lcos::detail::future_get_result<result_type>::call(
                 this->shared_state_);
 
@@ -682,8 +681,8 @@ namespace hpx {
             return lcos::detail::future_value<R>::get(HPX_MOVE(*result));
         }
 
-        typename hpx::traits::future_traits<future>::result_type get(
-            error_code& ec)
+        hpx::traits::future_traits<future>::result_type get(error_code& ec)
+            HPX_PRE(this->valid())
         {
             if (!this->shared_state_)
             {
@@ -695,7 +694,7 @@ namespace hpx {
             auto on_exit = hpx::experimental::scope_exit(
                 [this] { this->shared_state_.reset(); });
 
-            using result_type = typename shared_state_type::result_type;
+            using result_type = shared_state_type::result_type;
             result_type* result =
                 lcos::detail::future_get_result<result_type>::call(
                     this->shared_state_, ec);
@@ -743,7 +742,6 @@ namespace hpx {
         /// \tparam F           The type of the function/function object to use
         ///                     (deduced). F must meet requirements of
         ///                     \a MoveConstructible.
-        /// \tparam error_code  The type of error code.
         ///
         /// \param f            A continuation to be attached.
         /// \param ec           Used to hold error code value originated during the
@@ -758,6 +756,7 @@ namespace hpx {
         ///                          after it returns.
         template <typename F>
         decltype(auto) then(F&& f, error_code& ec = throws)
+            HPX_PRE(this->valid()) HPX_POST(!this->valid())
         {
 #if defined(HPX_COMPUTE_DEVICE_CODE)
             // This and the similar ifdefs below for future::then and
@@ -786,7 +785,6 @@ namespace hpx {
         /// \tparam F           The type of the function/function object to use
         ///                     (deduced). F must meet requirements of
         ///                     \a MoveConstructible.
-        /// \tparam error_code  The type of error code.
         ///
         /// \param t0           The executor or launch policy to be used.
         /// \param f            A continuation to be attached.
@@ -802,6 +800,7 @@ namespace hpx {
         ///                          after it returns.
         template <typename T0, typename F>
         decltype(auto) then(T0&& t0, F&& f, error_code& ec = throws)
+            HPX_PRE(this->valid()) HPX_POST(!this->valid())
         {
 #if defined(HPX_COMPUTE_DEVICE_CODE)
             HPX_ASSERT(false);
@@ -820,11 +819,8 @@ namespace hpx {
         template <typename Allocator, typename F>
         auto then_alloc(Allocator const& alloc, F&& f, error_code& ec = throws)
             -> decltype(base_type::then_alloc(
-#if defined(HPX_CUDA_VERSION) && (HPX_CUDA_VERSION < 1104)
                 alloc, std::move(*this), std::forward<F>(f), ec))
-#else
-                alloc, HPX_MOVE(*this), HPX_FORWARD(F, f), ec))
-#endif
+                HPX_PRE(this->valid()) HPX_POST(!this->valid())
         {
 #if defined(HPX_COMPUTE_DEVICE_CODE)
             HPX_ASSERT(false);
@@ -901,7 +897,7 @@ namespace hpx {
 
     public:
         using result_type = R;
-        using shared_state_type = typename base_type::shared_state_type;
+        using shared_state_type = base_type::shared_state_type;
 
     private:
         template <typename Future>
@@ -1013,8 +1009,9 @@ namespace hpx {
         // Throws: the stored exception, if an exception was stored in the
         //         shared state.
         // Postcondition: valid() == false.
-        typename hpx::traits::future_traits<shared_future>::result_type get()
-            const HPX_PRE(this->valid())    //-V659
+        hpx::traits::future_traits<shared_future>::result_type get()
+            const    //-V659
+            HPX_PRE(this->valid())
         {
             if (!this->shared_state_)
             {
@@ -1023,7 +1020,7 @@ namespace hpx {
                     "this future has no valid shared state");
             }
 
-            using result_type = typename shared_state_type::result_type;
+            using result_type = shared_state_type::result_type;
             result_type* result =
                 lcos::detail::future_get_result<result_type>::call(
                     this->shared_state_);
@@ -1032,10 +1029,11 @@ namespace hpx {
             return lcos::detail::future_value<R>::get(*result);
         }
 
-        typename hpx::traits::future_traits<shared_future>::result_type get(
+        hpx::traits::future_traits<shared_future>::result_type get(
             error_code& ec) const    //-V659
+            HPX_PRE(this->valid())
         {
-            using result_type = typename shared_state_type::result_type;
+            using result_type = shared_state_type::result_type;
             if (!this->shared_state_)
             {
                 HPX_THROWS_IF(ec, hpx::error::no_state, "shared_future<R>::get",
@@ -1069,6 +1067,7 @@ namespace hpx {
         /// \copydoc hpx::future::then(F&& f, error_code& ec = throws)
         template <typename F>
         decltype(auto) then(F&& f, error_code& ec = throws) const
+            HPX_PRE(this->valid())
         {
 #if defined(HPX_COMPUTE_DEVICE_CODE)
             HPX_ASSERT(false);
@@ -1085,6 +1084,7 @@ namespace hpx {
         /// \copydoc hpx::future::then(T0&& t0, F&& f, error_code& ec = throws)
         template <typename T0, typename F>
         decltype(auto) then(T0&& t0, F&& f, error_code& ec = throws) const
+            HPX_PRE(this->valid())
         {
 #if defined(HPX_COMPUTE_DEVICE_CODE)
             HPX_ASSERT(false);
@@ -1099,12 +1099,8 @@ namespace hpx {
 
         template <typename Allocator, typename F>
         auto then_alloc(Allocator const& alloc, F&& f, error_code& ec = throws)
-            -> decltype(base_type::then_alloc(
-#if defined(HPX_CUDA_VERSION) && (HPX_CUDA_VERSION < 1104)
-                alloc, std::move(*this), std::forward<F>(f), ec))
-#else
-                alloc, HPX_MOVE(*this), HPX_FORWARD(F, f), ec))
-#endif
+            -> decltype(base_type::then_alloc(alloc, std::move(*this),
+                std::forward<F>(f), ec)) HPX_PRE(this->valid())
         {
 #if defined(HPX_COMPUTE_DEVICE_CODE)
             HPX_ASSERT(false);
@@ -1224,11 +1220,11 @@ namespace hpx {
         using shared_state = traits::shared_state_allocator_t<
             lcos::detail::future_data<result_type>, base_allocator>;
 
-        using other_allocator = typename std::allocator_traits<
+        using other_allocator = std::allocator_traits<
             base_allocator>::template rebind_alloc<shared_state>;
         using traits = std::allocator_traits<other_allocator>;
 
-        using init_no_addref = typename shared_state::init_no_addref;
+        using init_no_addref = shared_state::init_no_addref;
 
         using unique_ptr = std::unique_ptr<shared_state,
             util::allocator_deleter<other_allocator>>;
@@ -1292,7 +1288,7 @@ namespace hpx {
     future<T> make_exceptional_future(std::exception_ptr const& e)
     {
         using shared_state = lcos::detail::future_data<T>;
-        using init_no_addref = typename shared_state::init_no_addref;
+        using init_no_addref = shared_state::init_no_addref;
 
         hpx::intrusive_ptr<shared_state> p(
             new shared_state(init_no_addref{}, e), false);
@@ -1325,7 +1321,7 @@ namespace hpx {
     {
         using result_type = hpx::util::decay_unwrap_t<T>;
         using shared_state = lcos::detail::timed_future_data<result_type>;
-        using init_no_addref = typename shared_state::init_no_addref;
+        using init_no_addref = shared_state::init_no_addref;
 
         hpx::intrusive_ptr<shared_state> p(
             new shared_state(
@@ -1453,7 +1449,7 @@ namespace hpx::lcos::detail {
             if constexpr (!std::is_void_v<hpx::traits::future_traits_t<Future>>)
             {
                 using value_type =
-                    typename hpx::traits::future_traits<Future>::result_type;
+                    hpx::traits::future_traits<Future>::result_type;
 
                 value_type const& value =
                     *(hpx::traits::future_access<Future>::get_shared_state(f)

--- a/libs/core/iostream/CMakeLists.txt
+++ b/libs/core/iostream/CMakeLists.txt
@@ -113,7 +113,13 @@ add_hpx_module(
   COMPAT_HEADERS ${iostream_compat_headers}
   DEPENDENCIES ${additional_dependencies}
   INCLUDE_DIRECTORIES ${additional_include_directories}
-  MODULE_DEPENDENCIES hpx_config hpx_assertion hpx_datastructures hpx_functional
-                      hpx_iterator_support hpx_type_support
+  MODULE_DEPENDENCIES
+    hpx_config
+    hpx_assertion
+    hpx_datastructures
+    hpx_filesystem
+    hpx_functional
+    hpx_iterator_support
+    hpx_type_support
   CMAKE_SUBDIRS tests
 )

--- a/libs/core/iostream/include/hpx/iostream/device/file_descriptor.hpp
+++ b/libs/core/iostream/include/hpx/iostream/device/file_descriptor.hpp
@@ -17,6 +17,7 @@
 #include <hpx/config.hpp>
 #include <hpx/iostream/categories.hpp>
 #include <hpx/iostream/positioning.hpp>
+#include <hpx/modules/filesystem.hpp>
 
 #include <cstdint>
 #include <filesystem>
@@ -90,7 +91,7 @@ namespace hpx::iostream {
                 std::ios_base::out)
         {
             init();
-            open(path.string(), mode);
+            open(hpx::filesystem::to_string(path), mode);
         }
 
         // Copy constructor

--- a/libs/core/iostream/src/file_descriptor.cpp
+++ b/libs/core/iostream/src/file_descriptor.cpp
@@ -12,6 +12,7 @@
 #include <hpx/config.hpp>    // BOOST_JOIN
 #include <hpx/iostream/detail/error.hpp>
 #include <hpx/iostream/device/file_descriptor.hpp>
+#include <hpx/modules/filesystem.hpp>
 
 #include <cassert>
 #include <cerrno>
@@ -242,8 +243,8 @@ namespace hpx::iostream {
                 dwDesiredAccess = GENERIC_WRITE;
             }
 
-            HANDLE handle = ::CreateFileA(p.string().c_str(), dwDesiredAccess,
-                FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr,
+            HANDLE handle = ::CreateFileA(hpx::filesystem::to_string(p).c_str(),
+                dwDesiredAccess, FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr,
                 dwCreationDisposition, FILE_ATTRIBUTE_NORMAL, nullptr);
             if (handle != INVALID_HANDLE_VALUE)
             {

--- a/libs/core/iostream/tests/unit/detail/temp_file.hpp
+++ b/libs/core/iostream/tests/unit/detail/temp_file.hpp
@@ -11,6 +11,9 @@
 
 #pragma once
 
+#include <hpx/config.hpp>
+#include <hpx/modules/filesystem.hpp>
+
 #include <cctype>
 #include <cstddef>
 #include <cstdio>
@@ -32,7 +35,7 @@ namespace hpx::iostream::test {
             auto temp_path = std::filesystem::temp_directory_path();
             std::string unique_filename =
                 "file_" + std::to_string(std::random_device{}()) + ".tmp";
-            return (temp_path / unique_filename).string();
+            return hpx::filesystem::to_string(temp_path / unique_filename);
         }
 
     public:

--- a/libs/core/plugin/include/hpx/plugin/detail/dll_dlopen.hpp
+++ b/libs/core/plugin/include/hpx/plugin/detail/dll_dlopen.hpp
@@ -342,7 +342,7 @@ namespace hpx::util::plugin {
             result = directory;
             ::dlerror();    // Clear the error state.
 #else
-            result = path(dll_name).parent_path().string();
+            result = hpx::filesystem::to_string(path(dll_name).parent_path());
 #endif
 #elif defined(__APPLE__)
             // SO staticfloat's solution
@@ -362,7 +362,8 @@ namespace hpx::util::plugin {
                         if (((intptr_t) dll_handle & (-4)) ==
                             ((intptr_t) probe_handle & (-4)))
                         {
-                            result = path(image_name).parent_path().string();
+                            result = hpx::filesystem::to_string(
+                                path(image_name).parent_path());
                             break;
                         }
                     }

--- a/libs/core/prefix/src/find_prefix.cpp
+++ b/libs/core/prefix/src/find_prefix.cpp
@@ -66,8 +66,8 @@ namespace hpx::util {
 
             using hpx::filesystem::path;
 
-            std::string prefix =
-                path(dll.get_directory(ec)).parent_path().string();
+            std::string prefix = hpx::filesystem::to_string(
+                path(dll.get_directory(ec)).parent_path());
 
             if (ec || prefix.empty())
                 return hpx_prefix();
@@ -124,7 +124,7 @@ namespace hpx::util {
         using hpx::filesystem::path;
         path const p(get_executable_filename(argv0));
 
-        return p.parent_path().parent_path().string();
+        return hpx::filesystem::to_string(p.parent_path().parent_path());
     }
 
     std::string get_executable_filename(char const* argv0)

--- a/libs/core/runtime_configuration/src/init_ini_data.cpp
+++ b/libs/core/runtime_configuration/src/init_ini_data.cpp
@@ -62,10 +62,10 @@ namespace hpx::util {
             if (nullptr != file_suffix)
                 inipath /= fs::path(file_suffix);
 
-            if (handle_ini_file(ini, inipath.string()))
+            if (handle_ini_file(ini, hpx::filesystem::to_string(inipath)))
             {
                 LBT_(info).format("loaded configuration (${{{}}}): {}", env_var,
-                    inipath.string());
+                    hpx::filesystem::to_string(inipath));
                 return true;
             }
         }
@@ -111,7 +111,8 @@ namespace hpx::util {
 
         // look in the current directory first
         {
-            std::string cwd = fs::current_path().string() + "/.hpx.ini";
+            std::string cwd =
+                hpx::filesystem::to_string(fs::current_path()) + "/.hpx.ini";
             bool result2 = handle_ini_file(ini, cwd);
             if (result2)
             {
@@ -202,9 +203,9 @@ namespace hpx::util {
                     // read and merge the ini file into the main ini hierarchy
                     try
                     {
-                        ini.merge(p.string());
-                        LBT_(info).format(
-                            "loaded configuration: {}", p.string());
+                        ini.merge(hpx::filesystem::to_string(p));
+                        LBT_(info).format("loaded configuration: {}",
+                            hpx::filesystem::to_string(p));
                     }
                     // NOLINTNEXTLINE(bugprone-empty-catch)
                     catch (hpx::exception const& /*e*/)
@@ -515,7 +516,8 @@ namespace hpx::util {
 
                 // make sure every module name is loaded exactly once, the
                 // first occurrence of a module name is used
-                std::string basename = canonical_curr.filename().string();
+                std::string basename =
+                    hpx::filesystem::to_string(canonical_curr.filename());
                 std::pair<std::map<std::string, fs::path>::iterator, bool> p =
                     basenames.emplace(basename, canonical_curr);
 
@@ -527,8 +529,8 @@ namespace hpx::util {
                 {
                     LRT_(warning).format(
                         "skipping module {} ({}): ignored because of: {}",
-                        basename, canonical_curr.string(),
-                        p.first->second.string());
+                        basename, hpx::filesystem::to_string(canonical_curr),
+                        hpx::filesystem::to_string(p.first->second));
                 }
             }
         }
@@ -548,36 +550,39 @@ namespace hpx::util {
 
         for (auto const& p : libdata)
         {
-            LRT_(info).format("attempting to load: {}", p.first.string());
+            LRT_(info).format(
+                "attempting to load: {}", hpx::filesystem::to_string(p.first));
 
             // get the handle of the library
             error_code ec(throwmode::lightweight);
-            hpx::util::plugin::dll d(p.first.string(), p.second);
+            hpx::util::plugin::dll d(
+                hpx::filesystem::to_string(p.first), p.second);
             d.load_library(ec);
             if (ec)
             {
                 LRT_(info).format("skipping (load_library failed): {}: {}",
-                    p.first.string(), get_error_what(ec));
+                    hpx::filesystem::to_string(p.first), get_error_what(ec));
                 continue;
             }
 
             bool must_keep_loaded = false;
 
             // get the component factory
-            std::string curr_fullname(p.first.parent_path().string());
+            std::string curr_fullname(
+                hpx::filesystem::to_string(p.first.parent_path()));
             load_component_factory(
                 d, ini, curr_fullname, component_registries, p.second, ec);
             if (ec)
             {
                 LRT_(info).format(
                     "skipping (load_component_factory failed): {}: {}",
-                    p.first.string(), get_error_what(ec));
+                    hpx::filesystem::to_string(p.first), get_error_what(ec));
                 ec = error_code(throwmode::lightweight);    // reinit ec
             }
             else
             {
-                LRT_(debug).format(
-                    "load_component_factory succeeded: {}", p.first.string());
+                LRT_(debug).format("load_component_factory succeeded: {}",
+                    hpx::filesystem::to_string(p.first));
                 must_keep_loaded = true;
             }
 
@@ -589,12 +594,12 @@ namespace hpx::util {
             {
                 LRT_(info).format(
                     "skipping (load_plugin_factory failed): {}: {}",
-                    p.first.string(), get_error_what(ec));
+                    hpx::filesystem::to_string(p.first), get_error_what(ec));
             }
             else
             {
-                LRT_(debug).format(
-                    "load_plugin_factory succeeded: {}", p.first.string());
+                LRT_(debug).format("load_plugin_factory succeeded: {}",
+                    hpx::filesystem::to_string(p.first));
 
                 std::copy(tmp_regs.begin(), tmp_regs.end(),
                     std::back_inserter(plugin_registries));

--- a/libs/core/runtime_configuration/src/runtime_configuration.cpp
+++ b/libs/core/runtime_configuration/src/runtime_configuration.cpp
@@ -568,17 +568,17 @@ namespace hpx::util {
             if (fsec)
                 canonical_p = this_p;
 
-            if (auto const [it, ok] =
-                    component_paths.emplace(canonical_p.string());
+            if (auto const [it, ok] = component_paths.emplace(
+                    hpx::filesystem::to_string(canonical_p));
                 ok)
             {
                 // have all path elements, now find ini files in there...
                 fs::path const this_path(*it);
                 if (fs::exists(this_path, fsec) && !fsec)
                 {
-                    plugin_list_type tmp_regs =
-                        util::init_ini_data_default(this_path.string(), *this,
-                            basenames, modules_, component_registries);
+                    plugin_list_type tmp_regs = util::init_ini_data_default(
+                        hpx::filesystem::to_string(this_path), *this, basenames,
+                        modules_, component_registries);
 
                     std::copy(tmp_regs.begin(), tmp_regs.end(),
                         std::back_inserter(plugin_registries));

--- a/libs/core/schedulers/include/hpx/schedulers/local_priority_queue_scheduler.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/local_priority_queue_scheduler.hpp
@@ -734,6 +734,10 @@ namespace hpx::threads::policies {
             auto const steal = [&](std::size_t idx) -> bool {
                 HPX_ASSERT(idx != num_thread);
 
+                // suppress contracts warning about 'num_thread' not implicitly
+                // captured by a contract assertion
+                (void) num_thread;
+
                 if (thread_queue_type* q = queues_[idx].data_;
                     q->get_next_thread(thrd, true, true))
                 {
@@ -746,6 +750,10 @@ namespace hpx::threads::policies {
             std::size_t const num_high = num_high_priority_queues_;
             auto const steal_hp = [&](std::size_t idx) -> bool {
                 HPX_ASSERT(idx != num_thread);
+
+                // suppress contracts warning about 'num_thread' not implicitly
+                // captured by a contract assertion
+                (void) num_thread;
 
                 if (idx < num_high)
                 {
@@ -1441,6 +1449,10 @@ namespace hpx::threads::policies {
             auto const steal = [&](std::size_t idx) -> bool {
                 HPX_ASSERT(idx != num_thread);
 
+                // suppress contracts warning about 'num_thread' not implicitly
+                // captured by a contract assertion
+                (void) num_thread;
+
                 thread_queue_type* q = queues_[idx].data_;
                 result = this_queue->wait_or_add_new(true, added, q) && result;
 
@@ -1455,6 +1467,10 @@ namespace hpx::threads::policies {
             std::size_t const num_high = num_high_priority_queues_;
             auto const steal_hp = [&](std::size_t idx) -> bool {
                 HPX_ASSERT(idx != num_thread);
+
+                // suppress contracts warning about 'num_thread' not implicitly
+                // captured by a contract assertion
+                (void) num_thread;
 
                 // If the stealing thread has a high-priority queue, try
                 // high-priority victims first (and then their normal queues).

--- a/libs/core/serialization/tests/unit/CMakeLists.txt
+++ b/libs/core/serialization/tests/unit/CMakeLists.txt
@@ -35,7 +35,7 @@ if(HPX_SERIALIZATION_WITH_BOOST_TYPES)
   set(tests ${tests} serialization_boost_variant)
 endif()
 
-if(NOT HPX_SERIALIZATION_WITH_ALLOW_AUTO_GENERATE)
+if(NOT HPX_WITH_CXX26_REFLECTION)
   set(tests ${tests} serialization_brace_initializable)
 endif()
 

--- a/libs/core/serialization/tests/unit/refl/CMakeLists.txt
+++ b/libs/core/serialization/tests/unit/refl/CMakeLists.txt
@@ -18,7 +18,7 @@ set(tests
     reflection_qualified_name_of
 )
 
-if(HPX_SERIALIZATION_WITH_ALLOW_AUTO_GENERATE)
+if(HPX_WITH_CXX26_REFLECTION)
   foreach(test ${tests})
     set(sources ${test}.cpp)
 

--- a/libs/full/agas/src/addressing_service.cpp
+++ b/libs/full/agas/src/addressing_service.cpp
@@ -1561,6 +1561,7 @@ namespace hpx::agas {
         naming::gid_type& mutable_gid = const_cast<hpx::id_type&>(id).get_gid();
         naming::gid_type const new_gid =
             naming::detail::split_gid_if_needed(hpx::launch::sync, mutable_gid);
+
         std::int64_t const new_credit =
             naming::detail::get_credit_from_gid(new_gid);
 
@@ -1586,6 +1587,7 @@ namespace hpx::agas {
         naming::gid_type& mutable_gid = const_cast<hpx::id_type&>(id).get_gid();
         naming::gid_type const new_gid =
             naming::detail::split_gid_if_needed(hpx::launch::sync, mutable_gid);
+
         std::int64_t new_credit = naming::detail::get_credit_from_gid(new_gid);
 
         future<bool> f = symbol_ns_.bind_async(name, new_gid);

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/promise_lco.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/promise_lco.hpp
@@ -218,7 +218,7 @@ namespace hpx {
         HPX_ALWAYS_EXPORT hpx::components::managed_component<
             lcos::detail::promise_lco<void, hpx::util::unused_type>>::heap_type&
         component_heap_helper<hpx::components::managed_component<
-            lcos::detail::promise_lco<void, hpx::util::unused_type>>>(...);
+            lcos::detail::promise_lco<void, hpx::util::unused_type>>>();
 
         template <typename Result, typename RemoteResult>
         struct HPX_ALWAYS_EXPORT

--- a/libs/full/collectives/tests/performance/benchmark_collectives.cpp
+++ b/libs/full/collectives/tests/performance/benchmark_collectives.cpp
@@ -14,6 +14,7 @@
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/modules/collectives.hpp>
+#include <hpx/modules/filesystem.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <algorithm>
@@ -79,8 +80,8 @@ void create_parent_dir(std::filesystem::path const& file_path)
         }
         else
         {
-            throw std::runtime_error(
-                "Failed to create directory: " + dir_path.string());
+            throw std::runtime_error("Failed to create directory: " +
+                hpx::filesystem::to_string(dir_path));
         }
     }
 }

--- a/libs/full/command_line_handling/src/parse_command_line.cpp
+++ b/libs/full/command_line_handling/src/parse_command_line.cpp
@@ -172,7 +172,7 @@ namespace hpx::util {
                     ~util::commandline_error_mode::report_missing_config_file;
                 std::vector<std::string> options =
                     hpx::local::detail::read_config_file_options(
-                        filename.string(), mode);
+                        hpx::filesystem::to_string(filename), mode);
 
                 if (handle_config_file_options(
                         options, desc_cfgfile, vm, ini, node, mode))

--- a/libs/full/components_base/include/hpx/components_base/macros.hpp
+++ b/libs/full/components_base/include/hpx/components_base/macros.hpp
@@ -256,7 +256,7 @@
     namespace hpx::components::detail {                                        \
         template <>                                                            \
         HPX_ALWAYS_EXPORT Component::heap_type&                                \
-        component_heap_helper<Component>(...)                                  \
+        component_heap_helper<Component>()                                     \
         {                                                                      \
             util::reinitializable_static<Component::heap_type> heap;           \
             return heap.get();                                                 \

--- a/libs/full/components_base/include/hpx/components_base/server/component_heap.hpp
+++ b/libs/full/components_base/include/hpx/components_base/server/component_heap.hpp
@@ -24,19 +24,22 @@ namespace hpx::components {
         struct HPX_ALWAYS_EXPORT component_heap_impl;
 
         HPX_CXX_EXPORT template <typename Component>
-        Component::heap_type& component_heap_helper(
-            typename detail::component_heap_impl<Component>::valid*)
-        {
-            return detail::component_heap_impl<Component>::call();
-        }
-
-        HPX_CXX_EXPORT template <typename Component>
-        HPX_ALWAYS_EXPORT Component::heap_type& component_heap_helper(...);
+        HPX_ALWAYS_EXPORT Component::heap_type& component_heap_helper();
     }    // namespace detail
 
     HPX_CXX_EXPORT template <typename Component>
     Component::heap_type& component_heap()
     {
-        return detail::component_heap_helper<Component>(nullptr);
+        if constexpr (requires {
+                          typename detail::component_heap_impl<
+                              Component>::valid;
+                      })
+        {
+            return detail::component_heap_impl<Component>::call();
+        }
+        else
+        {
+            return detail::component_heap_helper<Component>();
+        }
     }
 }    // namespace hpx::components

--- a/libs/full/naming/src/credit_handling.cpp
+++ b/libs/full/naming/src/credit_handling.cpp
@@ -267,9 +267,10 @@ namespace hpx::naming {
                 // An early decref can't happen as the id_type with the new
                 // credit is guaranteed to arrive only after we incremented the
                 // credit successfully in agas.
-                HPX_ASSERT(get_log2credit_from_gid(gid) > 0);
+                HPX_ASSERT(has_credits(gid));
                 std::int16_t const src_log2credits =
                     get_log2credit_from_gid(gid);
+                HPX_ASSERT(src_log2credits > 0);
 
                 // Credit exhaustion - we need to get more.
                 if (src_log2credits == 1)
@@ -366,6 +367,7 @@ namespace hpx::naming {
         {
             HPX_ASSERT_OWNS_LOCK(l);
 
+            HPX_ASSERT(has_credits(id));
             std::int16_t const log2credits = get_log2credit_from_gid(id);
             HPX_ASSERT(log2credits > 0);
 

--- a/libs/full/naming_base/include/hpx/naming_base/gid_type.hpp
+++ b/libs/full/naming_base/include/hpx/naming_base/gid_type.hpp
@@ -23,6 +23,7 @@
 #include <iosfwd>
 #include <mutex>
 #include <string>
+#include <type_traits>
 
 #include <hpx/config/warnings_prefix.hpp>
 
@@ -609,10 +610,9 @@ namespace hpx::naming {
             return ret;
         }
 
-        HPX_CXX_EXPORT inline std::int64_t power2(
+        HPX_CXX_EXPORT constexpr std::int64_t power2(
             std::int16_t const log2credits) noexcept
         {
-            HPX_ASSERT(log2credits >= 0);
             return static_cast<std::int64_t>(1) << log2credits;
         }
 
@@ -654,7 +654,6 @@ namespace hpx::naming {
         HPX_CXX_EXPORT constexpr std::int16_t get_log2credit_from_gid(
             gid_type const& gid) noexcept
         {
-            HPX_ASSERT(has_credits(gid));
             return static_cast<std::int16_t>(
                 (gid.get_msb() >> gid_type::credit_shift) &
                 gid_type::credit_base_mask);
@@ -689,6 +688,7 @@ namespace hpx::naming {
             if (credits != 0)
             {
                 std::int16_t const log2credits = detail::log2(credits);
+                HPX_ASSERT(log2credits >= 0);
                 HPX_ASSERT(detail::power2(log2credits) == credits);
 
                 set_log2credit_for_gid(id, log2credits);

--- a/libs/full/runtime_components/tests/unit/components/launch_process.cpp
+++ b/libs/full/runtime_components/tests/unit/components/launch_process.cpp
@@ -73,7 +73,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
 
     // set up command line for launched executable
     std::vector<std::string> args;
-    args.push_back(exe.string());
+    args.push_back(hpx::filesystem::to_string(exe));
     args.push_back("--exit_code=42");
     args.push_back("--component=test_server");
     args.push_back("--set_message=accessed");
@@ -109,12 +109,13 @@ int hpx_main(hpx::program_options::variables_map& vm)
     env.push_back("HPX_ON_STARTUP_WAIT_ON_LATCH=launch_process");
 
     // launch test executable
-    process::child c =
-        process::execute(hpx::find_here(), process::run_exe(exe.string()),
-            process::set_args(args), process::set_env(env),
-            process::start_in_dir(base_dir.string()), process::throw_on_error(),
-            process::wait_on_latch("launch_process")    // same as above!
-        );
+    process::child c = process::execute(
+        hpx::find_here(), process::run_exe(hpx::filesystem::to_string(exe)),
+        process::set_args(args), process::set_env(env),
+        process::start_in_dir(hpx::filesystem::to_string(base_dir)),
+        process::throw_on_error(),
+        process::wait_on_latch("launch_process")    // same as above!
+    );
 
     {
         // now create an instance of the test_server component

--- a/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
+++ b/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
@@ -1145,12 +1145,12 @@ namespace hpx { namespace components { namespace server {
                     LRT_(warning).format(
                         "static loading failed: {}: {}: couldn't find factory "
                         "in global static factory map",
-                        lib.string(), instance);
+                        hpx::filesystem::to_string(lib), instance);
                     return false;
                 }
 
-                LRT_(info).format(
-                    "static loading succeeded: {}: {}", lib.string(), instance);
+                LRT_(info).format("static loading succeeded: {}: {}",
+                    hpx::filesystem::to_string(lib), instance);
             }
 
             // make sure startup/shutdown registration is called once for each
@@ -1172,13 +1172,13 @@ namespace hpx { namespace components { namespace server {
         catch (std::logic_error const& e)
         {
             LRT_(warning).format("static loading failed: {}: {}: {}",
-                lib.string(), instance, e.what());
+                hpx::filesystem::to_string(lib), instance, e.what());
             return false;
         }
         catch (std::exception const& e)
         {
             LRT_(warning).format("static loading failed: {}: {}: {}",
-                lib.string(), instance, e.what());
+                hpx::filesystem::to_string(lib), instance, e.what());
             return false;
         }
         return true;    // component got loaded
@@ -1588,7 +1588,8 @@ namespace hpx { namespace components { namespace server {
 
         // first, try using the path as the full path to the library
         error_code ec(throwmode::lightweight);
-        hpx::util::plugin::dll d(lib.string(), HPX_MANGLE_STRING(component));
+        hpx::util::plugin::dll d(
+            hpx::filesystem::to_string(lib), HPX_MANGLE_STRING(component));
         d.load_library(ec);
         if (ec)
         {
@@ -1599,7 +1600,8 @@ namespace hpx { namespace components { namespace server {
             if (ec)
             {
                 LRT_(warning).format("dynamic loading failed: {}: {}: {}",
-                    lib.string(), instance, get_error_what(ec));
+                    hpx::filesystem::to_string(lib), instance,
+                    get_error_what(ec));
                 return false;    // next please :-P
             }
         }
@@ -1754,7 +1756,7 @@ namespace hpx { namespace components { namespace server {
                     d, "factory");
 
                 LRT_(info).format("dynamic loading succeeded: {}: {}",
-                    lib.string(), instance);
+                    hpx::filesystem::to_string(lib), instance);
             }
 
             // make sure startup/shutdown registration is called once for each
@@ -1776,13 +1778,13 @@ namespace hpx { namespace components { namespace server {
         catch (std::logic_error const& e)
         {
             LRT_(warning).format("dynamic loading failed: {}: {}: {}",
-                lib.string(), instance, e.what());
+                hpx::filesystem::to_string(lib), instance, e.what());
             return false;
         }
         catch (std::exception const& e)
         {
             LRT_(warning).format("dynamic loading failed: {}: {}: {}",
-                lib.string(), instance, e.what());
+                hpx::filesystem::to_string(lib), instance, e.what());
             return false;
         }
         return true;    // component got loaded
@@ -1961,13 +1963,14 @@ namespace hpx { namespace components { namespace server {
                     }
 
                     LRT_(info).format("dynamic loading succeeded: {}: {}",
-                        lib.string(), instance);
+                        hpx::filesystem::to_string(lib), instance);
                 }
                 else
                 {
                     LRT_(warning).format(
                         "dynamic loading of plugin factory failed: {}: {}: {}",
-                        lib.string(), instance, get_error_what(ec));
+                        hpx::filesystem::to_string(lib), instance,
+                        get_error_what(ec));
                 }
             }
 
@@ -1989,13 +1992,13 @@ namespace hpx { namespace components { namespace server {
         catch (std::logic_error const& e)
         {
             LRT_(warning).format("dynamic loading failed: {}: {}: {}",
-                lib.string(), instance, e.what());
+                hpx::filesystem::to_string(lib), instance, e.what());
             return false;
         }
         catch (std::exception const& e)
         {
             LRT_(warning).format("dynamic loading failed: {}: {}: {}",
-                lib.string(), instance, e.what());
+                hpx::filesystem::to_string(lib), instance, e.what());
             return false;
         }
         return true;
@@ -2017,7 +2020,8 @@ namespace hpx { namespace components { namespace server {
 
         // get the handle of the library
         error_code ec(throwmode::lightweight);
-        hpx::util::plugin::dll d(lib.string(), HPX_MANGLE_STRING(plugin));
+        hpx::util::plugin::dll d(
+            hpx::filesystem::to_string(lib), HPX_MANGLE_STRING(plugin));
         d.load_library(ec);
         if (ec)
         {
@@ -2028,7 +2032,8 @@ namespace hpx { namespace components { namespace server {
             if (ec)
             {
                 LRT_(warning).format("dynamic loading failed: {}: {}: {}",
-                    lib.string(), instance, get_error_what(ec));
+                    hpx::filesystem::to_string(lib), instance,
+                    get_error_what(ec));
                 return false;    // next please :-P
             }
         }


### PR DESCRIPTION
## What this is

A standalone, buildable contracts infrastructure - violation handler with enforce/observe/ignore mode dispatch, the macro layer (`HPX_CONTRACT_ASSERT`, `HPX_PRE`, `HPX_POST`), and a minimal `optional<T>` annotated with P3471 preconditions. Lives in `poc/contracts/` and builds independently of HPX's CMake so anyone can run it without a full HPX build.                                   
This is a proof-of-concept : not the real integration, just enough to show the approach is sound.

---

## What I built

Three files that form the core of what the full project would need:

* `violation_handler.hpp` - a `violation_info` struct that mirrors what `std::contract_violation` will look like in C++26, plus a customizable handler (default: log to stderr + abort). This is the same pattern HPX already uses for `assertion_handler`.

* `contract_macros.hpp` - `HPX_CONTRACT_ASSERT`, `HPX_PRE`, `HPX_POST` macros that dispatch to the right behavior depending on a compile-time mode flag.

---

## How it works

The key idea is compile-time mode selection:

* `-DHPX_CONTRACTS_MODE=0` → ENFORCE: check predicate, call handler, abort on violation
* `-DHPX_CONTRACTS_MODE=1` → OBSERVE: check predicate, call handler, continue
* `-DHPX_CONTRACTS_MODE=2` → IGNORE: predicate never evaluated (zero cost)

These map directly to P2900's three semantics. In IGNORE mode `HPX_CONTRACT_ASSERT(expr)` compiles to `((void)0)` - zero overhead.

The violation handler is user-installable (same API as `hpx::assertion::set_assertion_handler`), which makes it testable - instead of aborting, tests install a recording handler that captures violations and check them.

## What this isn't

This is not the actual implementation. Specifically:

* The violation handler here is header-only. In the real module it would be a compiled `.cpp` under `libs/core/contracts/src/` with `HPX_CORE_EXPORT` linkage.
* The macros here don't touch `HPX_ASSERT` at all. The real integration (via `HPX_CONTRACTS_WITH_ASSERTS_AS_CONTRACT_ASSERTS`) is already in the existing contracts module.
* No CMake integration into HPX's build system - this builds standalone on purpose so reviewers can run it without a full HPX build.

---

## Questions for reviewers

1. The violation handler is `noexcept` throughout (matching the existing `handle_assert`). Is that right for observe mode too, or should we allow the handler to throw in observe mode to integrate with HPX's exception-based error propagation?

2. For `HPX_PRE` / `HPX_POST` in fallback mode - I currently put them as body statements (top of function / before return). When native contracts land, they move to the declaration. Does HPX want a migration story for that, or is it acceptable that fallback-mode and native-mode `HPX_PRE` are syntactically in different positions?

3. Is the priority order right - containers first, then futures, then parallel algorithms? Or should futures come first since `future::get()` on an invalid future is probably the most common real-world bug?

