### PR TITLE
Fix Sender Algorithm Customization

### DIFF
--- a/libs/core/execution_base/include/hpx/execution_base/completion_signatures.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/completion_signatures.hpp
@@ -550,13 +550,13 @@ namespace hpx::execution::experimental {
     //    using with_awaitable_senders =
     //    hpx::execution::experimental::with_awaitable_senders<Promise>;
 
-    HPX_CXX_CORE_EXPORT template <typename ReceiverID>
+    HPX_CXX_CORE_EXPORT template <typename Awaitable, typename Receiver>
     using operation = hpx::execution::experimental::stdexec_internal::
-        __connect_await::__operation<ReceiverID>;
+        __connect_await::__opstate<Awaitable, Receiver>;
 
-    HPX_CXX_CORE_EXPORT template <typename ReceiverID>
+    HPX_CXX_CORE_EXPORT template <typename Awaitable, typename Receiver>
     using promise = hpx::execution::experimental::stdexec_internal::
-        __connect_await::__promise<ReceiverID>;
+        __connect_await::__promise<Awaitable, Receiver>;
 
     HPX_CXX_CORE_EXPORT using connect_awaitable_t =
         hpx::execution::experimental::stdexec_internal::__connect_awaitable_t;

--- a/libs/core/execution_base/include/hpx/execution_base/stdexec_forward.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/stdexec_forward.hpp
@@ -47,6 +47,13 @@
 namespace hpx::execution::experimental {
     // Domain
     HPX_CXX_CORE_EXPORT using stdexec::default_domain;
+    HPX_CXX_CORE_EXPORT using stdexec::get_domain;
+    HPX_CXX_CORE_EXPORT using stdexec::get_domain_t;
+
+    // Completion domain (P3826R5)
+    HPX_CXX_CORE_EXPORT using stdexec::get_completion_domain;
+    HPX_CXX_CORE_EXPORT using stdexec::get_completion_domain_t;
+    HPX_CXX_CORE_EXPORT using stdexec::indeterminate_domain;
 
     // Receiver
     HPX_CXX_CORE_EXPORT using stdexec::set_error_t;
@@ -176,9 +183,6 @@ namespace hpx::execution::experimental {
         HPX_CXX_CORE_EXPORT using namespace stdexec::tags;
     }
 
-    // Domain
-    HPX_CXX_CORE_EXPORT using stdexec::default_domain;
-
     // Execute (moved to exec:: namespace in newer stdexec)
     HPX_CXX_CORE_EXPORT using exec::execute;
     HPX_CXX_CORE_EXPORT using exec::execute_t;
@@ -240,10 +244,6 @@ namespace hpx::execution::experimental {
     // Then
     HPX_CXX_CORE_EXPORT using stdexec::then;
     HPX_CXX_CORE_EXPORT using stdexec::then_t;
-
-    // Transfer just
-    HPX_CXX_CORE_EXPORT using stdexec::transfer_just;
-    HPX_CXX_CORE_EXPORT using stdexec::transfer_just_t;
 
     // Completion signature manipulators
     HPX_CXX_CORE_EXPORT using stdexec::completion_signatures_of_t;

--- a/libs/core/executors/include/hpx/executors/thread_pool_scheduler.hpp
+++ b/libs/core/executors/include/hpx/executors/thread_pool_scheduler.hpp
@@ -67,6 +67,8 @@ namespace hpx::execution::experimental {
     template <typename Sender>
     concept bulk_chunked_or_unchunked_sender =
         hpx::execution::experimental::stdexec_internal::__sender_for<Sender,
+            hpx::execution::experimental::bulk_t> ||
+        hpx::execution::experimental::stdexec_internal::__sender_for<Sender,
             hpx::execution::experimental::bulk_chunked_t> ||
         hpx::execution::experimental::stdexec_internal::__sender_for<Sender,
             hpx::execution::experimental::bulk_unchunked_t>;
@@ -79,6 +81,10 @@ namespace hpx::execution::experimental {
         // transform_sender for bulk operations
         // (following stdexec parallel_scheduler pattern)
         template <bulk_chunked_or_unchunked_sender Sender, typename Env>
+            requires std::same_as<std::decay_t<decltype(
+                         hpx::execution::experimental::get_scheduler(
+                             std::declval<Env const&>()))>,
+                thread_pool_policy_scheduler<Policy>>
         constexpr auto transform_sender(
             hpx::execution::experimental::set_value_t, Sender&& sndr,
             Env const& env) const noexcept
@@ -92,16 +98,18 @@ namespace hpx::execution::experimental {
             auto iota_shape =
                 hpx::util::counting_shape(decltype(shape){0}, shape);
 
+            // bulk_t and bulk_unchunked_t use unchunked mode (f(index, ...values))
+            // bulk_chunked_t uses chunked mode (f(begin, end, ...values))
             constexpr bool is_chunked =
-                !hpx::execution::experimental::stdexec_internal::__sender_for<
-                    Sender, hpx::execution::experimental::bulk_unchunked_t>;
+                hpx::execution::experimental::stdexec_internal::__sender_for<
+                    Sender, hpx::execution::experimental::bulk_chunked_t>;
 
             return hpx::execution::experimental::detail::
                 thread_pool_bulk_sender<Policy, std::decay_t<decltype(child)>,
                     std::decay_t<decltype(iota_shape)>,
-                    std::decay_t<decltype(f)>, is_chunked>{HPX_MOVE(sched),
+                    std::decay_t<decltype(f)>, is_chunked>(HPX_MOVE(sched),
                     HPX_FORWARD(decltype(child), child), HPX_MOVE(iota_shape),
-                    HPX_FORWARD(decltype(f), f)};
+                    HPX_FORWARD(decltype(f), f));
         }
     };
 
@@ -382,6 +390,18 @@ namespace hpx::execution::experimental {
                 {
                     return stdexec::get_domain(e.sched);
                 }
+
+                // P3826R5: get_completion_domain queries
+                // The completing domain is resolved via:
+                //   sender env -> get_completion_scheduler<set_value_t>
+                //              -> scheduler -> get_completion_domain<set_value_t>
+                //              -> thread_pool_domain
+                template <typename CPO>
+                auto query(
+                    stdexec::get_completion_domain_t<CPO>) const noexcept
+                {
+                    return stdexec::get_domain(sched);
+                }
             };
 
             friend constexpr auto tag_invoke(
@@ -455,6 +475,17 @@ namespace hpx::execution::experimental {
         /// Returns the execution domain of this scheduler (following system_context.hpp pattern).
         [[nodiscard]]
         auto query(stdexec::get_domain_t) const noexcept
+            -> thread_pool_domain<Policy>
+        {
+            return {};
+        }
+
+        /// P3826R5: Returns the completion domain for this scheduler.
+        /// The domain resolution chain uses this to determine which domains
+        /// transform_sender to invoke for bulk operations.
+        template <typename CPO>
+        [[nodiscard]]
+        auto query(stdexec::get_completion_domain_t<CPO>) const noexcept
             -> thread_pool_domain<Policy>
         {
             return {};

--- a/libs/core/executors/include/hpx/executors/thread_pool_scheduler.hpp
+++ b/libs/core/executors/include/hpx/executors/thread_pool_scheduler.hpp
@@ -17,6 +17,7 @@
 #include <hpx/modules/timing.hpp>
 #include <hpx/modules/topology.hpp>
 
+#include <concepts>
 #include <cstddef>
 #include <exception>
 #include <string>
@@ -81,9 +82,9 @@ namespace hpx::execution::experimental {
         // transform_sender for bulk operations
         // (following stdexec parallel_scheduler pattern)
         template <bulk_chunked_or_unchunked_sender Sender, typename Env>
-            requires std::same_as<std::decay_t<decltype(
-                         hpx::execution::experimental::get_scheduler(
-                             std::declval<Env const&>()))>,
+            requires std::same_as<
+                std::decay_t<decltype(hpx::execution::experimental::
+                        get_scheduler(std::declval<Env const&>()))>,
                 thread_pool_policy_scheduler<Policy>>
         constexpr auto transform_sender(
             hpx::execution::experimental::set_value_t, Sender&& sndr,
@@ -397,8 +398,7 @@ namespace hpx::execution::experimental {
                 //              -> scheduler -> get_completion_domain<set_value_t>
                 //              -> thread_pool_domain
                 template <typename CPO>
-                auto query(
-                    stdexec::get_completion_domain_t<CPO>) const noexcept
+                auto query(stdexec::get_completion_domain_t<CPO>) const noexcept
                 {
                     return stdexec::get_domain(sched);
                 }

--- a/libs/core/executors/include/hpx/executors/thread_pool_scheduler_bulk.hpp
+++ b/libs/core/executors/include/hpx/executors/thread_pool_scheduler_bulk.hpp
@@ -751,8 +751,7 @@ namespace hpx::execution::experimental::detail {
 
             // P3826R5: report the completion domain for this bulk sender
             template <typename CPO>
-            auto query(
-                stdexec::get_completion_domain_t<CPO>) const noexcept
+            auto query(stdexec::get_completion_domain_t<CPO>) const noexcept
             {
                 return stdexec::get_domain(sch);
             }

--- a/libs/core/executors/include/hpx/executors/thread_pool_scheduler_bulk.hpp
+++ b/libs/core/executors/include/hpx/executors/thread_pool_scheduler_bulk.hpp
@@ -748,6 +748,14 @@ namespace hpx::execution::experimental::detail {
             {
                 return e.sch;
             }
+
+            // P3826R5: report the completion domain for this bulk sender
+            template <typename CPO>
+            auto query(
+                stdexec::get_completion_domain_t<CPO>) const noexcept
+            {
+                return stdexec::get_domain(sch);
+            }
         };
 
         // It may be also be correct to forward the entire env of the

--- a/libs/core/executors/tests/unit/thread_pool_scheduler.cpp
+++ b/libs/core/executors/tests/unit/thread_pool_scheduler.cpp
@@ -2203,11 +2203,11 @@ void test_stdexec_domain_queries()
     static_assert(std::is_base_of_v<ex::default_domain,
                       ex::thread_pool_domain<hpx::launch>>,
         "thread_pool_domain should derive from default_domain");
-    // 2. Verify domain is accessible via stdexec::get_domain
+    // 2. Verify domain is accessible via ex::get_domain (forwarded from stdexec)
     static_assert(
-        requires { stdexec::get_domain(scheduler); },
+        requires { ex::get_domain(scheduler); },
         "scheduler should support get_domain query");
-    auto domain = stdexec::get_domain(scheduler);
+    auto domain = ex::get_domain(scheduler);
 
     // 3. Verify the domain type is thread_pool_domain
     static_assert(


### PR DESCRIPTION
Fixes #7131 

Implement [P3826R5](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2026/p3826r3.html) completion domain support:

Add get_completion_domain_t<CPO> queries to:

- thread_pool_scheduler
- sender environments (including bulk sender)

Forward the necessary stdexec symbols:
- get_completion_domain
- get_completion_domain_t
- indeterminate_domain

Domain resolution chain correctly maps to thread_pool_domain