### PR TITLE
pass executor to hpx::dataflow in sort and partial_sort

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/algorithms/partial_sort.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/partial_sort.hpp
@@ -401,6 +401,7 @@ namespace hpx::parallel {
                 }
 
                 return hpx::dataflow(
+                    policy.executor(),
                     [last](hpx::future<Iter>&& leftf,
                         hpx::future<Iter>&& rightf) -> Iter {
                         if (leftf.has_exception() || rightf.has_exception())

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/sort.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/sort.hpp
@@ -250,6 +250,7 @@ namespace hpx::parallel {
                 policy, c_first, last, comp, chunk_size);
 
             return hpx::dataflow(
+                policy.executor(),
                 [last](hpx::future<RandomIt>&& leftf,
                     hpx::future<RandomIt>&& rightf) -> RandomIt {
                     if (leftf.has_exception() || rightf.has_exception())


### PR DESCRIPTION
related to #7123 

## Proposed Changes

- Without an explicit executor, `hpx::dataflow(lambda, future1, future2)` is intercepted by stdexec which unwraps `hpx::future<T>` before passing to the lambda, breaking the `(hpx::future<T>&&, hpx::future<T>&&)` signatures in `sort.hpp` and `partial_sort.hpp`
- Passing `policy.executor()` as the first arg forces HPX's executor-based dataflow overload, preserving future wrapping — required for mandatory stdexec compatibility

## Any background context you want to provide?

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
