### PR TITLE
execution: add native upon_error and upon_stopped sender adaptors

### DIFF
--- a/libs/core/execution/CMakeLists.txt
+++ b/libs/core/execution/CMakeLists.txt
@@ -29,6 +29,8 @@ set(execution_headers
     hpx/execution/algorithms/sync_wait.hpp
     hpx/execution/algorithms/then.hpp
     hpx/execution/algorithms/transfer.hpp
+    hpx/execution/algorithms/upon_error.hpp
+    hpx/execution/algorithms/upon_stopped.hpp
     hpx/execution/algorithms/transfer_just.hpp
     hpx/execution/algorithms/when_all.hpp
     hpx/execution/algorithms/when_all_vector.hpp

--- a/libs/core/execution/include/hpx/execution/algorithms/upon_error.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/upon_error.hpp
@@ -1,0 +1,256 @@
+//  Copyright (c) 2021 ETH Zurich
+//  Copyright (c) 2022-2025 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#if defined(HPX_HAVE_STDEXEC)
+#include <hpx/modules/execution_base.hpp>
+#else
+
+#include <hpx/execution/algorithms/detail/partial_algorithm.hpp>
+#include <hpx/modules/concepts.hpp>
+#include <hpx/modules/errors.hpp>
+#include <hpx/modules/execution_base.hpp>
+#include <hpx/modules/functional.hpp>
+#include <hpx/modules/tag_invoke.hpp>
+#include <hpx/modules/type_support.hpp>
+
+#include <exception>
+#include <type_traits>
+#include <utility>
+
+namespace hpx::execution::experimental {
+
+    namespace detail {
+
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
+        // Receiver adaptor that intercepts set_error and converts it to
+        // set_value by invoking f(error). set_value and set_stopped are
+        // forwarded unchanged to the downstream receiver.
+        HPX_CXX_CORE_EXPORT template <typename Receiver, typename F>
+        struct upon_error_receiver
+        {
+            HPX_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
+            HPX_NO_UNIQUE_ADDRESS std::decay_t<F> f;
+
+            // set_value: pass through unchanged
+            template <typename... Ts>
+            friend void tag_invoke(
+                set_value_t, upon_error_receiver&& r, Ts&&... ts) noexcept
+            {
+                hpx::execution::experimental::set_value(
+                    HPX_MOVE(r.receiver), HPX_FORWARD(Ts, ts)...);
+            }
+
+            // set_stopped: pass through unchanged
+            friend void tag_invoke(
+                set_stopped_t, upon_error_receiver&& r) noexcept
+            {
+                hpx::execution::experimental::set_stopped(HPX_MOVE(r.receiver));
+            }
+
+        private:
+            template <typename Error>
+            void set_error_helper(Error&& error) && noexcept
+            {
+                using result_type =
+                    hpx::util::invoke_result_t<F, std::decay_t<Error>>;
+                hpx::detail::try_catch_exception_ptr(
+                    [&]() {
+                        if constexpr (std::is_void_v<result_type>)
+                        {
+                            HPX_INVOKE(std::move(f), HPX_FORWARD(Error, error));
+                            hpx::execution::experimental::set_value(
+                                HPX_MOVE(receiver));
+                        }
+                        else
+                        {
+                            auto&& result = HPX_INVOKE(
+                                std::move(f), HPX_FORWARD(Error, error));
+                            hpx::execution::experimental::set_value(
+                                HPX_MOVE(receiver), HPX_MOVE(result));
+                        }
+                    },
+                    [&](std::exception_ptr ep) {
+                        hpx::execution::experimental::set_error(
+                            HPX_MOVE(receiver), HPX_MOVE(ep));
+                    });
+            }
+
+        public:
+            // clang-format off
+            template <typename Error,
+                HPX_CONCEPT_REQUIRES_(
+                    hpx::is_invocable_v<F, std::decay_t<Error>>
+                )>
+            // clang-format on
+            friend void tag_invoke(
+                set_error_t, upon_error_receiver&& r, Error&& error) noexcept
+            {
+                HPX_MOVE(r).set_error_helper(HPX_FORWARD(Error, error));
+            }
+        };
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic pop
+#endif
+
+        HPX_CXX_CORE_EXPORT template <typename Sender, typename F>
+        struct upon_error_sender
+        {
+            using is_sender = void;
+
+            HPX_NO_UNIQUE_ADDRESS std::decay_t<Sender> sender;
+            HPX_NO_UNIQUE_ADDRESS std::decay_t<F> f;
+
+            // For each error type E in upstream error_types, upon_error
+            // converts it to a value by calling f(E), producing either
+            // Tuple<> (if f returns void) or Tuple<invoke_result_t<F, E>>.
+            //
+            // Note: gen_value_from_error uses hpx::tuple directly since
+            // transform_t requires a single-argument transformer, and in
+            // practice value_types checks always use hpx::tuple.
+            template <typename Error>
+            struct gen_value_from_error
+            {
+                using result_type =
+                    hpx::util::invoke_result_t<F, std::decay_t<Error>>;
+                using type = std::conditional_t<std::is_void_v<result_type>,
+                    hpx::tuple<>, hpx::tuple<result_type>>;
+            };
+
+            template <typename Env>
+            struct generate_completion_signatures
+            {
+                // value_types:
+                //   - upstream value completions (forwarded unchanged)
+                //   - for each error type E, Tuple<invoke_result_t<F, E>>
+                //     (or Tuple<> if void) added as a new value alternative
+                template <template <typename...> typename Tuple,
+                    template <typename...> typename Variant>
+                using value_types = hpx::util::detail::unique_concat_t<
+                    value_types_of_t<Sender, Env, Tuple, Variant>,
+                    hpx::util::detail::transform_t<
+                        error_types_of_t<Sender, Env, Variant>,
+                        gen_value_from_error>>;
+
+                // error_types: only std::exception_ptr (if f itself throws)
+                template <template <typename...> typename Variant>
+                using error_types = Variant<std::exception_ptr>;
+
+                // sends_stopped: same as upstream (stopped channel untouched)
+                static constexpr bool sends_stopped =
+                    sends_stopped_of_v<Sender, Env>;
+            };
+
+            template <typename Env>
+            friend auto tag_invoke(get_completion_signatures_t,
+                upon_error_sender const&,
+                Env) -> generate_completion_signatures<Env>;
+
+            // Propagate completion scheduler for set_value_t and set_stopped_t
+            // channels (error channel is consumed, not forwarded).
+            // clang-format off
+            template <typename CPO,
+                HPX_CONCEPT_REQUIRES_(
+                    meta::value<meta::one_of<
+                        std::decay_t<CPO>, set_value_t, set_stopped_t>> &&
+                    detail::has_completion_scheduler_v<CPO, Sender>
+                )>
+            // clang-format on
+            friend constexpr auto tag_invoke(
+                hpx::execution::experimental::get_completion_scheduler_t<CPO>
+                    tag,
+                upon_error_sender const& s)
+            {
+                return tag(s.sender);
+            }
+
+            template <typename Receiver>
+            friend auto tag_invoke(
+                connect_t, upon_error_sender&& s, Receiver&& receiver)
+            {
+                return hpx::execution::experimental::connect(HPX_MOVE(s.sender),
+                    upon_error_receiver<Receiver, F>{
+                        HPX_FORWARD(Receiver, receiver), HPX_MOVE(s.f)});
+            }
+
+            template <typename Receiver>
+            friend auto tag_invoke(
+                connect_t, upon_error_sender& s, Receiver&& receiver)
+            {
+                return hpx::execution::experimental::connect(s.sender,
+                    upon_error_receiver<Receiver, F>{
+                        HPX_FORWARD(Receiver, receiver), s.f});
+            }
+        };
+    }    // namespace detail
+
+    // execution::upon_error is the error-channel counterpart of then.
+    // It attaches an invocable as a handler for the error completion of the
+    // input sender. The handler is called with the error value and its return
+    // value is sent as a value completion to downstream. If the handler itself
+    // throws, the exception is forwarded as a set_error(exception_ptr).
+    //
+    // Value and stopped completions from the input sender are forwarded
+    // unchanged.
+    //
+    // upon_error is guaranteed to not begin executing the handler before the
+    // returned sender is started.
+    HPX_CXX_CORE_EXPORT inline constexpr struct upon_error_t final
+      : hpx::functional::detail::tag_priority<upon_error_t>
+    {
+    private:
+        // clang-format off
+        template <typename Sender, typename F,
+            HPX_CONCEPT_REQUIRES_(
+                is_sender_v<Sender> &&
+                experimental::detail::is_completion_scheduler_tag_invocable_v<
+                    hpx::execution::experimental::set_value_t,
+                    Sender, upon_error_t, F
+                >
+            )>
+        // clang-format on
+        friend constexpr HPX_FORCEINLINE auto tag_override_invoke(
+            upon_error_t, Sender&& sender, F&& f)
+        {
+            auto scheduler =
+                hpx::execution::experimental::get_completion_scheduler<
+                    hpx::execution::experimental::set_value_t>(sender);
+
+            return hpx::functional::tag_invoke(upon_error_t{},
+                HPX_MOVE(scheduler), HPX_FORWARD(Sender, sender),
+                HPX_FORWARD(F, f));
+        }
+
+        // clang-format off
+        template <typename Sender, typename F,
+            HPX_CONCEPT_REQUIRES_(
+                is_sender_v<Sender>
+            )>
+        // clang-format on
+        friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(
+            upon_error_t, Sender&& sender, F&& f)
+        {
+            return detail::upon_error_sender<Sender, F>{
+                HPX_FORWARD(Sender, sender), HPX_FORWARD(F, f)};
+        }
+
+        template <typename F>
+        friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(
+            upon_error_t, F&& f)
+        {
+            return detail::partial_algorithm<upon_error_t, F>{
+                HPX_FORWARD(F, f)};
+        }
+    } upon_error{};
+}    // namespace hpx::execution::experimental
+
+#endif

--- a/libs/core/execution/include/hpx/execution/algorithms/upon_stopped.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/upon_stopped.hpp
@@ -1,0 +1,244 @@
+//  Copyright (c) 2021 ETH Zurich
+//  Copyright (c) 2022-2025 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#if defined(HPX_HAVE_STDEXEC)
+#include <hpx/modules/execution_base.hpp>
+#else
+
+#include <hpx/execution/algorithms/detail/partial_algorithm.hpp>
+#include <hpx/modules/concepts.hpp>
+#include <hpx/modules/errors.hpp>
+#include <hpx/modules/execution_base.hpp>
+#include <hpx/modules/functional.hpp>
+#include <hpx/modules/tag_invoke.hpp>
+#include <hpx/modules/type_support.hpp>
+
+#include <exception>
+#include <type_traits>
+#include <utility>
+
+namespace hpx::execution::experimental {
+
+    namespace detail {
+
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
+        // Receiver adaptor that intercepts set_stopped and converts it to
+        // set_value by invoking f(). set_value and set_error are forwarded
+        // unchanged to the downstream receiver.
+        HPX_CXX_CORE_EXPORT template <typename Receiver, typename F>
+        struct upon_stopped_receiver
+        {
+            HPX_NO_UNIQUE_ADDRESS std::decay_t<Receiver> receiver;
+            HPX_NO_UNIQUE_ADDRESS std::decay_t<F> f;
+
+            // set_value: pass through unchanged
+            template <typename... Ts>
+            friend void tag_invoke(
+                set_value_t, upon_stopped_receiver&& r, Ts&&... ts) noexcept
+            {
+                hpx::execution::experimental::set_value(
+                    HPX_MOVE(r.receiver), HPX_FORWARD(Ts, ts)...);
+            }
+
+            // set_error: pass through unchanged
+            template <typename Error>
+            friend void tag_invoke(
+                set_error_t, upon_stopped_receiver&& r, Error&& error) noexcept
+            {
+                hpx::execution::experimental::set_error(
+                    HPX_MOVE(r.receiver), HPX_FORWARD(Error, error));
+            }
+
+        private:
+            void set_stopped_helper() && noexcept
+            {
+                using result_type = hpx::util::invoke_result_t<F>;
+                hpx::detail::try_catch_exception_ptr(
+                    [&]() {
+                        if constexpr (std::is_void_v<result_type>)
+                        {
+                            HPX_INVOKE(std::move(f), );
+                            hpx::execution::experimental::set_value(
+                                HPX_MOVE(receiver));
+                        }
+                        else
+                        {
+                            auto&& result = HPX_INVOKE(std::move(f), );
+                            hpx::execution::experimental::set_value(
+                                HPX_MOVE(receiver), HPX_MOVE(result));
+                        }
+                    },
+                    [&](std::exception_ptr ep) {
+                        hpx::execution::experimental::set_error(
+                            HPX_MOVE(receiver), HPX_MOVE(ep));
+                    });
+            }
+
+        public:
+            friend void tag_invoke(
+                set_stopped_t, upon_stopped_receiver&& r) noexcept
+            {
+                HPX_MOVE(r).set_stopped_helper();
+            }
+        };
+#if defined(HPX_GCC_VERSION) && HPX_GCC_VERSION >= 110000
+#pragma GCC diagnostic pop
+#endif
+
+        HPX_CXX_CORE_EXPORT template <typename Sender, typename F>
+        struct upon_stopped_sender
+        {
+            using is_sender = void;
+
+            HPX_NO_UNIQUE_ADDRESS std::decay_t<Sender> sender;
+            HPX_NO_UNIQUE_ADDRESS std::decay_t<F> f;
+
+            template <typename Env>
+            struct generate_completion_signatures
+            {
+            private:
+                // The value type produced when the stopped signal is handled:
+                // either Tuple<> if f() returns void, or Tuple<result_type>.
+                // Uses Tuple template parameter to stay consistent with
+                // value_types_of_t.
+                using stopped_result_type = hpx::util::invoke_result_t<F>;
+
+                template <template <typename...> typename Tuple>
+                using stopped_value_tuple =
+                    std::conditional_t<std::is_void_v<stopped_result_type>,
+                        Tuple<>, Tuple<stopped_result_type>>;
+
+            public:
+                // value_types:
+                //   - upstream value completions (forwarded unchanged)
+                //   - stopped_value_tuple<Tuple> added as a new alternative,
+                //     representing the value produced by the stopped handler
+                template <template <typename...> typename Tuple,
+                    template <typename...> typename Variant>
+                using value_types = hpx::util::detail::unique_concat_t<
+                    value_types_of_t<Sender, Env, Tuple, Variant>,
+                    Variant<stopped_value_tuple<Tuple>>>;
+
+                // error_types: upstream errors + std::exception_ptr (if f throws)
+                template <template <typename...> typename Variant>
+                using error_types = hpx::util::detail::unique_concat_t<
+                    error_types_of_t<Sender, Env, Variant>,
+                    Variant<std::exception_ptr>>;
+
+                // sends_stopped: false — the stopped signal is consumed by f
+                static constexpr bool sends_stopped = false;
+            };
+
+            template <typename Env>
+            friend auto tag_invoke(get_completion_signatures_t,
+                upon_stopped_sender const&,
+                Env) -> generate_completion_signatures<Env>;
+
+            // Propagate completion scheduler for set_value_t channel.
+            // set_error_t is forwarded, set_stopped_t is consumed.
+            // clang-format off
+            template <typename CPO,
+                HPX_CONCEPT_REQUIRES_(
+                    std::is_same_v<std::decay_t<CPO>, set_value_t> &&
+                    detail::has_completion_scheduler_v<CPO, Sender>
+                )>
+            // clang-format on
+            friend constexpr auto tag_invoke(
+                hpx::execution::experimental::get_completion_scheduler_t<CPO>
+                    tag,
+                upon_stopped_sender const& s)
+            {
+                return tag(s.sender);
+            }
+
+            template <typename Receiver>
+            friend auto tag_invoke(
+                connect_t, upon_stopped_sender&& s, Receiver&& receiver)
+            {
+                return hpx::execution::experimental::connect(HPX_MOVE(s.sender),
+                    upon_stopped_receiver<Receiver, F>{
+                        HPX_FORWARD(Receiver, receiver), HPX_MOVE(s.f)});
+            }
+
+            template <typename Receiver>
+            friend auto tag_invoke(
+                connect_t, upon_stopped_sender& s, Receiver&& receiver)
+            {
+                return hpx::execution::experimental::connect(s.sender,
+                    upon_stopped_receiver<Receiver, F>{
+                        HPX_FORWARD(Receiver, receiver), s.f});
+            }
+        };
+    }    // namespace detail
+
+    // execution::upon_stopped is the stopped-channel counterpart of then.
+    // It attaches an invocable as a handler for the stopped completion of the
+    // input sender. The handler is called with no arguments and its return
+    // value is sent as a value completion to downstream. If the handler itself
+    // throws, the exception is forwarded as a set_error(exception_ptr).
+    //
+    // Value and error completions from the input sender are forwarded
+    // unchanged. The returned sender never sends a stopped signal.
+    //
+    // upon_stopped is guaranteed to not begin executing the handler before the
+    // returned sender is started.
+    HPX_CXX_CORE_EXPORT inline constexpr struct upon_stopped_t final
+      : hpx::functional::detail::tag_priority<upon_stopped_t>
+    {
+    private:
+        // clang-format off
+        template <typename Sender, typename F,
+            HPX_CONCEPT_REQUIRES_(
+                is_sender_v<Sender> &&
+                experimental::detail::is_completion_scheduler_tag_invocable_v<
+                    hpx::execution::experimental::set_value_t,
+                    Sender, upon_stopped_t, F
+                >
+            )>
+        // clang-format on
+        friend constexpr HPX_FORCEINLINE auto tag_override_invoke(
+            upon_stopped_t, Sender&& sender, F&& f)
+        {
+            auto scheduler =
+                hpx::execution::experimental::get_completion_scheduler<
+                    hpx::execution::experimental::set_value_t>(sender);
+
+            return hpx::functional::tag_invoke(upon_stopped_t{},
+                HPX_MOVE(scheduler), HPX_FORWARD(Sender, sender),
+                HPX_FORWARD(F, f));
+        }
+
+        // clang-format off
+        template <typename Sender, typename F,
+            HPX_CONCEPT_REQUIRES_(
+                is_sender_v<Sender>
+            )>
+        // clang-format on
+        friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(
+            upon_stopped_t, Sender&& sender, F&& f)
+        {
+            return detail::upon_stopped_sender<Sender, F>{
+                HPX_FORWARD(Sender, sender), HPX_FORWARD(F, f)};
+        }
+
+        template <typename F>
+        friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(
+            upon_stopped_t, F&& f)
+        {
+            return detail::partial_algorithm<upon_stopped_t, F>{
+                HPX_FORWARD(F, f)};
+        }
+    } upon_stopped{};
+}    // namespace hpx::execution::experimental
+
+#endif

--- a/libs/core/execution/tests/unit/CMakeLists.txt
+++ b/libs/core/execution/tests/unit/CMakeLists.txt
@@ -22,6 +22,8 @@ set(tests
     algorithm_sync_wait_with_variant
     algorithm_then
     algorithm_transfer
+    algorithm_upon_error
+    algorithm_upon_stopped
     algorithm_transfer_just
     algorithm_transfer_when_all
     algorithm_when_all

--- a/libs/core/execution/tests/unit/algorithm_upon_error.cpp
+++ b/libs/core/execution/tests/unit/algorithm_upon_error.cpp
@@ -1,0 +1,173 @@
+//  Copyright (c) 2021 ETH Zurich
+//  Copyright (c) 2022-2025 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#include <hpx/execution.hpp>
+#include <hpx/init.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/thread.hpp>
+
+#include "algorithm_test_utils.hpp"
+
+#include <atomic>
+#include <exception>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+namespace ex = hpx::execution::experimental;
+
+int hpx_main()
+{
+    // upon_error: error is converted to value
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::upon_error(
+            ex::just_error(std::make_exception_ptr(std::runtime_error("err"))),
+            [](std::exception_ptr) { return 42; });
+        static_assert(ex::is_sender_v<decltype(s)>);
+#if defined(HPX_HAVE_STDEXEC)
+        static_assert(ex::is_sender_in_v<decltype(s), ex::empty_env>);
+#else
+        static_assert(ex::is_sender_v<decltype(s), ex::empty_env>);
+#endif
+
+        check_error_types<hpx::variant<std::exception_ptr>>(s);
+        check_sends_stopped<false>(s);
+
+        auto f = [](int x) { HPX_TEST_EQ(x, 42); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+    }
+
+    // upon_error: void-returning handler
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::upon_error(
+            ex::just_error(std::make_exception_ptr(std::runtime_error("err"))),
+            [](std::exception_ptr) { /* void */ });
+        static_assert(ex::is_sender_v<decltype(s)>);
+
+        check_error_types<hpx::variant<std::exception_ptr>>(s);
+        check_sends_stopped<false>(s);
+
+        auto f = [] {};
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+    }
+
+    // upon_error: value channel is forwarded unchanged
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::upon_error(
+            ex::just(7), [](std::exception_ptr) { return 99; });
+        static_assert(ex::is_sender_v<decltype(s)>);
+
+        auto f = [](int x) { HPX_TEST_EQ(x, 7); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+    }
+
+    // upon_error: handler that throws re-sends error as exception_ptr
+    {
+        std::atomic<bool> set_error_called{false};
+        auto s = ex::upon_error(
+            ex::just_error(std::make_exception_ptr(std::runtime_error("err"))),
+            [](std::exception_ptr) -> int {
+                throw std::runtime_error("handler_error");
+            });
+        static_assert(ex::is_sender_v<decltype(s)>);
+
+        auto r = error_callback_receiver<check_exception_ptr>{
+            check_exception_ptr{}, set_error_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_error_called);
+    }
+
+    // upon_error: pipe operator
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s =
+            ex::just_error(std::make_exception_ptr(std::runtime_error("e"))) |
+            ex::upon_error([](std::exception_ptr) { return std::string("ok"); });
+        static_assert(ex::is_sender_v<decltype(s)>);
+
+        check_error_types<hpx::variant<std::exception_ptr>>(s);
+        check_sends_stopped<false>(s);
+
+        auto f = [](std::string x) { HPX_TEST_EQ(x, std::string("ok")); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+    }
+
+    // upon_error: chained with then
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s =
+            ex::just_error(std::make_exception_ptr(std::runtime_error("e"))) |
+            ex::upon_error([](std::exception_ptr) { return 1; }) |
+            ex::then([](int x) { return x + 1; });
+        static_assert(ex::is_sender_v<decltype(s)>);
+
+        auto f = [](int x) { HPX_TEST_EQ(x, 2); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+    }
+
+    // upon_error: stopped channel is forwarded unchanged
+    {
+        std::atomic<bool> set_stopped_called{false};
+        auto s = ex::upon_error(
+            ex::just_stopped(), [](std::exception_ptr) { return 42; });
+        static_assert(ex::is_sender_v<decltype(s)>);
+
+        check_sends_stopped<true>(s);
+
+        auto r = expect_stopped_receiver{set_stopped_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_stopped_called);
+    }
+
+    // upon_error: error_sender (sends error from an otherwise-value sender)
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::upon_error(
+            error_sender<>{}, [](std::exception_ptr) { return 10; });
+        static_assert(ex::is_sender_v<decltype(s)>);
+
+        check_error_types<hpx::variant<std::exception_ptr>>(s);
+
+        auto f = [](int x) { HPX_TEST_EQ(x, 10); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+    }
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/execution/tests/unit/algorithm_upon_stopped.cpp
+++ b/libs/core/execution/tests/unit/algorithm_upon_stopped.cpp
@@ -1,0 +1,170 @@
+//  Copyright (c) 2021 ETH Zurich
+//  Copyright (c) 2022-2025 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#include <hpx/execution.hpp>
+#include <hpx/init.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/thread.hpp>
+
+#include "algorithm_test_utils.hpp"
+
+#include <atomic>
+#include <exception>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+
+namespace ex = hpx::execution::experimental;
+
+int hpx_main()
+{
+    // upon_stopped: stopped is converted to value
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::upon_stopped(ex::just_stopped(), [] { return 42; });
+        static_assert(ex::is_sender_v<decltype(s)>);
+#if defined(HPX_HAVE_STDEXEC)
+        static_assert(ex::is_sender_in_v<decltype(s), ex::empty_env>);
+#else
+        static_assert(ex::is_sender_v<decltype(s), ex::empty_env>);
+#endif
+
+        check_sends_stopped<false>(s);
+
+        auto f = [](int x) { HPX_TEST_EQ(x, 42); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+    }
+
+    // upon_stopped: void-returning handler
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::upon_stopped(ex::just_stopped(), [] { /* void */ });
+        static_assert(ex::is_sender_v<decltype(s)>);
+
+        check_sends_stopped<false>(s);
+
+        auto f = [] {};
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+    }
+
+    // upon_stopped: value channel is forwarded unchanged
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::upon_stopped(ex::just(7), [] { return 99; });
+        static_assert(ex::is_sender_v<decltype(s)>);
+
+        check_sends_stopped<false>(s);
+
+        auto f = [](int x) { HPX_TEST_EQ(x, 7); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+    }
+
+    // upon_stopped: error channel is forwarded unchanged
+    {
+        std::atomic<bool> set_error_called{false};
+        auto s = ex::upon_stopped(
+            ex::just_error(std::make_exception_ptr(std::runtime_error("err"))),
+            [] { return 42; });
+        static_assert(ex::is_sender_v<decltype(s)>);
+
+        check_sends_stopped<false>(s);
+
+        auto r = error_callback_receiver<check_exception_ptr>{
+            check_exception_ptr{}, set_error_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_error_called);
+    }
+
+    // upon_stopped: handler that throws re-sends error as exception_ptr
+    {
+        std::atomic<bool> set_error_called{false};
+        auto s = ex::upon_stopped(ex::just_stopped(), []() -> int {
+            throw std::runtime_error("handler_error");
+        });
+        static_assert(ex::is_sender_v<decltype(s)>);
+
+        check_sends_stopped<false>(s);
+
+        auto r = error_callback_receiver<check_exception_ptr>{
+            check_exception_ptr{}, set_error_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_error_called);
+    }
+
+    // upon_stopped: pipe operator
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::just_stopped() |
+            ex::upon_stopped([] { return std::string("recovered"); });
+        static_assert(ex::is_sender_v<decltype(s)>);
+
+        check_sends_stopped<false>(s);
+
+        auto f = [](std::string x) {
+            HPX_TEST_EQ(x, std::string("recovered"));
+        };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+    }
+
+    // upon_stopped: chained with then
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s = ex::just_stopped() |
+            ex::upon_stopped([] { return 1; }) |
+            ex::then([](int x) { return x + 1; });
+        static_assert(ex::is_sender_v<decltype(s)>);
+
+        auto f = [](int x) { HPX_TEST_EQ(x, 2); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+    }
+
+    // upon_stopped: stopped_sender_with_value_type (sends stopped even though
+    // it also advertises a value type)
+    {
+        std::atomic<bool> set_value_called{false};
+        auto s =
+            ex::upon_stopped(stopped_sender_with_value_type{}, [] { return 5; });
+        static_assert(ex::is_sender_v<decltype(s)>);
+
+        check_sends_stopped<false>(s);
+
+        auto f = [](int x) { HPX_TEST_EQ(x, 5); };
+        auto r = callback_receiver<decltype(f)>{f, set_value_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_value_called);
+    }
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION

● Fixes two unchecked items from #5045.

---

So I was looking at the P2300 tracking issue and noticed `upon_error` and `upon_stopped` have been sitting unchecked for a while. These are basically the error and stopped channel equivalents of `then` , pretty fundamental stuff for anyone trying to do error recovery in a sender pipeline without reaching for the heavier `let_error`/`let_stopped`.

Right now if you want to recover from an error and return a default value, you have to write:

```cpp
ex::let_error(sender, [](auto) { return ex::just(default_value); })
```
which is annoying because you're forced to wrap in just() even when you just want to return a plain value. upon_error lets you write:
```
ex::upon_error(sender, [](auto) { return default_value; })
```
Same story for upon_stopped. Also worth noting , these only exist today if you build with HPX_HAVE_STDEXEC. The native path has had nothing. This PR fills that gap.

---

### What I did

- Added upon_error.hpp and upon_stopped.hpp under libs/core/execution/include/hpx/execution/algorithms/
- Both follow the exact same structure as then.hpp : receiver adaptor, sender with completion signatures, CPO with tag_priority
- upon_error: intercepts set_error, calls f(error), sends result as set_value. Value and stopped signals pass through untouched.
- upon_stopped: intercepts set_stopped, calls f(), sends result as set_value. Value and error signals pass through untouched. The
  returned sender never sends stopped (sends_stopped = false).
- Both handle void-returning handlers and re-route any exception thrown inside f as set_error(exception_ptr) : same try_catch_exception_ptr pattern used throughout the existing algorithms.
- Pipe operator (|) works out of the box via the existing partial_algorithm mechanism.
- Registered both headers in the module CMakeLists.txt and added test files covering: error→value conversion, void handler, passthrough channels, handler that throws, pipe operator, chaining with then.
---

### What I didn't do

I intentionally left stopped_as_optional and stopped_as_error out of this PR , they're trivially implementable on top of upon_stopped but I wanted to keep this focused. Happy to do a follow-up for those.