### PR TITLE
Implement segmented version of mismatch algorithm

### DIFF
--- a/libs/full/segmented_algorithms/CMakeLists.txt
+++ b/libs/full/segmented_algorithms/CMakeLists.txt
@@ -30,6 +30,7 @@ set(segmented_algorithms_headers
     hpx/parallel/segmented_algorithms/is_sorted.hpp
     hpx/parallel/segmented_algorithms/is_partitioned.hpp
     hpx/parallel/segmented_algorithms/minmax.hpp
+    hpx/parallel/segmented_algorithms/mismatch.hpp
     hpx/parallel/segmented_algorithms/reduce.hpp
     hpx/parallel/segmented_algorithms/replace.hpp
     hpx/parallel/segmented_algorithms/replace_copy.hpp

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithm.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithm.hpp
@@ -23,6 +23,7 @@
 #include <hpx/parallel/segmented_algorithms/is_partitioned.hpp>
 #include <hpx/parallel/segmented_algorithms/is_sorted.hpp>
 #include <hpx/parallel/segmented_algorithms/minmax.hpp>
+#include <hpx/parallel/segmented_algorithms/mismatch.hpp>
 #include <hpx/parallel/segmented_algorithms/reduce.hpp>
 #include <hpx/parallel/segmented_algorithms/replace.hpp>
 #include <hpx/parallel/segmented_algorithms/replace_copy.hpp>

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/mismatch.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/mismatch.hpp
@@ -1,0 +1,488 @@
+//  Copyright (c) 2026 Abir Roy
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/modules/algorithms.hpp>
+#include <hpx/modules/executors.hpp>
+#include <hpx/parallel/segmented_algorithms/detail/dispatch.hpp>
+
+#include <algorithm>
+#include <exception>
+#include <iterator>
+#include <list>
+#include <numeric>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace hpx { namespace parallel {
+    ///////////////////////////////////////////////////////////////////////////
+    // mismatch
+    namespace detail {
+        ///////////////////////////////////////////////////////////////////////
+        /// \cond NOINTERNAL
+
+        template <typename Pred>
+        struct mismatch_distance_algo
+          : public algorithm<mismatch_distance_algo<Pred>,
+                std::pair<std::size_t, std::size_t>>
+        {
+            constexpr mismatch_distance_algo() noexcept
+              : algorithm<mismatch_distance_algo,
+                    std::pair<std::size_t, std::size_t>>(
+                    "mismatch_distance_algo")
+            {
+            }
+
+            template <typename T>
+            struct is_future : std::false_type
+            {
+            };
+            template <typename R>
+            struct is_future<hpx::future<R>> : std::true_type
+            {
+            };
+            template <typename R>
+            struct is_future<hpx::shared_future<R>> : std::true_type
+            {
+            };
+
+            template <typename ExPolicy, typename Iter1, typename Sent1,
+                typename Iter2>
+            static std::pair<std::size_t, std::size_t> sequential(
+                ExPolicy, Iter1 first1, Sent1 last1, Iter2 first2, Pred pred)
+            {
+                auto res =
+                    hpx::parallel::detail::mismatch<std::pair<Iter1, Iter2>>()
+                        .sequential(
+                            hpx::execution::seq, first1, last1, first2, pred);
+                return std::make_pair(std::distance(first1, res.first),
+                    std::distance(first2, res.second));
+            }
+
+            template <typename ExPolicy, typename Iter1, typename Sent1,
+                typename Iter2>
+            static auto parallel(ExPolicy&& policy, Iter1 first1, Sent1 last1,
+                Iter2 first2, Pred pred)
+            {
+                auto res =
+                    hpx::parallel::detail::mismatch<std::pair<Iter1, Iter2>>()
+                        .parallel(HPX_FORWARD(ExPolicy, policy), first1, last1,
+                            first2, pred);
+
+                using res_t = std::decay_t<decltype(res)>;
+                if constexpr (is_future<res_t>::value)
+                {
+                    return hpx::dataflow(
+                        [first1, first2](
+                            auto&& f) -> std::pair<std::size_t, std::size_t> {
+                            auto p = f.get();
+                            return std::make_pair(
+                                std::distance(first1, p.first),
+                                std::distance(first2, p.second));
+                        },
+                        HPX_MOVE(res));
+                }
+                else
+                {
+                    return std::make_pair(std::distance(first1, res.first),
+                        std::distance(first2, res.second));
+                }
+            }
+        };
+
+        // sequential remote implementation
+        template <typename ExPolicy, typename SegIter1, typename SegIter2,
+            typename Pred>
+        static typename util::detail::algorithm_result<ExPolicy,
+            std::pair<SegIter1, SegIter2>>::type
+        segmented_mismatch(ExPolicy const& policy, SegIter1 first1,
+            SegIter1 last1, SegIter2 first2, Pred&& pred, std::true_type)
+        {
+            typedef hpx::traits::segmented_iterator_traits<SegIter1> traits1;
+            typedef typename traits1::segment_iterator segment_iterator1;
+            typedef typename traits1::local_iterator local_iterator_type1;
+
+            typedef hpx::traits::segmented_iterator_traits<SegIter2> traits2;
+            typedef typename traits2::segment_iterator segment_iterator2;
+            typedef typename traits2::local_iterator local_iterator_type2;
+
+            segment_iterator1 sit1 = traits1::segment(first1);
+            segment_iterator1 send1 = traits1::segment(last1);
+            segment_iterator2 sit2 = traits2::segment(first2);
+
+            using result = util::detail::algorithm_result<ExPolicy,
+                std::pair<SegIter1, SegIter2>>;
+
+            mismatch_distance_algo<std::decay_t<Pred>> algo;
+
+            if (sit1 == send1)
+            {
+                local_iterator_type1 beg1 = traits1::local(first1);
+                local_iterator_type1 end1 = traits1::local(last1);
+                local_iterator_type2 beg2 = traits2::local(first2);
+
+                if (beg1 != end1)
+                {
+                    std::pair<std::size_t, std::size_t> local_dist =
+                        dispatch(traits1::get_id(sit1), algo, policy,
+                            std::true_type(), beg1, end1, beg2, pred);
+
+                    local_iterator_type1 res1 = beg1;
+                    std::advance(res1, local_dist.first);
+                    local_iterator_type2 res2 = beg2;
+                    std::advance(res2, local_dist.second);
+
+                    return result::get(
+                        std::make_pair(traits1::compose(sit1, res1),
+                            traits2::compose(sit2, res2)));
+                }
+            }
+            else
+            {
+                local_iterator_type1 beg1 = traits1::local(first1);
+                local_iterator_type1 end1 = traits1::end(sit1);
+                local_iterator_type2 beg2 = traits2::local(first2);
+
+                if (beg1 != end1)
+                {
+                    std::pair<std::size_t, std::size_t> local_dist =
+                        dispatch(traits1::get_id(sit1), algo, policy,
+                            std::true_type(), beg1, end1, beg2, pred);
+
+                    local_iterator_type1 res1 = beg1;
+                    std::advance(res1, local_dist.first);
+                    local_iterator_type2 res2 = beg2;
+                    std::advance(res2, local_dist.second);
+
+                    if (res1 != end1)
+                    {
+                        return result::get(
+                            std::make_pair(traits1::compose(sit1, res1),
+                                traits2::compose(sit2, res2)));
+                    }
+                }
+
+                for (++sit1, ++sit2; sit1 != send1; ++sit1, ++sit2)
+                {
+                    beg1 = traits1::begin(sit1);
+                    end1 = traits1::end(sit1);
+                    beg2 = traits2::begin(sit2);
+
+                    if (beg1 != end1)
+                    {
+                        std::pair<std::size_t, std::size_t> local_dist =
+                            dispatch(traits1::get_id(sit1), algo, policy,
+                                std::true_type(), beg1, end1, beg2, pred);
+
+                        local_iterator_type1 res1 = beg1;
+                        std::advance(res1, local_dist.first);
+                        local_iterator_type2 res2 = beg2;
+                        std::advance(res2, local_dist.second);
+
+                        if (res1 != end1)
+                        {
+                            return result::get(
+                                std::make_pair(traits1::compose(sit1, res1),
+                                    traits2::compose(sit2, res2)));
+                        }
+                    }
+                }
+
+                beg1 = traits1::begin(sit1);
+                end1 = traits1::local(last1);
+                beg2 = traits2::begin(sit2);
+
+                if (beg1 != end1)
+                {
+                    std::pair<std::size_t, std::size_t> local_dist =
+                        dispatch(traits1::get_id(sit1), algo, policy,
+                            std::true_type(), beg1, end1, beg2, pred);
+
+                    local_iterator_type1 res1 = beg1;
+                    std::advance(res1, local_dist.first);
+                    local_iterator_type2 res2 = beg2;
+                    std::advance(res2, local_dist.second);
+
+                    if (res1 != end1)
+                    {
+                        return result::get(
+                            std::make_pair(traits1::compose(sit1, res1),
+                                traits2::compose(sit2, res2)));
+                    }
+                }
+            }
+
+            auto dist = detail::distance(first1, last1);
+            SegIter2 expected_last2 = first2;
+            detail::advance(expected_last2, dist);
+            return result::get(std::make_pair(last1, expected_last2));
+        }
+
+        // parallel remote implementation
+        template <typename ExPolicy, typename SegIter1, typename SegIter2,
+            typename Pred>
+        static typename util::detail::algorithm_result<ExPolicy,
+            std::pair<SegIter1, SegIter2>>::type
+        segmented_mismatch(ExPolicy const& policy, SegIter1 first1,
+            SegIter1 last1, SegIter2 first2, Pred&& pred, std::false_type)
+        {
+            typedef hpx::traits::segmented_iterator_traits<SegIter1> traits1;
+            typedef typename traits1::segment_iterator segment_iterator1;
+            typedef typename traits1::local_iterator local_iterator_type1;
+
+            typedef hpx::traits::segmented_iterator_traits<SegIter2> traits2;
+            typedef typename traits2::segment_iterator segment_iterator2;
+            typedef typename traits2::local_iterator local_iterator_type2;
+
+            typedef std::integral_constant<bool,
+                !std::forward_iterator<SegIter1>>
+                forced_seq;
+
+            using result = util::detail::algorithm_result<ExPolicy,
+                std::pair<SegIter1, SegIter2>>;
+
+            segment_iterator1 sit1 = traits1::segment(first1);
+            segment_iterator1 send1 = traits1::segment(last1);
+            segment_iterator2 sit2 = traits2::segment(first2);
+
+            std::vector<hpx::future<std::pair<std::size_t, std::size_t>>>
+                segments;
+            segments.reserve(detail::distance(sit1, send1));
+
+            std::vector<std::tuple<segment_iterator1, segment_iterator2,
+                local_iterator_type1, local_iterator_type2,
+                local_iterator_type1>>
+                seg_data;
+            seg_data.reserve(detail::distance(sit1, send1));
+
+            mismatch_distance_algo<std::decay_t<Pred>> algo;
+
+            if (sit1 == send1)
+            {
+                local_iterator_type1 beg1 = traits1::local(first1);
+                local_iterator_type1 end1 = traits1::local(last1);
+                local_iterator_type2 beg2 = traits2::local(first2);
+
+                if (beg1 != end1)
+                {
+                    segments.push_back(dispatch_async(traits1::get_id(sit1),
+                        algo, policy, forced_seq(), beg1, end1, beg2, pred));
+                    seg_data.emplace_back(sit1, sit2, beg1, beg2, end1);
+                }
+            }
+            else
+            {
+                local_iterator_type1 beg1 = traits1::local(first1);
+                local_iterator_type1 end1 = traits1::end(sit1);
+                local_iterator_type2 beg2 = traits2::local(first2);
+
+                if (beg1 != end1)
+                {
+                    segments.push_back(dispatch_async(traits1::get_id(sit1),
+                        algo, policy, forced_seq(), beg1, end1, beg2, pred));
+                    seg_data.emplace_back(sit1, sit2, beg1, beg2, end1);
+                }
+
+                for (++sit1, ++sit2; sit1 != send1; ++sit1, ++sit2)
+                {
+                    beg1 = traits1::begin(sit1);
+                    end1 = traits1::end(sit1);
+                    beg2 = traits2::begin(sit2);
+
+                    if (beg1 != end1)
+                    {
+                        segments.push_back(
+                            dispatch_async(traits1::get_id(sit1), algo, policy,
+                                forced_seq(), beg1, end1, beg2, pred));
+                        seg_data.emplace_back(sit1, sit2, beg1, beg2, end1);
+                    }
+                }
+
+                beg1 = traits1::begin(sit1);
+                end1 = traits1::local(last1);
+                beg2 = traits2::begin(sit2);
+
+                if (beg1 != end1)
+                {
+                    segments.push_back(dispatch_async(traits1::get_id(sit1),
+                        algo, policy, forced_seq(), beg1, end1, beg2, pred));
+                    seg_data.emplace_back(sit1, sit2, beg1, beg2, end1);
+                }
+            }
+
+            auto dist = detail::distance(first1, last1);
+            SegIter2 expected_last2 = first2;
+            detail::advance(expected_last2, dist);
+
+            return result::get(dataflow(
+                [seg_data = HPX_MOVE(seg_data), last1, expected_last2](
+                    std::vector<
+                        hpx::future<std::pair<std::size_t, std::size_t>>>&&
+                        r_futures) mutable -> std::pair<SegIter1, SegIter2> {
+                    std::list<std::exception_ptr> errors;
+                    parallel::util::detail::handle_remote_exceptions<
+                        ExPolicy>::call(r_futures, errors);
+
+                    std::vector<std::pair<std::size_t, std::size_t>> r =
+                        hpx::unwrap(HPX_MOVE(r_futures));
+
+                    for (std::size_t i = 0; i < r.size(); ++i)
+                    {
+                        auto& data = seg_data[i];
+                        local_iterator_type1 res1 = std::get<2>(data);
+                        std::advance(res1, r[i].first);
+                        local_iterator_type2 res2 = std::get<3>(data);
+                        std::advance(res2, r[i].second);
+                        local_iterator_type1 end1 = std::get<4>(data);
+
+                        if (res1 != end1)
+                        {
+                            return std::make_pair(
+                                traits1::compose(std::get<0>(data), res1),
+                                traits2::compose(std::get<1>(data), res2));
+                        }
+                    }
+                    return std::make_pair(last1, expected_last2);
+                },
+                HPX_MOVE(segments)));
+        }
+        /// \endcond
+    }    // namespace detail
+}}    // namespace hpx::parallel
+
+namespace hpx::segmented {
+
+    template <typename SegIter1, typename SegIter2,
+        typename Pred = hpx::parallel::detail::equal_to>
+        requires(hpx::traits::is_iterator_v<SegIter1> &&
+            hpx::traits::is_segmented_iterator_v<SegIter1> &&
+            hpx::traits::is_iterator_v<SegIter2> &&
+            hpx::traits::is_segmented_iterator_v<SegIter2>)
+    std::pair<SegIter1, SegIter2> tag_invoke(hpx::mismatch_t, SegIter1 first1,
+        SegIter1 last1, SegIter2 first2, Pred&& pred = Pred())
+    {
+        static_assert(std::forward_iterator<SegIter1>,
+            "Requires at least forward iterator to First Vector");
+
+        static_assert(std::forward_iterator<SegIter2>,
+            "Requires at least forward iterator to Second Vector");
+
+        if (first1 == last1)
+            return std::make_pair(first1, first2);
+
+        return hpx::parallel::detail::segmented_mismatch(hpx::execution::seq,
+            first1, last1, first2, HPX_FORWARD(Pred, pred), std::true_type());
+    }
+
+    template <typename ExPolicy, typename SegIter1, typename SegIter2,
+        typename Pred = hpx::parallel::detail::equal_to>
+        requires(hpx::is_execution_policy_v<ExPolicy> &&
+            hpx::traits::is_iterator_v<SegIter1> &&
+            hpx::traits::is_segmented_iterator_v<SegIter1> &&
+            hpx::traits::is_iterator_v<SegIter2> &&
+            hpx::traits::is_segmented_iterator_v<SegIter2>)
+    hpx::parallel::util::detail::algorithm_result_t<ExPolicy,
+        std::pair<SegIter1, SegIter2>>
+    tag_invoke(hpx::mismatch_t, ExPolicy&& policy, SegIter1 first1,
+        SegIter1 last1, SegIter2 first2, Pred&& pred = Pred())
+    {
+        static_assert(std::forward_iterator<SegIter1>,
+            "Requires at least forward iterator to First Vector");
+
+        static_assert(std::forward_iterator<SegIter2>,
+            "Requires at least forward iterator to Second Vector");
+
+        using result = hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            std::pair<SegIter1, SegIter2>>;
+
+        if (first1 == last1)
+        {
+            return result::get(std::make_pair(first1, first2));
+        }
+
+        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
+
+        return hpx::parallel::detail::segmented_mismatch(
+            HPX_FORWARD(ExPolicy, policy), first1, last1, first2,
+            HPX_FORWARD(Pred, pred), is_seq());
+    }
+
+    template <typename SegIter1, typename SegIter2,
+        typename Pred = hpx::parallel::detail::equal_to>
+        requires(hpx::traits::is_iterator_v<SegIter1> &&
+            hpx::traits::is_segmented_iterator_v<SegIter1> &&
+            hpx::traits::is_iterator_v<SegIter2> &&
+            hpx::traits::is_segmented_iterator_v<SegIter2>)
+    std::pair<SegIter1, SegIter2> tag_invoke(hpx::mismatch_t, SegIter1 first1,
+        SegIter1 last1, SegIter2 first2, SegIter2 last2, Pred&& pred = Pred())
+    {
+        static_assert(std::forward_iterator<SegIter1>,
+            "Requires at least forward iterator to First Vector");
+
+        static_assert(std::forward_iterator<SegIter2>,
+            "Requires at least forward iterator to Second Vector");
+
+        auto dist1 = hpx::parallel::detail::distance(first1, last1);
+        auto dist2 = hpx::parallel::detail::distance(first2, last2);
+
+        if (dist1 > dist2)
+        {
+            last1 = first1;
+            hpx::parallel::detail::advance(last1, dist2);
+        }
+
+        if (first1 == last1)
+            return std::make_pair(first1, first2);
+
+        return hpx::parallel::detail::segmented_mismatch(hpx::execution::seq,
+            first1, last1, first2, HPX_FORWARD(Pred, pred), std::true_type());
+    }
+
+    template <typename ExPolicy, typename SegIter1, typename SegIter2,
+        typename Pred = hpx::parallel::detail::equal_to>
+        requires(hpx::is_execution_policy_v<ExPolicy> &&
+            hpx::traits::is_iterator_v<SegIter1> &&
+            hpx::traits::is_segmented_iterator_v<SegIter1> &&
+            hpx::traits::is_iterator_v<SegIter2> &&
+            hpx::traits::is_segmented_iterator_v<SegIter2>)
+    hpx::parallel::util::detail::algorithm_result_t<ExPolicy,
+        std::pair<SegIter1, SegIter2>>
+    tag_invoke(hpx::mismatch_t, ExPolicy&& policy, SegIter1 first1,
+        SegIter1 last1, SegIter2 first2, SegIter2 last2, Pred&& pred = Pred())
+    {
+        static_assert(std::forward_iterator<SegIter1>,
+            "Requires at least forward iterator to First Vector");
+
+        static_assert(std::forward_iterator<SegIter2>,
+            "Requires at least forward iterator to Second Vector");
+
+        auto dist1 = hpx::parallel::detail::distance(first1, last1);
+        auto dist2 = hpx::parallel::detail::distance(first2, last2);
+
+        if (dist1 > dist2)
+        {
+            last1 = first1;
+            hpx::parallel::detail::advance(last1, dist2);
+        }
+
+        using result = hpx::parallel::util::detail::algorithm_result<ExPolicy,
+            std::pair<SegIter1, SegIter2>>;
+
+        if (first1 == last1)
+        {
+            return result::get(std::make_pair(first1, first2));
+        }
+
+        using is_seq = hpx::is_sequenced_execution_policy<ExPolicy>;
+
+        return hpx::parallel::detail::segmented_mismatch(
+            HPX_FORWARD(ExPolicy, policy), first1, last1, first2,
+            HPX_FORWARD(Pred, pred), is_seq());
+    }
+}    // namespace hpx::segmented

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/mismatch.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/mismatch.hpp
@@ -12,10 +12,12 @@
 #include <hpx/parallel/segmented_algorithms/detail/dispatch.hpp>
 
 #include <algorithm>
+#include <cstddef>
 #include <exception>
 #include <iterator>
 #include <list>
 #include <numeric>
+#include <tuple>
 #include <type_traits>
 #include <utility>
 #include <vector>

--- a/libs/full/segmented_algorithms/tests/unit/CMakeLists.txt
+++ b/libs/full/segmented_algorithms/tests/unit/CMakeLists.txt
@@ -27,6 +27,7 @@ set(tests
     partitioned_vector_min_element2
     partitioned_vector_minmax_element1
     partitioned_vector_minmax_element2
+    partitioned_vector_mismatch
     partitioned_vector_move
     partitioned_vector_target
     partitioned_vector_transform1

--- a/libs/full/segmented_algorithms/tests/unit/partitioned_vector_mismatch.cpp
+++ b/libs/full/segmented_algorithms/tests/unit/partitioned_vector_mismatch.cpp
@@ -1,0 +1,174 @@
+//  Copyright (c) 2026 Abir Roy
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/partitioned_vector_predef.hpp>
+#include <hpx/include/runtime.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/parallel/segmented_algorithms/mismatch.hpp>
+
+#include <cstddef>
+#include <iterator>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename T>
+void iota_vector(hpx::partitioned_vector<T>& v, T val)
+{
+    typename hpx::partitioned_vector<T>::iterator it = v.begin(), end = v.end();
+    for (; it != end; ++it)
+        *it = val++;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// mismatch tests
+///////////////////////////////////////////////////////////////////////////////
+template <typename T, typename DistPolicy, typename ExPolicy>
+void mismatch_algo_tests_with_policy(
+    std::size_t size, DistPolicy const& policy, ExPolicy const& mismatch_policy)
+{
+    hpx::partitioned_vector<T> v1(size, policy);
+    hpx::partitioned_vector<T> v2(size, policy);
+
+    // Fill both vectors identically
+    iota_vector(v1, T(0));
+    iota_vector(v2, T(0));
+
+    // Test Match
+    auto res3 =
+        hpx::mismatch(mismatch_policy, v1.begin(), v1.end(), v2.begin());
+    HPX_TEST(res3.first == v1.end() && res3.second == v2.end());
+
+    auto res4 = hpx::mismatch(
+        mismatch_policy, v1.begin(), v1.end(), v2.begin(), v2.end());
+    HPX_TEST(res4.first == v1.end() && res4.second == v2.end());
+
+    // Calculate exact midpoint iterators
+    auto it1 = v1.begin();
+    std::advance(it1, size / 2);
+    auto it2 = v2.begin();
+    std::advance(it2, size / 2);
+
+    // Mutate v2 to cause a mismatch at the midpoint
+    *it2 = T(9999);
+
+    // Test Mismatch
+    res3 = hpx::mismatch(mismatch_policy, v1.begin(), v1.end(), v2.begin());
+    HPX_TEST(res3.first == it1 && res3.second == it2);
+
+    res4 = hpx::mismatch(
+        mismatch_policy, v1.begin(), v1.end(), v2.begin(), v2.end());
+    HPX_TEST(res4.first == it1 && res4.second == it2);
+}
+
+template <typename T, typename DistPolicy, typename ExPolicy>
+void mismatch_algo_tests_with_policy_async(
+    std::size_t size, DistPolicy const& policy, ExPolicy const& mismatch_policy)
+{
+    hpx::partitioned_vector<T> v1(size, policy);
+    hpx::partitioned_vector<T> v2(size, policy);
+
+    iota_vector(v1, T(0));
+    iota_vector(v2, T(0));
+
+    // Test Match (Async)
+    auto f1_3 =
+        hpx::mismatch(mismatch_policy, v1.begin(), v1.end(), v2.begin());
+    auto res1_3 = f1_3.get();
+    HPX_TEST(res1_3.first == v1.end() && res1_3.second == v2.end());
+
+    auto f1_4 = hpx::mismatch(
+        mismatch_policy, v1.begin(), v1.end(), v2.begin(), v2.end());
+    auto res1_4 = f1_4.get();
+    HPX_TEST(res1_4.first == v1.end() && res1_4.second == v2.end());
+
+    // Mutate
+    auto it1 = v1.begin();
+    std::advance(it1, size / 2);
+    auto it2 = v2.begin();
+    std::advance(it2, size / 2);
+    *it2 = T(9999);
+
+    // Test Mismatch (Async)
+    auto f2_3 =
+        hpx::mismatch(mismatch_policy, v1.begin(), v1.end(), v2.begin());
+    auto res2_3 = f2_3.get();
+    HPX_TEST(res2_3.first == it1 && res2_3.second == it2);
+
+    auto f2_4 = hpx::mismatch(
+        mismatch_policy, v1.begin(), v1.end(), v2.begin(), v2.end());
+    auto res2_4 = f2_4.get();
+    HPX_TEST(res2_4.first == it1 && res2_4.second == it2);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename T, typename DistPolicy>
+void mismatch_tests_with_policy(
+    std::size_t size, std::size_t, DistPolicy const& policy)
+{
+    using namespace hpx::execution;
+
+    mismatch_algo_tests_with_policy<T>(size, policy, seq);
+    mismatch_algo_tests_with_policy<T>(size, policy, par);
+
+    mismatch_algo_tests_with_policy_async<T>(size, policy, seq(task));
+    mismatch_algo_tests_with_policy_async<T>(size, policy, par(task));
+}
+
+template <typename T>
+void mismatch_empty_tests()
+{
+    hpx::partitioned_vector<T> v1;
+    hpx::partitioned_vector<T> v2;
+
+    using namespace hpx::execution;
+
+    auto r_seq = hpx::mismatch(seq, v1.begin(), v1.end(), v2.begin(), v2.end());
+    HPX_TEST(r_seq.first == v1.end() && r_seq.second == v2.end());
+
+    auto r_par = hpx::mismatch(par, v1.begin(), v1.end(), v2.begin(), v2.end());
+    HPX_TEST(r_par.first == v1.end() && r_par.second == v2.end());
+
+    auto r_seq_t =
+        hpx::mismatch(seq(task), v1.begin(), v1.end(), v2.begin(), v2.end())
+            .get();
+    HPX_TEST(r_seq_t.first == v1.end() && r_seq_t.second == v2.end());
+
+    auto r_par_t =
+        hpx::mismatch(par(task), v1.begin(), v1.end(), v2.begin(), v2.end())
+            .get();
+    HPX_TEST(r_par_t.first == v1.end() && r_par_t.second == v2.end());
+}
+
+template <typename T>
+void mismatch_tests()
+{
+    mismatch_empty_tests<T>();
+
+    std::size_t const length = 64;
+    std::vector<hpx::id_type> localities = hpx::find_all_localities();
+
+    mismatch_tests_with_policy<T>(length, 1, hpx::container_layout);
+    mismatch_tests_with_policy<T>(length, 3, hpx::container_layout(3));
+    mismatch_tests_with_policy<T>(
+        length, 3, hpx::container_layout(3, localities));
+    mismatch_tests_with_policy<T>(
+        length, localities.size(), hpx::container_layout(localities));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int main()
+{
+    mismatch_tests<int>();
+    mismatch_tests<double>();
+
+    return hpx::util::report_errors();
+}
+
+#endif


### PR DESCRIPTION
Fixes #1338 

## Proposed Changes

- Added the segmented version of `hpx::mismatch`.
- Built a custom local algorithm (`mismatch_distance_algo`) that calculates integer offsets (`std::distance`) on the remote partitions instead of trying to send raw iterators over the wire.
- Reconstructed the global iterators on the main thread using std::advance once the async tasks resolve.
- Added full unit test coverage for match/mismatch scenarios across all execution policies (including seq(task) and par(task)).

## Any background context you want to provide?

`std::mismatch` differs from std::equal and `std::find` by returning a `std::pair` of iterators. HPX's internal algorithm_result_helper and dispatch_async pathways currently lack specializations to serialize a pair of wrapped local_iterator types across network boundaries simultaneously.

To adhere to the standard without modifying the core HPX serialization engine, this implementation intercepts the iterators at the physical segment level. It calculates their local integer distances from the chunk boundaries, serializes the resulting size primitives back to the main thread, and rebuilds the required global composite iterators.

## Checklist

Not all points below apply to all pull requests.

- [X] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
