### PR TITLE
Add segmented is_partitioned

### DIFF
--- a/libs/full/include/include/hpx/include/parallel_is_partitioned.hpp
+++ b/libs/full/include/include/hpx/include/parallel_is_partitioned.hpp
@@ -7,3 +7,4 @@
 #pragma once
 
 #include <hpx/modules/algorithms.hpp>
+#include <hpx/parallel/segmented_algorithms/is_partitioned.hpp>

--- a/libs/full/segmented_algorithms/CMakeLists.txt
+++ b/libs/full/segmented_algorithms/CMakeLists.txt
@@ -15,6 +15,7 @@ set(segmented_algorithms_headers
     hpx/parallel/segmented_algorithms/all_any_none.hpp
     hpx/parallel/segmented_algorithms/count.hpp
     hpx/parallel/segmented_algorithms/detail/dispatch.hpp
+    hpx/parallel/segmented_algorithms/detail/is_partitioned.hpp
     hpx/parallel/segmented_algorithms/detail/reduce.hpp
     hpx/parallel/segmented_algorithms/detail/scan.hpp
     hpx/parallel/segmented_algorithms/detail/transfer.hpp

--- a/libs/full/segmented_algorithms/CMakeLists.txt
+++ b/libs/full/segmented_algorithms/CMakeLists.txt
@@ -27,6 +27,7 @@ set(segmented_algorithms_headers
     hpx/parallel/segmented_algorithms/generate.hpp
     hpx/parallel/segmented_algorithms/inclusive_scan.hpp
     hpx/parallel/segmented_algorithms/is_sorted.hpp
+    hpx/parallel/segmented_algorithms/is_partitioned.hpp
     hpx/parallel/segmented_algorithms/minmax.hpp
     hpx/parallel/segmented_algorithms/reduce.hpp
     hpx/parallel/segmented_algorithms/replace.hpp

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithm.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithm.hpp
@@ -20,6 +20,7 @@
 #include <hpx/parallel/segmented_algorithms/for_each.hpp>
 #include <hpx/parallel/segmented_algorithms/generate.hpp>
 #include <hpx/parallel/segmented_algorithms/inclusive_scan.hpp>
+#include <hpx/parallel/segmented_algorithms/is_partitioned.hpp>
 #include <hpx/parallel/segmented_algorithms/is_sorted.hpp>
 #include <hpx/parallel/segmented_algorithms/minmax.hpp>
 #include <hpx/parallel/segmented_algorithms/reduce.hpp>

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/is_partitioned.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/is_partitioned.hpp
@@ -1,0 +1,87 @@
+//  Copyright (c) 2026 Mo'men Samir
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/modules/algorithms.hpp>
+#include <hpx/modules/executors.hpp>
+
+#include <iterator>
+#include <type_traits>
+#include <utility>
+
+namespace hpx::parallel::detail {
+    struct local_result
+    {
+        bool local_res;     // local is_partitioned result
+        bool first_elem;    // predicate value of first element in segment
+        bool last_elem;     // predicate value of last element in segment
+
+        template <typename Archive>
+        void serialize(Archive& ar, unsigned)
+        {
+            ar & local_res & first_elem & last_elem;
+        }
+    };
+
+    template <typename Iter>
+    struct seg_is_partitioned
+      : algorithm<seg_is_partitioned<Iter>, local_result>
+    {
+        seg_is_partitioned()
+          : algorithm<seg_is_partitioned<Iter>, local_result>("is_partitioned")
+        {
+        }
+
+        template <typename ExPolicy, typename FwdIter, typename Pred,
+            typename Proj>
+        static local_result sequential(ExPolicy&& policy, FwdIter first,
+            FwdIter last, Pred&& pred, Proj&& proj)
+        {
+            util::invoke_projected<Pred, Proj> pred_projected{pred, proj};
+
+            bool first_elem = HPX_INVOKE(pred_projected, *first);
+            bool last_elem = HPX_INVOKE(pred_projected, *std::prev(last));
+
+            bool result = is_partitioned<FwdIter, FwdIter>().call(
+                hpx::execution::seq, first, last, HPX_FORWARD(Pred, pred),
+                HPX_FORWARD(Proj, proj));
+
+            return {result, first_elem, last_elem};
+        }
+
+        template <typename ExPolicy, typename FwdIter, typename Pred,
+            typename Proj>
+        static util::detail::algorithm_result_t<ExPolicy, local_result>
+        parallel(ExPolicy&& policy, FwdIter first, FwdIter last, Pred&& pred,
+            Proj&& proj)
+        {
+            util::invoke_projected<Pred, Proj> pred_projected{pred, proj};
+
+            bool first_elem = HPX_INVOKE(pred_projected, *first);
+            bool last_elem = HPX_INVOKE(pred_projected, *std::prev(last));
+
+            auto result = is_partitioned<FwdIter, FwdIter>().call(
+                HPX_FORWARD(ExPolicy, policy), first, last,
+                HPX_FORWARD(Pred, pred), HPX_FORWARD(Proj, proj));
+
+            if constexpr (hpx::traits::is_future_v<decltype(result)>)
+            {
+                return result.then([first_elem, last_elem](
+                                       hpx::future<bool>&& f) -> local_result {
+                    return {f.get(), first_elem, last_elem};
+                });
+            }
+            else
+            {
+                return util::detail::algorithm_result<ExPolicy,
+                    local_result>::get(local_result{
+                    result, first_elem, last_elem});
+            }
+        }
+    };
+}    // namespace hpx::parallel::detail

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/is_partitioned.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/is_partitioned.hpp
@@ -20,12 +20,6 @@ namespace hpx::parallel::detail {
         bool local_res;     // local is_partitioned result
         bool first_elem;    // predicate value of first element in segment
         bool last_elem;     // predicate value of last element in segment
-
-        template <typename Archive>
-        void serialize(Archive& ar, unsigned)
-        {
-            ar & local_res & first_elem & last_elem;
-        }
     };
 
     template <typename Iter>
@@ -39,7 +33,7 @@ namespace hpx::parallel::detail {
 
         template <typename ExPolicy, typename FwdIter, typename Pred,
             typename Proj>
-        static local_result sequential(ExPolicy&& policy, FwdIter first,
+        static local_result sequential(ExPolicy&& /* policy */, FwdIter first,
             FwdIter last, Pred&& pred, Proj&& proj)
         {
             util::invoke_projected<Pred, Proj> pred_projected{pred, proj};

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/is_partitioned.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/is_partitioned.hpp
@@ -1,0 +1,318 @@
+//  Copyright (c) 2026 Mo'men Samir
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/modules/algorithms.hpp>
+#include <hpx/modules/executors.hpp>
+#include <hpx/modules/functional.hpp>
+#include <hpx/modules/type_support.hpp>
+#include <hpx/parallel/segmented_algorithms/detail/dispatch.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <exception>
+#include <iterator>
+#include <list>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace hpx::parallel { namespace detail {
+
+    ///////////////////////////////////////////////////////////////////////////
+    // segmented_is_partitioned
+
+    ///////////////////////////////////////////////////////////////////////
+    /// \cond NOINTERNAL
+
+    // sequential remote implementation
+
+    template <typename Algo, typename ExPolicy, typename SegIter, typename Pred,
+        typename Proj>
+    static util::detail::algorithm_result_t<ExPolicy, bool>
+    segmented_is_partitioned(Algo&& algo, ExPolicy const& policy, SegIter first,
+        SegIter last, Pred&& pred, Proj&& proj, std::true_type)
+    {
+        using traits = hpx::traits::segmented_iterator_traits<SegIter>;
+        using segment_iterator = typename traits::segment_iterator;
+        using local_iterator_type = typename traits::local_iterator;
+        using result = util::detail::algorithm_result<ExPolicy, bool>;
+        util::invoke_projected<Pred, Proj> pred_projected{pred, proj};
+
+        segment_iterator sit = traits::segment(first);
+        segment_iterator send = traits::segment(last);
+
+        if (sit == send)
+        {
+            // All elements are on the same partition.
+            local_iterator_type beg = traits::local(first);
+            local_iterator_type end = traits::local(last);
+            if (beg == end)
+                return result::get(true);
+
+            return result::get(dispatch(traits::get_id(sit), algo, policy,
+                std::true_type(), beg, end, pred, proj));
+        }
+
+        // `false_found` becomes true as soon as any segment's last element
+        // fails pred.  After that, every subsequent segment's first element
+        // must also fail pred (otherwise the global sequence is not
+        // partitioned).
+        bool false_found = false;
+
+        // Handle the remaining part of the first partition.
+        {
+            local_iterator_type beg = traits::local(first);
+            local_iterator_type end = traits::end(sit);
+
+            if (beg != end)
+            {
+                bool r = dispatch(traits::get_id(sit), algo, policy,
+                    std::true_type(), beg, end, pred, proj);
+                if (!r)
+                    return result::get(false);
+
+                // If the last element of this segment fails pred
+                // all subsequent elements must also fail.
+                SegIter seg_last = traits::compose(sit, std::prev(end));
+                if (!HPX_INVOKE(pred_projected, *seg_last))
+                    false_found = true;
+            }
+        }
+
+        // Handle full middle partitions.
+        for (++sit; sit != send; ++sit)
+        {
+            local_iterator_type beg = traits::begin(sit);
+            local_iterator_type end = traits::end(sit);
+
+            if (beg != end)
+            {
+                // Cross-segment boundary check
+                // Once a false element is found in previous segments, all
+                // subsequent elements must be false.
+                if (false_found)
+                {
+                    SegIter seg_first = traits::compose(sit, beg);
+                    if (HPX_INVOKE(pred_projected, *seg_first))
+                        return result::get(false);
+                }
+
+                bool r = dispatch(traits::get_id(sit), algo, policy,
+                    std::true_type(), beg, end, pred, proj);
+                if (!r)
+                    return result::get(false);
+
+                // if local is_partitioned returns true for this segment check
+                // the last element for false
+                if (!false_found)
+                {
+                    SegIter seg_last = traits::compose(sit, std::prev(end));
+                    if (!HPX_INVOKE(pred_projected, *seg_last))
+                        false_found = true;
+                }
+            }
+        }
+
+        // Handle the beginning of the last partition.
+        {
+            local_iterator_type beg = traits::begin(sit);
+            local_iterator_type end = traits::local(last);
+
+            if (beg != end)
+            {
+                if (false_found)
+                {
+                    SegIter seg_first = traits::compose(sit, beg);
+                    if (HPX_INVOKE(pred_projected, *seg_first))
+                        return result::get(false);
+                }
+
+                bool r = dispatch(traits::get_id(sit), algo, policy,
+                    std::true_type(), beg, end, pred, proj);
+                if (!r)
+                    return result::get(false);
+            }
+        }
+
+        return result::get(true);
+    }
+
+    // parallel remote implementation
+
+    template <typename Algo, typename ExPolicy, typename SegIter, typename Pred,
+        typename Proj>
+    static util::detail::algorithm_result_t<ExPolicy, bool>
+    segmented_is_partitioned(Algo&& algo, ExPolicy const& policy, SegIter first,
+        SegIter last, Pred&& pred, Proj&& proj, std::false_type)
+    {
+        using traits = hpx::traits::segmented_iterator_traits<SegIter>;
+        using segment_iterator = typename traits::segment_iterator;
+        using local_iterator_type = typename traits::local_iterator;
+        using result = util::detail::algorithm_result<ExPolicy, bool>;
+
+        using forced_seq =
+            std::integral_constant<bool, !std::forward_iterator<SegIter>>;
+
+        using segment_type = std::vector<hpx::future<bool>>;
+
+        util::invoke_projected<Pred, Proj> pred_projected{pred, proj};
+
+        segment_iterator sit = traits::segment(first);
+        segment_iterator send = traits::segment(last);
+
+        auto const size = std::distance(sit, send);
+
+        segment_type segments;
+        segments.reserve(size + 1);
+
+        std::vector<SegIter> between_segments;
+        between_segments.reserve(size);
+
+        if (sit == send)
+        {
+            // All elements on the same partition.
+            local_iterator_type beg = traits::local(first);
+            local_iterator_type end = traits::local(last);
+            if (beg != end)
+            {
+                segments.push_back(dispatch_async(traits::get_id(sit), algo,
+                    policy, forced_seq(), beg, end, pred, proj));
+            }
+        }
+        else
+        {
+            // Handle the remaining part of the first partition.
+            local_iterator_type beg = traits::local(first);
+            local_iterator_type end = traits::end(sit);
+
+            if (beg != end)
+            {
+                segments.push_back(dispatch_async(traits::get_id(sit), algo,
+                    policy, forced_seq(), beg, end, pred, proj));
+            }
+
+            // Handle full middle partitions.
+            for (++sit; sit != send; ++sit)
+            {
+                beg = traits::begin(sit);
+                end = traits::end(sit);
+
+                if (beg != end)
+                {
+                    between_segments.push_back(traits::compose(sit, beg));
+                    segments.push_back(dispatch_async(traits::get_id(sit), algo,
+                        policy, forced_seq(), beg, end, pred, proj));
+                }
+            }
+
+            // Handle the beginning of the last partition.
+            beg = traits::begin(sit);
+            end = traits::local(last);
+            if (beg != end)
+            {
+                between_segments.push_back(traits::compose(sit, beg));
+                segments.push_back(dispatch_async(traits::get_id(sit), algo,
+                    policy, forced_seq(), beg, end, HPX_FORWARD(Pred, pred),
+                    HPX_FORWARD(Proj, proj)));
+            }
+        }
+
+        return result::get(dataflow(
+            [=](segment_type&& r) mutable -> bool {
+                std::list<std::exception_ptr> errors;
+                parallel::util::detail::handle_remote_exceptions<
+                    ExPolicy>::call(r, errors);
+                std::vector<bool> res = hpx::unwrap(HPX_MOVE(r));
+
+                // Every segment must be locally is_partitioned.
+                for (bool b : res)
+                {
+                    if (!b)
+                        return false;
+                }
+
+                // Cross-segment boundary check.
+                // Check the last element of each segment, If its false
+                // then the first element of the next segments must be false.
+                bool false_found = false;
+                for (auto const& seg_first : between_segments)
+                {
+                    SegIter prev_last = std::prev(seg_first);
+
+                    if (!HPX_INVOKE(pred_projected, *prev_last))
+                        false_found = true;
+
+                    if (false_found && HPX_INVOKE(pred_projected, *seg_first))
+                        return false;
+                }
+
+                return true;
+            },
+            HPX_MOVE(segments)));
+    }
+
+    /// \endcond
+
+}}    // namespace hpx::parallel::detail
+
+// The segmented iterators we support all live in namespace hpx::segmented
+namespace hpx::segmented {
+
+    template <typename InIter, typename Pred>
+        requires(hpx::traits::is_iterator_v<InIter> &&
+            hpx::traits::is_segmented_iterator_v<InIter>)
+    bool tag_invoke(
+        hpx::is_partitioned_t, InIter first, InIter last, Pred&& pred)
+    {
+        static_assert(std::forward_iterator<InIter>,
+            "Requires at least forward iterator.");
+
+        if (first == last)
+            return true;
+
+        using iterator_traits = hpx::traits::segmented_iterator_traits<InIter>;
+
+        return hpx::parallel::detail::segmented_is_partitioned(
+            hpx::parallel::detail::is_partitioned<
+                typename iterator_traits::local_iterator,
+                typename iterator_traits::local_iterator>(),
+            hpx::execution::seq, first, last, HPX_FORWARD(Pred, pred),
+            hpx::identity_v, std::true_type());
+    }
+
+    template <typename ExPolicy, typename SegIter, typename Pred>
+        requires(hpx::is_execution_policy_v<ExPolicy> &&
+            hpx::traits::is_iterator_v<SegIter> &&
+            hpx::traits::is_segmented_iterator_v<SegIter>)
+    hpx::parallel::util::detail::algorithm_result_t<ExPolicy, bool> tag_invoke(
+        hpx::is_partitioned_t, ExPolicy&& policy, SegIter first, SegIter last,
+        Pred&& pred)
+    {
+        static_assert(std::forward_iterator<SegIter>,
+            "Requires at least forward iterator.");
+
+        if (first == last)
+        {
+            using result =
+                hpx::parallel::util::detail::algorithm_result<ExPolicy, bool>;
+            return result::get(true);
+        }
+
+        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
+        using iterator_traits = hpx::traits::segmented_iterator_traits<SegIter>;
+
+        return hpx::parallel::detail::segmented_is_partitioned(
+            hpx::parallel::detail::is_partitioned<
+                typename iterator_traits::local_iterator,
+                typename iterator_traits::local_iterator>(),
+            HPX_FORWARD(ExPolicy, policy), first, last, HPX_FORWARD(Pred, pred),
+            hpx::identity_v, is_seq());
+    }
+
+}    // namespace hpx::segmented

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/is_partitioned.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/is_partitioned.hpp
@@ -12,6 +12,7 @@
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/type_support.hpp>
 #include <hpx/parallel/segmented_algorithms/detail/dispatch.hpp>
+#include <hpx/parallel/segmented_algorithms/detail/is_partitioned.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -42,7 +43,6 @@ namespace hpx::parallel { namespace detail {
         using segment_iterator = typename traits::segment_iterator;
         using local_iterator_type = typename traits::local_iterator;
         using result = util::detail::algorithm_result<ExPolicy, bool>;
-        util::invoke_projected<Pred, Proj> pred_projected{pred, proj};
 
         segment_iterator sit = traits::segment(first);
         segment_iterator send = traits::segment(last);
@@ -56,11 +56,12 @@ namespace hpx::parallel { namespace detail {
                 return result::get(true);
 
             return result::get(dispatch(traits::get_id(sit), algo, policy,
-                std::true_type(), beg, end, pred, proj));
+                std::true_type(), beg, end, pred, proj)
+                    .local_res);
         }
 
         // `false_found` becomes true as soon as any segment's last element
-        // fails pred.  After that, every subsequent segment's first element
+        // fails pred. After that, every subsequent segment's first element
         // must also fail pred (otherwise the global sequence is not
         // partitioned).
         bool false_found = false;
@@ -72,15 +73,15 @@ namespace hpx::parallel { namespace detail {
 
             if (beg != end)
             {
-                bool r = dispatch(traits::get_id(sit), algo, policy,
+                local_result r = dispatch(traits::get_id(sit), algo, policy,
                     std::true_type(), beg, end, pred, proj);
-                if (!r)
+
+                if (!r.local_res)
                     return result::get(false);
 
-                // If the last element of this segment fails pred
+                // If the last element of this segment fails pred,
                 // all subsequent elements must also fail.
-                SegIter seg_last = traits::compose(sit, std::prev(end));
-                if (!HPX_INVOKE(pred_projected, *seg_last))
+                if (!r.last_elem)
                     false_found = true;
             }
         }
@@ -93,29 +94,22 @@ namespace hpx::parallel { namespace detail {
 
             if (beg != end)
             {
-                // Cross-segment boundary check
-                // Once a false element is found in previous segments, all
-                // subsequent elements must be false.
-                if (false_found)
-                {
-                    SegIter seg_first = traits::compose(sit, beg);
-                    if (HPX_INVOKE(pred_projected, *seg_first))
-                        return result::get(false);
-                }
-
-                bool r = dispatch(traits::get_id(sit), algo, policy,
+                local_result r = dispatch(traits::get_id(sit), algo, policy,
                     std::true_type(), beg, end, pred, proj);
-                if (!r)
+
+                // Cross-segment boundary check.
+                // Once a false element is found in a previous segment, all
+                // subsequent elements must be false.
+                if (false_found && r.first_elem)
                     return result::get(false);
 
-                // if local is_partitioned returns true for this segment check
-                // the last element for false
-                if (!false_found)
-                {
-                    SegIter seg_last = traits::compose(sit, std::prev(end));
-                    if (!HPX_INVOKE(pred_projected, *seg_last))
-                        false_found = true;
-                }
+                if (!r.local_res)
+                    return result::get(false);
+
+                // If local is_partitioned returns true for this segment,
+                // check the last element to see if the false tail begins here.
+                if (!false_found && !r.last_elem)
+                    false_found = true;
             }
         }
 
@@ -126,16 +120,14 @@ namespace hpx::parallel { namespace detail {
 
             if (beg != end)
             {
-                if (false_found)
-                {
-                    SegIter seg_first = traits::compose(sit, beg);
-                    if (HPX_INVOKE(pred_projected, *seg_first))
-                        return result::get(false);
-                }
-
-                bool r = dispatch(traits::get_id(sit), algo, policy,
+                local_result r = dispatch(traits::get_id(sit), algo, policy,
                     std::true_type(), beg, end, pred, proj);
-                if (!r)
+
+                // Cross-segment boundary check for the last partition.
+                if (false_found && r.first_elem)
+                    return result::get(false);
+
+                if (!r.local_res)
                     return result::get(false);
             }
         }
@@ -159,9 +151,7 @@ namespace hpx::parallel { namespace detail {
         using forced_seq =
             std::integral_constant<bool, !std::forward_iterator<SegIter>>;
 
-        using segment_type = std::vector<hpx::future<bool>>;
-
-        util::invoke_projected<Pred, Proj> pred_projected{pred, proj};
+        using segment_type = std::vector<hpx::future<local_result>>;
 
         segment_iterator sit = traits::segment(first);
         segment_iterator send = traits::segment(last);
@@ -170,9 +160,6 @@ namespace hpx::parallel { namespace detail {
 
         segment_type segments;
         segments.reserve(size + 1);
-
-        std::vector<SegIter> between_segments;
-        between_segments.reserve(size);
 
         if (sit == send)
         {
@@ -205,7 +192,6 @@ namespace hpx::parallel { namespace detail {
 
                 if (beg != end)
                 {
-                    between_segments.push_back(traits::compose(sit, beg));
                     segments.push_back(dispatch_async(traits::get_id(sit), algo,
                         policy, forced_seq(), beg, end, pred, proj));
                 }
@@ -216,7 +202,6 @@ namespace hpx::parallel { namespace detail {
             end = traits::local(last);
             if (beg != end)
             {
-                between_segments.push_back(traits::compose(sit, beg));
                 segments.push_back(dispatch_async(traits::get_id(sit), algo,
                     policy, forced_seq(), beg, end, HPX_FORWARD(Pred, pred),
                     HPX_FORWARD(Proj, proj)));
@@ -225,33 +210,29 @@ namespace hpx::parallel { namespace detail {
 
         return result::get(dataflow(
             [=](segment_type&& r) mutable -> bool {
+                using local_result = hpx::parallel::detail::local_result;
+
                 std::list<std::exception_ptr> errors;
                 parallel::util::detail::handle_remote_exceptions<
                     ExPolicy>::call(r, errors);
-                std::vector<bool> res = hpx::unwrap(HPX_MOVE(r));
 
-                // Every segment must be locally is_partitioned.
-                for (bool b : res)
-                {
-                    if (!b)
-                        return false;
-                }
+                std::vector<local_result> res = hpx::unwrap(HPX_MOVE(r));
 
                 // Cross-segment boundary check.
-                // Check the last element of each segment, If its false
-                // then the first element of the next segments must be false.
+                // Once a false element is found, all subsequent elements must be false.
                 bool false_found = false;
-                for (auto const& seg_first : between_segments)
+                for (std::size_t i = 0; i < res.size(); ++i)
                 {
-                    SegIter prev_last = std::prev(seg_first);
-
-                    if (!HPX_INVOKE(pred_projected, *prev_last))
-                        false_found = true;
-
-                    if (false_found && HPX_INVOKE(pred_projected, *seg_first))
+                    if (!res[i].local_res)
                         return false;
+                    if (i + 1 < res.size())
+                    {
+                        if (!res[i].last_elem)
+                            false_found = true;
+                        if (false_found && res[i + 1].first_elem)
+                            return false;
+                    }
                 }
-
                 return true;
             },
             HPX_MOVE(segments)));
@@ -277,11 +258,10 @@ namespace hpx::segmented {
             return true;
 
         using iterator_traits = hpx::traits::segmented_iterator_traits<InIter>;
+        using local_iter = typename iterator_traits::local_iterator;
 
         return hpx::parallel::detail::segmented_is_partitioned(
-            hpx::parallel::detail::is_partitioned<
-                typename iterator_traits::local_iterator,
-                typename iterator_traits::local_iterator>(),
+            hpx::parallel::detail::seg_is_partitioned<local_iter>(),
             hpx::execution::seq, first, last, HPX_FORWARD(Pred, pred),
             hpx::identity_v, std::true_type());
     }
@@ -306,13 +286,11 @@ namespace hpx::segmented {
 
         using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
         using iterator_traits = hpx::traits::segmented_iterator_traits<SegIter>;
+        using local_iter = typename iterator_traits::local_iterator;
 
         return hpx::parallel::detail::segmented_is_partitioned(
-            hpx::parallel::detail::is_partitioned<
-                typename iterator_traits::local_iterator,
-                typename iterator_traits::local_iterator>(),
+            hpx::parallel::detail::seg_is_partitioned<local_iter>(),
             HPX_FORWARD(ExPolicy, policy), first, last, HPX_FORWARD(Pred, pred),
             hpx::identity_v, is_seq());
     }
-
 }    // namespace hpx::segmented

--- a/libs/full/segmented_algorithms/tests/unit/CMakeLists.txt
+++ b/libs/full/segmented_algorithms/tests/unit/CMakeLists.txt
@@ -45,6 +45,7 @@ set(tests
     partitioned_vector_inclusive_scan
     partitioned_vector_inclusive_scan2
     partitioned_vector_is_sorted
+    partitioned_vector_is_partitioned
     partitioned_vector_exclusive_scan
     partitioned_vector_exclusive_scan2
     partitioned_vector_none1

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_is_partitioned.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_is_partitioned.cpp
@@ -1,0 +1,322 @@
+//  Copyright (c) 2026 Mo'men Samir
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/parallel_is_partitioned.hpp>
+
+#include <hpx/include/partitioned_vector_predef.hpp>
+#include <hpx/include/runtime.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <cstddef>
+#include <iterator>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+#define SIZE 10007
+
+template <typename T>
+struct is_even
+{
+    bool operator()(T const& val) const
+    {
+        return val % T(2) == 0;
+    }
+
+    template <typename Archive>
+    void serialize(Archive&, unsigned)
+    {
+    }
+};
+
+///////////////////////////////////////////////////////////////////////////////
+// Initialization helpers
+
+template <typename T>
+void initialize_partitioned(hpx::partitioned_vector<T>& v)
+{
+    typename hpx::partitioned_vector<T>::iterator it = v.begin();
+    std::size_t const mid = v.size() / 2;
+    for (std::size_t i = 0; i < v.size(); ++i, ++it)
+        *it = (i < mid) ? T(2) : T(1);
+}
+
+template <typename T>
+void initialize_all_odd(hpx::partitioned_vector<T>& v)
+{
+    typename hpx::partitioned_vector<T>::iterator it = v.begin();
+    for (std::size_t i = 0; i < v.size(); ++i, ++it)
+        *it = T(1);
+}
+
+template <typename T>
+void initialize_all_even(hpx::partitioned_vector<T>& v)
+{
+    typename hpx::partitioned_vector<T>::iterator it = v.begin();
+    for (std::size_t i = 0; i < v.size(); ++i, ++it)
+        *it = T(2);
+}
+
+template <typename T>
+void initialize_violation_at_begin(hpx::partitioned_vector<T>& v)
+{
+    initialize_partitioned(v);
+    *v.begin() = T(1);
+}
+
+template <typename T>
+void initialize_violation_at_end(hpx::partitioned_vector<T>& v)
+{
+    initialize_partitioned(v);
+    typename hpx::partitioned_vector<T>::iterator last = v.end();
+    --last;
+    *last = T(2);
+}
+
+template <typename T>
+void initialize_seg_boundary_valid(hpx::partitioned_vector<T>& v,
+    std::size_t num_localities, std::size_t seg_size)
+{
+    typename hpx::partitioned_vector<T>::iterator it = v.begin();
+    for (std::size_t i = 0; i < num_localities * seg_size; ++i, ++it)
+        *it = (i < seg_size) ? T(2) : T(1);
+}
+
+template <typename T>
+void initialize_seg_boundary_cross_violation(hpx::partitioned_vector<T>& v,
+    std::size_t num_localities, std::size_t seg_size)
+{
+    typename hpx::partitioned_vector<T>::iterator it = v.begin();
+    for (std::size_t i = 0; i < num_localities * seg_size; ++i, ++it)
+        *it = T(2);
+
+    typename hpx::partitioned_vector<T>::iterator seg_end = v.begin();
+    std::advance(seg_end, seg_size - 1);
+    *seg_end = T(1);
+
+    typename hpx::partitioned_vector<T>::iterator rest = v.begin();
+    std::advance(rest, seg_size + 1);
+    for (std::size_t i = seg_size + 1; i < num_localities * seg_size;
+        ++i, ++rest)
+        *rest = T(1);
+}
+
+template <typename T>
+void initialize_seg_boundary_false_then_true_in_last_seg(
+    hpx::partitioned_vector<T>& v, std::size_t num_localities,
+    std::size_t seg_size)
+{
+    typename hpx::partitioned_vector<T>::iterator it = v.begin();
+    for (std::size_t i = 0; i < num_localities * seg_size; ++i, ++it)
+        *it = (i < seg_size) ? T(2) : T(1);
+
+    typename hpx::partitioned_vector<T>::iterator last = v.end();
+    --last;
+    *last = T(2);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename T>
+void test_is_partitioned(hpx::partitioned_vector<T>& v_part,
+    hpx::partitioned_vector<T>& v_odd, hpx::partitioned_vector<T>& v_even,
+    hpx::partitioned_vector<T>& v_viol_beg,
+    hpx::partitioned_vector<T>& v_viol_end,
+    hpx::partitioned_vector<T>& v_seg_valid,
+    hpx::partitioned_vector<T>& v_seg_cross,
+    hpx::partitioned_vector<T>& v_seg_last_viol)
+{
+    // Basic partitioned / uniform inputs
+    HPX_TEST(hpx::is_partitioned(v_part.begin(), v_part.end(), is_even<T>()));
+    HPX_TEST(hpx::is_partitioned(v_odd.begin(), v_odd.end(), is_even<T>()));
+    HPX_TEST(hpx::is_partitioned(v_even.begin(), v_even.end(), is_even<T>()));
+
+    // Violations at begin and end
+    HPX_TEST(!hpx::is_partitioned(
+        v_viol_beg.begin(), v_viol_beg.end(), is_even<T>()));
+    HPX_TEST(!hpx::is_partitioned(
+        v_viol_end.begin(), v_viol_end.end(), is_even<T>()));
+
+    // Segment-boundary edge cases
+    HPX_TEST(hpx::is_partitioned(
+        v_seg_valid.begin(), v_seg_valid.end(), is_even<T>()));
+    HPX_TEST(!hpx::is_partitioned(
+        v_seg_cross.begin(), v_seg_cross.end(), is_even<T>()));
+    HPX_TEST(!hpx::is_partitioned(
+        v_seg_last_viol.begin(), v_seg_last_viol.end(), is_even<T>()));
+}
+
+template <typename ExPolicy, typename T>
+void test_is_partitioned(ExPolicy&& policy, hpx::partitioned_vector<T>& v_part,
+    hpx::partitioned_vector<T>& v_odd, hpx::partitioned_vector<T>& v_even,
+    hpx::partitioned_vector<T>& v_viol_beg,
+    hpx::partitioned_vector<T>& v_viol_end,
+    hpx::partitioned_vector<T>& v_seg_valid,
+    hpx::partitioned_vector<T>& v_seg_cross,
+    hpx::partitioned_vector<T>& v_seg_last_viol)
+{
+    HPX_TEST(hpx::is_partitioned(
+        policy, v_part.begin(), v_part.end(), is_even<T>()));
+    HPX_TEST(
+        hpx::is_partitioned(policy, v_odd.begin(), v_odd.end(), is_even<T>()));
+    HPX_TEST(hpx::is_partitioned(
+        policy, v_even.begin(), v_even.end(), is_even<T>()));
+
+    HPX_TEST(!hpx::is_partitioned(
+        policy, v_viol_beg.begin(), v_viol_beg.end(), is_even<T>()));
+    HPX_TEST(!hpx::is_partitioned(
+        policy, v_viol_end.begin(), v_viol_end.end(), is_even<T>()));
+
+    HPX_TEST(hpx::is_partitioned(
+        policy, v_seg_valid.begin(), v_seg_valid.end(), is_even<T>()));
+    HPX_TEST(!hpx::is_partitioned(
+        policy, v_seg_cross.begin(), v_seg_cross.end(), is_even<T>()));
+    HPX_TEST(!hpx::is_partitioned(
+        policy, v_seg_last_viol.begin(), v_seg_last_viol.end(), is_even<T>()));
+}
+
+template <typename ExPolicy, typename T>
+void test_is_partitioned_async(ExPolicy&& policy,
+    hpx::partitioned_vector<T>& v_part, hpx::partitioned_vector<T>& v_odd,
+    hpx::partitioned_vector<T>& v_even, hpx::partitioned_vector<T>& v_viol_beg,
+    hpx::partitioned_vector<T>& v_viol_end,
+    hpx::partitioned_vector<T>& v_seg_valid,
+    hpx::partitioned_vector<T>& v_seg_cross,
+    hpx::partitioned_vector<T>& v_seg_last_viol)
+{
+    HPX_TEST(
+        hpx::is_partitioned(policy, v_part.begin(), v_part.end(), is_even<T>())
+            .get());
+    HPX_TEST(
+        hpx::is_partitioned(policy, v_odd.begin(), v_odd.end(), is_even<T>())
+            .get());
+    HPX_TEST(
+        hpx::is_partitioned(policy, v_even.begin(), v_even.end(), is_even<T>())
+            .get());
+
+    HPX_TEST(!hpx::is_partitioned(
+        policy, v_viol_beg.begin(), v_viol_beg.end(), is_even<T>())
+            .get());
+    HPX_TEST(!hpx::is_partitioned(
+        policy, v_viol_end.begin(), v_viol_end.end(), is_even<T>())
+            .get());
+
+    HPX_TEST(hpx::is_partitioned(
+        policy, v_seg_valid.begin(), v_seg_valid.end(), is_even<T>())
+            .get());
+    HPX_TEST(!hpx::is_partitioned(
+        policy, v_seg_cross.begin(), v_seg_cross.end(), is_even<T>())
+            .get());
+    HPX_TEST(!hpx::is_partitioned(
+        policy, v_seg_last_viol.begin(), v_seg_last_viol.end(), is_even<T>())
+            .get());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename T>
+void is_partitioned_tests(std::vector<hpx::id_type>& localities)
+{
+    std::size_t const num_localities = localities.size();
+    std::size_t const seg_size = SIZE / num_localities;
+    std::size_t const seg_total = num_localities * seg_size;
+
+    hpx::partitioned_vector<T> v_part(
+        SIZE, T(0), hpx::container_layout(localities));
+    hpx::partitioned_vector<T> v_odd(
+        SIZE, T(0), hpx::container_layout(localities));
+    hpx::partitioned_vector<T> v_even(
+        SIZE, T(0), hpx::container_layout(localities));
+    hpx::partitioned_vector<T> v_viol_beg(
+        SIZE, T(0), hpx::container_layout(localities));
+    hpx::partitioned_vector<T> v_viol_end(
+        SIZE, T(0), hpx::container_layout(localities));
+    hpx::partitioned_vector<T> v_seg_valid(
+        seg_total, T(0), hpx::container_layout(num_localities));
+    hpx::partitioned_vector<T> v_seg_cross(
+        seg_total, T(0), hpx::container_layout(num_localities));
+    hpx::partitioned_vector<T> v_seg_last_viol(
+        seg_total, T(0), hpx::container_layout(num_localities));
+
+    initialize_partitioned(v_part);
+    initialize_all_odd(v_odd);
+    initialize_all_even(v_even);
+    initialize_violation_at_begin(v_viol_beg);
+    initialize_violation_at_end(v_viol_end);
+    initialize_seg_boundary_valid(v_seg_valid, num_localities, seg_size);
+    initialize_seg_boundary_cross_violation(
+        v_seg_cross, num_localities, seg_size);
+    initialize_seg_boundary_false_then_true_in_last_seg(
+        v_seg_last_viol, num_localities, seg_size);
+
+    test_is_partitioned(v_part, v_odd, v_even, v_viol_beg, v_viol_end,
+        v_seg_valid, v_seg_cross, v_seg_last_viol);
+
+    test_is_partitioned(hpx::execution::seq, v_part, v_odd, v_even, v_viol_beg,
+        v_viol_end, v_seg_valid, v_seg_cross, v_seg_last_viol);
+    test_is_partitioned(hpx::execution::par, v_part, v_odd, v_even, v_viol_beg,
+        v_viol_end, v_seg_valid, v_seg_cross, v_seg_last_viol);
+
+    test_is_partitioned_async(hpx::execution::seq(hpx::execution::task), v_part,
+        v_odd, v_even, v_viol_beg, v_viol_end, v_seg_valid, v_seg_cross,
+        v_seg_last_viol);
+    test_is_partitioned_async(hpx::execution::par(hpx::execution::task), v_part,
+        v_odd, v_even, v_viol_beg, v_viol_end, v_seg_valid, v_seg_cross,
+        v_seg_last_viol);
+
+    {
+        hpx::partitioned_vector<T> v_sub(
+            SIZE, T(0), hpx::container_layout(localities));
+        initialize_partitioned(v_sub);
+
+        typename hpx::partitioned_vector<T>::iterator mid = v_sub.begin();
+        std::advance(mid, (v_sub.size() / 2) + 1);
+        *std::prev(mid, 2) = T(1);
+        *std::prev(mid) = T(2);
+
+        // no-policy
+        HPX_TEST(!hpx::is_partitioned(v_sub.begin(), mid, is_even<T>()));
+        HPX_TEST(
+            hpx::is_partitioned(v_sub.begin(), std::prev(mid), is_even<T>()));
+
+        // seq
+        HPX_TEST(!hpx::is_partitioned(
+            hpx::execution::seq, v_sub.begin(), mid, is_even<T>()));
+        HPX_TEST(hpx::is_partitioned(
+            hpx::execution::seq, v_sub.begin(), std::prev(mid), is_even<T>()));
+
+        // par
+        HPX_TEST(!hpx::is_partitioned(
+            hpx::execution::par, v_sub.begin(), mid, is_even<T>()));
+        HPX_TEST(hpx::is_partitioned(
+            hpx::execution::par, v_sub.begin(), std::prev(mid), is_even<T>()));
+
+        // seq(task)
+        HPX_TEST(!hpx::is_partitioned(hpx::execution::seq(hpx::execution::task),
+            v_sub.begin(), mid, is_even<T>())
+                .get());
+        HPX_TEST(hpx::is_partitioned(hpx::execution::seq(hpx::execution::task),
+            v_sub.begin(), std::prev(mid), is_even<T>())
+                .get());
+
+        // par(task)
+        HPX_TEST(!hpx::is_partitioned(hpx::execution::par(hpx::execution::task),
+            v_sub.begin(), mid, is_even<T>())
+                .get());
+        HPX_TEST(hpx::is_partitioned(hpx::execution::par(hpx::execution::task),
+            v_sub.begin(), std::prev(mid), is_even<T>())
+                .get());
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int main()
+{
+    std::vector<hpx::id_type> localities = hpx::find_all_localities();
+    is_partitioned_tests<int>(localities);
+    return hpx::util::report_errors();
+}
+#endif

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_is_partitioned.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_is_partitioned.cpp
@@ -99,9 +99,13 @@ void initialize_seg_boundary_cross_violation(hpx::partitioned_vector<T>& v,
     std::advance(seg_end, seg_size - 1);
     *seg_end = T(1);
 
+    typename hpx::partitioned_vector<T>::iterator viol = v.begin();
+    std::advance(viol, seg_size + 1);
+    *viol = T(2);
+
     typename hpx::partitioned_vector<T>::iterator rest = v.begin();
-    std::advance(rest, seg_size + 1);
-    for (std::size_t i = seg_size + 1; i < num_localities * seg_size;
+    std::advance(rest, seg_size + 2);
+    for (std::size_t i = seg_size + 2; i < num_localities * seg_size;
         ++i, ++rest)
         *rest = T(1);
 }
@@ -111,10 +115,12 @@ void initialize_seg_boundary_false_then_true_in_last_seg(
     hpx::partitioned_vector<T>& v, std::size_t num_localities,
     std::size_t seg_size)
 {
+    // Partition boundary falls between segment 0 (even) and the rest (odd)
     typename hpx::partitioned_vector<T>::iterator it = v.begin();
     for (std::size_t i = 0; i < num_localities * seg_size; ++i, ++it)
         *it = (i < seg_size) ? T(2) : T(1);
 
+    // Set the last element to even to violate partition in last seg
     typename hpx::partitioned_vector<T>::iterator last = v.end();
     --last;
     *last = T(2);
@@ -122,13 +128,11 @@ void initialize_seg_boundary_false_then_true_in_last_seg(
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename T>
-void test_is_partitioned(hpx::partitioned_vector<T>& v_part,
-    hpx::partitioned_vector<T>& v_odd, hpx::partitioned_vector<T>& v_even,
-    hpx::partitioned_vector<T>& v_viol_beg,
+void test_is_partitioned(std::size_t num_localities,
+    hpx::partitioned_vector<T>& v_part, hpx::partitioned_vector<T>& v_odd,
+    hpx::partitioned_vector<T>& v_even, hpx::partitioned_vector<T>& v_viol_beg,
     hpx::partitioned_vector<T>& v_viol_end,
-    hpx::partitioned_vector<T>& v_seg_valid,
-    hpx::partitioned_vector<T>& v_seg_cross,
-    hpx::partitioned_vector<T>& v_seg_last_viol)
+    hpx::partitioned_vector<T>& v_seg_valid)
 {
     // Basic partitioned / uniform inputs
     HPX_TEST(hpx::is_partitioned(v_part.begin(), v_part.end(), is_even<T>()));
@@ -141,23 +145,16 @@ void test_is_partitioned(hpx::partitioned_vector<T>& v_part,
     HPX_TEST(!hpx::is_partitioned(
         v_viol_end.begin(), v_viol_end.end(), is_even<T>()));
 
-    // Segment-boundary edge cases
     HPX_TEST(hpx::is_partitioned(
         v_seg_valid.begin(), v_seg_valid.end(), is_even<T>()));
-    HPX_TEST(!hpx::is_partitioned(
-        v_seg_cross.begin(), v_seg_cross.end(), is_even<T>()));
-    HPX_TEST(!hpx::is_partitioned(
-        v_seg_last_viol.begin(), v_seg_last_viol.end(), is_even<T>()));
 }
 
 template <typename ExPolicy, typename T>
-void test_is_partitioned(ExPolicy&& policy, hpx::partitioned_vector<T>& v_part,
-    hpx::partitioned_vector<T>& v_odd, hpx::partitioned_vector<T>& v_even,
-    hpx::partitioned_vector<T>& v_viol_beg,
+void test_is_partitioned(ExPolicy&& policy, std::size_t num_localities,
+    hpx::partitioned_vector<T>& v_part, hpx::partitioned_vector<T>& v_odd,
+    hpx::partitioned_vector<T>& v_even, hpx::partitioned_vector<T>& v_viol_beg,
     hpx::partitioned_vector<T>& v_viol_end,
-    hpx::partitioned_vector<T>& v_seg_valid,
-    hpx::partitioned_vector<T>& v_seg_cross,
-    hpx::partitioned_vector<T>& v_seg_last_viol)
+    hpx::partitioned_vector<T>& v_seg_valid)
 {
     HPX_TEST(hpx::is_partitioned(
         policy, v_part.begin(), v_part.end(), is_even<T>()));
@@ -173,20 +170,14 @@ void test_is_partitioned(ExPolicy&& policy, hpx::partitioned_vector<T>& v_part,
 
     HPX_TEST(hpx::is_partitioned(
         policy, v_seg_valid.begin(), v_seg_valid.end(), is_even<T>()));
-    HPX_TEST(!hpx::is_partitioned(
-        policy, v_seg_cross.begin(), v_seg_cross.end(), is_even<T>()));
-    HPX_TEST(!hpx::is_partitioned(
-        policy, v_seg_last_viol.begin(), v_seg_last_viol.end(), is_even<T>()));
 }
 
 template <typename ExPolicy, typename T>
-void test_is_partitioned_async(ExPolicy&& policy,
+void test_is_partitioned_async(ExPolicy&& policy, std::size_t num_localities,
     hpx::partitioned_vector<T>& v_part, hpx::partitioned_vector<T>& v_odd,
     hpx::partitioned_vector<T>& v_even, hpx::partitioned_vector<T>& v_viol_beg,
     hpx::partitioned_vector<T>& v_viol_end,
-    hpx::partitioned_vector<T>& v_seg_valid,
-    hpx::partitioned_vector<T>& v_seg_cross,
-    hpx::partitioned_vector<T>& v_seg_last_viol)
+    hpx::partitioned_vector<T>& v_seg_valid)
 {
     HPX_TEST(
         hpx::is_partitioned(policy, v_part.begin(), v_part.end(), is_even<T>())
@@ -207,12 +198,6 @@ void test_is_partitioned_async(ExPolicy&& policy,
 
     HPX_TEST(hpx::is_partitioned(
         policy, v_seg_valid.begin(), v_seg_valid.end(), is_even<T>())
-            .get());
-    HPX_TEST(!hpx::is_partitioned(
-        policy, v_seg_cross.begin(), v_seg_cross.end(), is_even<T>())
-            .get());
-    HPX_TEST(!hpx::is_partitioned(
-        policy, v_seg_last_viol.begin(), v_seg_last_viol.end(), is_even<T>())
             .get());
 }
 
@@ -236,10 +221,6 @@ void is_partitioned_tests(std::vector<hpx::id_type>& localities)
         SIZE, T(0), hpx::container_layout(localities));
     hpx::partitioned_vector<T> v_seg_valid(
         seg_total, T(0), hpx::container_layout(num_localities));
-    hpx::partitioned_vector<T> v_seg_cross(
-        seg_total, T(0), hpx::container_layout(num_localities));
-    hpx::partitioned_vector<T> v_seg_last_viol(
-        seg_total, T(0), hpx::container_layout(num_localities));
 
     initialize_partitioned(v_part);
     initialize_all_odd(v_odd);
@@ -247,26 +228,70 @@ void is_partitioned_tests(std::vector<hpx::id_type>& localities)
     initialize_violation_at_begin(v_viol_beg);
     initialize_violation_at_end(v_viol_end);
     initialize_seg_boundary_valid(v_seg_valid, num_localities, seg_size);
-    initialize_seg_boundary_cross_violation(
-        v_seg_cross, num_localities, seg_size);
-    initialize_seg_boundary_false_then_true_in_last_seg(
-        v_seg_last_viol, num_localities, seg_size);
 
-    test_is_partitioned(v_part, v_odd, v_even, v_viol_beg, v_viol_end,
-        v_seg_valid, v_seg_cross, v_seg_last_viol);
+    test_is_partitioned(num_localities, v_part, v_odd, v_even, v_viol_beg,
+        v_viol_end, v_seg_valid);
 
-    test_is_partitioned(hpx::execution::seq, v_part, v_odd, v_even, v_viol_beg,
-        v_viol_end, v_seg_valid, v_seg_cross, v_seg_last_viol);
-    test_is_partitioned(hpx::execution::par, v_part, v_odd, v_even, v_viol_beg,
-        v_viol_end, v_seg_valid, v_seg_cross, v_seg_last_viol);
+    test_is_partitioned(hpx::execution::seq, num_localities, v_part, v_odd,
+        v_even, v_viol_beg, v_viol_end, v_seg_valid);
+    test_is_partitioned(hpx::execution::par, num_localities, v_part, v_odd,
+        v_even, v_viol_beg, v_viol_end, v_seg_valid);
 
-    test_is_partitioned_async(hpx::execution::seq(hpx::execution::task), v_part,
-        v_odd, v_even, v_viol_beg, v_viol_end, v_seg_valid, v_seg_cross,
-        v_seg_last_viol);
-    test_is_partitioned_async(hpx::execution::par(hpx::execution::task), v_part,
-        v_odd, v_even, v_viol_beg, v_viol_end, v_seg_valid, v_seg_cross,
-        v_seg_last_viol);
+    test_is_partitioned_async(hpx::execution::seq(hpx::execution::task),
+        num_localities, v_part, v_odd, v_even, v_viol_beg, v_viol_end,
+        v_seg_valid);
+    test_is_partitioned_async(hpx::execution::par(hpx::execution::task),
+        num_localities, v_part, v_odd, v_even, v_viol_beg, v_viol_end,
+        v_seg_valid);
 
+    if (num_localities > 1)
+    {
+        hpx::partitioned_vector<T> v_seg_cross(
+            seg_total, T(0), hpx::container_layout(num_localities));
+        hpx::partitioned_vector<T> v_seg_last_viol(
+            seg_total, T(0), hpx::container_layout(num_localities));
+
+        initialize_seg_boundary_cross_violation(
+            v_seg_cross, num_localities, seg_size);
+        initialize_seg_boundary_false_then_true_in_last_seg(
+            v_seg_last_viol, num_localities, seg_size);
+
+        // no-policy
+        HPX_TEST(!hpx::is_partitioned(
+            v_seg_cross.begin(), v_seg_cross.end(), is_even<T>()));
+        HPX_TEST(!hpx::is_partitioned(
+            v_seg_last_viol.begin(), v_seg_last_viol.end(), is_even<T>()));
+
+        // seq
+        HPX_TEST(!hpx::is_partitioned(hpx::execution::seq, v_seg_cross.begin(),
+            v_seg_cross.end(), is_even<T>()));
+        HPX_TEST(!hpx::is_partitioned(hpx::execution::seq,
+            v_seg_last_viol.begin(), v_seg_last_viol.end(), is_even<T>()));
+
+        // par
+        HPX_TEST(!hpx::is_partitioned(hpx::execution::par, v_seg_cross.begin(),
+            v_seg_cross.end(), is_even<T>()));
+        HPX_TEST(!hpx::is_partitioned(hpx::execution::par,
+            v_seg_last_viol.begin(), v_seg_last_viol.end(), is_even<T>()));
+
+        // seq(task)
+        HPX_TEST(!hpx::is_partitioned(hpx::execution::seq(hpx::execution::task),
+            v_seg_cross.begin(), v_seg_cross.end(), is_even<T>())
+                .get());
+        HPX_TEST(!hpx::is_partitioned(hpx::execution::seq(hpx::execution::task),
+            v_seg_last_viol.begin(), v_seg_last_viol.end(), is_even<T>())
+                .get());
+
+        // par(task)
+        HPX_TEST(!hpx::is_partitioned(hpx::execution::par(hpx::execution::task),
+            v_seg_cross.begin(), v_seg_cross.end(), is_even<T>())
+                .get());
+        HPX_TEST(!hpx::is_partitioned(hpx::execution::par(hpx::execution::task),
+            v_seg_last_viol.begin(), v_seg_last_viol.end(), is_even<T>())
+                .get());
+    }
+
+    // Sub-range tests
     {
         hpx::partitioned_vector<T> v_sub(
             SIZE, T(0), hpx::container_layout(localities));

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_is_partitioned.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_is_partitioned.cpp
@@ -27,11 +27,6 @@ struct is_even
     {
         return val % T(2) == 0;
     }
-
-    template <typename Archive>
-    void serialize(Archive&, unsigned)
-    {
-    }
 };
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -128,7 +123,7 @@ void initialize_seg_boundary_false_then_true_in_last_seg(
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename T>
-void test_is_partitioned(std::size_t num_localities,
+void test_is_partitioned(std::size_t /* num_localities */,
     hpx::partitioned_vector<T>& v_part, hpx::partitioned_vector<T>& v_odd,
     hpx::partitioned_vector<T>& v_even, hpx::partitioned_vector<T>& v_viol_beg,
     hpx::partitioned_vector<T>& v_viol_end,
@@ -150,7 +145,7 @@ void test_is_partitioned(std::size_t num_localities,
 }
 
 template <typename ExPolicy, typename T>
-void test_is_partitioned(ExPolicy&& policy, std::size_t num_localities,
+void test_is_partitioned(ExPolicy&& policy, std::size_t /* num_localities */,
     hpx::partitioned_vector<T>& v_part, hpx::partitioned_vector<T>& v_odd,
     hpx::partitioned_vector<T>& v_even, hpx::partitioned_vector<T>& v_viol_beg,
     hpx::partitioned_vector<T>& v_viol_end,
@@ -173,9 +168,10 @@ void test_is_partitioned(ExPolicy&& policy, std::size_t num_localities,
 }
 
 template <typename ExPolicy, typename T>
-void test_is_partitioned_async(ExPolicy&& policy, std::size_t num_localities,
-    hpx::partitioned_vector<T>& v_part, hpx::partitioned_vector<T>& v_odd,
-    hpx::partitioned_vector<T>& v_even, hpx::partitioned_vector<T>& v_viol_beg,
+void test_is_partitioned_async(ExPolicy&& policy,
+    std::size_t /* num_localities */, hpx::partitioned_vector<T>& v_part,
+    hpx::partitioned_vector<T>& v_odd, hpx::partitioned_vector<T>& v_even,
+    hpx::partitioned_vector<T>& v_viol_beg,
     hpx::partitioned_vector<T>& v_viol_end,
     hpx::partitioned_vector<T>& v_seg_valid)
 {


### PR DESCRIPTION
Extends #1338 

## Proposed Changes

  - Add segmented version of parallel `is_partitioned`.
  
## Any background context you want to provide?
This completes segmented implementations of `is_sorted`, `is_sorted_until`, `is_partitioned` algorithms family.

## Checklist

Not all points below apply to all pull requests.

- [x] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
