### PR TITLE
Fix parallel is_sorted_until off by one cross boundary check

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/algorithms/is_sorted.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/is_sorted.hpp
@@ -403,6 +403,8 @@ namespace hpx::parallel {
                               pred_projected = HPX_MOVE(pred_projected)](
                               FwdIter_ part_begin, std::size_t part_size,
                               std::size_t base_idx) mutable -> void {
+                    std::size_t const cross_idx = base_idx + part_size;
+
                     FwdIter_ trail = part_begin++;
                     util::loop_idx_n<policy_type>(++base_idx, part_begin,
                         part_size - 1, tok,
@@ -419,12 +421,11 @@ namespace hpx::parallel {
                     // trail now points one past the current grouping unless
                     // canceled
 
-                    if (!tok.was_cancelled(base_idx + part_size) &&
-                        trail != last)
+                    if (!tok.was_cancelled(cross_idx) && trail != last)
                     {
                         if (HPX_INVOKE(pred_projected, *trail, *i))
                         {
-                            tok.cancel(base_idx + part_size);
+                            tok.cancel(cross_idx);
                         }
                     }
                 };

--- a/libs/core/algorithms/tests/regressions/CMakeLists.txt
+++ b/libs/core/algorithms/tests/regressions/CMakeLists.txt
@@ -16,6 +16,7 @@ set(tests
     for_loop_5735
     for_loop_with_auto_chunk_size
     includes_empty_ranges
+    is_sorted_until_chunk_boundary
     minimal_findend
     mismatch_differently_sized_ranges
     num_cores

--- a/libs/core/algorithms/tests/regressions/is_sorted_until_chunk_boundary.cpp
+++ b/libs/core/algorithms/tests/regressions/is_sorted_until_chunk_boundary.cpp
@@ -1,0 +1,48 @@
+//  Copyright (c) 2026 Mo'men Samir
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/algorithm.hpp>
+#include <hpx/init.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <cstddef>
+#include <numeric>
+#include <vector>
+
+void test_is_sorted_until_chunk_boundary()
+{
+    constexpr std::size_t size = 64;
+    constexpr std::size_t boundary = 32;
+
+    std::vector<std::size_t> c(size);
+    std::iota(c.begin(), c.end(), 0);
+
+    // Create inversion at the chunk boundary:
+    // compare c[32] with c[31].
+    c[boundary] = c[boundary - 1] - 1;
+
+    auto seq_it = hpx::is_sorted_until(hpx::execution::seq, c.begin(), c.end());
+    HPX_TEST_EQ(std::size_t(std::distance(c.begin(), seq_it)), boundary);
+
+    auto par_policy = hpx::execution::par.with(
+        hpx::execution::experimental::static_chunk_size(boundary));
+    auto par_it = hpx::is_sorted_until(par_policy, c.begin(), c.end());
+    HPX_TEST_EQ(std::size_t(std::distance(c.begin(), par_it)), boundary);
+}
+
+int hpx_main()
+{
+    test_is_sorted_until_chunk_boundary();
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
Fixes #

## Proposed Changes

  -  In parallel `is_sorted_until`, `base_idx` gets incremented then it's reused to compute the cross-partition cancellation index.
  - Fix : capture the value of `base_idx` before incrementing, use it for cross partition calculations.

## Any background context you want to provide?
This should also fix `partitioned_vector_is_sorted` unit test.

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [x] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
