### PR TITLE
Add static plugin loading support for HPX plugins

### DIFF
--- a/libs/core/runtime_configuration/include/hpx/runtime_configuration/init_ini_data.hpp
+++ b/libs/core/runtime_configuration/include/hpx/runtime_configuration/init_ini_data.hpp
@@ -44,6 +44,16 @@ namespace hpx::util {
         error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
+    // load plugin registry information for all statically registered plugin
+    // modules. Injects `static = 1` into each generated [hpx.plugins.*]
+    // section so load_plugins routes to the static loader at runtime.
+    HPX_CXX_CORE_EXPORT
+    std::vector<std::shared_ptr<plugins::plugin_registry_base>>
+    load_plugin_factory_static(util::section& ini, std::string const& name,
+        hpx::util::plugin::get_plugins_list_type get_factory,
+        error_code& ec = throws);
+
+    ///////////////////////////////////////////////////////////////////////////
     // global function to read component ini information
     HPX_CXX_CORE_EXPORT void merge_component_inis(section& ini);
 

--- a/libs/core/runtime_configuration/include/hpx/runtime_configuration/macros.hpp
+++ b/libs/core/runtime_configuration/include/hpx/runtime_configuration/macros.hpp
@@ -141,22 +141,45 @@
 ////////////////////////////////////////////////////////////////////////////////
 // from hpx/runtime_configuration/plugin_registry_base.hpp
 
-/// This macro is used to register the given component factory with Hpx.Plugin.
-/// This macro has to be used for each of the components.
+/// This macro is used to register the given plugin factory with Hpx.Plugin.
+/// This macro has to be used for each of the plugins. Ungated, matching the
+/// component analog (HPX_REGISTER_COMPONENT_REGISTRY).
 #define HPX_REGISTER_PLUGIN_BASE_REGISTRY(PluginType, name)                    \
     HPX_PLUGIN_EXPORT(HPX_PLUGIN_PLUGIN_PREFIX,                                \
         hpx::plugins::plugin_registry_base, PluginType, name, plugin)          \
     /**/
 
+////////////////////////////////////////////////////////////////////////////////
+// Mirror the component module gating pattern (lines 66-93 above):
+//   !APP_NAME && !STATIC_LINKING -> full expansion (dynamic build, library TU)
+//   STATIC_LINKING               -> full expansion (static build, any TU)
+//   APP_NAME only                -> nothing       (dynamic build, exe TU)
+#if !defined(HPX_APPLICATION_NAME) && !defined(HPX_HAVE_STATIC_LINKING)
+
 /// This macro is used to define the required Hpx.Plugin entry points. This
-/// macro has to be used in exactly one compilation unit of a component module.
+/// macro has to be used in exactly one compilation unit of a plugin module.
 #define HPX_REGISTER_PLUGIN_REGISTRY_MODULE()                                  \
     HPX_PLUGIN_EXPORT_LIST(HPX_PLUGIN_PLUGIN_PREFIX, plugin)                   \
+    HPX_INIT_REGISTRY_PLUGIN_MODULE_STATIC(HPX_PLUGIN_PLUGIN_PREFIX, plugin)   \
     /**/
 
 #define HPX_REGISTER_PLUGIN_REGISTRY_MODULE_DYNAMIC()                          \
     HPX_PLUGIN_EXPORT_LIST_DYNAMIC(HPX_PLUGIN_PLUGIN_PREFIX, plugin)           \
     /**/
+
+#else
+
+#if defined(HPX_HAVE_STATIC_LINKING)
+#define HPX_REGISTER_PLUGIN_REGISTRY_MODULE()                                  \
+    HPX_PLUGIN_EXPORT_LIST(HPX_PLUGIN_PLUGIN_PREFIX, plugin)                   \
+    HPX_INIT_REGISTRY_PLUGIN_MODULE_STATIC(HPX_PLUGIN_PLUGIN_PREFIX, plugin)   \
+    /**/
+#else
+#define HPX_REGISTER_PLUGIN_REGISTRY_MODULE()
+#endif
+#define HPX_REGISTER_PLUGIN_REGISTRY_MODULE_DYNAMIC()
+
+#endif
 
 ////////////////////////////////////////////////////////////////////////////////
 // from hpx/runtime_configuration/static_factory_data.hpp
@@ -230,5 +253,40 @@
                 hpx::components::init_registry_startup_shutdown(data);         \
             }                                                                  \
         } HPX_PP_CAT(module_startup_shutdown_data_, __LINE__);                 \
+    }                                                                          \
+    /**/
+
+///////////////////////////////////////////////////////////////////////////////
+// Static registration for plugin modules. Uses HPX_PLUGIN_NAME (not
+// HPX_COMPONENT_NAME) so the emitted symbol matches what
+// HPX_PLUGIN_EXPORT_LIST(HPX_PLUGIN_PLUGIN_PREFIX, ...) produces.
+#define HPX_INIT_REGISTRY_PLUGIN_MODULE_STATIC(name, base)                     \
+    HPX_DECLARE_FACTORY_STATIC(name, base);                                    \
+    namespace {                                                                \
+        struct HPX_PP_CAT(init_registry_plugin_module_static_, name)           \
+        {                                                                      \
+            HPX_PP_CAT(init_registry_plugin_module_static_, name)()            \
+            {                                                                  \
+                hpx::components::static_factory_load_data_type data =          \
+                    HPX_DEFINE_FACTORY_STATIC(HPX_PLUGIN_NAME, name, base);    \
+                hpx::components::init_registry_plugin_module(data);            \
+            }                                                                  \
+        } HPX_PP_CAT(plugin_module_data_, __LINE__);                           \
+    }                                                                          \
+    /**/
+
+///////////////////////////////////////////////////////////////////////////////
+#define HPX_INIT_REGISTRY_PLUGIN_FACTORY_STATIC(name, pluginname, base)        \
+    HPX_DECLARE_FACTORY_STATIC(name, base);                                    \
+    namespace {                                                                \
+        struct HPX_PP_CAT(init_registry_plugin_factory_static_, pluginname)    \
+        {                                                                      \
+            HPX_PP_CAT(init_registry_plugin_factory_static_, pluginname)()     \
+            {                                                                  \
+                hpx::components::static_factory_load_data_type data =          \
+                    HPX_DEFINE_FACTORY_STATIC(pluginname, name, base);         \
+                hpx::components::init_registry_plugin_factory(data);           \
+            }                                                                  \
+        } HPX_PP_CAT(pluginname, HPX_PP_CAT(_plugin_factory_data_, __LINE__)); \
     }                                                                          \
     /**/

--- a/libs/core/runtime_configuration/include/hpx/runtime_configuration/macros.hpp
+++ b/libs/core/runtime_configuration/include/hpx/runtime_configuration/macros.hpp
@@ -149,15 +149,10 @@
         hpx::plugins::plugin_registry_base, PluginType, name, plugin)          \
     /**/
 
-////////////////////////////////////////////////////////////////////////////////
-// Mirror the component module gating pattern (lines 66-93 above):
-//   !APP_NAME && !STATIC_LINKING -> full expansion (dynamic build, library TU)
-//   STATIC_LINKING               -> full expansion (static build, any TU)
-//   APP_NAME only                -> nothing       (dynamic build, exe TU)
-#if !defined(HPX_APPLICATION_NAME) && !defined(HPX_HAVE_STATIC_LINKING)
-
 /// This macro is used to define the required Hpx.Plugin entry points. This
 /// macro has to be used in exactly one compilation unit of a plugin module.
+/// Ungated: a plugin may live in a shared library, in a statically linked
+/// build, or directly in the application executable.
 #define HPX_REGISTER_PLUGIN_REGISTRY_MODULE()                                  \
     HPX_PLUGIN_EXPORT_LIST(HPX_PLUGIN_PLUGIN_PREFIX, plugin)                   \
     HPX_INIT_REGISTRY_PLUGIN_MODULE_STATIC(HPX_PLUGIN_PLUGIN_PREFIX, plugin)   \
@@ -166,20 +161,6 @@
 #define HPX_REGISTER_PLUGIN_REGISTRY_MODULE_DYNAMIC()                          \
     HPX_PLUGIN_EXPORT_LIST_DYNAMIC(HPX_PLUGIN_PLUGIN_PREFIX, plugin)           \
     /**/
-
-#else
-
-#if defined(HPX_HAVE_STATIC_LINKING)
-#define HPX_REGISTER_PLUGIN_REGISTRY_MODULE()                                  \
-    HPX_PLUGIN_EXPORT_LIST(HPX_PLUGIN_PLUGIN_PREFIX, plugin)                   \
-    HPX_INIT_REGISTRY_PLUGIN_MODULE_STATIC(HPX_PLUGIN_PLUGIN_PREFIX, plugin)   \
-    /**/
-#else
-#define HPX_REGISTER_PLUGIN_REGISTRY_MODULE()
-#endif
-#define HPX_REGISTER_PLUGIN_REGISTRY_MODULE_DYNAMIC()
-
-#endif
 
 ////////////////////////////////////////////////////////////////////////////////
 // from hpx/runtime_configuration/static_factory_data.hpp

--- a/libs/core/runtime_configuration/include/hpx/runtime_configuration/static_factory_data.hpp
+++ b/libs/core/runtime_configuration/include/hpx/runtime_configuration/static_factory_data.hpp
@@ -47,4 +47,21 @@ namespace hpx::components {
         std::string const& instance, util::plugin::get_plugins_list_type& f);
     HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void init_registry_startup_shutdown(
         static_factory_load_data_type const&);
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Static plugin registries. Mirrors the component side above but keeps
+    // plugin bookkeeping in its own maps so load_plugins_static can iterate
+    // only plugin modules (component loaders instantiate
+    // static_plugin_factory<component_registry_base>, which would cast
+    // incorrectly if plugin entries lived in the component maps).
+    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT
+        std::vector<static_factory_load_data_type>&
+        get_static_plugin_module_data();
+    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void init_registry_plugin_module(
+        static_factory_load_data_type const&);
+
+    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT bool get_static_plugin_factory(
+        std::string const& instance, util::plugin::get_plugins_list_type& f);
+    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void init_registry_plugin_factory(
+        static_factory_load_data_type const&);
 }    // namespace hpx::components

--- a/libs/core/runtime_configuration/src/init_ini_data.cpp
+++ b/libs/core/runtime_configuration/src/init_ini_data.cpp
@@ -278,6 +278,80 @@ namespace hpx::util {
         return registries;
     }
 
+    ///////////////////////////////////////////////////////////////////////////
+    // iterate over all statically registered plugin modules and construct
+    // default ini settings. Mirrors load_component_factory_static above, but
+    // targets plugin_registry_base and injects `static = 1` into every
+    // generated [hpx.plugins.*] section.
+    std::vector<std::shared_ptr<plugins::plugin_registry_base>>
+    load_plugin_factory_static(util::section& ini, std::string const& name,
+        hpx::util::plugin::get_plugins_list_type const get_factory,
+        error_code& ec)
+    {
+        hpx::util::plugin::static_plugin_factory<
+            plugins::plugin_registry_base> const pf(get_factory);
+        std::vector<std::shared_ptr<plugins::plugin_registry_base>> registries;
+
+        std::vector<std::string> names;
+        pf.get_names(names, ec);
+        if (ec)
+            return registries;
+
+        std::vector<std::string> ini_data;
+        if (names.empty())
+        {
+            // module exports no plugin registries - nothing to inject
+            return registries;
+        }
+
+        registries.reserve(names.size());
+        for (std::string const& s : names)
+        {
+            std::shared_ptr<plugins::plugin_registry_base> registry(
+                pf.create(s, ec));
+            if (ec)
+                continue;
+
+            registry->get_plugin_info(ini_data);
+            registries.push_back(HPX_MOVE(registry));
+        }
+
+        // Inject `static = 1` into every [hpx.plugins.*] section the
+        // registries just emitted. plugin_registry_base::get_plugin_info
+        // doesn't know about static linking, so we mark the sections here
+        // before handing them to the ini parser. Without this, load_plugins
+        // would fall through to the dynamic branch and throw.
+        std::vector<std::string> marked;
+        marked.reserve(ini_data.size() + names.size());
+        bool in_plugin_section = false;
+        bool static_line_pending = false;
+        auto flush_static_line = [&]() {
+            if (static_line_pending)
+            {
+                marked.emplace_back("static = 1");
+                static_line_pending = false;
+            }
+        };
+        for (std::string const& line : ini_data)
+        {
+            std::string trimmed = line;
+            hpx::string_util::trim(trimmed);
+            if (!trimmed.empty() && trimmed.front() == '[')
+            {
+                flush_static_line();
+                in_plugin_section = trimmed.rfind("[hpx.plugins.", 0) == 0;
+                if (in_plugin_section)
+                    static_line_pending = true;
+            }
+            marked.push_back(line);
+        }
+        flush_static_line();
+
+        ini.parse("<plugin registry>", marked, false, false);
+        (void) name;    // retained for parity with component loader
+        return registries;
+    }
+
     static void load_component_factory(hpx::util::plugin::dll& d,
         util::section& ini, std::string const& curr,
         std::vector<std::shared_ptr<components::component_registry_base>>&

--- a/libs/core/runtime_configuration/src/runtime_configuration.cpp
+++ b/libs/core/runtime_configuration/src/runtime_configuration.cpp
@@ -658,6 +658,25 @@ namespace hpx::util {
         load_component_paths(plugin_registries, component_registries,
             plugin_paths, "", component_paths, basenames);
 
+        // In static builds there are no shared libraries to dlopen, so
+        // pull in statically registered plugin modules instead. In dynamic
+        // builds the DLL scan above already loaded every plugin .so (whose
+        // file-scope constructors populate get_static_plugin_module_data()),
+        // so iterating the static map here would create duplicate registry
+        // objects and duplicate init() calls.
+#if defined(HPX_HAVE_STATIC_LINKING)
+        for (components::static_factory_load_data_type const& d :
+            components::get_static_plugin_module_data())
+        {
+            auto new_registries =
+                util::load_plugin_factory_static(*this, d.name, d.get_factory);
+            plugin_registries.reserve(
+                plugin_registries.size() + new_registries.size());
+            std::move(new_registries.begin(), new_registries.end(),
+                std::back_inserter(plugin_registries));
+        }
+#endif
+
         // read system and user ini files _again_, to allow the user to
         // overwrite the settings from the default component ini's.
         util::init_ini_data_base(*this, hpx_ini_file);

--- a/libs/core/runtime_configuration/src/runtime_configuration.cpp
+++ b/libs/core/runtime_configuration/src/runtime_configuration.cpp
@@ -658,16 +658,22 @@ namespace hpx::util {
         load_component_paths(plugin_registries, component_registries,
             plugin_paths, "", component_paths, basenames);
 
-        // In static builds there are no shared libraries to dlopen, so
-        // pull in statically registered plugin modules instead. In dynamic
-        // builds the DLL scan above already loaded every plugin .so (whose
-        // file-scope constructors populate get_static_plugin_module_data()),
-        // so iterating the static map here would create duplicate registry
-        // objects and duplicate init() calls.
-#if defined(HPX_HAVE_STATIC_LINKING)
+        // Pull in any statically registered plugin modules. This covers
+        // three cases:
+        //   - static HPX build: no shared libraries to dlopen, the static
+        //     map is the only source of plugins.
+        //   - plugin baked into the application exe (dynamic HPX build): the
+        //     exe's static ctor pushed an entry here; the DLL scan above
+        //     never saw it.
+        //   - plugin shared libraries dlopen'd by the scan: their file-scope
+        //     ctors also push here, so we skip those via modules_ (keyed by
+        //     module name) to avoid duplicate registry objects.
         for (components::static_factory_load_data_type const& d :
             components::get_static_plugin_module_data())
         {
+            if (modules_.find(d.name) != modules_.end())
+                continue;    // already loaded via DLL scan
+
             auto new_registries =
                 util::load_plugin_factory_static(*this, d.name, d.get_factory);
             plugin_registries.reserve(
@@ -675,7 +681,6 @@ namespace hpx::util {
             std::move(new_registries.begin(), new_registries.end(),
                 std::back_inserter(plugin_registries));
         }
-#endif
 
         // read system and user ini files _again_, to allow the user to
         // overwrite the settings from the default component ini's.

--- a/libs/core/runtime_configuration/src/static_factory_data.cpp
+++ b/libs/core/runtime_configuration/src/static_factory_data.cpp
@@ -137,4 +137,55 @@ namespace hpx::components {
         f = it->second;
         return true;
     }
+
+    ///////////////////////////////////////////////////////////////////////////
+    std::vector<static_factory_load_data_type>& get_static_plugin_module_data()
+    {
+        static std::vector<static_factory_load_data_type>
+            global_plugin_module_init_data;
+        return global_plugin_module_init_data;
+    }
+
+    void init_registry_plugin_module(
+        static_factory_load_data_type const& data)    //-V835
+    {
+        if (get_initial_static_loading())
+        {
+            get_static_plugin_module_data().push_back(data);
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    static std::map<std::string, util::plugin::get_plugins_list_type>&
+    get_static_plugin_factory_data()
+    {
+        static std::map<std::string, util::plugin::get_plugins_list_type>
+            global_plugin_factory_init_data;
+        return global_plugin_factory_init_data;
+    }
+
+    void init_registry_plugin_factory(
+        static_factory_load_data_type const& data)    //-V835
+    {
+        if (get_initial_static_loading())
+        {
+            get_static_plugin_factory_data().emplace(
+                data.name, data.get_factory);
+        }
+    }
+
+    bool get_static_plugin_factory(
+        std::string const& instance, util::plugin::get_plugins_list_type& f)
+    {
+        using map_type =
+            std::map<std::string, util::plugin::get_plugins_list_type>;
+
+        map_type const& m = get_static_plugin_factory_data();
+        auto const it = m.find(instance);
+        if (it == m.end())
+            return false;
+
+        f = it->second;
+        return true;
+    }
 }    // namespace hpx::components

--- a/libs/core/runtime_configuration/tests/unit/CMakeLists.txt
+++ b/libs/core/runtime_configuration/tests/unit/CMakeLists.txt
@@ -1,5 +1,25 @@
-# Copyright (c) 2019 The STE||AR-Group
+# Copyright (c) 2026 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(tests static_plugin_registry)
+
+foreach(test ${tests})
+  set(sources ${test}.cpp)
+
+  source_group("Source Files" FILES ${sources})
+
+  add_hpx_executable(
+    ${test}_test INTERNAL_FLAGS
+    SOURCES ${sources} ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL NOLIBS
+    DEPENDENCIES hpx_core
+    FOLDER "Tests/Unit/Modules/Core/RuntimeConfiguration"
+  )
+
+  add_hpx_unit_test(
+    "modules.runtime_configuration" ${test} ${${test}_PARAMETERS}
+  )
+endforeach()

--- a/libs/core/runtime_configuration/tests/unit/static_plugin_registry.cpp
+++ b/libs/core/runtime_configuration/tests/unit/static_plugin_registry.cpp
@@ -5,7 +5,14 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 // Unit tests for the static plugin registry infrastructure that supports
-// static linking of HPX plugins (binary filters, message handlers, etc.).
+// static linking of HPX plugins (binary filters, message handlers, etc.)
+// and plugins implemented directly inside the application executable.
+
+// HPX_PLUGIN_NAME must be defined before <hpx/config.hpp> so that
+// config.hpp can derive HPX_PLUGIN_PLUGIN_PREFIX from it. This stands in
+// for the target_compile_definition CMake adds for plugin targets; here
+// the "plugin" lives in the test executable itself.
+#define HPX_PLUGIN_NAME app_local_plugin
 
 #include <hpx/config.hpp>
 #include <hpx/modules/datastructures.hpp>
@@ -14,6 +21,7 @@
 #include <hpx/modules/plugin.hpp>
 #include <hpx/modules/testing.hpp>
 #include <hpx/runtime_configuration/init_ini_data.hpp>
+#include <hpx/runtime_configuration/macros.hpp>
 #include <hpx/runtime_configuration/plugin_registry_base.hpp>
 #include <hpx/runtime_configuration/static_factory_data.hpp>
 
@@ -137,6 +145,21 @@ static struct multi_plugin_exporter
         get_multi_plugin_map().insert({"fake_beta", hpx::any_nonser(wb)});
     }
 } multi_exporter_instance;
+
+struct app_local_plugin_registry : hpx::plugins::plugin_registry_base
+{
+    bool get_plugin_info(std::vector<std::string>& fillini) override
+    {
+        fillini.emplace_back("[hpx.plugins.app_local_plugin_instance]");
+        fillini.emplace_back("name = app_local_plugin_instance");
+        fillini.emplace_back("enabled = 1");
+        return true;
+    }
+};
+
+HPX_REGISTER_PLUGIN_BASE_REGISTRY(
+    app_local_plugin_registry, app_local_plugin_instance)
+HPX_REGISTER_PLUGIN_REGISTRY_MODULE()
 
 ///////////////////////////////////////////////////////////////////////////////
 // Test: init_registry_plugin_module stores a plugin module entry and
@@ -299,6 +322,49 @@ void test_load_plugin_factory_static_multi_section()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// End-to-end test for the macro-based in-app plugin registration above.
+// Finds the entry pushed by HPX_REGISTER_PLUGIN_REGISTRY_MODULE's static
+// ctor, then runs it through load_plugin_factory_static and asserts the
+// generated ini section matches what app_local_plugin_registry produced.
+void test_app_local_plugin_via_macros()
+{
+    hpx::util::plugin::get_plugins_list_type get_factory = nullptr;
+    for (auto const& entry : hpx::components::get_static_plugin_module_data())
+    {
+        if (std::string(entry.name) == "app_local_plugin")
+        {
+            get_factory = entry.get_factory;
+            break;
+        }
+    }
+    HPX_TEST(get_factory != nullptr);
+    if (get_factory == nullptr)
+        return;
+
+    hpx::util::section ini;
+    hpx::error_code ec(hpx::throwmode::lightweight);
+    auto registries = hpx::util::load_plugin_factory_static(
+        ini, "app_local_plugin", get_factory, ec);
+
+    HPX_TEST(!ec);
+    HPX_TEST(!registries.empty());
+
+    HPX_TEST(ini.has_section("hpx.plugins.app_local_plugin_instance"));
+    if (ini.has_section("hpx.plugins.app_local_plugin_instance"))
+    {
+        auto* sect = ini.get_section("hpx.plugins.app_local_plugin_instance");
+        HPX_TEST(sect != nullptr);
+        if (sect != nullptr)
+        {
+            HPX_TEST_EQ(sect->get_entry("static", "0"), std::string("1"));
+            HPX_TEST_EQ(sect->get_entry("name", ""),
+                std::string("app_local_plugin_instance"));
+            HPX_TEST_EQ(sect->get_entry("enabled", "0"), std::string("1"));
+        }
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
 int main()
 {
     test_init_registry_plugin_module();
@@ -307,6 +373,7 @@ int main()
     test_load_plugin_factory_static();
     test_load_plugin_factory_static_empty();
     test_load_plugin_factory_static_multi_section();
+    test_app_local_plugin_via_macros();
 
     return hpx::util::report_errors();
 }

--- a/libs/core/runtime_configuration/tests/unit/static_plugin_registry.cpp
+++ b/libs/core/runtime_configuration/tests/unit/static_plugin_registry.cpp
@@ -19,11 +19,8 @@
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/ini.hpp>
 #include <hpx/modules/plugin.hpp>
+#include <hpx/modules/runtime_configuration.hpp>
 #include <hpx/modules/testing.hpp>
-#include <hpx/runtime_configuration/init_ini_data.hpp>
-#include <hpx/runtime_configuration/macros.hpp>
-#include <hpx/runtime_configuration/plugin_registry_base.hpp>
-#include <hpx/runtime_configuration/static_factory_data.hpp>
 
 #include <algorithm>
 #include <cstddef>

--- a/libs/core/runtime_configuration/tests/unit/static_plugin_registry.cpp
+++ b/libs/core/runtime_configuration/tests/unit/static_plugin_registry.cpp
@@ -1,0 +1,311 @@
+//  Copyright (c) 2026 Abhishek Bansal
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Unit tests for the static plugin registry infrastructure that supports
+// static linking of HPX plugins (binary filters, message handlers, etc.).
+
+#include <hpx/config.hpp>
+#include <hpx/modules/datastructures.hpp>
+#include <hpx/modules/errors.hpp>
+#include <hpx/modules/ini.hpp>
+#include <hpx/modules/plugin.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/runtime_configuration/init_ini_data.hpp>
+#include <hpx/runtime_configuration/plugin_registry_base.hpp>
+#include <hpx/runtime_configuration/static_factory_data.hpp>
+
+#include <algorithm>
+#include <map>
+#include <memory>
+#include <string>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+// Minimal plugin_registry_base implementations for testing.
+// get_plugin_info() emits ini lines in the same format real plugin registries
+// use (see plugin_registry::get_plugin_info in plugin_factories).
+
+struct fake_plugin_registry : hpx::plugins::plugin_registry_base
+{
+    bool get_plugin_info(std::vector<std::string>& fillini) override
+    {
+        fillini.emplace_back("[hpx.plugins.fake_test_plugin_instance]");
+        fillini.emplace_back("name = fake_test_plugin_instance");
+        fillini.emplace_back("enabled = 1");
+        return true;
+    }
+};
+
+// Two additional registries that live in the same exported-plugins map.
+// Used by test_load_plugin_factory_static_multi_section to verify that
+// the static = 1 injection logic handles two consecutive [hpx.plugins.*]
+// sections correctly (the fragile part of the section-rewriting loop).
+struct fake_plugin_registry_alpha : hpx::plugins::plugin_registry_base
+{
+    bool get_plugin_info(std::vector<std::string>& fillini) override
+    {
+        fillini.emplace_back("[hpx.plugins.fake_alpha]");
+        fillini.emplace_back("name = fake_alpha");
+        fillini.emplace_back("enabled = 1");
+        return true;
+    }
+};
+
+struct fake_plugin_registry_beta : hpx::plugins::plugin_registry_base
+{
+    bool get_plugin_info(std::vector<std::string>& fillini) override
+    {
+        fillini.emplace_back("[hpx.plugins.fake_beta]");
+        fillini.emplace_back("name = fake_beta");
+        fillini.emplace_back("enabled = 1");
+        return true;
+    }
+};
+
+///////////////////////////////////////////////////////////////////////////////
+// Set up the plugin export infrastructure manually, mirroring what the
+// HPX_PLUGIN_EXPORT_LIST + HPX_PLUGIN_EXPORT macros expand to:
+//
+// 1. A function returning a pointer to a static map (exported plugins list)
+// 2. A concrete_factory<plugin_registry_base, fake_plugin_registry> entry
+//    registered in that map under the lowercase plugin name
+
+static std::map<std::string, hpx::any_nonser>& get_fake_plugin_map()
+{
+    static std::map<std::string, hpx::any_nonser> r;
+    return r;
+}
+
+static std::map<std::string, hpx::any_nonser>* HPX_PLUGIN_API
+fake_get_plugins_list()
+{
+    return &get_fake_plugin_map();
+}
+
+// Register the concrete factory into the map at static-init time.
+static struct fake_plugin_exporter
+{
+    fake_plugin_exporter()
+    {
+        static hpx::util::plugin::concrete_factory<
+            hpx::plugins::plugin_registry_base, fake_plugin_registry>
+            cf;
+        hpx::util::plugin::abstract_factory<hpx::plugins::plugin_registry_base>*
+            w = &cf;
+        get_fake_plugin_map().insert(
+            {"fake_test_plugin_instance", hpx::any_nonser(w)});
+    }
+} fake_exporter_instance;
+
+///////////////////////////////////////////////////////////////////////////////
+// A second exported-plugins map with TWO registries. This exercises the
+// multi-section path through load_plugin_factory_static's injection loop.
+
+static std::map<std::string, hpx::any_nonser>& get_multi_plugin_map()
+{
+    static std::map<std::string, hpx::any_nonser> r;
+    return r;
+}
+
+static std::map<std::string, hpx::any_nonser>* HPX_PLUGIN_API
+multi_get_plugins_list()
+{
+    return &get_multi_plugin_map();
+}
+
+static struct multi_plugin_exporter
+{
+    multi_plugin_exporter()
+    {
+        static hpx::util::plugin::concrete_factory<
+            hpx::plugins::plugin_registry_base, fake_plugin_registry_alpha>
+            cf_alpha;
+        static hpx::util::plugin::concrete_factory<
+            hpx::plugins::plugin_registry_base, fake_plugin_registry_beta>
+            cf_beta;
+
+        hpx::util::plugin::abstract_factory<hpx::plugins::plugin_registry_base>*
+            wa = &cf_alpha;
+        hpx::util::plugin::abstract_factory<hpx::plugins::plugin_registry_base>*
+            wb = &cf_beta;
+
+        get_multi_plugin_map().insert({"fake_alpha", hpx::any_nonser(wa)});
+        get_multi_plugin_map().insert({"fake_beta", hpx::any_nonser(wb)});
+    }
+} multi_exporter_instance;
+
+///////////////////////////////////////////////////////////////////////////////
+// Test: init_registry_plugin_module stores a plugin module entry and
+//       get_static_plugin_module_data returns it.
+void test_init_registry_plugin_module()
+{
+    auto const size_before =
+        hpx::components::get_static_plugin_module_data().size();
+
+    hpx::components::static_factory_load_data_type const data{
+        "fake_test_plugin_module", &fake_get_plugins_list};
+    hpx::components::init_registry_plugin_module(data);
+
+    auto const& modules = hpx::components::get_static_plugin_module_data();
+    HPX_TEST(modules.size() > size_before);
+
+    bool found = false;
+    for (auto const& entry : modules)
+    {
+        if (std::string(entry.name) == "fake_test_plugin_module")
+        {
+            HPX_TEST(entry.get_factory == &fake_get_plugins_list);
+            found = true;
+            break;
+        }
+    }
+    HPX_TEST(found);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Test: init_registry_plugin_factory stores a factory entry and
+//       get_static_plugin_factory can retrieve it by instance name.
+void test_init_registry_plugin_factory()
+{
+    hpx::components::static_factory_load_data_type const data{
+        "fake_test_plugin_instance", &fake_get_plugins_list};
+    hpx::components::init_registry_plugin_factory(data);
+
+    hpx::util::plugin::get_plugins_list_type f = nullptr;
+    bool const ok = hpx::components::get_static_plugin_factory(
+        "fake_test_plugin_instance", f);
+
+    HPX_TEST(ok);
+    HPX_TEST(f == &fake_get_plugins_list);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Test: get_static_plugin_factory returns false for an unknown name.
+void test_get_static_plugin_factory_not_found()
+{
+    hpx::util::plugin::get_plugins_list_type f = nullptr;
+    bool const ok = hpx::components::get_static_plugin_factory(
+        "nonexistent_plugin_xyz_12345", f);
+
+    HPX_TEST(!ok);
+    HPX_TEST(f == nullptr);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Test: load_plugin_factory_static creates an ini section with
+//       [hpx.plugins.<instance>] containing static = 1, and returns a
+//       non-empty vector of registry objects.
+void test_load_plugin_factory_static()
+{
+    hpx::util::section ini;
+
+    hpx::error_code ec(hpx::throwmode::lightweight);
+    auto registries = hpx::util::load_plugin_factory_static(
+        ini, "fake_test_plugin_instance", &fake_get_plugins_list, ec);
+
+    HPX_TEST(!ec);
+    HPX_TEST(!registries.empty());
+
+    HPX_TEST(ini.has_section("hpx.plugins.fake_test_plugin_instance"));
+    if (ini.has_section("hpx.plugins.fake_test_plugin_instance"))
+    {
+        auto* sect = ini.get_section("hpx.plugins.fake_test_plugin_instance");
+        HPX_TEST(sect != nullptr);
+
+        if (sect != nullptr)
+        {
+            // Key assertion: static = 1 was injected by
+            // load_plugin_factory_static
+            std::string const static_val = sect->get_entry("static", "0");
+            HPX_TEST_EQ(static_val, std::string("1"));
+
+            std::string const name_val = sect->get_entry("name", "");
+            HPX_TEST_EQ(name_val, std::string("fake_test_plugin_instance"));
+
+            std::string const enabled_val = sect->get_entry("enabled", "0");
+            HPX_TEST_EQ(enabled_val, std::string("1"));
+        }
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// An empty plugins list function - exports no factories.
+static std::map<std::string, hpx::any_nonser>* HPX_PLUGIN_API
+empty_get_plugins_list()
+{
+    static std::map<std::string, hpx::any_nonser> m;
+    return &m;
+}
+
+// Test: load_plugin_factory_static with an empty factory (no names exported)
+//       returns an empty vector and does not create any section.
+void test_load_plugin_factory_static_empty()
+{
+    hpx::util::section ini;
+    hpx::error_code ec(hpx::throwmode::lightweight);
+    auto registries = hpx::util::load_plugin_factory_static(
+        ini, "empty_plugin", &empty_get_plugins_list, ec);
+
+    HPX_TEST(!ec);
+    HPX_TEST(registries.empty());
+    HPX_TEST(!ini.has_section("hpx.plugins.empty_plugin"));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Test: load_plugin_factory_static with two registries in one module.
+// The injection loop must insert static = 1 into BOTH [hpx.plugins.fake_alpha]
+// and [hpx.plugins.fake_beta]. This exercises the state machine that tracks
+// section headers - a bug here (e.g. only marking the first or last section)
+// would silently break multi-plugin modules in static builds.
+void test_load_plugin_factory_static_multi_section()
+{
+    hpx::util::section ini;
+
+    hpx::error_code ec(hpx::throwmode::lightweight);
+    auto registries = hpx::util::load_plugin_factory_static(
+        ini, "multi_test", &multi_get_plugins_list, ec);
+
+    HPX_TEST(!ec);
+    HPX_TEST_EQ(registries.size(), std::size_t(2));
+
+    // Both plugin sections must exist and both must have static = 1.
+    HPX_TEST(ini.has_section("hpx.plugins.fake_alpha"));
+    if (ini.has_section("hpx.plugins.fake_alpha"))
+    {
+        auto* sect = ini.get_section("hpx.plugins.fake_alpha");
+        HPX_TEST(sect != nullptr);
+        if (sect != nullptr)
+        {
+            HPX_TEST_EQ(sect->get_entry("static", "0"), std::string("1"));
+            HPX_TEST_EQ(sect->get_entry("name", ""), std::string("fake_alpha"));
+        }
+    }
+
+    HPX_TEST(ini.has_section("hpx.plugins.fake_beta"));
+    if (ini.has_section("hpx.plugins.fake_beta"))
+    {
+        auto* sect = ini.get_section("hpx.plugins.fake_beta");
+        HPX_TEST(sect != nullptr);
+        if (sect != nullptr)
+        {
+            HPX_TEST_EQ(sect->get_entry("static", "0"), std::string("1"));
+            HPX_TEST_EQ(sect->get_entry("name", ""), std::string("fake_beta"));
+        }
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int main()
+{
+    test_init_registry_plugin_module();
+    test_init_registry_plugin_factory();
+    test_get_static_plugin_factory_not_found();
+    test_load_plugin_factory_static();
+    test_load_plugin_factory_static_empty();
+    test_load_plugin_factory_static_multi_section();
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/runtime_configuration/tests/unit/static_plugin_registry.cpp
+++ b/libs/core/runtime_configuration/tests/unit/static_plugin_registry.cpp
@@ -18,6 +18,7 @@
 #include <hpx/runtime_configuration/static_factory_data.hpp>
 
 #include <algorithm>
+#include <cstddef>
 #include <map>
 #include <memory>
 #include <string>

--- a/libs/full/plugin_factories/include/hpx/plugin_factories/binary_filter_factory_base.hpp
+++ b/libs/full/plugin_factories/include/hpx/plugin_factories/binary_filter_factory_base.hpp
@@ -32,9 +32,12 @@ namespace hpx::plugins {
 }    // namespace hpx::plugins
 
 ///////////////////////////////////////////////////////////////////////////////
-/// This macro is used to register the given component factory with
-/// Hpx.Plugin. This macro has to be used for each of the component factories.
+/// This macro is used to register the given binary filter factory with
+/// Hpx.Plugin. This macro has to be used for each of the binary filter
+/// factories.
 #define HPX_REGISTER_BINARY_FILTER_FACTORY_BASE(FactoryType, pluginname)       \
     HPX_PLUGIN_EXPORT(HPX_PLUGIN_PLUGIN_PREFIX,                                \
         hpx::plugins::plugin_factory_base, FactoryType, pluginname, factory)   \
+    HPX_INIT_REGISTRY_PLUGIN_FACTORY_STATIC(                                   \
+        HPX_PLUGIN_PLUGIN_PREFIX, pluginname, factory)                         \
     /**/

--- a/libs/full/plugin_factories/include/hpx/plugin_factories/message_handler_factory_base.hpp
+++ b/libs/full/plugin_factories/include/hpx/plugin_factories/message_handler_factory_base.hpp
@@ -41,11 +41,14 @@ namespace hpx::plugins {
 }    // namespace hpx::plugins
 
 ///////////////////////////////////////////////////////////////////////////////
-/// This macro is used to register the given component factory with
-/// Hpx.Plugin. This macro has to be used for each of the component factories.
+/// This macro is used to register the given message handler factory with
+/// Hpx.Plugin. This macro has to be used for each of the message handler
+/// factories.
 #define HPX_REGISTER_MESSAGE_HANDLER_FACTORY_BASE(FactoryType, pluginname)     \
     HPX_PLUGIN_EXPORT(HPX_PLUGIN_PLUGIN_PREFIX,                                \
         hpx::plugins::plugin_factory_base, FactoryType, pluginname, factory)   \
+    HPX_INIT_REGISTRY_PLUGIN_FACTORY_STATIC(                                   \
+        HPX_PLUGIN_PLUGIN_PREFIX, pluginname, factory)                         \
     /**/
 
 #endif

--- a/libs/full/plugin_factories/include/hpx/plugin_factories/plugin_factory_base.hpp
+++ b/libs/full/plugin_factories/include/hpx/plugin_factories/plugin_factory_base.hpp
@@ -60,15 +60,10 @@ struct hpx::util::plugin::virtual_constructor<hpx::plugins::plugin_factory_base>
         HPX_PLUGIN_PLUGIN_PREFIX, pluginname, factory)                         \
 /**/
 
-////////////////////////////////////////////////////////////////////////////////
-// Mirror the component module gating pattern (macros.hpp lines 66-93):
-//   !APP_NAME && !STATIC_LINKING -> full expansion (dynamic build, library TU)
-//   STATIC_LINKING               -> full expansion (static build, any TU)
-//   APP_NAME only                -> nothing       (dynamic build, exe TU)
-#if !defined(HPX_APPLICATION_NAME) && !defined(HPX_HAVE_STATIC_LINKING)
-
 /// This macro is used to define the required Hpx.Plugin entry points. This
 /// macro has to be used in exactly one compilation unit of a plugin module.
+/// Ungated: a plugin may live in a shared library, in a statically linked
+/// build, or directly in the application executable.
 #define HPX_REGISTER_PLUGIN_MODULE()                                           \
     HPX_PLUGIN_EXPORT_LIST(HPX_PLUGIN_PLUGIN_PREFIX, factory)                  \
     HPX_REGISTER_PLUGIN_REGISTRY_MODULE()                                      \
@@ -78,17 +73,3 @@ struct hpx::util::plugin::virtual_constructor<hpx::plugins::plugin_factory_base>
     HPX_PLUGIN_EXPORT_LIST(HPX_PLUGIN_PLUGIN_PREFIX, factory)                  \
     HPX_REGISTER_PLUGIN_REGISTRY_MODULE_DYNAMIC()                              \
     /**/
-
-#else
-
-#if defined(HPX_HAVE_STATIC_LINKING)
-#define HPX_REGISTER_PLUGIN_MODULE()                                           \
-    HPX_PLUGIN_EXPORT_LIST(HPX_PLUGIN_PLUGIN_PREFIX, factory)                  \
-    HPX_REGISTER_PLUGIN_REGISTRY_MODULE()                                      \
-    /**/
-#else
-#define HPX_REGISTER_PLUGIN_MODULE()
-#endif
-#define HPX_REGISTER_PLUGIN_MODULE_DYNAMIC()
-
-#endif

--- a/libs/full/plugin_factories/include/hpx/plugin_factories/plugin_factory_base.hpp
+++ b/libs/full/plugin_factories/include/hpx/plugin_factories/plugin_factory_base.hpp
@@ -50,15 +50,25 @@ struct hpx::util::plugin::virtual_constructor<hpx::plugins::plugin_factory_base>
 };
 
 ////////////////////////////////////////////////////////////////////////////////
-/// This macro is used to register the given component factory with
-/// Hpx.Plugin. This macro has to be used for each of the component factories.
+/// This macro is used to register the given plugin factory with Hpx.Plugin.
+/// This macro has to be used for each of the plugin factories. Ungated,
+/// matching the component analog (HPX_REGISTER_COMPONENT_FACTORY).
 #define HPX_REGISTER_PLUGIN_FACTORY_BASE(FactoryType, pluginname)              \
     HPX_PLUGIN_EXPORT(HPX_PLUGIN_PLUGIN_PREFIX,                                \
         hpx::plugins::plugin_factory_base, FactoryType, pluginname, factory)   \
+    HPX_INIT_REGISTRY_PLUGIN_FACTORY_STATIC(                                   \
+        HPX_PLUGIN_PLUGIN_PREFIX, pluginname, factory)                         \
 /**/
 
+////////////////////////////////////////////////////////////////////////////////
+// Mirror the component module gating pattern (macros.hpp lines 66-93):
+//   !APP_NAME && !STATIC_LINKING -> full expansion (dynamic build, library TU)
+//   STATIC_LINKING               -> full expansion (static build, any TU)
+//   APP_NAME only                -> nothing       (dynamic build, exe TU)
+#if !defined(HPX_APPLICATION_NAME) && !defined(HPX_HAVE_STATIC_LINKING)
+
 /// This macro is used to define the required Hpx.Plugin entry points. This
-/// macro has to be used in exactly one compilation unit of a component module.
+/// macro has to be used in exactly one compilation unit of a plugin module.
 #define HPX_REGISTER_PLUGIN_MODULE()                                           \
     HPX_PLUGIN_EXPORT_LIST(HPX_PLUGIN_PLUGIN_PREFIX, factory)                  \
     HPX_REGISTER_PLUGIN_REGISTRY_MODULE()                                      \
@@ -68,3 +78,17 @@ struct hpx::util::plugin::virtual_constructor<hpx::plugins::plugin_factory_base>
     HPX_PLUGIN_EXPORT_LIST(HPX_PLUGIN_PLUGIN_PREFIX, factory)                  \
     HPX_REGISTER_PLUGIN_REGISTRY_MODULE_DYNAMIC()                              \
     /**/
+
+#else
+
+#if defined(HPX_HAVE_STATIC_LINKING)
+#define HPX_REGISTER_PLUGIN_MODULE()                                           \
+    HPX_PLUGIN_EXPORT_LIST(HPX_PLUGIN_PLUGIN_PREFIX, factory)                  \
+    HPX_REGISTER_PLUGIN_REGISTRY_MODULE()                                      \
+    /**/
+#else
+#define HPX_REGISTER_PLUGIN_MODULE()
+#endif
+#define HPX_REGISTER_PLUGIN_MODULE_DYNAMIC()
+
+#endif

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/server/runtime_support.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/server/runtime_support.hpp
@@ -56,15 +56,13 @@ namespace hpx::components::server {
         {
             plugin_factory(
                 std::shared_ptr<plugins::plugin_factory_base> const& f,
-                hpx::util::plugin::dll const& d, bool enabled)
+                bool enabled)
               : first(f)
-              , second(d)
               , isenabled(enabled)
             {
             }
 
             std::shared_ptr<plugins::plugin_factory_base> first;
-            hpx::util::plugin::dll const& second;
             bool isenabled;
         };
         using plugin_factory_type = plugin_factory;
@@ -319,6 +317,11 @@ namespace hpx::components::server {
             hpx::program_options::options_description& options,
             std::set<std::string>& startup_handled);
 #endif
+
+        bool load_plugin_static(util::section& ini, std::string const& instance,
+            std::string const& plugin, bool isenabled,
+            hpx::program_options::options_description& options,
+            std::set<std::string>& startup_handled);
 
         // the name says it all
         std::size_t dijkstra_termination_detection(

--- a/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
+++ b/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
@@ -1185,6 +1185,108 @@ namespace hpx { namespace components { namespace server {
     }
 
     ///////////////////////////////////////////////////////////////////////////
+    // Static equivalent of load_plugin. Looks up the statically registered
+    // plugin_factory_base getter by instance name and inserts the resulting
+    // factory into plugins_. Commandline options and startup/shutdown
+    // functions are handled via the existing component-side static helpers,
+    // which are agnostic to whether the module is a component or a plugin.
+    bool runtime_support::load_plugin_static(util::section& ini,
+        std::string const& instance, std::string const& plugin, bool isenabled,
+        hpx::program_options::options_description& options,
+        std::set<std::string>& startup_handled)
+    {
+        try
+        {
+            util::section const* glob_ini = nullptr;
+            if (ini.has_section("settings"))
+                glob_ini = ini.get_section("settings");
+
+            util::section const* plugin_ini = nullptr;
+            std::string const plugin_section("hpx.plugins." + instance);
+            if (ini.has_section(plugin_section))
+                plugin_ini = ini.get_section(plugin_section);
+
+            error_code ec(throwmode::lightweight);
+            if (nullptr == plugin_ini ||
+                "0" == plugin_ini->get_entry("no_factory", "0"))
+            {
+                util::plugin::get_plugins_list_type get_factory;
+                if (!components::get_static_plugin_factory(
+                        instance, get_factory))
+                {
+                    LRT_(warning).format(
+                        "static loading of plugin factory failed: {}: "
+                        "couldn't find factory in global static plugin "
+                        "factory map",
+                        instance);
+                    return false;
+                }
+
+                hpx::util::plugin::static_plugin_factory<
+                    plugins::plugin_factory_base> const pf(get_factory);
+
+                std::shared_ptr<plugins::plugin_factory_base> const f(
+                    pf.create(instance, ec, glob_ini, plugin_ini, isenabled));
+                if (!ec)
+                {
+                    plugin_factory_type data(f, isenabled);
+                    std::pair<plugin_map_type::iterator, bool> const p =
+                        plugins_.insert(
+                            plugin_map_type::value_type(instance, data));
+
+                    if (!p.second)
+                    {
+                        LRT_(fatal).format(
+                            "duplicate plugin type: {}", instance);
+                        return false;
+                    }
+
+                    LRT_(info).format(
+                        "static loading of plugin succeeded: {}", instance);
+                }
+                else
+                {
+                    LRT_(warning).format(
+                        "static loading of plugin factory failed: {}: {}",
+                        instance, get_error_what(ec));
+                    return false;
+                }
+            }
+
+            // Module-scoped startup/shutdown + commandline registration runs
+            // at most once per module. Plugin modules feed the same static
+            // commandline/startup maps as components via the shared
+            // HPX_REGISTER_COMMANDLINE_OPTIONS / HPX_REGISTER_STARTUP_SHUTDOWN
+            // macros, so the component-side helpers work unchanged.
+            if (startup_handled.find(plugin) == startup_handled.end())
+            {
+                startup_handled.insert(plugin);
+                load_commandline_options_static(plugin, options, ec);
+                if (ec)
+                    ec = error_code(throwmode::lightweight);
+                load_startup_shutdown_functions_static(plugin, ec);
+            }
+        }
+        catch (hpx::exception const&)
+        {
+            throw;
+        }
+        catch (std::logic_error const& e)
+        {
+            LRT_(warning).format(
+                "static loading of plugin failed: {}: {}", instance, e.what());
+            return false;
+        }
+        catch (std::exception const& e)
+        {
+            LRT_(warning).format(
+                "static loading of plugin failed: {}: {}", instance, e.what());
+            return false;
+        }
+        return true;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
     // Load all components from the ini files found in the configuration
     int runtime_support::load_components(util::section& ini,
         naming::gid_type const& prefix, agas::addressing_service& agas_client,
@@ -1776,12 +1878,8 @@ namespace hpx { namespace components { namespace server {
 
                 if (sect.get_entry("static", "0") == "1")
                 {
-                    // FIXME: implement statically linked plugins
-                    HPX_THROW_EXCEPTION(hpx::error::service_unavailable,
-                        "runtime_support::load_plugins",
-                        "static linking configuration does not support static "
-                        "loading of plugin '{}'",
-                        instance);
+                    load_plugin_static(ini, instance, component, isenabled,
+                        options, startup_handled);
                 }
                 else
                 {
@@ -1850,7 +1948,7 @@ namespace hpx { namespace components { namespace server {
                 if (!ec)
                 {
                     // store component factory and module for later use
-                    plugin_factory_type data(f, d, isenabled);
+                    plugin_factory_type data(f, isenabled);
                     std::pair<plugin_map_type::iterator, bool> p =
                         plugins_.insert(
                             plugin_map_type::value_type(instance, data));


### PR DESCRIPTION
## Proposed Changes

Plugins (binary filters, message handlers) could not be loaded in statically linked HPX builds. `load_plugins` threw "static loading of plugin not supported". Components already had full static loading infrastructure, but plugins were missing the parallel machinery.

- Added a dedicated static plugin registry (`init_registry_plugin_module`, `init_registry_plugin_factory`, `get_static_plugin_factory`) that mirrors the existing component-side registries but keeps plugin bookkeeping in separate maps.

- Added `load_plugin_factory_static()` which iterates plugin registries and injects `static = 1` into each `[hpx.plugins.*]` ini section. Added `load_plugin_static()` in runtime_support to instantiate plugin factories from the static registry.

- Added unit tests covering the registry infrastructure, `static = 1` injection for single and multi-plugin modules, and the empty-factory edge case.

## Checklist

Not all points below apply to all pull requests.

- [X] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
