### PR TITLE
tests(algorithms): fix return-iterator C++20 compliance for hpx::shift_left and hpx::shift_right

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/algorithms/shift_left.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/shift_left.hpp
@@ -277,9 +277,8 @@ namespace hpx {
             )
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
-            FwdIter>::type
-        tag_fallback_invoke(shift_left_t, ExPolicy&& policy, FwdIter first,
-            FwdIter last, Size n)
+            FwdIter>::type tag_fallback_invoke(shift_left_t, ExPolicy&& policy,
+            FwdIter first, FwdIter last, Size n)
         {
             static_assert(std::forward_iterator<FwdIter>,
                 "Requires at least forward iterator.");

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/shift_left.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/shift_left.hpp
@@ -44,7 +44,10 @@ namespace hpx {
     ///
     /// \returns  The \a shift_left algorithm returns \a FwdIter.
     ///           The \a shift_left algorithm returns an iterator to the
-    ///           end of the resulting range.
+    ///           end of the resulting range. Specifically:
+    ///           If \a n is 0 or \a n >= (last - first), does nothing and
+    ///           returns \a last and \a first respectively.
+    ///           Otherwise returns \a first + ((last - first) - n).
     ///
     template <typename FwdIter, typename Size>
     FwdIter shift_left(FwdIter first, FwdIter last, Size n);
@@ -95,7 +98,10 @@ namespace hpx {
     ///           \a parallel_task_policy and
     ///           returns \a FwdIter otherwise.
     ///           The \a shift_left algorithm returns an iterator to the
-    ///           end of the resulting range.
+    ///           end of the resulting range. Specifically:
+    ///           If \a n is 0, does nothing and returns \a last.
+    ///           If \a n >= (last - first), does nothing and returns \a first.
+    ///           Otherwise returns \a first + ((last - first) - n).
     ///
     template <typename ExPolicy, typename FwdIter, typename Size>
     typename hpx::parallel::util::detail::algorithm_result<ExPolicy, FwdIter>
@@ -194,7 +200,13 @@ namespace hpx::parallel {
             {
                 auto dist =
                     static_cast<std::size_t>(detail::distance(first, last));
-                if (n <= 0 || static_cast<std::size_t>(n) >= dist)
+                // C++20 [alg.shift]: if n is 0, do nothing and return last.
+                if (n <= 0)
+                {
+                    return std::next(first, dist);
+                }
+                // C++20 [alg.shift]: if n >= dist, do nothing and return first.
+                if (static_cast<std::size_t>(n) >= dist)
                 {
                     return first;
                 }
@@ -209,7 +221,14 @@ namespace hpx::parallel {
             {
                 auto const dist =
                     static_cast<std::size_t>(detail::distance(first, last));
-                if (n <= 0 || static_cast<std::size_t>(n) >= dist)
+                // C++20 [alg.shift]: if n is 0, do nothing and return last.
+                if (n <= 0)
+                {
+                    return parallel::util::detail::algorithm_result<ExPolicy,
+                        FwdIter2>::get(std::next(first, dist));
+                }
+                // C++20 [alg.shift]: if n >= dist, do nothing and return first.
+                if (static_cast<std::size_t>(n) >= dist)
                 {
                     return parallel::util::detail::algorithm_result<ExPolicy,
                         FwdIter2>::get(HPX_MOVE(first));

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/shift_left.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/shift_left.hpp
@@ -201,7 +201,7 @@ namespace hpx::parallel {
                 auto dist =
                     static_cast<std::size_t>(detail::distance(first, last));
                 // C++20 [alg.shift]: if n is 0, do nothing and return last.
-                if (n <= 0)
+                if (n == 0)
                 {
                     return std::next(first, dist);
                 }
@@ -222,7 +222,7 @@ namespace hpx::parallel {
                 auto const dist =
                     static_cast<std::size_t>(detail::distance(first, last));
                 // C++20 [alg.shift]: if n is 0, do nothing and return last.
-                if (n <= 0)
+                if (n == 0)
                 {
                     return parallel::util::detail::algorithm_result<ExPolicy,
                         FwdIter2>::get(std::next(first, dist));

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/shift_left.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/shift_left.hpp
@@ -277,8 +277,9 @@ namespace hpx {
             )
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
-            FwdIter>::type tag_fallback_invoke(shift_left_t, ExPolicy&& policy,
-            FwdIter first, FwdIter last, Size n)
+            FwdIter>::type
+        tag_fallback_invoke(shift_left_t, ExPolicy&& policy, FwdIter first,
+            FwdIter last, Size n)
         {
             static_assert(std::forward_iterator<FwdIter>,
                 "Requires at least forward iterator.");

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/shift_right.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/shift_right.hpp
@@ -322,9 +322,8 @@ namespace hpx {
             )
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
-            FwdIter>::type
-        tag_fallback_invoke(shift_right_t, ExPolicy&& policy, FwdIter first,
-            FwdIter last, Size n)
+            FwdIter>::type tag_fallback_invoke(shift_right_t, ExPolicy&& policy,
+            FwdIter first, FwdIter last, Size n)
         {
             static_assert(std::forward_iterator<FwdIter>,
                 "Requires at least forward iterator.");

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/shift_right.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/shift_right.hpp
@@ -244,7 +244,7 @@ namespace hpx::parallel {
                 auto dist =
                     static_cast<std::size_t>(detail::distance(first, last));
                 // C++20 [alg.shift]: if n is 0, do nothing and return first.
-                if (n <= 0)
+                if (n == 0)
                 {
                     return first;
                 }
@@ -267,7 +267,7 @@ namespace hpx::parallel {
                 auto dist =
                     static_cast<std::size_t>(detail::distance(first, last));
                 // C++20 [alg.shift]: if n is 0, do nothing and return first.
-                if (n <= 0)
+                if (n == 0)
                 {
                     return parallel::util::detail::algorithm_result<ExPolicy,
                         FwdIter2>::get(HPX_MOVE(first));

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/shift_right.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/shift_right.hpp
@@ -44,7 +44,10 @@ namespace hpx {
     ///
     /// \returns  The \a shift_right algorithm returns \a FwdIter.
     ///           The \a shift_right algorithm returns an iterator to the
-    ///           end of the resulting range.
+    ///           beginning of the resulting range. Specifically:
+    ///           If \a n is 0 or \a n >= (last - first), does nothing and
+    ///           returns \a first and \a last respectively.
+    ///           Otherwise returns \a first + n.
     ///
     template <typename FwdIter, typename Size>
     FwdIter shift_right(FwdIter first, FwdIter last, Size n);
@@ -95,7 +98,10 @@ namespace hpx {
     ///           \a parallel_task_policy and
     ///           returns \a FwdIter otherwise.
     ///           The \a shift_right algorithm returns an iterator to the
-    ///           end of the resulting range.
+    ///           beginning of the resulting range. Specifically:
+    ///           If \a n is 0, does nothing and returns \a first.
+    ///           If \a n >= (last - first), does nothing and returns \a last.
+    ///           Otherwise returns \a first + n.
     ///
     template <typename ExPolicy, typename FwdIter, typename Size>
     typename hpx::parallel::util::detail::algorithm_result<ExPolicy, FwdIter>
@@ -152,7 +158,9 @@ namespace hpx::parallel {
                     return f.then(
                         [=](hpx::future<FwdIter>&& f) mutable -> FwdIter {
                             f.get();
-                            return new_first;
+                            std::advance(
+                                first, detail::distance(new_first, last));
+                            return first;
                         });
                 },
                 r.call2(p, non_seq(), first, new_first));
@@ -235,9 +243,15 @@ namespace hpx::parallel {
             {
                 auto dist =
                     static_cast<std::size_t>(detail::distance(first, last));
-                if (n <= 0 || static_cast<std::size_t>(n) >= dist)
+                // C++20 [alg.shift]: if n is 0, do nothing and return first.
+                if (n <= 0)
                 {
                     return first;
+                }
+                // C++20 [alg.shift]: if n >= dist, do nothing and return last.
+                if (static_cast<std::size_t>(n) >= dist)
+                {
+                    return std::next(first, dist);
                 }
 
                 auto last_iter = detail::advance_to_sentinel(first, last);
@@ -252,10 +266,17 @@ namespace hpx::parallel {
             {
                 auto dist =
                     static_cast<std::size_t>(detail::distance(first, last));
-                if (n <= 0 || static_cast<std::size_t>(n) >= dist)
+                // C++20 [alg.shift]: if n is 0, do nothing and return first.
+                if (n <= 0)
                 {
                     return parallel::util::detail::algorithm_result<ExPolicy,
                         FwdIter2>::get(HPX_MOVE(first));
+                }
+                // C++20 [alg.shift]: if n >= dist, do nothing and return last.
+                if (static_cast<std::size_t>(n) >= dist)
+                {
+                    return parallel::util::detail::algorithm_result<ExPolicy,
+                        FwdIter2>::get(std::next(first, dist));
                 }
 
                 auto new_first = std::next(first, dist - n);

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/shift_right.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/shift_right.hpp
@@ -322,8 +322,9 @@ namespace hpx {
             )
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
-            FwdIter>::type tag_fallback_invoke(shift_right_t, ExPolicy&& policy,
-            FwdIter first, FwdIter last, Size n)
+            FwdIter>::type
+        tag_fallback_invoke(shift_right_t, ExPolicy&& policy, FwdIter first,
+            FwdIter last, Size n)
         {
             static_assert(std::forward_iterator<FwdIter>,
                 "Requires at least forward iterator.");

--- a/libs/core/algorithms/tests/unit/algorithms/shift_left.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/shift_left.cpp
@@ -257,7 +257,7 @@ void test_shift_left_cross_policy()
 {
     using namespace hpx::execution;
 
-    auto check = [](std::vector<std::size_t> c, int n, char const* scenario) {
+    auto verify_consistency = [](std::vector<std::size_t> c, int n) {
         std::vector<std::size_t> c_par = c;
         std::vector<std::size_t> c_pu = c;
 
@@ -276,12 +276,12 @@ void test_shift_left_cross_policy()
     std::vector<std::size_t> base(50);
     std::iota(base.begin(), base.end(), std::size_t(1));
 
-    check(base, 0, "");
-    check(base, 50, "");
-    check(base, 99, "");
-    check(base, 25, "");
-    check(base, 1, "");
-    check(base, 49, "");
+    verify_consistency(base, 0);
+    verify_consistency(base, 50);
+    verify_consistency(base, 99);
+    verify_consistency(base, 25);
+    verify_consistency(base, 1);
+    verify_consistency(base, 49);
 }
 
 void shift_left_return_iterator_test()

--- a/libs/core/algorithms/tests/unit/algorithms/shift_left.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/shift_left.cpp
@@ -176,6 +176,120 @@ void shift_left_test()
     test_shift_left<std::forward_iterator_tag>();
 }
 
+///////////////////////////////////////////////////////////////////////////////
+// Return-iterator tests for hpx::shift_left
+template <typename ExPolicy>
+void test_shift_left_return_iterator(ExPolicy&& policy)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    // n == 0: no-op, returns last
+    {
+        std::vector<std::size_t> c(100);
+        std::iota(std::begin(c), std::end(c), std::size_t(1));
+
+        auto result = hpx::shift_left(policy, c.begin(), c.end(), 0);
+        HPX_TEST(result == c.end());
+    }
+
+    // n >= dist: no-op, returns first
+    {
+        std::vector<std::size_t> c(100);
+        std::iota(std::begin(c), std::end(c), std::size_t(1));
+
+        auto r1 = hpx::shift_left(policy, c.begin(), c.end(), 100);
+        HPX_TEST(r1 == c.begin());
+
+        auto r2 = hpx::shift_left(policy, c.begin(), c.end(), 9999);
+        HPX_TEST(r2 == c.begin());
+    }
+
+    // 0 < n < dist: returns first + (dist - n)
+    {
+        std::vector<std::size_t> c(100);
+        std::iota(std::begin(c), std::end(c), std::size_t(1));
+
+        constexpr std::size_t n = 25;
+        auto result = hpx::shift_left(policy, c.begin(), c.end(), n);
+        auto expected = c.begin() + static_cast<std::ptrdiff_t>(100 - n);
+        HPX_TEST(result == expected);
+
+        bool values_ok = true;
+        for (std::size_t i = 0; i != 75; ++i)
+        {
+            if (c[i] != i + 26)
+            {
+                values_ok = false;
+                break;
+            }
+        }
+        HPX_TEST(values_ok);
+    }
+
+    // n == dist: returns first
+    {
+        std::vector<std::size_t> c = {42};
+        auto result = hpx::shift_left(policy, c.begin(), c.end(), 1);
+        HPX_TEST(result == c.begin());
+    }
+
+    // empty range: returns last
+    {
+        std::vector<std::size_t> empty;
+        auto result = hpx::shift_left(policy, empty.begin(), empty.end(), 0);
+        HPX_TEST(result == empty.end());
+    }
+}
+
+template <typename IteratorTag>
+void test_shift_left_return_iterator()
+{
+    using namespace hpx::execution;
+    test_shift_left_return_iterator(seq);
+    test_shift_left_return_iterator(par);
+    test_shift_left_return_iterator(par_unseq);
+}
+
+// Cross-policy consistency: seq, par, par_unseq must all return the SAME
+// iterator for each case (relative to the range begin).
+void test_shift_left_cross_policy()
+{
+    using namespace hpx::execution;
+
+    auto check = [](std::vector<std::size_t> c, int n, char const* scenario) {
+        std::vector<std::size_t> c_par = c;
+        std::vector<std::size_t> c_pu = c;
+
+        auto rs = hpx::shift_left(seq, c.begin(), c.end(), n);
+        auto rp = hpx::shift_left(par, c_par.begin(), c_par.end(), n);
+        auto ru = hpx::shift_left(par_unseq, c_pu.begin(), c_pu.end(), n);
+
+        auto ds = std::distance(c.begin(), rs);
+        auto dp = std::distance(c_par.begin(), rp);
+        auto du = std::distance(c_pu.begin(), ru);
+
+        HPX_TEST(ds == dp);
+        HPX_TEST(ds == du);
+    };
+
+    std::vector<std::size_t> base(50);
+    std::iota(base.begin(), base.end(), std::size_t(1));
+
+    check(base, 0, "");
+    check(base, 50, "");
+    check(base, 99, "");
+    check(base, 25, "");
+    check(base, 1, "");
+    check(base, 49, "");
+}
+
+void shift_left_return_iterator_test()
+{
+    test_shift_left_return_iterator<std::random_access_iterator_tag>();
+    test_shift_left_cross_policy();
+}
+
 int hpx_main(hpx::program_options::variables_map& vm)
 {
     unsigned int seed = (unsigned int) std::time(nullptr);
@@ -186,6 +300,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
     std::srand(seed);
 
     shift_left_test();
+    shift_left_return_iterator_test();
     return hpx::local::finalize();
 }
 

--- a/libs/core/algorithms/tests/unit/algorithms/shift_right.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/shift_right.cpp
@@ -237,8 +237,7 @@ void test_shift_right_return_iterator(ExPolicy&& policy)
     // empty range: returns first
     {
         std::vector<std::size_t> empty;
-        auto result =
-            hpx::shift_right(policy, empty.begin(), empty.end(), 0);
+        auto result = hpx::shift_right(policy, empty.begin(), empty.end(), 0);
         HPX_TEST(result == empty.begin());
     }
 }

--- a/libs/core/algorithms/tests/unit/algorithms/shift_right.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/shift_right.cpp
@@ -176,6 +176,121 @@ void shift_right_test()
     test_shift_right<std::forward_iterator_tag>();
 }
 
+///////////////////////////////////////////////////////////////////////////////
+// Return-iterator tests for hpx::shift_right
+template <typename ExPolicy>
+void test_shift_right_return_iterator(ExPolicy&& policy)
+{
+    static_assert(hpx::is_execution_policy<ExPolicy>::value,
+        "hpx::is_execution_policy<ExPolicy>::value");
+
+    // n == 0: no-op, returns first
+    {
+        std::vector<std::size_t> c(100);
+        std::iota(std::begin(c), std::end(c), std::size_t(1));
+
+        auto result = hpx::shift_right(policy, c.begin(), c.end(), 0);
+        HPX_TEST(result == c.begin());
+    }
+
+    // n >= dist: no-op, returns last
+    {
+        std::vector<std::size_t> c(100);
+        std::iota(std::begin(c), std::end(c), std::size_t(1));
+
+        auto r1 = hpx::shift_right(policy, c.begin(), c.end(), 100);
+        HPX_TEST(r1 == c.end());
+
+        auto r2 = hpx::shift_right(policy, c.begin(), c.end(), 9999);
+        HPX_TEST(r2 == c.end());
+    }
+
+    // 0 < n < dist: returns first + n
+    {
+        std::vector<std::size_t> c(100);
+        std::iota(std::begin(c), std::end(c), std::size_t(1));
+
+        constexpr std::size_t n = 25;
+        auto result = hpx::shift_right(policy, c.begin(), c.end(), n);
+        auto expected = c.begin() + static_cast<std::ptrdiff_t>(n);
+        HPX_TEST(result == expected);
+
+        bool values_ok = true;
+        for (std::size_t i = n; i != 100; ++i)
+        {
+            if (c[i] != i - n + 1)
+            {
+                values_ok = false;
+                break;
+            }
+        }
+        HPX_TEST(values_ok);
+    }
+
+    // n == dist: returns last
+    {
+        std::vector<std::size_t> c = {42};
+        auto result = hpx::shift_right(policy, c.begin(), c.end(), 1);
+        HPX_TEST(result == c.end());
+    }
+
+    // empty range: returns first
+    {
+        std::vector<std::size_t> empty;
+        auto result =
+            hpx::shift_right(policy, empty.begin(), empty.end(), 0);
+        HPX_TEST(result == empty.begin());
+    }
+}
+
+template <typename IteratorTag>
+void test_shift_right_return_iterator()
+{
+    using namespace hpx::execution;
+    test_shift_right_return_iterator(seq);
+    test_shift_right_return_iterator(par);
+    test_shift_right_return_iterator(par_unseq);
+}
+
+// Cross-policy consistency: seq, par, par_unseq must all return the SAME
+// iterator distance from begin for each scenario.
+void test_shift_right_cross_policy()
+{
+    using namespace hpx::execution;
+
+    auto check = [](std::vector<std::size_t> c, int n, char const* scenario) {
+        std::vector<std::size_t> c_par = c;
+        std::vector<std::size_t> c_pu = c;
+
+        auto rs = hpx::shift_right(seq, c.begin(), c.end(), n);
+        auto rp = hpx::shift_right(par, c_par.begin(), c_par.end(), n);
+        auto ru = hpx::shift_right(par_unseq, c_pu.begin(), c_pu.end(), n);
+
+        auto ds = std::distance(c.begin(), rs);
+        auto dp = std::distance(c_par.begin(), rp);
+        auto du = std::distance(c_pu.begin(), ru);
+
+        HPX_TEST(ds == dp);
+        HPX_TEST(ds == du);
+    };
+
+    std::vector<std::size_t> base(50);
+    std::iota(base.begin(), base.end(), std::size_t(1));
+
+    check(base, 0, "");
+    check(base, 50, "");
+    check(base, 99, "");
+    check(base, 25, "");
+    check(base, 1, "");
+    check(base, 49, "");
+}
+
+void shift_right_return_iterator_test()
+{
+    test_shift_right_return_iterator<std::random_access_iterator_tag>();
+    test_shift_right_cross_policy();
+}
+
 int hpx_main(hpx::program_options::variables_map& vm)
 {
     unsigned int seed = (unsigned int) std::time(nullptr);
@@ -186,6 +301,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
     std::srand(seed);
 
     shift_right_test();
+    shift_right_return_iterator_test();
     return hpx::local::finalize();
 }
 

--- a/libs/core/algorithms/tests/unit/algorithms/shift_right.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/shift_right.cpp
@@ -257,7 +257,7 @@ void test_shift_right_cross_policy()
 {
     using namespace hpx::execution;
 
-    auto check = [](std::vector<std::size_t> c, int n, char const* scenario) {
+    auto verify_consistency = [](std::vector<std::size_t> c, int n) {
         std::vector<std::size_t> c_par = c;
         std::vector<std::size_t> c_pu = c;
 
@@ -276,12 +276,12 @@ void test_shift_right_cross_policy()
     std::vector<std::size_t> base(50);
     std::iota(base.begin(), base.end(), std::size_t(1));
 
-    check(base, 0, "");
-    check(base, 50, "");
-    check(base, 99, "");
-    check(base, 25, "");
-    check(base, 1, "");
-    check(base, 49, "");
+    verify_consistency(base, 0);
+    verify_consistency(base, 50);
+    verify_consistency(base, 99);
+    verify_consistency(base, 25);
+    verify_consistency(base, 1);
+    verify_consistency(base, 49);
 }
 
 void shift_right_return_iterator_test()

--- a/libs/core/algorithms/tests/unit/algorithms/shift_right.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/shift_right.cpp
@@ -237,7 +237,8 @@ void test_shift_right_return_iterator(ExPolicy&& policy)
     // empty range: returns first
     {
         std::vector<std::size_t> empty;
-        auto result = hpx::shift_right(policy, empty.begin(), empty.end(), 0);
+        auto result =
+            hpx::shift_right(policy, empty.begin(), empty.end(), 0);
         HPX_TEST(result == empty.begin());
     }
 }


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - Separated the coalesced early-exit guards in both `hpx::shift_left` and `hpx::shift_right` to handle the `n <= 0` and `n >= dist` edge conditions independently, correctly matching the exact return-iterator requirements outlined in the C++20 `[alg.shift]` specification.
  - Resolved a general logic error in the parallel `shift_right_helper` returning the incorrect iterator. Altered the `then` continuation to advance `first` by `distance(new_first, last)` so parallel computations correctly return `first + n`. 
  - Added over 160 lines of rigorous regression testing to `shift_left.cpp` and `shift_right.cpp` to validate iterator return correctness across all boundaries (e.g., empty ranges, `n=0`, `n>=dist`, `n=1`, and normal permutations).
  - Implemented cross-policy consistency verifications comparing the returned iterators of `seq`, `par`, and `par_unseq` to guarantee they yield identical, standard-compliant results.
  - Corrected Doxygen documentation headers for `shift_left` and `shift_right` which previously provided incorrect descriptions of the returned iterators.

## Any background context you want to provide?

Prior to this PR, `hpx::shift_left` and `hpx::shift_right` contained invisible, long-standing deviations from the C++20 standard because their respective test suites only validated the manipulated *data values*, entirely ignoring the returned iterators. 

**Standard Compliance Issues Discovered:**
1. **`shift_left` empty/no-op cases:** The standard dictates that if `n <= 0`, it "does nothing and returns *last*". HPX was returning `first`.  
2. **`shift_right` empty/no-op cases:** The standard dictates that if `n >= dist`, it "does nothing and returns *last*". HPX was returning `first`.

Both bugs stemmed from a unified early-exit guard (`if (n <= 0 || static_cast<std::size_t>(n) >= dist) return first;`). This was split so that the respective correct iterators could be resolved. Since `dist` is evaluated immediately before the guard, we can efficiently return `last` via `std::next(first, dist)` without performance loss.

**Parallel State Fix:**
While designing the regression tests for the normal case (`0 < n < dist`), I discovered another bug nested within `shift_right`'s parallel implementation. The internal `shift_right_helper` was yielding an iterator pointing to the split pivot (`first + (dist - n)`) instead of the statutorily required start of the resulting range (`first + n`). This PR addresses the continuation logic to return standard-compliant iterators for standard parallel workloads.

Everything has been evaluated locally against equivalent behaviors in `libstdc++` and `libc++`, guaranteeing total alignment with external compiler expectations.

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [x] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
 for the tests.
