### PR TITLE
Add hierarchical all_reduce and all_gather via reduce+broadcast composition

### DIFF
--- a/libs/full/collectives/include/hpx/collectives/all_gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_gather.hpp
@@ -387,8 +387,8 @@ namespace hpx::collectives {
 
     ////////////////////////////////////////////////////////////////////////////
     // Hierarchical all_gather: gather (bottom-up) + broadcast (top-down)
-    // Uses 2k/2k+1 generation mapping: user generation k maps to
-    // internal generation 2k (gather phase) and 2k+1 (broadcast phase)
+    // Uses 2k-1/2k generation mapping: user generation k maps to
+    // internal generation 2k-1 (gather phase) and 2k (broadcast phase)
     //
     // Key difference from all_reduce: the gather phase produces vector<T>
     // (O(N) data), so the broadcast phase transfers O(N) instead of a scalar.

--- a/libs/full/collectives/include/hpx/collectives/all_gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_gather.hpp
@@ -420,7 +420,7 @@ namespace hpx::collectives {
         generation_arg const gather_gen(2 * generation);
         generation_arg const broadcast_gen(2 * generation + 1);
 
-        if (this_site.get() == root_site.get())
+        if (this_site == root_site)
         {
             std::vector<arg_type> gathered = gather_here(hpx::launch::sync,
                 communicators, HPX_FORWARD(T, local_result), this_site, gather_gen);

--- a/libs/full/collectives/include/hpx/collectives/all_gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_gather.hpp
@@ -423,8 +423,7 @@ namespace hpx::collectives {
         generation_arg const broadcast_gen(2 * generation + 1);
 
         std::vector<arg_type> gathered = gather_here(hpx::launch::sync,
-            communicators, HPX_FORWARD(T, local_result), this_site,
-            gather_gen);
+            communicators, HPX_FORWARD(T, local_result), this_site, gather_gen);
 
         return broadcast_to(
             communicators, HPX_MOVE(gathered), this_site, broadcast_gen);
@@ -437,11 +436,10 @@ namespace hpx::collectives {
         this_site_arg const this_site = this_site_arg(),
         generation_arg const generation = generation_arg())
     {
-        return all_gather(communicators, HPX_FORWARD(T, local_result),
-            this_site, generation)
+        return all_gather(
+            communicators, HPX_FORWARD(T, local_result), this_site, generation)
             .get();
     }
-
 
     // --- INTERNAL API (Non-root site overloads) ---
     namespace detail {
@@ -457,11 +455,12 @@ namespace hpx::collectives {
 
             if (generation.is_default())
             {
-                return hpx::make_exceptional_future<std::vector<arg_type>>(
-                    HPX_GET_EXCEPTION(hpx::error::bad_parameter,
-                        "hpx::collectives::all_gather (hierarchical)",
-                        "hierarchical all_gather requires an explicit generation "
-                        "number for the 2k/2k+1 internal mapping"));
+                return hpx::make_exceptional_future<
+                    std::vector<arg_type>>(HPX_GET_EXCEPTION(
+                    hpx::error::bad_parameter,
+                    "hpx::collectives::all_gather (hierarchical)",
+                    "hierarchical all_gather requires an explicit generation "
+                    "number for the 2k/2k+1 internal mapping"));
             }
 
             if (this_site.is_default())

--- a/libs/full/collectives/include/hpx/collectives/all_gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_gather.hpp
@@ -422,26 +422,21 @@ namespace hpx::collectives {
 
         if (this_site == root_site)
         {
-            auto gather_fut = gather_here(communicators,
-                HPX_FORWARD(T, local_result), this_site, gather_gen);
+            std::vector<arg_type> gathered = gather_here(communicators,
+                HPX_FORWARD(T, local_result), this_site, gather_gen)
+                                                 .get();
 
-            return gather_fut.then(hpx::launch::sync,
-                [communicators, this_site, broadcast_gen](auto f) {
-                    return broadcast_to(
-                        communicators, f.get(), this_site, broadcast_gen);
-                });
+            return broadcast_to(
+                communicators, HPX_MOVE(gathered), this_site, broadcast_gen);
         }
         else
         {
-            auto gather_fut = gather_there(communicators,
-                HPX_FORWARD(T, local_result), this_site, gather_gen);
+            gather_there(communicators, HPX_FORWARD(T, local_result), this_site,
+                gather_gen)
+                .get();
 
-            return gather_fut.then(hpx::launch::sync,
-                [communicators, this_site, broadcast_gen](auto f) {
-                    f.get();    // Propagate any exceptions from gather phase
-                    return broadcast_from<std::vector<arg_type>>(
-                        communicators, this_site, broadcast_gen);
-                });
+            return broadcast_from<std::vector<arg_type>>(
+                communicators, this_site, broadcast_gen);
         }
     }
 

--- a/libs/full/collectives/include/hpx/collectives/all_gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_gather.hpp
@@ -422,17 +422,18 @@ namespace hpx::collectives {
 
         if (this_site == root_site)
         {
-            std::vector<arg_type> gathered =
-                gather_here(hpx::launch::sync, communicators,
-                    HPX_FORWARD(T, local_result), this_site, gather_gen);
+            std::vector<arg_type> gathered = gather_here(communicators,
+                HPX_FORWARD(T, local_result), this_site, gather_gen)
+                                                 .get();
 
             return broadcast_to(
                 communicators, HPX_MOVE(gathered), this_site, broadcast_gen);
         }
         else
         {
-            gather_there(hpx::launch::sync, communicators,
-                HPX_FORWARD(T, local_result), this_site, gather_gen);
+            gather_there(communicators, HPX_FORWARD(T, local_result), this_site,
+                gather_gen)
+                .get();
 
             return broadcast_from<std::vector<arg_type>>(
                 communicators, this_site, broadcast_gen);

--- a/libs/full/collectives/include/hpx/collectives/all_gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_gather.hpp
@@ -394,6 +394,8 @@ namespace hpx::collectives {
     // Key difference from all_reduce: the gather phase produces vector<T>
     // (O(N) data), so the broadcast phase transfers O(N) instead of a scalar.
 
+    // --- PUBLIC API (Root site overloads) ---
+
     // Root site overload
     template <typename T>
     hpx::future<std::vector<std::decay_t<T>>> all_gather(
@@ -403,7 +405,6 @@ namespace hpx::collectives {
     {
         using arg_type = std::decay_t<T>;
 
-        // Map user generation k to internal generations 2k, 2k+1
         if (generation.is_default())
         {
             return hpx::make_exceptional_future<std::vector<arg_type>>(
@@ -421,53 +422,15 @@ namespace hpx::collectives {
         generation_arg const gather_gen(2 * generation);
         generation_arg const broadcast_gen(2 * generation + 1);
 
-        // Phase 1: hierarchical gather (bottom-up) — produces vector<T>
         std::vector<arg_type> gathered = gather_here(hpx::launch::sync,
             communicators, HPX_FORWARD(T, local_result), this_site,
             gather_gen);
 
-        // Phase 2: hierarchical broadcast (top-down) — sends vector<T>
         return broadcast_to(
             communicators, HPX_MOVE(gathered), this_site, broadcast_gen);
     }
 
-    // Non-root site overload
-    template <typename T>
-    hpx::future<std::vector<std::decay_t<T>>> all_gather_there(
-        hierarchical_communicator const& communicators, T&& local_result,
-        this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg())
-    {
-        using arg_type = std::decay_t<T>;
-
-        if (generation.is_default())
-        {
-            return hpx::make_exceptional_future<std::vector<arg_type>>(
-                HPX_GET_EXCEPTION(hpx::error::bad_parameter,
-                    "hpx::collectives::all_gather (hierarchical)",
-                    "hierarchical all_gather requires an explicit generation "
-                    "number for the 2k/2k+1 internal mapping"));
-        }
-
-        if (this_site.is_default())
-        {
-            this_site = agas::get_locality_id();
-        }
-
-        generation_arg const gather_gen(2 * generation);
-        generation_arg const broadcast_gen(2 * generation + 1);
-
-        // Phase 1: hierarchical gather (send up)
-        gather_there(hpx::launch::sync, communicators,
-            HPX_FORWARD(T, local_result), this_site, gather_gen);
-
-        // Phase 2: hierarchical broadcast (receive down) — receives vector<T>
-        return broadcast_from<std::vector<arg_type>>(
-            communicators, this_site, broadcast_gen);
-    }
-
-    ////////////////////////////////////////////////////////////////////////////
-    // Sync versions of hierarchical all_gather
+    // Sync version (Root site)
     template <typename T>
     std::vector<std::decay_t<T>> all_gather(hpx::launch::sync_policy,
         hierarchical_communicator const& communicators, T&& local_result,
@@ -479,16 +442,56 @@ namespace hpx::collectives {
             .get();
     }
 
-    template <typename T>
-    std::vector<std::decay_t<T>> all_gather_there(hpx::launch::sync_policy,
-        hierarchical_communicator const& communicators, T&& local_result,
-        this_site_arg const this_site = this_site_arg(),
-        generation_arg const generation = generation_arg())
-    {
-        return all_gather_there(communicators, HPX_FORWARD(T, local_result),
-            this_site, generation)
-            .get();
-    }
+
+    // --- INTERNAL API (Non-root site overloads) ---
+    namespace detail {
+
+        // Non-root site overload
+        template <typename T>
+        hpx::future<std::vector<std::decay_t<T>>> all_gather_there(
+            hierarchical_communicator const& communicators, T&& local_result,
+            this_site_arg this_site = this_site_arg(),
+            generation_arg const generation = generation_arg())
+        {
+            using arg_type = std::decay_t<T>;
+
+            if (generation.is_default())
+            {
+                return hpx::make_exceptional_future<std::vector<arg_type>>(
+                    HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                        "hpx::collectives::all_gather (hierarchical)",
+                        "hierarchical all_gather requires an explicit generation "
+                        "number for the 2k/2k+1 internal mapping"));
+            }
+
+            if (this_site.is_default())
+            {
+                this_site = agas::get_locality_id();
+            }
+
+            generation_arg const gather_gen(2 * generation);
+            generation_arg const broadcast_gen(2 * generation + 1);
+
+            gather_there(hpx::launch::sync, communicators,
+                HPX_FORWARD(T, local_result), this_site, gather_gen);
+
+            return broadcast_from<std::vector<arg_type>>(
+                communicators, this_site, broadcast_gen);
+        }
+
+        // Sync version (Non-root site)
+        template <typename T>
+        std::vector<std::decay_t<T>> all_gather_there(hpx::launch::sync_policy,
+            hierarchical_communicator const& communicators, T&& local_result,
+            this_site_arg const this_site = this_site_arg(),
+            generation_arg const generation = generation_arg())
+        {
+            return all_gather_there(communicators, HPX_FORWARD(T, local_result),
+                this_site, generation)
+                .get();
+        }
+
+    }    // namespace detail
 }    // namespace hpx::collectives
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libs/full/collectives/include/hpx/collectives/all_gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_gather.hpp
@@ -408,6 +408,15 @@ namespace hpx::collectives {
         }
 
         // Map user generation k to internal generations 2k, 2k+1
+        if (generation == generation_arg())
+        {
+            return hpx::make_exceptional_future<std::vector<arg_type>>(
+                HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                    "hpx::collectives::all_gather (hierarchical)",
+                    "hierarchical all_gather requires an explicit generation "
+                    "number for the 2k/2k+1 internal mapping"));
+        }
+
         std::size_t const k = generation;
         generation_arg const gather_gen(2 * k);
         generation_arg const broadcast_gen(2 * k + 1);
@@ -436,6 +445,15 @@ namespace hpx::collectives {
             this_site = agas::get_locality_id();
         }
 
+        if (generation == generation_arg())
+        {
+            return hpx::make_exceptional_future<std::vector<arg_type>>(
+                HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                    "hpx::collectives::all_gather (hierarchical)",
+                    "hierarchical all_gather requires an explicit generation "
+                    "number for the 2k/2k+1 internal mapping"));
+        }
+        
         std::size_t const k = generation;
         generation_arg const gather_gen(2 * k);
         generation_arg const broadcast_gen(2 * k + 1);

--- a/libs/full/collectives/include/hpx/collectives/all_gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_gather.hpp
@@ -422,8 +422,9 @@ namespace hpx::collectives {
 
         if (this_site == root_site)
         {
-            std::vector<arg_type> gathered = gather_here(hpx::launch::sync,
-                communicators, HPX_FORWARD(T, local_result), this_site, gather_gen);
+            std::vector<arg_type> gathered =
+                gather_here(hpx::launch::sync, communicators,
+                    HPX_FORWARD(T, local_result), this_site, gather_gen);
 
             return broadcast_to(
                 communicators, HPX_MOVE(gathered), this_site, broadcast_gen);

--- a/libs/full/collectives/include/hpx/collectives/all_gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_gather.hpp
@@ -393,14 +393,13 @@ namespace hpx::collectives {
     // Key difference from all_reduce: the gather phase produces vector<T>
     // (O(N) data), so the broadcast phase transfers O(N) instead of a scalar.
 
-    // --- PUBLIC API (Root site overloads) ---
-
-    // Root site overload
+    // Async overload
     template <typename T>
     hpx::future<std::vector<std::decay_t<T>>> all_gather(
         hierarchical_communicator const& communicators, T&& local_result,
         this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg())
+        generation_arg const generation = generation_arg(),
+        root_site_arg root_site = root_site_arg())
     {
         using arg_type = std::decay_t<T>;
 
@@ -421,75 +420,36 @@ namespace hpx::collectives {
         generation_arg const gather_gen(2 * generation);
         generation_arg const broadcast_gen(2 * generation + 1);
 
-        std::vector<arg_type> gathered = gather_here(hpx::launch::sync,
-            communicators, HPX_FORWARD(T, local_result), this_site, gather_gen);
-
-        return broadcast_to(
-            communicators, HPX_MOVE(gathered), this_site, broadcast_gen);
-    }
-
-    // Sync version (Root site)
-    template <typename T>
-    std::vector<std::decay_t<T>> all_gather(hpx::launch::sync_policy,
-        hierarchical_communicator const& communicators, T&& local_result,
-        this_site_arg const this_site = this_site_arg(),
-        generation_arg const generation = generation_arg())
-    {
-        return all_gather(
-            communicators, HPX_FORWARD(T, local_result), this_site, generation)
-            .get();
-    }
-
-    // --- INTERNAL API (Non-root site overloads) ---
-    namespace detail {
-
-        // Non-root site overload
-        template <typename T>
-        hpx::future<std::vector<std::decay_t<T>>> all_gather_there(
-            hierarchical_communicator const& communicators, T&& local_result,
-            this_site_arg this_site = this_site_arg(),
-            generation_arg const generation = generation_arg())
+        if (this_site.get() == root_site.get())
         {
-            using arg_type = std::decay_t<T>;
+            std::vector<arg_type> gathered = gather_here(hpx::launch::sync,
+                communicators, HPX_FORWARD(T, local_result), this_site, gather_gen);
 
-            if (generation.is_default())
-            {
-                return hpx::make_exceptional_future<
-                    std::vector<arg_type>>(HPX_GET_EXCEPTION(
-                    hpx::error::bad_parameter,
-                    "hpx::collectives::all_gather (hierarchical)",
-                    "hierarchical all_gather requires an explicit generation "
-                    "number for the 2k/2k+1 internal mapping"));
-            }
-
-            if (this_site.is_default())
-            {
-                this_site = agas::get_locality_id();
-            }
-
-            generation_arg const gather_gen(2 * generation);
-            generation_arg const broadcast_gen(2 * generation + 1);
-
+            return broadcast_to(
+                communicators, HPX_MOVE(gathered), this_site, broadcast_gen);
+        }
+        else
+        {
             gather_there(hpx::launch::sync, communicators,
                 HPX_FORWARD(T, local_result), this_site, gather_gen);
 
             return broadcast_from<std::vector<arg_type>>(
                 communicators, this_site, broadcast_gen);
         }
+    }
 
-        // Sync version (Non-root site)
-        template <typename T>
-        std::vector<std::decay_t<T>> all_gather_there(hpx::launch::sync_policy,
-            hierarchical_communicator const& communicators, T&& local_result,
-            this_site_arg const this_site = this_site_arg(),
-            generation_arg const generation = generation_arg())
-        {
-            return all_gather_there(communicators, HPX_FORWARD(T, local_result),
-                this_site, generation)
-                .get();
-        }
-
-    }    // namespace detail
+    // Sync version
+    template <typename T>
+    std::vector<std::decay_t<T>> all_gather(hpx::launch::sync_policy,
+        hierarchical_communicator const& communicators, T&& local_result,
+        this_site_arg const this_site = this_site_arg(),
+        generation_arg const generation = generation_arg(),
+        root_site_arg root_site = root_site_arg())
+    {
+        return all_gather(communicators, HPX_FORWARD(T, local_result),
+            this_site, generation, root_site)
+            .get();
+    }
 }    // namespace hpx::collectives
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libs/full/collectives/include/hpx/collectives/all_gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_gather.hpp
@@ -212,7 +212,10 @@ namespace hpx { namespace collectives {
 
 #include <hpx/async_distributed/async.hpp>
 #include <hpx/collectives/argument_types.hpp>
+#include <hpx/collectives/broadcast.hpp>
 #include <hpx/collectives/create_communicator.hpp>
+#include <hpx/collectives/gather.hpp>
+#include <hpx/components_base/agas_interface.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/futures.hpp>
@@ -379,6 +382,94 @@ namespace hpx::collectives {
         return all_gather(create_communicator(basename, num_sites, this_site,
                               generation, root_site),
             HPX_FORWARD(T, local_result), this_site)
+            .get();
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Hierarchical all_gather: gather (bottom-up) + broadcast (top-down)
+    // Uses 2k/2k+1 generation mapping: user generation k maps to
+    // internal generation 2k (gather phase) and 2k+1 (broadcast phase)
+    //
+    // Key difference from all_reduce: the gather phase produces vector<T>
+    // (O(N) data), so the broadcast phase transfers O(N) instead of a scalar.
+
+    // Root site overload
+    template <typename T>
+    hpx::future<std::vector<std::decay_t<T>>> all_gather(
+        hierarchical_communicator const& communicators, T&& local_result,
+        this_site_arg this_site = this_site_arg(),
+        generation_arg const generation = generation_arg())
+    {
+        using arg_type = std::decay_t<T>;
+
+        if (this_site.is_default())
+        {
+            this_site = agas::get_locality_id();
+        }
+
+        // Map user generation k to internal generations 2k, 2k+1
+        std::size_t const k = generation;
+        generation_arg const gather_gen(2 * k);
+        generation_arg const broadcast_gen(2 * k + 1);
+
+        // Phase 1: hierarchical gather (bottom-up) — produces vector<T>
+        std::vector<arg_type> gathered = gather_here(hpx::launch::sync,
+            communicators, HPX_FORWARD(T, local_result), this_site,
+            gather_gen);
+
+        // Phase 2: hierarchical broadcast (top-down) — sends vector<T>
+        return broadcast_to(
+            communicators, HPX_MOVE(gathered), this_site, broadcast_gen);
+    }
+
+    // Non-root site overload
+    template <typename T>
+    hpx::future<std::vector<std::decay_t<T>>> all_gather_there(
+        hierarchical_communicator const& communicators, T&& local_result,
+        this_site_arg this_site = this_site_arg(),
+        generation_arg const generation = generation_arg())
+    {
+        using arg_type = std::decay_t<T>;
+
+        if (this_site.is_default())
+        {
+            this_site = agas::get_locality_id();
+        }
+
+        std::size_t const k = generation;
+        generation_arg const gather_gen(2 * k);
+        generation_arg const broadcast_gen(2 * k + 1);
+
+        // Phase 1: hierarchical gather (send up)
+        gather_there(hpx::launch::sync, communicators,
+            HPX_FORWARD(T, local_result), this_site, gather_gen);
+
+        // Phase 2: hierarchical broadcast (receive down) — receives vector<T>
+        return broadcast_from<std::vector<arg_type>>(
+            communicators, this_site, broadcast_gen);
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Sync versions of hierarchical all_gather
+    template <typename T>
+    std::vector<std::decay_t<T>> all_gather(hpx::launch::sync_policy,
+        hierarchical_communicator const& communicators, T&& local_result,
+        this_site_arg const this_site = this_site_arg(),
+        generation_arg const generation = generation_arg())
+    {
+        return all_gather(communicators, HPX_FORWARD(T, local_result),
+            this_site, generation)
+            .get();
+    }
+
+    template <typename T>
+    std::vector<std::decay_t<T>> all_gather_there(hpx::launch::sync_policy,
+        hierarchical_communicator const& communicators, T&& local_result,
+        this_site_arg const this_site = this_site_arg(),
+        generation_arg const generation = generation_arg())
+    {
+        return all_gather_there(communicators, HPX_FORWARD(T, local_result),
+            this_site, generation)
             .get();
     }
 }    // namespace hpx::collectives

--- a/libs/full/collectives/include/hpx/collectives/all_gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_gather.hpp
@@ -417,8 +417,8 @@ namespace hpx::collectives {
             this_site = agas::get_locality_id();
         }
 
-        generation_arg const gather_gen(2 * generation);
-        generation_arg const broadcast_gen(2 * generation + 1);
+        generation_arg const gather_gen(2 * generation - 1);
+        generation_arg const broadcast_gen(2 * generation);
 
         if (this_site == root_site)
         {

--- a/libs/full/collectives/include/hpx/collectives/all_gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_gather.hpp
@@ -418,9 +418,8 @@ namespace hpx::collectives {
                     "number for the 2k/2k+1 internal mapping"));
         }
 
-        std::size_t const k = generation;
-        generation_arg const gather_gen(2 * k);
-        generation_arg const broadcast_gen(2 * k + 1);
+        generation_arg const gather_gen(2 * generation);
+        generation_arg const broadcast_gen(2 * generation + 1);
 
         // Phase 1: hierarchical gather (bottom-up) — produces vector<T>
         std::vector<arg_type> gathered = gather_here(hpx::launch::sync,
@@ -455,9 +454,8 @@ namespace hpx::collectives {
                     "number for the 2k/2k+1 internal mapping"));
         }
 
-        std::size_t const k = generation;
-        generation_arg const gather_gen(2 * k);
-        generation_arg const broadcast_gen(2 * k + 1);
+        generation_arg const gather_gen(2 * generation);
+        generation_arg const broadcast_gen(2 * generation + 1);
 
         // Phase 1: hierarchical gather (send up)
         gather_there(hpx::launch::sync, communicators,

--- a/libs/full/collectives/include/hpx/collectives/all_gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_gather.hpp
@@ -403,11 +403,6 @@ namespace hpx::collectives {
     {
         using arg_type = std::decay_t<T>;
 
-        if (this_site.is_default())
-        {
-            this_site = agas::get_locality_id();
-        }
-
         // Map user generation k to internal generations 2k, 2k+1
         if (generation.is_default())
         {
@@ -416,6 +411,11 @@ namespace hpx::collectives {
                     "hpx::collectives::all_gather (hierarchical)",
                     "hierarchical all_gather requires an explicit generation "
                     "number for the 2k/2k+1 internal mapping"));
+        }
+
+        if (this_site.is_default())
+        {
+            this_site = agas::get_locality_id();
         }
 
         generation_arg const gather_gen(2 * generation);
@@ -440,11 +440,6 @@ namespace hpx::collectives {
     {
         using arg_type = std::decay_t<T>;
 
-        if (this_site.is_default())
-        {
-            this_site = agas::get_locality_id();
-        }
-
         if (generation.is_default())
         {
             return hpx::make_exceptional_future<std::vector<arg_type>>(
@@ -452,6 +447,11 @@ namespace hpx::collectives {
                     "hpx::collectives::all_gather (hierarchical)",
                     "hierarchical all_gather requires an explicit generation "
                     "number for the 2k/2k+1 internal mapping"));
+        }
+
+        if (this_site.is_default())
+        {
+            this_site = agas::get_locality_id();
         }
 
         generation_arg const gather_gen(2 * generation);

--- a/libs/full/collectives/include/hpx/collectives/all_gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_gather.hpp
@@ -409,7 +409,7 @@ namespace hpx::collectives {
         }
 
         // Map user generation k to internal generations 2k, 2k+1
-        if (generation == generation_arg())
+        if (generation.is_default())
         {
             return hpx::make_exceptional_future<std::vector<arg_type>>(
                 HPX_GET_EXCEPTION(hpx::error::bad_parameter,
@@ -446,7 +446,7 @@ namespace hpx::collectives {
             this_site = agas::get_locality_id();
         }
 
-        if (generation == generation_arg())
+        if (generation.is_default())
         {
             return hpx::make_exceptional_future<std::vector<arg_type>>(
                 HPX_GET_EXCEPTION(hpx::error::bad_parameter,

--- a/libs/full/collectives/include/hpx/collectives/all_gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_gather.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2019-2025 Hartmut Kaiser
+//  Copyright (c) 2026 Anshuman Agrawal
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -453,7 +454,7 @@ namespace hpx::collectives {
                     "hierarchical all_gather requires an explicit generation "
                     "number for the 2k/2k+1 internal mapping"));
         }
-        
+
         std::size_t const k = generation;
         generation_arg const gather_gen(2 * k);
         generation_arg const broadcast_gen(2 * k + 1);

--- a/libs/full/collectives/include/hpx/collectives/all_gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_gather.hpp
@@ -216,7 +216,6 @@ namespace hpx { namespace collectives {
 #include <hpx/collectives/broadcast.hpp>
 #include <hpx/collectives/create_communicator.hpp>
 #include <hpx/collectives/gather.hpp>
-#include <hpx/components_base/agas_interface.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/futures.hpp>

--- a/libs/full/collectives/include/hpx/collectives/all_gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_gather.hpp
@@ -422,21 +422,26 @@ namespace hpx::collectives {
 
         if (this_site == root_site)
         {
-            std::vector<arg_type> gathered = gather_here(communicators,
-                HPX_FORWARD(T, local_result), this_site, gather_gen)
-                                                 .get();
+            auto gather_fut = gather_here(communicators,
+                HPX_FORWARD(T, local_result), this_site, gather_gen);
 
-            return broadcast_to(
-                communicators, HPX_MOVE(gathered), this_site, broadcast_gen);
+            return gather_fut.then(hpx::launch::sync,
+                [communicators, this_site, broadcast_gen](auto f) {
+                    return broadcast_to(
+                        communicators, f.get(), this_site, broadcast_gen);
+                });
         }
         else
         {
-            gather_there(communicators, HPX_FORWARD(T, local_result), this_site,
-                gather_gen)
-                .get();
+            auto gather_fut = gather_there(communicators,
+                HPX_FORWARD(T, local_result), this_site, gather_gen);
 
-            return broadcast_from<std::vector<arg_type>>(
-                communicators, this_site, broadcast_gen);
+            return gather_fut.then(hpx::launch::sync,
+                [communicators, this_site, broadcast_gen](auto f) {
+                    f.get();    // Propagate any exceptions from gather phase
+                    return broadcast_from<std::vector<arg_type>>(
+                        communicators, this_site, broadcast_gen);
+                });
         }
     }
 

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -428,31 +428,6 @@ namespace hpx::collectives {
     }
 
     ////////////////////////////////////////////////////////////////////////////
-    // Helper: lift a scalar reduction op to work element-wise on vectors
-    namespace detail {
-
-        template <typename F>
-        struct vector_reduce_op
-        {
-            F op_;
-
-            template <typename T>
-            std::vector<T> operator()(
-                std::vector<T> const& lhs, std::vector<T> const& rhs) const
-            {
-                HPX_ASSERT(lhs.size() == rhs.size());
-                std::vector<T> result;
-                result.reserve(lhs.size());
-                for (std::size_t i = 0; i != lhs.size(); ++i)
-                {
-                    result.push_back(HPX_INVOKE(op_, lhs[i], rhs[i]));
-                }
-                return result;
-            }
-        };
-    }    // namespace detail
-
-    ////////////////////////////////////////////////////////////////////////////
     // Hierarchical all_reduce: reduce (bottom-up) + broadcast (top-down)
     // Uses 2k/2k+1 generation mapping: user generation k maps to
     // internal generation 2k (reduce phase) and 2k+1 (broadcast phase)
@@ -500,54 +475,6 @@ namespace hpx::collectives {
                 reduce_gen);
 
             return broadcast_from<arg_type>(
-                communicators, this_site, broadcast_gen);
-        }
-    }
-
-    // Vector overload
-    template <typename T, typename F>
-    hpx::future<std::vector<T>> all_reduce(
-        hierarchical_communicator const& communicators,
-        std::vector<T>&& local_result, F&& op,
-        this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg(),
-        root_site_arg root_site = root_site_arg())
-    {
-        if (generation.is_default())
-        {
-            return hpx::make_exceptional_future<std::vector<T>>(
-                HPX_GET_EXCEPTION(hpx::error::bad_parameter,
-                    "hpx::collectives::all_reduce (hierarchical, vector)",
-                    "hierarchical all_reduce requires an explicit generation "
-                    "number for the 2k/2k+1 internal mapping"));
-        }
-
-        if (this_site.is_default())
-        {
-            this_site = agas::get_locality_id();
-        }
-
-        generation_arg const reduce_gen(2 * generation);
-        generation_arg const broadcast_gen(2 * generation + 1);
-
-        detail::vector_reduce_op<std::decay_t<F>> vec_op{HPX_FORWARD(F, op)};
-
-        if (this_site == root_site)
-        {
-            std::vector<T> reduced = reduce_here(hpx::launch::sync,
-                communicators, HPX_MOVE(local_result), HPX_MOVE(vec_op),
-                this_site, reduce_gen);
-
-            return broadcast_to(
-                communicators, HPX_MOVE(reduced), this_site, broadcast_gen);
-        }
-        else
-        {
-            reduce_there(hpx::launch::sync, communicators,
-                HPX_MOVE(local_result), HPX_MOVE(vec_op), this_site,
-                reduce_gen);
-
-            return broadcast_from<std::vector<T>>(
                 communicators, this_site, broadcast_gen);
         }
     }

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -433,11 +433,12 @@ namespace hpx::collectives {
     // Helper: lift a scalar reduction op to work element-wise on vectors
     namespace detail {
 
-        template <typename T, typename F>
+        template <typename F>
         struct vector_reduce_op
         {
             F op_;
 
+            template <typename T>
             std::vector<T> operator()(
                 std::vector<T> const& lhs, std::vector<T> const& rhs) const
             {
@@ -446,7 +447,7 @@ namespace hpx::collectives {
                 result.reserve(lhs.size());
                 for (std::size_t i = 0; i != lhs.size(); ++i)
                 {
-                    result.push_back(op_(lhs[i], rhs[i]));
+                    result.push_back(HPX_INVOKE(op_, lhs[i], rhs[i]));
                 }
                 return result;
             }
@@ -566,7 +567,7 @@ namespace hpx::collectives {
         generation_arg const broadcast_gen(2 * k + 1);
 
         // Lift scalar op to element-wise vector op
-        detail::vector_reduce_op<T, std::decay_t<F>> vec_op{
+        detail::vector_reduce_op<std::decay_t<F>> vec_op{
             HPX_FORWARD(F, op)};
 
         // Phase 1: hierarchical reduce (bottom-up) with vector op
@@ -605,7 +606,7 @@ namespace hpx::collectives {
         generation_arg const reduce_gen(2 * k);
         generation_arg const broadcast_gen(2 * k + 1);
 
-        detail::vector_reduce_op<T, std::decay_t<F>> vec_op{
+        detail::vector_reduce_op<std::decay_t<F>> vec_op{
             HPX_FORWARD(F, op)};
 
         // Phase 1: hierarchical reduce (send up)

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -232,7 +232,7 @@ namespace hpx { namespace collectives {
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/type_support.hpp>
-
+#include <hpx/functional/invoke.hpp>
 #include <cstddef>
 #include <type_traits>
 #include <utility>

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -534,8 +534,8 @@ namespace hpx::collectives {
 
         if (this_site == root_site)
         {
-            std::vector<T> reduced = reduce_here(hpx::launch::sync, communicators,
-                HPX_MOVE(local_result), HPX_MOVE(vec_op),
+            std::vector<T> reduced = reduce_here(hpx::launch::sync,
+                communicators, HPX_MOVE(local_result), HPX_MOVE(vec_op),
                 this_site, reduce_gen);
 
             return broadcast_to(

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2019-2025 Hartmut Kaiser
+//  Copyright (c) 2026 Anshuman Agrawal
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -468,11 +468,6 @@ namespace hpx::collectives {
     {
         using arg_type = std::decay_t<T>;
 
-        if (this_site.is_default())
-        {
-            this_site = agas::get_locality_id();
-        }
-
         // Hierarchical all_reduce requires explicit generation for 2k/2k+1
         if (generation.is_default())
         {
@@ -481,6 +476,11 @@ namespace hpx::collectives {
                 "hpx::collectives::all_reduce (hierarchical)",
                 "hierarchical all_reduce requires an explicit generation "
                 "number for the 2k/2k+1 internal mapping"));
+        }
+
+        if (this_site.is_default())
+        {
+            this_site = agas::get_locality_id();
         }
 
         // Map user generation k to internal generations 2k, 2k+1
@@ -508,11 +508,6 @@ namespace hpx::collectives {
         {
             using arg_type = std::decay_t<T>;
 
-            if (this_site.is_default())
-            {
-                this_site = agas::get_locality_id();
-            }
-
             if (generation.is_default())
             {
                 return hpx::make_exceptional_future<arg_type>(HPX_GET_EXCEPTION(
@@ -521,6 +516,12 @@ namespace hpx::collectives {
                     "hierarchical all_reduce requires an explicit generation "
                     "number for the 2k/2k+1 internal mapping"));
             }
+
+            if (this_site.is_default())
+            {
+                this_site = agas::get_locality_id();
+            }
+ 
 
             generation_arg const reduce_gen(2 * generation);
             generation_arg const broadcast_gen(2 * generation + 1);
@@ -549,11 +550,6 @@ namespace hpx::collectives {
         this_site_arg this_site = this_site_arg(),
         generation_arg const generation = generation_arg())
     {
-        if (this_site.is_default())
-        {
-            this_site = agas::get_locality_id();
-        }
-
         if (generation.is_default())
         {
             return hpx::make_exceptional_future<std::vector<T>>(
@@ -561,6 +557,11 @@ namespace hpx::collectives {
                     "hpx::collectives::all_reduce (hierarchical, vector)",
                     "hierarchical all_reduce requires an explicit generation "
                     "number for the 2k/2k+1 internal mapping"));
+        }
+
+        if (this_site.is_default())
+        {
+            this_site = agas::get_locality_id();
         }
 
         generation_arg const reduce_gen(2 * generation);
@@ -588,11 +589,6 @@ namespace hpx::collectives {
         this_site_arg this_site = this_site_arg(),
         generation_arg const generation = generation_arg())
     {
-        if (this_site.is_default())
-        {
-            this_site = agas::get_locality_id();
-        }
-
         if (generation.is_default())
         {
             return hpx::make_exceptional_future<std::vector<T>>(
@@ -601,6 +597,11 @@ namespace hpx::collectives {
                     "hierarchical all_reduce requires an explicit generation "
                     "number for the 2k/2k+1 internal mapping"));
         }
+        
+        if (this_site.is_default())
+        {
+            this_site = agas::get_locality_id();
+        } 
 
         generation_arg const reduce_gen(2 * generation);
         generation_arg const broadcast_gen(2 * generation + 1);

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -461,16 +461,19 @@ namespace hpx::collectives {
 
         if (this_site == root_site)
         {
-            arg_type reduced = reduce_here(hpx::launch::sync, communicators,
-                HPX_FORWARD(T, local_result), this_site, reduce_gen);
+            arg_type reduced =
+                reduce_here(communicators, HPX_FORWARD(T, local_result),
+                    HPX_FORWARD(F, op), this_site, reduce_gen)
+                    .get();
 
             return broadcast_to(
                 communicators, HPX_MOVE(reduced), this_site, broadcast_gen);
         }
         else
         {
-            reduce_there(hpx::launch::sync, communicators,
-                HPX_FORWARD(T, local_result), this_site, reduce_gen);
+            reduce_there(communicators, HPX_FORWARD(T, local_result),
+                HPX_FORWARD(F, op), this_site, reduce_gen)
+                .get();
 
             return broadcast_from<arg_type>(
                 communicators, this_site, broadcast_gen);

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -457,14 +457,13 @@ namespace hpx::collectives {
     // Uses 2k/2k+1 generation mapping: user generation k maps to
     // internal generation 2k (reduce phase) and 2k+1 (broadcast phase)
 
-    // --- PUBLIC API (Root site overloads) ---
-
-    // Root site overload (scalar)
+    // Scalar overload
     template <typename T, typename F>
     hpx::future<std::decay_t<T>> all_reduce(
         hierarchical_communicator const& communicators, T&& local_result,
         F&& op, this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg())
+        generation_arg const generation = generation_arg(),
+        root_site_arg root_site = root_site_arg())
     {
         using arg_type = std::decay_t<T>;
 
@@ -485,21 +484,34 @@ namespace hpx::collectives {
         generation_arg const reduce_gen(2 * generation);
         generation_arg const broadcast_gen(2 * generation + 1);
 
-        arg_type reduced = reduce_here(hpx::launch::sync, communicators,
-            HPX_FORWARD(T, local_result), HPX_FORWARD(F, op), this_site,
-            reduce_gen);
+        if (this_site.get() == root_site.get())
+        {
+            arg_type reduced = reduce_here(hpx::launch::sync, communicators,
+                HPX_FORWARD(T, local_result), HPX_FORWARD(F, op), this_site,
+                reduce_gen);
 
-        return broadcast_to(
-            communicators, HPX_MOVE(reduced), this_site, broadcast_gen);
+            return broadcast_to(
+                communicators, HPX_MOVE(reduced), this_site, broadcast_gen);
+        }
+        else
+        {
+            reduce_there(hpx::launch::sync, communicators,
+                HPX_FORWARD(T, local_result), HPX_FORWARD(F, op), this_site,
+                reduce_gen);
+
+            return broadcast_from<arg_type>(
+                communicators, this_site, broadcast_gen);
+        }
     }
 
-    // Root site overload (vector)
+    // Vector overload
     template <typename T, typename F>
     hpx::future<std::vector<T>> all_reduce(
         hierarchical_communicator const& communicators,
         std::vector<T>&& local_result, F&& op,
         this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg())
+        generation_arg const generation = generation_arg(),
+        root_site_arg root_site = root_site_arg())
     {
         if (generation.is_default())
         {
@@ -520,90 +532,17 @@ namespace hpx::collectives {
 
         detail::vector_reduce_op<std::decay_t<F>> vec_op{HPX_FORWARD(F, op)};
 
-        std::vector<T> reduced = reduce_here(hpx::launch::sync, communicators,
-            HPX_MOVE(local_result), HPX_MOVE(vec_op), this_site, reduce_gen);
-
-        return broadcast_to(
-            communicators, HPX_MOVE(reduced), this_site, broadcast_gen);
-    }
-
-    // Sync version (Root site)
-    template <typename T, typename F>
-    std::decay_t<T> all_reduce(hpx::launch::sync_policy,
-        hierarchical_communicator const& communicators, T&& local_result,
-        F&& op, this_site_arg const this_site = this_site_arg(),
-        generation_arg const generation = generation_arg())
-    {
-        return all_reduce(communicators, HPX_FORWARD(T, local_result),
-            HPX_FORWARD(F, op), this_site, generation)
-            .get();
-    }
-
-    // --- INTERNAL API (Non-root site overloads) ---
-    namespace detail {
-
-        // Non-root site overload (scalar)
-        template <typename T, typename F>
-        hpx::future<std::decay_t<T>> all_reduce_there(
-            hierarchical_communicator const& communicators, T&& local_result,
-            F&& op, this_site_arg this_site = this_site_arg(),
-            generation_arg const generation = generation_arg())
+        if (this_site.get() == root_site.get())
         {
-            using arg_type = std::decay_t<T>;
+            std::vector<T> reduced = reduce_here(hpx::launch::sync, communicators,
+                HPX_MOVE(local_result), HPX_MOVE(vec_op),
+                this_site, reduce_gen);
 
-            if (generation.is_default())
-            {
-                return hpx::make_exceptional_future<arg_type>(HPX_GET_EXCEPTION(
-                    hpx::error::bad_parameter,
-                    "hpx::collectives::all_reduce_there (hierarchical)",
-                    "hierarchical all_reduce requires an explicit generation "
-                    "number for the 2k/2k+1 internal mapping"));
-            }
-
-            if (this_site.is_default())
-            {
-                this_site = agas::get_locality_id();
-            }
-
-            generation_arg const reduce_gen(2 * generation);
-            generation_arg const broadcast_gen(2 * generation + 1);
-
-            reduce_there(hpx::launch::sync, communicators,
-                HPX_FORWARD(T, local_result), HPX_FORWARD(F, op), this_site,
-                reduce_gen);
-
-            return broadcast_from<arg_type>(
-                communicators, this_site, broadcast_gen);
+            return broadcast_to(
+                communicators, HPX_MOVE(reduced), this_site, broadcast_gen);
         }
-
-        // Non-root site overload (vector)
-        template <typename T, typename F>
-        hpx::future<std::vector<T>> all_reduce_there(
-            hierarchical_communicator const& communicators,
-            std::vector<T>&& local_result, F&& op,
-            this_site_arg this_site = this_site_arg(),
-            generation_arg const generation = generation_arg())
+        else
         {
-            if (generation.is_default())
-            {
-                return hpx::make_exceptional_future<
-                    std::vector<T>>(HPX_GET_EXCEPTION(hpx::error::bad_parameter,
-                    "hpx::collectives::all_reduce_there (hierarchical, vector)",
-                    "hierarchical all_reduce requires an explicit generation "
-                    "number for the 2k/2k+1 internal mapping"));
-            }
-
-            if (this_site.is_default())
-            {
-                this_site = agas::get_locality_id();
-            }
-
-            generation_arg const reduce_gen(2 * generation);
-            generation_arg const broadcast_gen(2 * generation + 1);
-
-            detail::vector_reduce_op<std::decay_t<F>> vec_op{
-                HPX_FORWARD(F, op)};
-
             reduce_there(hpx::launch::sync, communicators,
                 HPX_MOVE(local_result), HPX_MOVE(vec_op), this_site,
                 reduce_gen);
@@ -611,20 +550,20 @@ namespace hpx::collectives {
             return broadcast_from<std::vector<T>>(
                 communicators, this_site, broadcast_gen);
         }
+    }
 
-        // Sync version (Non-root site)
-        template <typename T, typename F>
-        std::decay_t<T> all_reduce_there(hpx::launch::sync_policy,
-            hierarchical_communicator const& communicators, T&& local_result,
-            F&& op, this_site_arg const this_site = this_site_arg(),
-            generation_arg const generation = generation_arg())
-        {
-            return all_reduce_there(communicators, HPX_FORWARD(T, local_result),
-                HPX_FORWARD(F, op), this_site, generation)
-                .get();
-        }
-
-    }    // namespace detail
+    // Sync version
+    template <typename T, typename F>
+    std::decay_t<T> all_reduce(hpx::launch::sync_policy,
+        hierarchical_communicator const& communicators, T&& local_result,
+        F&& op, this_site_arg const this_site = this_site_arg(),
+        generation_arg const generation = generation_arg(),
+        root_site_arg root_site = root_site_arg())
+    {
+        return all_reduce(communicators, HPX_FORWARD(T, local_result),
+            HPX_FORWARD(F, op), this_site, generation, root_site)
+            .get();
+    }
 }    // namespace hpx::collectives
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -484,7 +484,7 @@ namespace hpx::collectives {
         generation_arg const reduce_gen(2 * generation);
         generation_arg const broadcast_gen(2 * generation + 1);
 
-        if (this_site.get() == root_site.get())
+        if (this_site == root_site)
         {
             arg_type reduced = reduce_here(hpx::launch::sync, communicators,
                 HPX_FORWARD(T, local_result), HPX_FORWARD(F, op), this_site,
@@ -532,7 +532,7 @@ namespace hpx::collectives {
 
         detail::vector_reduce_op<std::decay_t<F>> vec_op{HPX_FORWARD(F, op)};
 
-        if (this_site.get() == root_site.get())
+        if (this_site == root_site)
         {
             std::vector<T> reduced = reduce_here(hpx::launch::sync, communicators,
                 HPX_MOVE(local_result), HPX_MOVE(vec_op),

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -471,11 +471,11 @@ namespace hpx::collectives {
 
         if (generation.is_default())
         {
-            return hpx::make_exceptional_future<arg_type>(HPX_GET_EXCEPTION(
-                hpx::error::bad_parameter,
-                "hpx::collectives::all_reduce (hierarchical)",
-                "hierarchical all_reduce requires an explicit generation "
-                "number for the 2k/2k+1 internal mapping"));
+            return hpx::make_exceptional_future<arg_type>(
+                HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                    "hpx::collectives::all_reduce (hierarchical)",
+                    "hierarchical all_reduce requires an explicit generation "
+                    "number for the 2k/2k+1 internal mapping"));
         }
 
         if (this_site.is_default())
@@ -521,9 +521,8 @@ namespace hpx::collectives {
 
         detail::vector_reduce_op<std::decay_t<F>> vec_op{HPX_FORWARD(F, op)};
 
-        std::vector<T> reduced = reduce_here(hpx::launch::sync,
-            communicators, HPX_MOVE(local_result), HPX_MOVE(vec_op),
-            this_site, reduce_gen);
+        std::vector<T> reduced = reduce_here(hpx::launch::sync, communicators,
+            HPX_MOVE(local_result), HPX_MOVE(vec_op), this_site, reduce_gen);
 
         return broadcast_to(
             communicators, HPX_MOVE(reduced), this_site, broadcast_gen);
@@ -540,7 +539,6 @@ namespace hpx::collectives {
             HPX_FORWARD(F, op), this_site, generation)
             .get();
     }
-
 
     // --- INTERNAL API (Non-root site overloads) ---
     namespace detail {
@@ -589,17 +587,17 @@ namespace hpx::collectives {
         {
             if (generation.is_default())
             {
-                return hpx::make_exceptional_future<std::vector<T>>(
-                    HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                return hpx::make_exceptional_future<
+                    std::vector<T>>(HPX_GET_EXCEPTION(hpx::error::bad_parameter,
                     "hpx::collectives::all_reduce_there (hierarchical, vector)",
                     "hierarchical all_reduce requires an explicit generation "
                     "number for the 2k/2k+1 internal mapping"));
             }
-            
+
             if (this_site.is_default())
             {
                 this_site = agas::get_locality_id();
-            } 
+            }
 
             generation_arg const reduce_gen(2 * generation);
             generation_arg const broadcast_gen(2 * generation + 1);

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -222,7 +222,10 @@ namespace hpx { namespace collectives {
 #include <hpx/assert.hpp>
 #include <hpx/async_distributed/async.hpp>
 #include <hpx/collectives/argument_types.hpp>
+#include <hpx/collectives/broadcast.hpp>
 #include <hpx/collectives/create_communicator.hpp>
+#include <hpx/collectives/reduce.hpp>
+#include <hpx/components_base/agas_interface.hpp>
 #include <hpx/modules/algorithms.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/components_base.hpp>
@@ -232,6 +235,7 @@ namespace hpx { namespace collectives {
 #include <cstddef>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 namespace hpx::traits {
 
@@ -421,6 +425,182 @@ namespace hpx::collectives {
         return all_reduce(create_communicator(basename, num_sites, this_site,
                               generation, root_site),
             HPX_FORWARD(T, local_result), HPX_FORWARD(F, op), this_site)
+            .get();
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Helper: lift a scalar reduction op to work element-wise on vectors
+    namespace detail {
+
+        template <typename T, typename F>
+        struct vector_reduce_op
+        {
+            F op_;
+
+            std::vector<T> operator()(
+                std::vector<T> const& lhs, std::vector<T> const& rhs) const
+            {
+                HPX_ASSERT(lhs.size() == rhs.size());
+                std::vector<T> result;
+                result.reserve(lhs.size());
+                for (std::size_t i = 0; i != lhs.size(); ++i)
+                {
+                    result.push_back(op_(lhs[i], rhs[i]));
+                }
+                return result;
+            }
+        };
+    }    // namespace detail
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Hierarchical all_reduce: reduce (bottom-up) + broadcast (top-down)
+    // Uses 2k/2k+1 generation mapping: user generation k maps to
+    // internal generation 2k (reduce phase) and 2k+1 (broadcast phase)
+
+    // Root site overload
+    template <typename T, typename F>
+    hpx::future<std::decay_t<T>> all_reduce(
+        hierarchical_communicator const& communicators, T&& local_result,
+        F&& op, this_site_arg this_site = this_site_arg(),
+        generation_arg const generation = generation_arg())
+    {
+        using arg_type = std::decay_t<T>;
+
+        if (this_site.is_default())
+        {
+            this_site = agas::get_locality_id();
+        }
+
+        // Map user generation k to internal generations 2k, 2k+1
+        std::size_t const k = generation;
+        generation_arg const reduce_gen(2 * k);
+        generation_arg const broadcast_gen(2 * k + 1);
+
+        // Phase 1: hierarchical reduce (bottom-up)
+        arg_type reduced = reduce_here(hpx::launch::sync, communicators,
+            HPX_FORWARD(T, local_result), HPX_FORWARD(F, op), this_site,
+            reduce_gen);
+
+        // Phase 2: hierarchical broadcast (top-down)
+        return broadcast_to(
+            communicators, HPX_MOVE(reduced), this_site, broadcast_gen);
+    }
+
+    // Non-root site overload
+    template <typename T, typename F>
+    hpx::future<std::decay_t<T>> all_reduce_there(
+        hierarchical_communicator const& communicators, T&& local_result,
+        F&& op, this_site_arg this_site = this_site_arg(),
+        generation_arg const generation = generation_arg())
+    {
+        using arg_type = std::decay_t<T>;
+
+        if (this_site.is_default())
+        {
+            this_site = agas::get_locality_id();
+        }
+
+        std::size_t const k = generation;
+        generation_arg const reduce_gen(2 * k);
+        generation_arg const broadcast_gen(2 * k + 1);
+
+        // Phase 1: hierarchical reduce (send up)
+        reduce_there(hpx::launch::sync, communicators,
+            HPX_FORWARD(T, local_result), HPX_FORWARD(F, op), this_site,
+            reduce_gen);
+
+        // Phase 2: hierarchical broadcast (receive down)
+        return broadcast_from<arg_type>(
+            communicators, this_site, broadcast_gen);
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Hierarchical all_reduce for vector types
+    // Wraps a scalar op (e.g. std::plus<int>) to work element-wise on
+    // vector<T> before passing to reduce_here/reduce_there
+
+    // Root site, vector overload
+    template <typename T, typename F>
+    hpx::future<std::vector<T>> all_reduce(
+        hierarchical_communicator const& communicators,
+        std::vector<T>&& local_result, F&& op,
+        this_site_arg this_site = this_site_arg(),
+        generation_arg const generation = generation_arg())
+    {
+        if (this_site.is_default())
+        {
+            this_site = agas::get_locality_id();
+        }
+
+        std::size_t const k = generation;
+        generation_arg const reduce_gen(2 * k);
+        generation_arg const broadcast_gen(2 * k + 1);
+
+        // Lift scalar op to element-wise vector op
+        detail::vector_reduce_op<T, std::decay_t<F>> vec_op{
+            HPX_FORWARD(F, op)};
+
+        // Phase 1: hierarchical reduce (bottom-up) with vector op
+        std::vector<T> reduced = reduce_here(hpx::launch::sync,
+            communicators, HPX_MOVE(local_result), HPX_MOVE(vec_op),
+            this_site, reduce_gen);
+
+        // Phase 2: hierarchical broadcast (top-down)
+        return broadcast_to(
+            communicators, HPX_MOVE(reduced), this_site, broadcast_gen);
+    }
+
+    // Non-root site, vector overload
+    template <typename T, typename F>
+    hpx::future<std::vector<T>> all_reduce_there(
+        hierarchical_communicator const& communicators,
+        std::vector<T>&& local_result, F&& op,
+        this_site_arg this_site = this_site_arg(),
+        generation_arg const generation = generation_arg())
+    {
+        if (this_site.is_default())
+        {
+            this_site = agas::get_locality_id();
+        }
+
+        std::size_t const k = generation;
+        generation_arg const reduce_gen(2 * k);
+        generation_arg const broadcast_gen(2 * k + 1);
+
+        detail::vector_reduce_op<T, std::decay_t<F>> vec_op{
+            HPX_FORWARD(F, op)};
+
+        // Phase 1: hierarchical reduce (send up)
+        reduce_there(hpx::launch::sync, communicators,
+            HPX_MOVE(local_result), HPX_MOVE(vec_op), this_site,
+            reduce_gen);
+
+        // Phase 2: hierarchical broadcast (receive down)
+        return broadcast_from<std::vector<T>>(
+            communicators, this_site, broadcast_gen);
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Sync versions of hierarchical all_reduce
+    template <typename T, typename F>
+    std::decay_t<T> all_reduce(hpx::launch::sync_policy,
+        hierarchical_communicator const& communicators, T&& local_result,
+        F&& op, this_site_arg const this_site = this_site_arg(),
+        generation_arg const generation = generation_arg())
+    {
+        return all_reduce(communicators, HPX_FORWARD(T, local_result),
+            HPX_FORWARD(F, op), this_site, generation)
+            .get();
+    }
+
+    template <typename T, typename F>
+    std::decay_t<T> all_reduce_there(hpx::launch::sync_policy,
+        hierarchical_communicator const& communicators, T&& local_result,
+        F&& op, this_site_arg const this_site = this_site_arg(),
+        generation_arg const generation = generation_arg())
+    {
+        return all_reduce_there(communicators, HPX_FORWARD(T, local_result),
+            HPX_FORWARD(F, op), this_site, generation)
             .get();
     }
 }    // namespace hpx::collectives

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -589,8 +589,8 @@ namespace hpx::collectives {
         {
             if (generation.is_default())
             {
-                return hpx::make_exceptional_future
-                    std::vector<T>>(HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                return hpx::make_exceptional_future<std::vector<T>>(
+                    HPX_GET_EXCEPTION(hpx::error::bad_parameter,
                     "hpx::collectives::all_reduce_there (hierarchical, vector)",
                     "hierarchical all_reduce requires an explicit generation "
                     "number for the 2k/2k+1 internal mapping"));

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -484,9 +484,8 @@ namespace hpx::collectives {
         }
 
         // Map user generation k to internal generations 2k, 2k+1
-        std::size_t const k = generation;
-        generation_arg const reduce_gen(2 * k);
-        generation_arg const broadcast_gen(2 * k + 1);
+        generation_arg const reduce_gen(2 * generation);
+        generation_arg const broadcast_gen(2 * generation + 1);
 
         // Phase 1: hierarchical reduce (bottom-up)
         arg_type reduced = reduce_here(hpx::launch::sync, communicators,
@@ -521,9 +520,8 @@ namespace hpx::collectives {
                 "number for the 2k/2k+1 internal mapping"));
         }
 
-        std::size_t const k = generation;
-        generation_arg const reduce_gen(2 * k);
-        generation_arg const broadcast_gen(2 * k + 1);
+        generation_arg const reduce_gen(2 * generation);
+        generation_arg const broadcast_gen(2 * generation + 1);
 
         // Phase 1: hierarchical reduce (send up)
         reduce_there(hpx::launch::sync, communicators,
@@ -562,9 +560,8 @@ namespace hpx::collectives {
                     "number for the 2k/2k+1 internal mapping"));
         }
 
-        std::size_t const k = generation;
-        generation_arg const reduce_gen(2 * k);
-        generation_arg const broadcast_gen(2 * k + 1);
+        generation_arg const reduce_gen(2 * generation);
+        generation_arg const broadcast_gen(2 * generation + 1);
 
         // Lift scalar op to element-wise vector op
         detail::vector_reduce_op<std::decay_t<F>> vec_op{
@@ -602,9 +599,8 @@ namespace hpx::collectives {
                     "number for the 2k/2k+1 internal mapping"));
         }
 
-        std::size_t const k = generation;
-        generation_arg const reduce_gen(2 * k);
-        generation_arg const broadcast_gen(2 * k + 1);
+        generation_arg const reduce_gen(2 * generation);
+        generation_arg const broadcast_gen(2 * generation + 1);
 
         detail::vector_reduce_op<std::decay_t<F>> vec_op{
             HPX_FORWARD(F, op)};

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -497,40 +497,43 @@ namespace hpx::collectives {
             communicators, HPX_MOVE(reduced), this_site, broadcast_gen);
     }
 
-    // Non-root site overload
-    template <typename T, typename F>
-    hpx::future<std::decay_t<T>> all_reduce_there(
-        hierarchical_communicator const& communicators, T&& local_result,
-        F&& op, this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg())
-    {
-        using arg_type = std::decay_t<T>;
+    namespace detail {
 
-        if (this_site.is_default())
+        // Non-root site overload
+        template <typename T, typename F>
+        hpx::future<std::decay_t<T>> all_reduce_there(
+            hierarchical_communicator const& communicators, T&& local_result,
+            F&& op, this_site_arg this_site = this_site_arg(),
+            generation_arg const generation = generation_arg())
         {
-            this_site = agas::get_locality_id();
+            using arg_type = std::decay_t<T>;
+
+            if (this_site.is_default())
+            {
+                this_site = agas::get_locality_id();
+            }
+
+            if (generation.is_default())
+            {
+                return hpx::make_exceptional_future<arg_type>(HPX_GET_EXCEPTION(
+                    hpx::error::bad_parameter,
+                    "hpx::collectives::all_reduce_there (hierarchical)",
+                    "hierarchical all_reduce requires an explicit generation "
+                    "number for the 2k/2k+1 internal mapping"));
+            }
+
+            generation_arg const reduce_gen(2 * generation);
+            generation_arg const broadcast_gen(2 * generation + 1);
+
+            // Phase 1: hierarchical reduce (send up)
+            reduce_there(hpx::launch::sync, communicators,
+                HPX_FORWARD(T, local_result), HPX_FORWARD(F, op), this_site,
+                reduce_gen);
+
+            // Phase 2: hierarchical broadcast (receive down)
+            return broadcast_from<arg_type>(
+                communicators, this_site, broadcast_gen);
         }
-
-        if (generation.is_default())
-        {
-            return hpx::make_exceptional_future<arg_type>(HPX_GET_EXCEPTION(
-                hpx::error::bad_parameter,
-                "hpx::collectives::all_reduce_there (hierarchical)",
-                "hierarchical all_reduce requires an explicit generation "
-                "number for the 2k/2k+1 internal mapping"));
-        }
-
-        generation_arg const reduce_gen(2 * generation);
-        generation_arg const broadcast_gen(2 * generation + 1);
-
-        // Phase 1: hierarchical reduce (send up)
-        reduce_there(hpx::launch::sync, communicators,
-            HPX_FORWARD(T, local_result), HPX_FORWARD(F, op), this_site,
-            reduce_gen);
-
-        // Phase 2: hierarchical broadcast (receive down)
-        return broadcast_from<arg_type>(
-            communicators, this_site, broadcast_gen);
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -232,7 +232,6 @@ namespace hpx { namespace collectives {
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/type_support.hpp>
-#include <hpx/functional/invoke.hpp>
 #include <cstddef>
 #include <type_traits>
 #include <utility>
@@ -459,7 +458,9 @@ namespace hpx::collectives {
     // Uses 2k/2k+1 generation mapping: user generation k maps to
     // internal generation 2k (reduce phase) and 2k+1 (broadcast phase)
 
-    // Root site overload
+    // --- PUBLIC API (Root site overloads) ---
+
+    // Root site overload (scalar)
     template <typename T, typename F>
     hpx::future<std::decay_t<T>> all_reduce(
         hierarchical_communicator const& communicators, T&& local_result,
@@ -468,7 +469,6 @@ namespace hpx::collectives {
     {
         using arg_type = std::decay_t<T>;
 
-        // Hierarchical all_reduce requires explicit generation for 2k/2k+1
         if (generation.is_default())
         {
             return hpx::make_exceptional_future<arg_type>(HPX_GET_EXCEPTION(
@@ -483,66 +483,18 @@ namespace hpx::collectives {
             this_site = agas::get_locality_id();
         }
 
-        // Map user generation k to internal generations 2k, 2k+1
         generation_arg const reduce_gen(2 * generation);
         generation_arg const broadcast_gen(2 * generation + 1);
 
-        // Phase 1: hierarchical reduce (bottom-up)
         arg_type reduced = reduce_here(hpx::launch::sync, communicators,
             HPX_FORWARD(T, local_result), HPX_FORWARD(F, op), this_site,
             reduce_gen);
 
-        // Phase 2: hierarchical broadcast (top-down)
         return broadcast_to(
             communicators, HPX_MOVE(reduced), this_site, broadcast_gen);
     }
 
-    namespace detail {
-
-        // Non-root site overload
-        template <typename T, typename F>
-        hpx::future<std::decay_t<T>> all_reduce_there(
-            hierarchical_communicator const& communicators, T&& local_result,
-            F&& op, this_site_arg this_site = this_site_arg(),
-            generation_arg const generation = generation_arg())
-        {
-            using arg_type = std::decay_t<T>;
-
-            if (generation.is_default())
-            {
-                return hpx::make_exceptional_future<arg_type>(HPX_GET_EXCEPTION(
-                    hpx::error::bad_parameter,
-                    "hpx::collectives::all_reduce_there (hierarchical)",
-                    "hierarchical all_reduce requires an explicit generation "
-                    "number for the 2k/2k+1 internal mapping"));
-            }
-
-            if (this_site.is_default())
-            {
-                this_site = agas::get_locality_id();
-            }
- 
-
-            generation_arg const reduce_gen(2 * generation);
-            generation_arg const broadcast_gen(2 * generation + 1);
-
-            // Phase 1: hierarchical reduce (send up)
-            reduce_there(hpx::launch::sync, communicators,
-                HPX_FORWARD(T, local_result), HPX_FORWARD(F, op), this_site,
-                reduce_gen);
-
-            // Phase 2: hierarchical broadcast (receive down)
-            return broadcast_from<arg_type>(
-                communicators, this_site, broadcast_gen);
-        }
-    }
-
-    ////////////////////////////////////////////////////////////////////////////
-    // Hierarchical all_reduce for vector types
-    // Wraps a scalar op (e.g. std::plus<int>) to work element-wise on
-    // vector<T> before passing to reduce_here/reduce_there
-
-    // Root site, vector overload
+    // Root site overload (vector)
     template <typename T, typename F>
     hpx::future<std::vector<T>> all_reduce(
         hierarchical_communicator const& communicators,
@@ -567,60 +519,17 @@ namespace hpx::collectives {
         generation_arg const reduce_gen(2 * generation);
         generation_arg const broadcast_gen(2 * generation + 1);
 
-        // Lift scalar op to element-wise vector op
-        detail::vector_reduce_op<std::decay_t<F>> vec_op{
-            HPX_FORWARD(F, op)};
+        detail::vector_reduce_op<std::decay_t<F>> vec_op{HPX_FORWARD(F, op)};
 
-        // Phase 1: hierarchical reduce (bottom-up) with vector op
         std::vector<T> reduced = reduce_here(hpx::launch::sync,
             communicators, HPX_MOVE(local_result), HPX_MOVE(vec_op),
             this_site, reduce_gen);
 
-        // Phase 2: hierarchical broadcast (top-down)
         return broadcast_to(
             communicators, HPX_MOVE(reduced), this_site, broadcast_gen);
     }
 
-    // Non-root site, vector overload
-    template <typename T, typename F>
-    hpx::future<std::vector<T>> all_reduce_there(
-        hierarchical_communicator const& communicators,
-        std::vector<T>&& local_result, F&& op,
-        this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg())
-    {
-        if (generation.is_default())
-        {
-            return hpx::make_exceptional_future<std::vector<T>>(
-                HPX_GET_EXCEPTION(hpx::error::bad_parameter,
-                    "hpx::collectives::all_reduce_there (hierarchical, vector)",
-                    "hierarchical all_reduce requires an explicit generation "
-                    "number for the 2k/2k+1 internal mapping"));
-        }
-        
-        if (this_site.is_default())
-        {
-            this_site = agas::get_locality_id();
-        } 
-
-        generation_arg const reduce_gen(2 * generation);
-        generation_arg const broadcast_gen(2 * generation + 1);
-
-        detail::vector_reduce_op<std::decay_t<F>> vec_op{
-            HPX_FORWARD(F, op)};
-
-        // Phase 1: hierarchical reduce (send up)
-        reduce_there(hpx::launch::sync, communicators,
-            HPX_MOVE(local_result), HPX_MOVE(vec_op), this_site,
-            reduce_gen);
-
-        // Phase 2: hierarchical broadcast (receive down)
-        return broadcast_from<std::vector<T>>(
-            communicators, this_site, broadcast_gen);
-    }
-
-    ////////////////////////////////////////////////////////////////////////////
-    // Sync versions of hierarchical all_reduce
+    // Sync version (Root site)
     template <typename T, typename F>
     std::decay_t<T> all_reduce(hpx::launch::sync_policy,
         hierarchical_communicator const& communicators, T&& local_result,
@@ -632,16 +541,92 @@ namespace hpx::collectives {
             .get();
     }
 
-    template <typename T, typename F>
-    std::decay_t<T> all_reduce_there(hpx::launch::sync_policy,
-        hierarchical_communicator const& communicators, T&& local_result,
-        F&& op, this_site_arg const this_site = this_site_arg(),
-        generation_arg const generation = generation_arg())
-    {
-        return all_reduce_there(communicators, HPX_FORWARD(T, local_result),
-            HPX_FORWARD(F, op), this_site, generation)
-            .get();
-    }
+
+    // --- INTERNAL API (Non-root site overloads) ---
+    namespace detail {
+
+        // Non-root site overload (scalar)
+        template <typename T, typename F>
+        hpx::future<std::decay_t<T>> all_reduce_there(
+            hierarchical_communicator const& communicators, T&& local_result,
+            F&& op, this_site_arg this_site = this_site_arg(),
+            generation_arg const generation = generation_arg())
+        {
+            using arg_type = std::decay_t<T>;
+
+            if (generation.is_default())
+            {
+                return hpx::make_exceptional_future<arg_type>(HPX_GET_EXCEPTION(
+                    hpx::error::bad_parameter,
+                    "hpx::collectives::all_reduce_there (hierarchical)",
+                    "hierarchical all_reduce requires an explicit generation "
+                    "number for the 2k/2k+1 internal mapping"));
+            }
+
+            if (this_site.is_default())
+            {
+                this_site = agas::get_locality_id();
+            }
+
+            generation_arg const reduce_gen(2 * generation);
+            generation_arg const broadcast_gen(2 * generation + 1);
+
+            reduce_there(hpx::launch::sync, communicators,
+                HPX_FORWARD(T, local_result), HPX_FORWARD(F, op), this_site,
+                reduce_gen);
+
+            return broadcast_from<arg_type>(
+                communicators, this_site, broadcast_gen);
+        }
+
+        // Non-root site overload (vector)
+        template <typename T, typename F>
+        hpx::future<std::vector<T>> all_reduce_there(
+            hierarchical_communicator const& communicators,
+            std::vector<T>&& local_result, F&& op,
+            this_site_arg this_site = this_site_arg(),
+            generation_arg const generation = generation_arg())
+        {
+            if (generation.is_default())
+            {
+                return hpx::make_exceptional_future<std::vector<T>>(
+                    HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                        "hpx::collectives::all_reduce_there (hierarchical, vector)",
+                        "hierarchical all_reduce requires an explicit generation "
+                        "number for the 2k/2k+1 internal mapping"));
+            }
+            
+            if (this_site.is_default())
+            {
+                this_site = agas::get_locality_id();
+            } 
+
+            generation_arg const reduce_gen(2 * generation);
+            generation_arg const broadcast_gen(2 * generation + 1);
+
+            detail::vector_reduce_op<std::decay_t<F>> vec_op{HPX_FORWARD(F, op)};
+
+            reduce_there(hpx::launch::sync, communicators,
+                HPX_MOVE(local_result), HPX_MOVE(vec_op), this_site,
+                reduce_gen);
+
+            return broadcast_from<std::vector<T>>(
+                communicators, this_site, broadcast_gen);
+        }
+
+        // Sync version (Non-root site)
+        template <typename T, typename F>
+        std::decay_t<T> all_reduce_there(hpx::launch::sync_policy,
+            hierarchical_communicator const& communicators, T&& local_result,
+            F&& op, this_site_arg const this_site = this_site_arg(),
+            generation_arg const generation = generation_arg())
+        {
+            return all_reduce_there(communicators, HPX_FORWARD(T, local_result),
+                HPX_FORWARD(F, op), this_site, generation)
+                .get();
+        }
+
+    }    // namespace detail
 }    // namespace hpx::collectives
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -473,7 +473,7 @@ namespace hpx::collectives {
         }
 
         // Hierarchical all_reduce requires explicit generation for 2k/2k+1
-        if (generation == generation_arg())
+        if (generation.is_default())
         {
             return hpx::make_exceptional_future<arg_type>(HPX_GET_EXCEPTION(
                 hpx::error::bad_parameter,
@@ -511,7 +511,7 @@ namespace hpx::collectives {
             this_site = agas::get_locality_id();
         }
 
-        if (generation == generation_arg())
+        if (generation.is_default())
         {
             return hpx::make_exceptional_future<arg_type>(HPX_GET_EXCEPTION(
                 hpx::error::bad_parameter,
@@ -552,7 +552,7 @@ namespace hpx::collectives {
             this_site = agas::get_locality_id();
         }
 
-        if (generation == generation_arg())
+        if (generation.is_default())
         {
             return hpx::make_exceptional_future<std::vector<T>>(
                 HPX_GET_EXCEPTION(hpx::error::bad_parameter,
@@ -592,7 +592,7 @@ namespace hpx::collectives {
             this_site = agas::get_locality_id();
         }
 
-        if (generation == generation_arg())
+        if (generation.is_default())
         {
             return hpx::make_exceptional_future<std::vector<T>>(
                 HPX_GET_EXCEPTION(hpx::error::bad_parameter,

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -226,7 +226,6 @@ namespace hpx { namespace collectives {
 #include <hpx/collectives/broadcast.hpp>
 #include <hpx/collectives/create_communicator.hpp>
 #include <hpx/collectives/reduce.hpp>
-#include <hpx/components_base/agas_interface.hpp>
 #include <hpx/modules/algorithms.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/components_base.hpp>

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -461,28 +461,22 @@ namespace hpx::collectives {
 
         if (this_site == root_site)
         {
-            auto reduce_fut =
+            arg_type reduced =
                 reduce_here(communicators, HPX_FORWARD(T, local_result),
-                    HPX_FORWARD(F, op), this_site, reduce_gen);
+                    HPX_FORWARD(F, op), this_site, reduce_gen)
+                    .get();
 
-            return reduce_fut.then(hpx::launch::sync,
-                [communicators, this_site, broadcast_gen](auto f) {
-                    return broadcast_to(
-                        communicators, f.get(), this_site, broadcast_gen);
-                });
+            return broadcast_to(
+                communicators, HPX_MOVE(reduced), this_site, broadcast_gen);
         }
         else
         {
-            auto reduce_fut =
-                reduce_there(communicators, HPX_FORWARD(T, local_result),
-                    HPX_FORWARD(F, op), this_site, reduce_gen);
+            reduce_there(communicators, HPX_FORWARD(T, local_result),
+                HPX_FORWARD(F, op), this_site, reduce_gen)
+                .get();
 
-            return reduce_fut.then(hpx::launch::sync,
-                [communicators, this_site, broadcast_gen](auto f) {
-                    f.get();    // Propagate any exceptions from reduce phase
-                    return broadcast_from<arg_type>(
-                        communicators, this_site, broadcast_gen);
-                });
+            return broadcast_from<arg_type>(
+                communicators, this_site, broadcast_gen);
         }
     }
 

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -456,8 +456,8 @@ namespace hpx::collectives {
             this_site = agas::get_locality_id();
         }
 
-        generation_arg const reduce_gen(2 * generation);
-        generation_arg const broadcast_gen(2 * generation + 1);
+        generation_arg const reduce_gen(2 * generation - 1);
+        generation_arg const broadcast_gen(2 * generation);
 
         if (this_site == root_site)
         {

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -462,8 +462,7 @@ namespace hpx::collectives {
         if (this_site == root_site)
         {
             arg_type reduced = reduce_here(hpx::launch::sync, communicators,
-                HPX_FORWARD(T, local_result), HPX_FORWARD(F, op), this_site,
-                reduce_gen);
+                HPX_FORWARD(T, local_result), this_site, reduce_gen);
 
             return broadcast_to(
                 communicators, HPX_MOVE(reduced), this_site, broadcast_gen);
@@ -471,8 +470,7 @@ namespace hpx::collectives {
         else
         {
             reduce_there(hpx::launch::sync, communicators,
-                HPX_FORWARD(T, local_result), HPX_FORWARD(F, op), this_site,
-                reduce_gen);
+                HPX_FORWARD(T, local_result), this_site, reduce_gen);
 
             return broadcast_from<arg_type>(
                 communicators, this_site, broadcast_gen);

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -461,22 +461,28 @@ namespace hpx::collectives {
 
         if (this_site == root_site)
         {
-            arg_type reduced =
+            auto reduce_fut =
                 reduce_here(communicators, HPX_FORWARD(T, local_result),
-                    HPX_FORWARD(F, op), this_site, reduce_gen)
-                    .get();
+                    HPX_FORWARD(F, op), this_site, reduce_gen);
 
-            return broadcast_to(
-                communicators, HPX_MOVE(reduced), this_site, broadcast_gen);
+            return reduce_fut.then(hpx::launch::sync,
+                [communicators, this_site, broadcast_gen](auto f) {
+                    return broadcast_to(
+                        communicators, f.get(), this_site, broadcast_gen);
+                });
         }
         else
         {
-            reduce_there(communicators, HPX_FORWARD(T, local_result),
-                HPX_FORWARD(F, op), this_site, reduce_gen)
-                .get();
+            auto reduce_fut =
+                reduce_there(communicators, HPX_FORWARD(T, local_result),
+                    HPX_FORWARD(F, op), this_site, reduce_gen);
 
-            return broadcast_from<arg_type>(
-                communicators, this_site, broadcast_gen);
+            return reduce_fut.then(hpx::launch::sync,
+                [communicators, this_site, broadcast_gen](auto f) {
+                    f.get();    // Propagate any exceptions from reduce phase
+                    return broadcast_from<arg_type>(
+                        communicators, this_site, broadcast_gen);
+                });
         }
     }
 

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -471,6 +471,16 @@ namespace hpx::collectives {
             this_site = agas::get_locality_id();
         }
 
+        // Hierarchical all_reduce requires explicit generation for 2k/2k+1
+        if (generation == generation_arg())
+        {
+            return hpx::make_exceptional_future<arg_type>(HPX_GET_EXCEPTION(
+                hpx::error::bad_parameter,
+                "hpx::collectives::all_reduce (hierarchical)",
+                "hierarchical all_reduce requires an explicit generation "
+                "number for the 2k/2k+1 internal mapping"));
+        }
+
         // Map user generation k to internal generations 2k, 2k+1
         std::size_t const k = generation;
         generation_arg const reduce_gen(2 * k);
@@ -498,6 +508,15 @@ namespace hpx::collectives {
         if (this_site.is_default())
         {
             this_site = agas::get_locality_id();
+        }
+
+        if (generation == generation_arg())
+        {
+            return hpx::make_exceptional_future<arg_type>(HPX_GET_EXCEPTION(
+                hpx::error::bad_parameter,
+                "hpx::collectives::all_reduce_there (hierarchical)",
+                "hierarchical all_reduce requires an explicit generation "
+                "number for the 2k/2k+1 internal mapping"));
         }
 
         std::size_t const k = generation;
@@ -532,6 +551,15 @@ namespace hpx::collectives {
             this_site = agas::get_locality_id();
         }
 
+        if (generation == generation_arg())
+        {
+            return hpx::make_exceptional_future<std::vector<T>>(
+                HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                    "hpx::collectives::all_reduce (hierarchical, vector)",
+                    "hierarchical all_reduce requires an explicit generation "
+                    "number for the 2k/2k+1 internal mapping"));
+        }
+
         std::size_t const k = generation;
         generation_arg const reduce_gen(2 * k);
         generation_arg const broadcast_gen(2 * k + 1);
@@ -561,6 +589,15 @@ namespace hpx::collectives {
         if (this_site.is_default())
         {
             this_site = agas::get_locality_id();
+        }
+
+        if (generation == generation_arg())
+        {
+            return hpx::make_exceptional_future<std::vector<T>>(
+                HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                    "hpx::collectives::all_reduce_there (hierarchical, vector)",
+                    "hierarchical all_reduce requires an explicit generation "
+                    "number for the 2k/2k+1 internal mapping"));
         }
 
         std::size_t const k = generation;

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -429,8 +429,8 @@ namespace hpx::collectives {
 
     ////////////////////////////////////////////////////////////////////////////
     // Hierarchical all_reduce: reduce (bottom-up) + broadcast (top-down)
-    // Uses 2k/2k+1 generation mapping: user generation k maps to
-    // internal generation 2k (reduce phase) and 2k+1 (broadcast phase)
+    // Uses 2k-1/2k generation mapping: user generation k maps to
+    // internal generation 2k-1 (reduce phase) and 2k (broadcast phase)
 
     // Scalar overload
     template <typename T, typename F>

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -589,11 +589,11 @@ namespace hpx::collectives {
         {
             if (generation.is_default())
             {
-                return hpx::make_exceptional_future<std::vector<T>>(
-                    HPX_GET_EXCEPTION(hpx::error::bad_parameter,
-                        "hpx::collectives::all_reduce_there (hierarchical, vector)",
-                        "hierarchical all_reduce requires an explicit generation "
-                        "number for the 2k/2k+1 internal mapping"));
+                return hpx::make_exceptional_future
+                    std::vector<T>>(HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                    "hpx::collectives::all_reduce_there (hierarchical, vector)",
+                    "hierarchical all_reduce requires an explicit generation "
+                    "number for the 2k/2k+1 internal mapping"));
             }
             
             if (this_site.is_default())
@@ -604,7 +604,8 @@ namespace hpx::collectives {
             generation_arg const reduce_gen(2 * generation);
             generation_arg const broadcast_gen(2 * generation + 1);
 
-            detail::vector_reduce_op<std::decay_t<F>> vec_op{HPX_FORWARD(F, op)};
+            detail::vector_reduce_op<std::decay_t<F>> vec_op{
+                HPX_FORWARD(F, op)};
 
             reduce_there(hpx::launch::sync, communicators,
                 HPX_MOVE(local_result), HPX_MOVE(vec_op), this_site,

--- a/libs/full/collectives/tests/performance/benchmark_collectives.cpp
+++ b/libs/full/collectives/tests/performance/benchmark_collectives.cpp
@@ -457,7 +457,7 @@ void test_all_reduce_hierarchical(int arity, int lpn, std::size_t iterations,
         hpx::chrono::high_resolution_timer const timer;
         // NOLINTNEXTLINE(bugprone-use-after-move)
         hpx::future<std::vector<int>> ft_data =
-            all_reduce(communicators, std::move(send_data), vector_adder{},
+            all_reduce(communicators, std::move(send_data), std::plus<int>{},
                 this_site_arg(this_locality), generation_arg(i + 1));
         recv_data = ft_data.get();
 

--- a/libs/full/collectives/tests/performance/benchmark_collectives.cpp
+++ b/libs/full/collectives/tests/performance/benchmark_collectives.cpp
@@ -10,10 +10,10 @@
 #include <hpx/config.hpp>
 
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
+#include <hpx/collectives/all_reduce.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/modules/collectives.hpp>
-#include <hpx/collectives/all_reduce.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <filesystem>
@@ -459,9 +459,9 @@ void test_all_reduce_hierarchical(int arity, int lpn, std::size_t iterations,
         if (this_locality == 0)
         {
             // NOLINTNEXTLINE(bugprone-use-after-move)
-            ft_data = all_reduce(communicators, std::move(send_data),
-                vector_adder{}, this_site_arg(this_locality),
-                generation_arg(i + 1));
+            ft_data =
+                all_reduce(communicators, std::move(send_data), vector_adder{},
+                    this_site_arg(this_locality), generation_arg(i + 1));
         }
         else
         {
@@ -477,8 +477,7 @@ void test_all_reduce_hierarchical(int arity, int lpn, std::size_t iterations,
         result[i] = timer.elapsed();
 
         // Check for correctness — every site should have the sum
-        HPX_TEST_EQ(
-            i * num_localities, static_cast<std::size_t>(recv_data[0]));
+        HPX_TEST_EQ(i * num_localities, static_cast<std::size_t>(recv_data[0]));
     }
 
     if (this_locality == 0)
@@ -773,8 +772,7 @@ void test_one_shot_use_all_reduce(int lpn, std::size_t iterations,
         result[i] = timer.elapsed();
 
         // Check for correctness
-        HPX_TEST_EQ(
-            i * num_localities, static_cast<std::size_t>(recv_data[0]));
+        HPX_TEST_EQ(i * num_localities, static_cast<std::size_t>(recv_data[0]));
     }
 
     if (this_locality == 0)
@@ -1081,8 +1079,7 @@ void test_multiple_use_with_generation_all_reduce(int lpn,
         result[i] = timer.elapsed();
 
         // Check for correctness
-        HPX_TEST_EQ(
-            i * num_localities, static_cast<std::size_t>(recv_data[0]));
+        HPX_TEST_EQ(i * num_localities, static_cast<std::size_t>(recv_data[0]));
     }
 
     if (this_locality == 0)

--- a/libs/full/collectives/tests/performance/benchmark_collectives.cpp
+++ b/libs/full/collectives/tests/performance/benchmark_collectives.cpp
@@ -457,7 +457,7 @@ void test_all_reduce_hierarchical(int arity, int lpn, std::size_t iterations,
         hpx::chrono::high_resolution_timer const timer;
         // NOLINTNEXTLINE(bugprone-use-after-move)
         hpx::future<std::vector<int>> ft_data =
-            all_reduce(communicators, std::move(send_data), std::plus<int>{},
+            all_reduce(communicators, std::move(send_data), vector_adder{},
                 this_site_arg(this_locality), generation_arg(i + 1));
         recv_data = ft_data.get();
 

--- a/libs/full/collectives/tests/performance/benchmark_collectives.cpp
+++ b/libs/full/collectives/tests/performance/benchmark_collectives.cpp
@@ -455,28 +455,18 @@ void test_all_reduce_hierarchical(int arity, int lpn, std::size_t iterations,
 
         // Time collective
         hpx::chrono::high_resolution_timer const timer;
-        hpx::future<std::vector<int>> ft_data;
-        if (this_locality == 0)
-        {
-            // NOLINTNEXTLINE(bugprone-use-after-move)
-            ft_data =
-                all_reduce(communicators, std::move(send_data), vector_adder{},
-                    this_site_arg(this_locality), generation_arg(i + 1));
-        }
-        else
-        {
-            // NOLINTNEXTLINE(bugprone-use-after-move)
-            ft_data = all_reduce_there(communicators, std::move(send_data),
-                vector_adder{}, this_site_arg(this_locality),
-                generation_arg(i + 1));
-        }
+        // NOLINTNEXTLINE(bugprone-use-after-move)
+        hpx::future<std::vector<int>> ft_data =
+            all_reduce(communicators, std::move(send_data), vector_adder{},
+                this_site_arg(this_locality), generation_arg(i + 1));
         recv_data = ft_data.get();
+
         // Synchronize
         barrier.wait();
         // Write runtime into vector
         result[i] = timer.elapsed();
 
-        // Check for correctness — every site should have the sum
+        // Check for correctness: every site should have the sum
         HPX_TEST_EQ(i * num_localities, static_cast<std::size_t>(recv_data[0]));
     }
 

--- a/libs/full/collectives/tests/performance/benchmark_collectives.cpp
+++ b/libs/full/collectives/tests/performance/benchmark_collectives.cpp
@@ -12,6 +12,7 @@
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/modules/collectives.hpp>
+#include <hpx/collectives/all_reduce.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <filesystem>
@@ -26,6 +27,7 @@ constexpr char const* scatter_direct_basename = "/test/scatter_direct/";
 constexpr char const* reduce_direct_basename = "/test/reduce_direct/";
 constexpr char const* broadcast_direct_basename = "/test/broadcast_direct/";
 constexpr char const* gather_direct_basename = "/test/gather_direct/";
+constexpr char const* all_reduce_direct_basename = "/test/all_reduce_direct/";
 
 struct vector_adder
 {
@@ -423,6 +425,68 @@ void test_gather_hierarchical(int arity, int lpn, std::size_t iterations,
     }
 }
 
+void test_all_reduce_hierarchical(int arity, int lpn, std::size_t iterations,
+    int test_size, std::string const& operation)
+{
+    // Get parameters
+    std::size_t const num_localities =
+        hpx::get_num_localities(hpx::launch::sync);
+    std::size_t const this_locality = hpx::get_locality_id();
+    // Ensure at least two localities
+    HPX_TEST_LTE(static_cast<std::size_t>(2), num_localities);
+    // Create hierarchical communicators
+    auto communicators =
+        create_hierarchical_communicator(all_reduce_direct_basename,
+            num_sites_arg(num_localities), this_site_arg(this_locality),
+            arity_arg(arity), generation_arg(1), root_site_arg(0));
+    // Barrier for synchronization
+    char const* const barrier_test_name = "/test/barrier/hierarchical";
+    hpx::distributed::barrier barrier(barrier_test_name);
+    // Result vector
+    std::vector<double> result(iterations, 0.0);
+    // Data
+    std::vector<int> send_data;
+    std::vector<int> recv_data;
+
+    for (std::size_t i = 0; i != iterations; ++i)
+    {
+        send_data = std::vector<int>(test_size, static_cast<int>(i));
+
+        // Time collective
+        hpx::chrono::high_resolution_timer const timer;
+        hpx::future<std::vector<int>> ft_data;
+        if (this_locality == 0)
+        {
+            // NOLINTNEXTLINE(bugprone-use-after-move)
+            ft_data = all_reduce(communicators, std::move(send_data),
+                vector_adder{}, this_site_arg(this_locality),
+                generation_arg(i + 1));
+        }
+        else
+        {
+            // NOLINTNEXTLINE(bugprone-use-after-move)
+            ft_data = all_reduce_there(communicators, std::move(send_data),
+                vector_adder{}, this_site_arg(this_locality),
+                generation_arg(i + 1));
+        }
+        recv_data = ft_data.get();
+        // Synchronize
+        barrier.wait();
+        // Write runtime into vector
+        result[i] = timer.elapsed();
+
+        // Check for correctness — every site should have the sum
+        HPX_TEST_EQ(
+            i * num_localities, static_cast<std::size_t>(recv_data[0]));
+    }
+
+    if (this_locality == 0)
+    {
+        write_to_file(operation, "hierarchical", arity, num_localities, lpn,
+            test_size, iterations, result);
+    }
+}
+
 ////////////////////////////////////////////////////////////////////////////////////////
 // One shot collectives
 void test_one_shot_use_scatter(int lpn, std::size_t iterations, int test_size,
@@ -663,6 +727,53 @@ void test_one_shot_use_gather(int lpn, std::size_t iterations, int test_size,
                 HPX_TEST_EQ(i + j, static_cast<std::size_t>(recv_data[j][0]));
             }
         }
+    }
+
+    if (this_locality == 0)
+    {
+        write_to_file(operation, "single_use", -1, num_localities, lpn,
+            test_size, iterations, result);
+    }
+}
+
+void test_one_shot_use_all_reduce(int lpn, std::size_t iterations,
+    int test_size, std::string const& operation)
+{
+    // Get parameters
+    std::size_t const num_localities =
+        hpx::get_num_localities(hpx::launch::sync);
+    std::size_t const this_locality = hpx::get_locality_id();
+    // Ensure at least two localities
+    HPX_TEST_LTE(static_cast<std::size_t>(2), num_localities);
+    // Barrier for synchronization
+    char const* const barrier_test_name = "/test/barrier/single";
+    hpx::distributed::barrier barrier(barrier_test_name);
+    // Result vector
+    std::vector<double> result(iterations, 0.0);
+    // Data
+    std::vector<int> send_data;
+    std::vector<int> recv_data;
+
+    for (std::size_t i = 0; i != iterations; ++i)
+    {
+        send_data = std::vector<int>(test_size, static_cast<int>(i));
+
+        // Time collective
+        hpx::chrono::high_resolution_timer const timer;
+        hpx::future<std::vector<int>> ft_data =
+            // NOLINTNEXTLINE(bugprone-use-after-move)
+            all_reduce(all_reduce_direct_basename, std::move(send_data),
+                vector_adder{}, num_sites_arg(num_localities),
+                this_site_arg(this_locality), generation_arg(i + 1));
+        recv_data = ft_data.get();
+        // Synchronize
+        barrier.wait();
+        // Write runtime into vector
+        result[i] = timer.elapsed();
+
+        // Check for correctness
+        HPX_TEST_EQ(
+            i * num_localities, static_cast<std::size_t>(recv_data[0]));
     }
 
     if (this_locality == 0)
@@ -930,6 +1041,56 @@ void test_multiple_use_with_generation_gather(
     }
 }
 
+void test_multiple_use_with_generation_all_reduce(int lpn,
+    std::size_t iterations, int test_size, std::string const& operation)
+{
+    // Get parameters
+    std::size_t const num_localities =
+        hpx::get_num_localities(hpx::launch::sync);
+    std::size_t const this_locality = hpx::get_locality_id();
+    // Ensure at least two localities
+    HPX_TEST_LTE(static_cast<std::size_t>(2), num_localities);
+    // Create communicator
+    auto const all_reduce_direct_client =
+        create_communicator(all_reduce_direct_basename,
+            num_sites_arg(num_localities), this_site_arg(this_locality));
+    // Barrier for synchronization
+    char const* const barrier_test_name = "/test/barrier/generation";
+    hpx::distributed::barrier barrier(barrier_test_name);
+    // Result vector
+    std::vector<double> result(iterations, 0.0);
+    // Data
+    std::vector<int> send_data;
+    std::vector<int> recv_data;
+
+    for (std::size_t i = 0; i != iterations; ++i)
+    {
+        send_data = std::vector<int>(test_size, static_cast<int>(i));
+
+        // Time collective
+        hpx::chrono::high_resolution_timer const timer;
+        hpx::future<std::vector<int>> ft_data =
+            // NOLINTNEXTLINE(bugprone-use-after-move)
+            all_reduce(all_reduce_direct_client, std::move(send_data),
+                vector_adder{}, generation_arg(i + 1));
+        recv_data = ft_data.get();
+        // Synchronize
+        barrier.wait();
+        // Write runtime into vector
+        result[i] = timer.elapsed();
+
+        // Check for correctness
+        HPX_TEST_EQ(
+            i * num_localities, static_cast<std::size_t>(recv_data[0]));
+    }
+
+    if (this_locality == 0)
+    {
+        write_to_file(operation, "multi_use", -1, num_localities, lpn,
+            test_size, iterations, result);
+    }
+}
+
 int hpx_main(hpx::program_options::variables_map& vm)
 {
     int const arity = vm["arity"].as<int>();
@@ -998,6 +1159,21 @@ int hpx_main(hpx::program_options::variables_map& vm)
                     arity, lpn, iterations, test_size, operation);
             }
         }
+        else if (operation == "all_reduce")
+        {
+            if (arity == -1)
+            {
+                test_one_shot_use_all_reduce(
+                    lpn, iterations, test_size, operation);
+                test_multiple_use_with_generation_all_reduce(
+                    lpn, iterations, test_size, operation);
+            }
+            else
+            {
+                test_all_reduce_hierarchical(
+                    arity, lpn, iterations, test_size, operation);
+            }
+        }
     }
 
     return hpx::finalize();
@@ -1018,7 +1194,7 @@ int main(int argc, char* argv[])
         ("iterations", value<int>()->default_value(10),
             "Number of Iteration the collective is executed")
         ("operation", value<std::string>()->default_value("scatter"),
-            "Collective Operation (scatter, reduce, broadcast, gather)");
+            "Collective Operation (scatter, reduce, broadcast, gather, all_reduce)");
     // clang-format on
 
     std::vector<std::string> const cfg = {"hpx.run_hpx_main!=1"};

--- a/libs/full/collectives/tests/performance/benchmark_collectives.cpp
+++ b/libs/full/collectives/tests/performance/benchmark_collectives.cpp
@@ -1,6 +1,7 @@
 //  Copyright (c) 2025 Lukas Zeil
 //  Copyright (c) 2025 Alexander Strack
 //  Copyright (c) 2025 Hartmut Kaiser
+//  Copyright (c) 2026 Anshuman Agrawal
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying


### PR DESCRIPTION
While studying the hierarchical communicator from #6834, I implemented
hierarchical `all_reduce` and `all_gather` by composing existing
reduce/gather + broadcast primitives over the hierarchical communicator.

## Approach

- Root sites: `reduce_here` (sync) → `broadcast_to`
- Non-root sites: `reduce_there` (async+get) → `broadcast_from`
- Distinct, monotonically incrementing generations per phase:
  user generation `k` maps to internal generations `2k-1` (reduce) and `2k` (broadcast)
  (per @hkaiser's guidance on #6834)

## Benchmark results

Using HPX's standard `benchmark_collectives_test` binary. Comparing against
`multi_use` flat as the baseline since hierarchical also reuses communicators
across iterations.

Setup: single int, 100 iterations, DGX H100 compute node, 1 HPX thread per locality.

| Procs | Flat multi_use (μs) | Hier arity=2 (μs) | Hier arity=4 (μs) |
|-------|---------------------|--------------------|--------------------|
| 4     | 50                  | 101                | —                  |
| 8     | 98                  | 139                | 141                |
| 16    | 166                 | 198                | 849                |
| 32    | 465                 | 346                | 1,120              |

Hierarchical arity=2 overtakes flat at 32 processes (1.34x speedup).
Per maintainer feedback, arity=2 is the recommended default for ≥16 ranks.

Arity=4 shows regression at P≥16 — appears to originate in the hierarchical
communicator's tree-partitioning logic rather than the composition layer.

## Questions

1. Is reduce→broadcast the right composition, or would a different
   decomposition be preferred?
2. For vector types, should I add a dedicated specialization or adjust
   existing overload resolution?

## Status

Ready for review.

- [x] Correctness tests pass (4, 8, 16 localities, arities 2 and 4)
- [x] Single-node benchmarks on DGX H100 compute node
- [x] Generation mapping fix (2k-1/2k)
- [ ] Larger message sizes
- [ ] Multi-node benchmarks
- [ ] 64-process results (queued on cluster)