### PR TITLE
Fix memory leak in overlapping relocation test functions (#7184)

### DIFF
--- a/libs/core/algorithms/tests/unit/algorithms/uninitialized_relocate.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/uninitialized_relocate.cpp
@@ -10,206 +10,12 @@
 #include <hpx/modules/testing.hpp>
 #include <hpx/modules/type_support.hpp>
 
-#include <atomic>
+#include "uninitialized_relocate_test_utils.hpp"
+
 #include <cstddef>
-#include <random>
-#include <set>
 #include <type_traits>
-#include <utility>
 
-constexpr int N = 500;    // number of objects to construct
-constexpr int M = 200;    // number of objects to relocate
-constexpr int K = 100;    // number of objects to relocate before throwing
-
-static_assert(N > M);
-static_assert(M > K);
-
-using hpx::experimental::is_trivially_relocatable_v;
 using hpx::experimental::uninitialized_relocate;
-
-std::mutex m;
-
-template <typename F>
-void simple_mutex_operation(F&& f)
-{
-    std::lock_guard<std::mutex> lk(m);
-    f();
-}
-
-// enum for the different types of objects
-enum relocation_category
-{
-    trivially_relocatable,
-    non_trivially_relocatable,
-    non_trivially_relocatable_throwing
-};
-
-template <relocation_category c, bool overlapping_test = false>
-struct counted_struct
-{
-    static std::set<counted_struct<c, overlapping_test>*> made;
-    static std::atomic<int> moved;
-    static std::atomic<int> destroyed;
-    int data;
-
-    explicit counted_struct(int data)
-      : data(data)
-    {
-        // Check that we are not constructing an object on top of another
-        simple_mutex_operation([&]() {
-            HPX_TEST(!made.count(this));
-            made.insert(this);
-        });
-    }
-
-    counted_struct(counted_struct&& other) noexcept(
-        c != non_trivially_relocatable_throwing)
-      : data(other.data)
-    {
-        if constexpr (c == non_trivially_relocatable_throwing)
-        {
-            if (moved++ == K - 1)
-            {
-                throw 42;
-            }
-        }
-        else
-        {
-            moved++;
-        }
-
-        // Check that we are not constructing an object on top of another
-        simple_mutex_operation([&]() {
-            // Unless we are testing overlapping relocation
-            // we should not be move-constructing an object on top of another
-            if constexpr (!overlapping_test)
-            {
-                HPX_TEST(!made.count(this));
-            }
-            made.insert(this);
-        });
-    }
-
-    ~counted_struct()
-    {
-        destroyed++;
-
-        // Check that the object was constructed
-        // and not already destroyed
-        simple_mutex_operation([&]() {
-            HPX_TEST(made.count(this));
-            made.erase(this);
-        });
-    }
-
-    // making sure the address is never directly accessed
-    friend void operator&(counted_struct) = delete;
-};
-
-template <relocation_category c, bool overlapping_test>
-std::set<counted_struct<c, overlapping_test>*>
-    counted_struct<c, overlapping_test>::made;
-
-template <relocation_category c, bool overlapping_test>
-std::atomic<int> counted_struct<c, overlapping_test>::moved = 0;
-
-template <relocation_category c, bool overlapping_test>
-std::atomic<int> counted_struct<c, overlapping_test>::destroyed = 0;
-
-// Non overlapping relocation testing mechanisms
-using trivially_relocatable_struct = counted_struct<trivially_relocatable>;
-HPX_DECLARE_TRIVIALLY_RELOCATABLE(trivially_relocatable_struct);
-
-using non_trivially_relocatable_struct =
-    counted_struct<non_trivially_relocatable>;
-
-using non_trivially_relocatable_struct_throwing =
-    counted_struct<non_trivially_relocatable_throwing>;
-
-// Overlapping relocation testing mechanisms
-using trivially_relocatable_struct_overlapping =
-    counted_struct<trivially_relocatable, true>;
-HPX_DECLARE_TRIVIALLY_RELOCATABLE(trivially_relocatable_struct_overlapping);
-
-using non_trivially_relocatable_struct_overlapping =
-    counted_struct<non_trivially_relocatable, true>;
-
-using non_trivially_relocatable_struct_throwing_overlapping =
-    counted_struct<non_trivially_relocatable_throwing, true>;
-
-// Check that the correct types are trivially relocatable
-static_assert(is_trivially_relocatable_v<trivially_relocatable_struct>);
-static_assert(
-    is_trivially_relocatable_v<trivially_relocatable_struct_overlapping>);
-
-static_assert(!is_trivially_relocatable_v<non_trivially_relocatable_struct>);
-static_assert(
-    !is_trivially_relocatable_v<non_trivially_relocatable_struct_overlapping>);
-
-static_assert(
-    !is_trivially_relocatable_v<non_trivially_relocatable_struct_throwing>);
-static_assert(!is_trivially_relocatable_v<
-    non_trivially_relocatable_struct_throwing_overlapping>);
-
-void clear()
-{
-    // Reset for the next test
-    trivially_relocatable_struct::moved = 0;
-    trivially_relocatable_struct::destroyed = 0;
-    trivially_relocatable_struct::made.clear();
-
-    trivially_relocatable_struct_overlapping::moved = 0;
-    trivially_relocatable_struct_overlapping::destroyed = 0;
-    trivially_relocatable_struct_overlapping::made.clear();
-
-    non_trivially_relocatable_struct::moved = 0;
-    non_trivially_relocatable_struct::destroyed = 0;
-    non_trivially_relocatable_struct::made.clear();
-
-    non_trivially_relocatable_struct_overlapping::moved = 0;
-    non_trivially_relocatable_struct_overlapping::destroyed = 0;
-    non_trivially_relocatable_struct_overlapping::made.clear();
-
-    non_trivially_relocatable_struct_throwing::moved = 0;
-    non_trivially_relocatable_struct_throwing::destroyed = 0;
-    non_trivially_relocatable_struct_throwing::made.clear();
-
-    non_trivially_relocatable_struct_throwing_overlapping::moved = 0;
-    non_trivially_relocatable_struct_throwing_overlapping::destroyed = 0;
-    non_trivially_relocatable_struct_throwing_overlapping::made.clear();
-}
-
-template <typename T>
-std::pair<T*, T*> setup()
-{
-    clear();
-
-    void* mem1 = std::malloc(N * sizeof(T));
-    void* mem2 = std::malloc(N * sizeof(T));
-
-    HPX_TEST(mem1 && mem2);
-
-    T* ptr1 = static_cast<T*>(mem1);
-    T* ptr2 = static_cast<T*>(mem2);
-
-    HPX_TEST(T::made.size() == 0);
-    HPX_TEST(T::moved == 0);
-    HPX_TEST(T::destroyed == 0);
-
-    for (int i = 0; i < N; i++)
-    {
-        hpx::construct_at(ptr1 + i, i);
-    }
-
-    // fill ptr2 with 0 after M
-    std::fill(static_cast<std::byte*>(mem2) + M * sizeof(T),
-        static_cast<std::byte*>(mem2) + N * sizeof(T), std::byte{0});
-
-    // N objects constructed
-    HPX_TEST(T::made.size() == N);
-
-    return {ptr1, ptr2};
-}
 
 template <typename Ex>
 void test()
@@ -377,7 +183,7 @@ void test_overlapping()
     static_assert(M + offset <= N);
 
     {    // Overlapping trivially-relocatable
-        auto [ptr, ___] = setup<trivially_relocatable_struct_overlapping>();
+        auto ptr = setup_single<trivially_relocatable_struct_overlapping>();
 
         // Destroy the objects that will be overwritten for bookkeeping
         std::destroy(ptr, ptr + offset);
@@ -423,7 +229,7 @@ void test_overlapping()
         std::free(ptr);
     }
     {    // Overlapping non-trivially relocatable
-        auto [ptr, ___] = setup<non_trivially_relocatable_struct_overlapping>();
+        auto ptr = setup_single<non_trivially_relocatable_struct_overlapping>();
 
         // Destroy the objects that will be overwritten for bookkeeping purposes
         std::destroy(ptr, ptr + offset);
@@ -460,8 +266,8 @@ void test_overlapping()
         std::free(ptr);
     }
     {    // Overlapping non-trivially relocatable throwing
-        auto [ptr, ___] =
-            setup<non_trivially_relocatable_struct_throwing_overlapping>();
+        auto ptr = setup_single<
+            non_trivially_relocatable_struct_throwing_overlapping>();
 
         // Destroy the objects that will be overwritten for bookkeeping purposes
         std::destroy(ptr, ptr + offset);
@@ -530,7 +336,7 @@ void test_right_overlapping()
     static_assert(M + offset <= N);
 
     {    // Right-overlapping trivially-relocatable
-        auto [ptr, ___] = setup<trivially_relocatable_struct_overlapping>();
+        auto ptr = setup_single<trivially_relocatable_struct_overlapping>();
 
         // Destroy the objects in [M, M + offset) that will be overwritten
         // by the destination tail extending beyond the source range

--- a/libs/core/algorithms/tests/unit/algorithms/uninitialized_relocate_backward.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/uninitialized_relocate_backward.cpp
@@ -10,206 +10,12 @@
 #include <hpx/modules/testing.hpp>
 #include <hpx/modules/type_support.hpp>
 
-#include <atomic>
+#include "uninitialized_relocate_test_utils.hpp"
+
 #include <cstddef>
-#include <random>
-#include <set>
 #include <type_traits>
-#include <utility>
 
-constexpr int N = 500;    // number of objects to construct
-constexpr int M = 200;    // number of objects to relocate
-constexpr int K = 100;    // number of objects to relocate before throwing
-
-static_assert(N > M);
-static_assert(M > K);
-
-using hpx::experimental::is_trivially_relocatable_v;
 using hpx::experimental::uninitialized_relocate_backward;
-
-std::mutex m;
-
-template <typename F>
-void simple_mutex_operation(F&& f)
-{
-    std::lock_guard<std::mutex> lk(m);
-    f();
-}
-
-// enum for the different types of objects
-enum relocation_category
-{
-    trivially_relocatable,
-    non_trivially_relocatable,
-    non_trivially_relocatable_throwing
-};
-
-template <relocation_category c, bool overlapping_test = false>
-struct counted_struct
-{
-    static std::set<counted_struct<c, overlapping_test>*> made;
-    static std::atomic<int> moved;
-    static std::atomic<int> destroyed;
-    int data;
-
-    explicit counted_struct(int data)
-      : data(data)
-    {
-        // Check that we are not constructing an object on top of another
-        simple_mutex_operation([&]() {
-            HPX_TEST(!made.count(this));
-            made.insert(this);
-        });
-    }
-
-    counted_struct(counted_struct&& other) noexcept(
-        c != non_trivially_relocatable_throwing)
-      : data(other.data)
-    {
-        if constexpr (c == non_trivially_relocatable_throwing)
-        {
-            if (moved++ == K - 1)
-            {
-                throw 42;
-            }
-        }
-        else
-        {
-            moved++;
-        }
-
-        // Check that we are not constructing an object on top of another
-        simple_mutex_operation([&]() {
-            // Unless we are testing overlapping relocation
-            // we should not be move-constructing an object on top of another
-            if constexpr (!overlapping_test)
-            {
-                HPX_TEST(!made.count(this));
-            }
-            made.insert(this);
-        });
-    }
-
-    ~counted_struct()
-    {
-        destroyed++;
-
-        // Check that the object was constructed
-        // and not already destroyed
-        simple_mutex_operation([&]() {
-            HPX_TEST(made.count(this));
-            made.erase(this);
-        });
-    }
-
-    // making sure the address is never directly accessed
-    friend void operator&(counted_struct) = delete;
-};
-
-template <relocation_category c, bool overlapping_test>
-std::set<counted_struct<c, overlapping_test>*>
-    counted_struct<c, overlapping_test>::made;
-
-template <relocation_category c, bool overlapping_test>
-std::atomic<int> counted_struct<c, overlapping_test>::moved = 0;
-
-template <relocation_category c, bool overlapping_test>
-std::atomic<int> counted_struct<c, overlapping_test>::destroyed = 0;
-
-// Non overlapping relocation testing mechanisms
-using trivially_relocatable_struct = counted_struct<trivially_relocatable>;
-HPX_DECLARE_TRIVIALLY_RELOCATABLE(trivially_relocatable_struct);
-
-using non_trivially_relocatable_struct =
-    counted_struct<non_trivially_relocatable>;
-
-using non_trivially_relocatable_struct_throwing =
-    counted_struct<non_trivially_relocatable_throwing>;
-
-// Overlapping relocation testing mechanisms
-using trivially_relocatable_struct_overlapping =
-    counted_struct<trivially_relocatable, true>;
-HPX_DECLARE_TRIVIALLY_RELOCATABLE(trivially_relocatable_struct_overlapping);
-
-using non_trivially_relocatable_struct_overlapping =
-    counted_struct<non_trivially_relocatable, true>;
-
-using non_trivially_relocatable_struct_throwing_overlapping =
-    counted_struct<non_trivially_relocatable_throwing, true>;
-
-// Check that the correct types are trivially relocatable
-static_assert(is_trivially_relocatable_v<trivially_relocatable_struct>);
-static_assert(
-    is_trivially_relocatable_v<trivially_relocatable_struct_overlapping>);
-
-static_assert(!is_trivially_relocatable_v<non_trivially_relocatable_struct>);
-static_assert(
-    !is_trivially_relocatable_v<non_trivially_relocatable_struct_overlapping>);
-
-static_assert(
-    !is_trivially_relocatable_v<non_trivially_relocatable_struct_throwing>);
-static_assert(!is_trivially_relocatable_v<
-    non_trivially_relocatable_struct_throwing_overlapping>);
-
-void clear()
-{
-    // Reset for the next test
-    trivially_relocatable_struct::moved = 0;
-    trivially_relocatable_struct::destroyed = 0;
-    trivially_relocatable_struct::made.clear();
-
-    trivially_relocatable_struct_overlapping::moved = 0;
-    trivially_relocatable_struct_overlapping::destroyed = 0;
-    trivially_relocatable_struct_overlapping::made.clear();
-
-    non_trivially_relocatable_struct::moved = 0;
-    non_trivially_relocatable_struct::destroyed = 0;
-    non_trivially_relocatable_struct::made.clear();
-
-    non_trivially_relocatable_struct_overlapping::moved = 0;
-    non_trivially_relocatable_struct_overlapping::destroyed = 0;
-    non_trivially_relocatable_struct_overlapping::made.clear();
-
-    non_trivially_relocatable_struct_throwing::moved = 0;
-    non_trivially_relocatable_struct_throwing::destroyed = 0;
-    non_trivially_relocatable_struct_throwing::made.clear();
-
-    non_trivially_relocatable_struct_throwing_overlapping::moved = 0;
-    non_trivially_relocatable_struct_throwing_overlapping::destroyed = 0;
-    non_trivially_relocatable_struct_throwing_overlapping::made.clear();
-}
-
-template <typename T>
-std::pair<T*, T*> setup()
-{
-    clear();
-
-    void* mem1 = std::malloc(N * sizeof(T));
-    void* mem2 = std::malloc(N * sizeof(T));
-
-    HPX_TEST(mem1 && mem2);
-
-    T* ptr1 = static_cast<T*>(mem1);
-    T* ptr2 = static_cast<T*>(mem2);
-
-    HPX_TEST(T::made.size() == 0);
-    HPX_TEST(T::moved == 0);
-    HPX_TEST(T::destroyed == 0);
-
-    for (int i = 0; i < N; i++)
-    {
-        hpx::construct_at(ptr1 + i, i);
-    }
-
-    // fill ptr2 with 0 after M
-    std::fill(static_cast<std::byte*>(mem2) + M * sizeof(T),
-        static_cast<std::byte*>(mem2) + N * sizeof(T), std::byte{0});
-
-    // N objects constructed
-    HPX_TEST(T::made.size() == N);
-
-    return {ptr1, ptr2};
-}
 
 template <typename Ex>
 void test()
@@ -377,7 +183,7 @@ void test_overlapping()
     static_assert(M + offset <= N);
 
     {    // Overlapping trivially-relocatable
-        auto [ptr, ___] = setup<trivially_relocatable_struct_overlapping>();
+        auto ptr = setup_single<trivially_relocatable_struct_overlapping>();
 
         // Destroy the objects that will be overwritten for bookkeeping
         std::destroy(ptr + M, ptr + M + offset);
@@ -422,7 +228,7 @@ void test_overlapping()
         std::free(ptr);
     }
     {    // Overlapping non-trivially relocatable
-        auto [ptr, ___] = setup<non_trivially_relocatable_struct_overlapping>();
+        auto ptr = setup_single<non_trivially_relocatable_struct_overlapping>();
 
         // Destroy the objects that will be overwritten for bookkeeping purposes
         std::destroy(ptr + M, ptr + M + offset);
@@ -458,8 +264,8 @@ void test_overlapping()
         std::free(ptr);
     }
     {    // Overlapping non-trivially relocatable throwing
-        auto [ptr, ___] =
-            setup<non_trivially_relocatable_struct_throwing_overlapping>();
+        auto ptr = setup_single<
+            non_trivially_relocatable_struct_throwing_overlapping>();
 
         // Destroy the objects that will be overwritten for bookkeeping purposes
         std::destroy(ptr + M, ptr + M + offset);

--- a/libs/core/algorithms/tests/unit/algorithms/uninitialized_relocate_backward_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/uninitialized_relocate_backward_sender.cpp
@@ -10,208 +10,12 @@
 #include <hpx/modules/testing.hpp>
 #include <hpx/modules/type_support.hpp>
 
-#include <atomic>
-#include <random>
-#include <set>
-#include <type_traits>
-#include <utility>
+#include "uninitialized_relocate_test_utils.hpp"
 
-constexpr int N = 500;    // number of objects to construct
-constexpr int M = 200;    // number of objects to relocate
-constexpr int K = 100;    // number of objects to relocate before throwing
-
-static_assert(N > M);
-static_assert(M > K);
-
-using hpx::experimental::is_trivially_relocatable_v;
 using hpx::experimental::uninitialized_relocate_backward;
 
 namespace ex = hpx::execution::experimental;
 namespace tt = hpx::this_thread::experimental;
-
-std::mutex m;
-
-template <typename F>
-void simple_mutex_operation(F&& f)
-{
-    std::lock_guard<std::mutex> lk(m);
-    f();
-}
-
-// enum for the different types of objects
-enum relocation_category
-{
-    trivially_relocatable,
-    non_trivially_relocatable,
-    non_trivially_relocatable_throwing
-};
-
-template <relocation_category c, bool overlapping_test = false>
-struct counted_struct
-{
-    static std::set<counted_struct<c, overlapping_test>*> made;
-    static std::atomic<int> moved;
-    static std::atomic<int> destroyed;
-    int data;
-
-    explicit counted_struct(int data)
-      : data(data)
-    {
-        // Check that we are not constructing an object on top of another
-        simple_mutex_operation([&]() {
-            HPX_TEST(!made.count(this));
-            made.insert(this);
-        });
-    }
-
-    counted_struct(counted_struct&& other) noexcept(
-        c != non_trivially_relocatable_throwing)
-      : data(other.data)
-    {
-        if constexpr (c == non_trivially_relocatable_throwing)
-        {
-            if (moved++ == K - 1)
-            {
-                throw 42;
-            }
-        }
-        else
-        {
-            moved++;
-        }
-
-        // Check that we are not constructing an object on top of another
-        simple_mutex_operation([&]() {
-            // Unless we are testing overlapping relocation
-            // we should not be move-constructing an object on top of another
-            if constexpr (!overlapping_test)
-            {
-                HPX_TEST(!made.count(this));
-            }
-            made.insert(this);
-        });
-    }
-
-    ~counted_struct()
-    {
-        destroyed++;
-
-        // Check that the object was constructed
-        // and not already destroyed
-        simple_mutex_operation([&]() {
-            HPX_TEST(made.count(this));
-            made.erase(this);
-        });
-    }
-
-    // making sure the address is never directly accessed
-    friend void operator&(counted_struct) = delete;
-};
-
-template <relocation_category c, bool overlapping_test>
-std::set<counted_struct<c, overlapping_test>*>
-    counted_struct<c, overlapping_test>::made;
-
-template <relocation_category c, bool overlapping_test>
-std::atomic<int> counted_struct<c, overlapping_test>::moved = 0;
-
-template <relocation_category c, bool overlapping_test>
-std::atomic<int> counted_struct<c, overlapping_test>::destroyed = 0;
-
-// Non overlapping relocation testing mechanisms
-using trivially_relocatable_struct = counted_struct<trivially_relocatable>;
-HPX_DECLARE_TRIVIALLY_RELOCATABLE(trivially_relocatable_struct);
-
-using non_trivially_relocatable_struct =
-    counted_struct<non_trivially_relocatable>;
-
-using non_trivially_relocatable_struct_throwing =
-    counted_struct<non_trivially_relocatable_throwing>;
-
-// Overlapping relocation testing mechanisms
-using trivially_relocatable_struct_overlapping =
-    counted_struct<trivially_relocatable, true>;
-HPX_DECLARE_TRIVIALLY_RELOCATABLE(trivially_relocatable_struct_overlapping);
-
-using non_trivially_relocatable_struct_overlapping =
-    counted_struct<non_trivially_relocatable, true>;
-
-using non_trivially_relocatable_struct_throwing_overlapping =
-    counted_struct<non_trivially_relocatable_throwing, true>;
-
-// Check that the correct types are trivially relocatable
-static_assert(is_trivially_relocatable_v<trivially_relocatable_struct>);
-static_assert(
-    is_trivially_relocatable_v<trivially_relocatable_struct_overlapping>);
-
-static_assert(!is_trivially_relocatable_v<non_trivially_relocatable_struct>);
-static_assert(
-    !is_trivially_relocatable_v<non_trivially_relocatable_struct_overlapping>);
-
-static_assert(
-    !is_trivially_relocatable_v<non_trivially_relocatable_struct_throwing>);
-static_assert(!is_trivially_relocatable_v<
-    non_trivially_relocatable_struct_throwing_overlapping>);
-
-void clear()
-{
-    // Reset for the next test
-    trivially_relocatable_struct::moved = 0;
-    trivially_relocatable_struct::destroyed = 0;
-    trivially_relocatable_struct::made.clear();
-
-    trivially_relocatable_struct_overlapping::moved = 0;
-    trivially_relocatable_struct_overlapping::destroyed = 0;
-    trivially_relocatable_struct_overlapping::made.clear();
-
-    non_trivially_relocatable_struct::moved = 0;
-    non_trivially_relocatable_struct::destroyed = 0;
-    non_trivially_relocatable_struct::made.clear();
-
-    non_trivially_relocatable_struct_overlapping::moved = 0;
-    non_trivially_relocatable_struct_overlapping::destroyed = 0;
-    non_trivially_relocatable_struct_overlapping::made.clear();
-
-    non_trivially_relocatable_struct_throwing::moved = 0;
-    non_trivially_relocatable_struct_throwing::destroyed = 0;
-    non_trivially_relocatable_struct_throwing::made.clear();
-
-    non_trivially_relocatable_struct_throwing_overlapping::moved = 0;
-    non_trivially_relocatable_struct_throwing_overlapping::destroyed = 0;
-    non_trivially_relocatable_struct_throwing_overlapping::made.clear();
-}
-
-template <typename T>
-std::pair<T*, T*> setup()
-{
-    clear();
-
-    void* mem1 = std::malloc(N * sizeof(T));
-    void* mem2 = std::malloc(N * sizeof(T));
-
-    HPX_TEST(mem1 && mem2);
-
-    T* ptr1 = static_cast<T*>(mem1);
-    T* ptr2 = static_cast<T*>(mem2);
-
-    HPX_TEST(T::made.size() == 0);
-    HPX_TEST(T::moved == 0);
-    HPX_TEST(T::destroyed == 0);
-
-    for (int i = 0; i < N; i++)
-    {
-        hpx::construct_at(ptr1 + i, i);
-    }
-
-    // fill ptr2 with 0 after M
-    std::fill(static_cast<std::byte*>(mem2) + M * sizeof(T),
-        static_cast<std::byte*>(mem2) + N * sizeof(T), std::byte{0});
-
-    // N objects constructed
-    HPX_TEST(T::made.size() == N);
-
-    return {ptr1, ptr2};
-}
 
 template <typename LnPolicy, typename ExPolicy>
 void test(LnPolicy ln_policy, ExPolicy ex_policy)
@@ -385,7 +189,7 @@ void test_overlapping(LnPolicy ln_policy, ExPolicy ex_policy)
     static_assert(M + offset <= N);
 
     {    // Overlapping trivially-relocatable
-        auto [ptr, ___] = setup<trivially_relocatable_struct_overlapping>();
+        auto ptr = setup_single<trivially_relocatable_struct_overlapping>();
 
         // Destroy the objects that will be overwritten for bookkeeping
         std::destroy(ptr + M, ptr + M + offset);
@@ -431,7 +235,7 @@ void test_overlapping(LnPolicy ln_policy, ExPolicy ex_policy)
         std::free(ptr);
     }
     {    // Overlapping non-trivially relocatable
-        auto [ptr, ___] = setup<non_trivially_relocatable_struct_overlapping>();
+        auto ptr = setup_single<non_trivially_relocatable_struct_overlapping>();
 
         // Destroy the objects that will be overwritten for bookkeeping purposes
         std::destroy(ptr + M, ptr + M + offset);
@@ -468,8 +272,8 @@ void test_overlapping(LnPolicy ln_policy, ExPolicy ex_policy)
         std::free(ptr);
     }
     {    // Overlapping non-trivially relocatable throwing
-        auto [ptr, ___] =
-            setup<non_trivially_relocatable_struct_throwing_overlapping>();
+        auto ptr = setup_single<
+            non_trivially_relocatable_struct_throwing_overlapping>();
 
         // Destroy the objects that will be overwritten for bookkeeping purposes
         std::destroy(ptr + M, ptr + M + offset);

--- a/libs/core/algorithms/tests/unit/algorithms/uninitialized_relocate_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/uninitialized_relocate_sender.cpp
@@ -10,207 +10,12 @@
 #include <hpx/modules/testing.hpp>
 #include <hpx/modules/type_support.hpp>
 
-#include <atomic>
-#include <random>
-#include <set>
-#include <utility>
+#include "uninitialized_relocate_test_utils.hpp"
 
-constexpr int N = 500;    // number of objects to construct
-constexpr int M = 200;    // number of objects to relocate
-constexpr int K = 100;    // number of objects to relocate before throwing
-
-static_assert(N > M);
-static_assert(M > K);
-
-using hpx::experimental::is_trivially_relocatable_v;
 using hpx::experimental::uninitialized_relocate;
 
 namespace ex = hpx::execution::experimental;
 namespace tt = hpx::this_thread::experimental;
-
-std::mutex m;
-
-template <typename F>
-void simple_mutex_operation(F&& f)
-{
-    std::lock_guard<std::mutex> lk(m);
-    f();
-}
-
-// enum for the different types of objects
-enum relocation_category
-{
-    trivially_relocatable,
-    non_trivially_relocatable,
-    non_trivially_relocatable_throwing
-};
-
-template <relocation_category c, bool overlapping_test = false>
-struct counted_struct
-{
-    static std::set<counted_struct<c, overlapping_test>*> made;
-    static std::atomic<int> moved;
-    static std::atomic<int> destroyed;
-    int data;
-
-    explicit counted_struct(int data)
-      : data(data)
-    {
-        // Check that we are not constructing an object on top of another
-        simple_mutex_operation([&]() {
-            HPX_TEST(!made.count(this));
-            made.insert(this);
-        });
-    }
-
-    counted_struct(counted_struct&& other) noexcept(
-        c != non_trivially_relocatable_throwing)
-      : data(other.data)
-    {
-        if constexpr (c == non_trivially_relocatable_throwing)
-        {
-            if (moved++ == K - 1)
-            {
-                throw 42;
-            }
-        }
-        else
-        {
-            moved++;
-        }
-
-        // Check that we are not constructing an object on top of another
-        simple_mutex_operation([&]() {
-            // Unless we are testing overlapping relocation
-            // we should not be move-constructing an object on top of another
-            if constexpr (!overlapping_test)
-            {
-                HPX_TEST(!made.count(this));
-            }
-            made.insert(this);
-        });
-    }
-
-    ~counted_struct()
-    {
-        destroyed++;
-
-        // Check that the object was constructed
-        // and not already destroyed
-        simple_mutex_operation([&]() {
-            HPX_TEST(made.count(this));
-            made.erase(this);
-        });
-    }
-
-    // making sure the address is never directly accessed
-    friend void operator&(counted_struct) = delete;
-};
-
-template <relocation_category c, bool overlapping_test>
-std::set<counted_struct<c, overlapping_test>*>
-    counted_struct<c, overlapping_test>::made;
-
-template <relocation_category c, bool overlapping_test>
-std::atomic<int> counted_struct<c, overlapping_test>::moved = 0;
-
-template <relocation_category c, bool overlapping_test>
-std::atomic<int> counted_struct<c, overlapping_test>::destroyed = 0;
-
-// Non overlapping relocation testing mechanisms
-using trivially_relocatable_struct = counted_struct<trivially_relocatable>;
-HPX_DECLARE_TRIVIALLY_RELOCATABLE(trivially_relocatable_struct);
-
-using non_trivially_relocatable_struct =
-    counted_struct<non_trivially_relocatable>;
-
-using non_trivially_relocatable_struct_throwing =
-    counted_struct<non_trivially_relocatable_throwing>;
-
-// Overlapping relocation testing mechanisms
-using trivially_relocatable_struct_overlapping =
-    counted_struct<trivially_relocatable, true>;
-HPX_DECLARE_TRIVIALLY_RELOCATABLE(trivially_relocatable_struct_overlapping);
-
-using non_trivially_relocatable_struct_overlapping =
-    counted_struct<non_trivially_relocatable, true>;
-
-using non_trivially_relocatable_struct_throwing_overlapping =
-    counted_struct<non_trivially_relocatable_throwing, true>;
-
-// Check that the correct types are trivially relocatable
-static_assert(is_trivially_relocatable_v<trivially_relocatable_struct>);
-static_assert(
-    is_trivially_relocatable_v<trivially_relocatable_struct_overlapping>);
-
-static_assert(!is_trivially_relocatable_v<non_trivially_relocatable_struct>);
-static_assert(
-    !is_trivially_relocatable_v<non_trivially_relocatable_struct_overlapping>);
-
-static_assert(
-    !is_trivially_relocatable_v<non_trivially_relocatable_struct_throwing>);
-static_assert(!is_trivially_relocatable_v<
-    non_trivially_relocatable_struct_throwing_overlapping>);
-
-void clear()
-{
-    // Reset for the next test
-    trivially_relocatable_struct::moved = 0;
-    trivially_relocatable_struct::destroyed = 0;
-    trivially_relocatable_struct::made.clear();
-
-    trivially_relocatable_struct_overlapping::moved = 0;
-    trivially_relocatable_struct_overlapping::destroyed = 0;
-    trivially_relocatable_struct_overlapping::made.clear();
-
-    non_trivially_relocatable_struct::moved = 0;
-    non_trivially_relocatable_struct::destroyed = 0;
-    non_trivially_relocatable_struct::made.clear();
-
-    non_trivially_relocatable_struct_overlapping::moved = 0;
-    non_trivially_relocatable_struct_overlapping::destroyed = 0;
-    non_trivially_relocatable_struct_overlapping::made.clear();
-
-    non_trivially_relocatable_struct_throwing::moved = 0;
-    non_trivially_relocatable_struct_throwing::destroyed = 0;
-    non_trivially_relocatable_struct_throwing::made.clear();
-
-    non_trivially_relocatable_struct_throwing_overlapping::moved = 0;
-    non_trivially_relocatable_struct_throwing_overlapping::destroyed = 0;
-    non_trivially_relocatable_struct_throwing_overlapping::made.clear();
-}
-
-template <typename T>
-std::pair<T*, T*> setup()
-{
-    clear();
-
-    void* mem1 = std::malloc(N * sizeof(T));
-    void* mem2 = std::malloc(N * sizeof(T));
-
-    HPX_TEST(mem1 && mem2);
-
-    T* ptr1 = static_cast<T*>(mem1);
-    T* ptr2 = static_cast<T*>(mem2);
-
-    HPX_TEST(T::made.size() == 0);
-    HPX_TEST(T::moved == 0);
-    HPX_TEST(T::destroyed == 0);
-
-    for (int i = 0; i < N; i++)
-    {
-        hpx::construct_at(ptr1 + i, i);
-    }
-
-    // fill ptr2 with 0 after M
-    std::fill(static_cast<std::byte*>(mem2) + M * sizeof(T),
-        static_cast<std::byte*>(mem2) + N * sizeof(T), std::byte{0});
-
-    // N objects constructed
-    HPX_TEST(T::made.size() == N);
-
-    return {ptr1, ptr2};
-}
 
 template <typename LnPolicy, typename ExPolicy>
 void test(LnPolicy ln_policy, ExPolicy&& ex_policy)
@@ -384,7 +189,7 @@ void test_overlapping(LnPolicy ln_policy, ExPolicy&& ex_policy)
     auto exec = ex::explicit_scheduler_executor(scheduler_t(ln_policy));
 
     {    // Overlapping trivially-relocatable
-        auto [ptr, ___] = setup<trivially_relocatable_struct_overlapping>();
+        auto ptr = setup_single<trivially_relocatable_struct_overlapping>();
 
         // Destroy the objects that will be overwritten for bookkeeping
         std::destroy(ptr, ptr + offset);
@@ -431,7 +236,7 @@ void test_overlapping(LnPolicy ln_policy, ExPolicy&& ex_policy)
         std::free(ptr);
     }
     {    // Overlapping non-trivially relocatable
-        auto [ptr, ___] = setup<non_trivially_relocatable_struct_overlapping>();
+        auto ptr = setup_single<non_trivially_relocatable_struct_overlapping>();
 
         // Destroy the objects that will be overwritten for bookkeeping purposes
         std::destroy(ptr, ptr + offset);
@@ -469,8 +274,8 @@ void test_overlapping(LnPolicy ln_policy, ExPolicy&& ex_policy)
         std::free(ptr);
     }
     {    // Overlapping non-trivially relocatable throwing
-        auto [ptr, ___] =
-            setup<non_trivially_relocatable_struct_throwing_overlapping>();
+        auto ptr = setup_single<
+            non_trivially_relocatable_struct_throwing_overlapping>();
 
         // Destroy the objects that will be overwritten for bookkeeping purposes
         std::destroy(ptr, ptr + offset);

--- a/libs/core/algorithms/tests/unit/algorithms/uninitialized_relocate_test_utils.hpp
+++ b/libs/core/algorithms/tests/unit/algorithms/uninitialized_relocate_test_utils.hpp
@@ -15,6 +15,7 @@
 #include <hpx/modules/testing.hpp>
 #include <hpx/modules/type_support.hpp>
 
+#include <algorithm>
 #include <atomic>
 #include <cstddef>
 #include <cstdlib>

--- a/libs/core/algorithms/tests/unit/algorithms/uninitialized_relocate_test_utils.hpp
+++ b/libs/core/algorithms/tests/unit/algorithms/uninitialized_relocate_test_utils.hpp
@@ -1,0 +1,267 @@
+//  Copyright (c) 2023 Isidoros Tsaousis-Seiras
+//  Copyright (c) 2025 Jatin Sharma
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Shared test infrastructure for the uninitialized_relocate family of
+// algorithm tests. Extracted to avoid duplication across
+// uninitialized_relocate.cpp, uninitialized_relocaten.cpp,
+// uninitialized_relocate_backward.cpp and their sender variants.
+
+#pragma once
+
+#include <hpx/modules/testing.hpp>
+#include <hpx/modules/type_support.hpp>
+
+#include <atomic>
+#include <cstddef>
+#include <cstdlib>
+#include <mutex>
+#include <set>
+#include <utility>
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+constexpr int N = 500;    // number of objects to construct
+constexpr int M = 200;    // number of objects to relocate
+constexpr int K = 100;    // number of objects to relocate before throwing
+
+static_assert(N > M);
+static_assert(M > K);
+
+using hpx::experimental::is_trivially_relocatable_v;
+
+// ---------------------------------------------------------------------------
+// Thread-safe bookkeeping helpers
+// ---------------------------------------------------------------------------
+// NOLINTNEXTLINE(cppcoreguidelines-avoid-non-const-global-variables)
+inline std::mutex& get_test_mutex()
+{
+    static std::mutex m;
+    return m;
+}
+
+template <typename F>
+void simple_mutex_operation(F&& f)
+{
+    std::lock_guard<std::mutex> lk(get_test_mutex());
+    f();
+}
+
+// ---------------------------------------------------------------------------
+// counted_struct – tracks constructions, moves, and destructions
+// ---------------------------------------------------------------------------
+enum relocation_category
+{
+    trivially_relocatable,
+    non_trivially_relocatable,
+    non_trivially_relocatable_throwing
+};
+
+template <relocation_category c, bool overlapping_test = false>
+struct counted_struct
+{
+    static std::set<counted_struct<c, overlapping_test>*> made;
+    static std::atomic<int> moved;
+    static std::atomic<int> destroyed;
+    int data;
+
+    explicit counted_struct(int data)
+      : data(data)
+    {
+        // Check that we are not constructing an object on top of another
+        simple_mutex_operation([&]() {
+            HPX_TEST(!made.count(this));
+            made.insert(this);
+        });
+    }
+
+    counted_struct(counted_struct&& other) noexcept(
+        c != non_trivially_relocatable_throwing)
+      : data(other.data)
+    {
+        if constexpr (c == non_trivially_relocatable_throwing)
+        {
+            if (moved++ == K - 1)
+            {
+                throw 42;
+            }
+        }
+        else
+        {
+            moved++;
+        }
+
+        // Check that we are not constructing an object on top of another
+        simple_mutex_operation([&]() {
+            // Unless we are testing overlapping relocation
+            // we should not be move-constructing an object on top of another
+            if constexpr (!overlapping_test)
+            {
+                HPX_TEST(!made.count(this));
+            }
+            made.insert(this);
+        });
+    }
+
+    ~counted_struct()
+    {
+        destroyed++;
+
+        // Check that the object was constructed
+        // and not already destroyed
+        simple_mutex_operation([&]() {
+            HPX_TEST(made.count(this));
+            made.erase(this);
+        });
+    }
+
+    // making sure the address is never directly accessed
+    friend void operator&(counted_struct) = delete;
+};
+
+template <relocation_category c, bool overlapping_test>
+std::set<counted_struct<c, overlapping_test>*>
+    counted_struct<c, overlapping_test>::made;
+
+template <relocation_category c, bool overlapping_test>
+std::atomic<int> counted_struct<c, overlapping_test>::moved = 0;
+
+template <relocation_category c, bool overlapping_test>
+std::atomic<int> counted_struct<c, overlapping_test>::destroyed = 0;
+
+// ---------------------------------------------------------------------------
+// Type aliases
+// ---------------------------------------------------------------------------
+
+// Non overlapping relocation testing mechanisms
+using trivially_relocatable_struct = counted_struct<trivially_relocatable>;
+HPX_DECLARE_TRIVIALLY_RELOCATABLE(trivially_relocatable_struct);
+
+using non_trivially_relocatable_struct =
+    counted_struct<non_trivially_relocatable>;
+
+using non_trivially_relocatable_struct_throwing =
+    counted_struct<non_trivially_relocatable_throwing>;
+
+// Overlapping relocation testing mechanisms
+using trivially_relocatable_struct_overlapping =
+    counted_struct<trivially_relocatable, true>;
+HPX_DECLARE_TRIVIALLY_RELOCATABLE(trivially_relocatable_struct_overlapping);
+
+using non_trivially_relocatable_struct_overlapping =
+    counted_struct<non_trivially_relocatable, true>;
+
+using non_trivially_relocatable_struct_throwing_overlapping =
+    counted_struct<non_trivially_relocatable_throwing, true>;
+
+// Check that the correct types are trivially relocatable
+static_assert(is_trivially_relocatable_v<trivially_relocatable_struct>);
+static_assert(
+    is_trivially_relocatable_v<trivially_relocatable_struct_overlapping>);
+
+static_assert(!is_trivially_relocatable_v<non_trivially_relocatable_struct>);
+static_assert(
+    !is_trivially_relocatable_v<non_trivially_relocatable_struct_overlapping>);
+
+static_assert(
+    !is_trivially_relocatable_v<non_trivially_relocatable_struct_throwing>);
+static_assert(!is_trivially_relocatable_v<
+    non_trivially_relocatable_struct_throwing_overlapping>);
+
+// ---------------------------------------------------------------------------
+// clear() – resets all static state between tests
+// ---------------------------------------------------------------------------
+inline void clear()
+{
+    trivially_relocatable_struct::moved = 0;
+    trivially_relocatable_struct::destroyed = 0;
+    trivially_relocatable_struct::made.clear();
+
+    trivially_relocatable_struct_overlapping::moved = 0;
+    trivially_relocatable_struct_overlapping::destroyed = 0;
+    trivially_relocatable_struct_overlapping::made.clear();
+
+    non_trivially_relocatable_struct::moved = 0;
+    non_trivially_relocatable_struct::destroyed = 0;
+    non_trivially_relocatable_struct::made.clear();
+
+    non_trivially_relocatable_struct_overlapping::moved = 0;
+    non_trivially_relocatable_struct_overlapping::destroyed = 0;
+    non_trivially_relocatable_struct_overlapping::made.clear();
+
+    non_trivially_relocatable_struct_throwing::moved = 0;
+    non_trivially_relocatable_struct_throwing::destroyed = 0;
+    non_trivially_relocatable_struct_throwing::made.clear();
+
+    non_trivially_relocatable_struct_throwing_overlapping::moved = 0;
+    non_trivially_relocatable_struct_throwing_overlapping::destroyed = 0;
+    non_trivially_relocatable_struct_throwing_overlapping::made.clear();
+}
+
+// ---------------------------------------------------------------------------
+// setup<T>() – allocates two buffers for non-overlapping tests
+// ---------------------------------------------------------------------------
+template <typename T>
+std::pair<T*, T*> setup()
+{
+    clear();
+
+    void* mem1 = std::malloc(N * sizeof(T));
+    void* mem2 = std::malloc(N * sizeof(T));
+
+    HPX_TEST(mem1 && mem2);
+
+    T* ptr1 = static_cast<T*>(mem1);
+    T* ptr2 = static_cast<T*>(mem2);
+
+    HPX_TEST(T::made.size() == 0);
+    HPX_TEST(T::moved == 0);
+    HPX_TEST(T::destroyed == 0);
+
+    for (int i = 0; i < N; i++)
+    {
+        hpx::construct_at(ptr1 + i, i);
+    }
+
+    // fill ptr2 with 0 after M
+    std::fill(static_cast<std::byte*>(mem2) + M * sizeof(T),
+        static_cast<std::byte*>(mem2) + N * sizeof(T), std::byte{0});
+
+    // N objects constructed
+    HPX_TEST(T::made.size() == N);
+
+    return {ptr1, ptr2};
+}
+
+// ---------------------------------------------------------------------------
+// setup_single<T>() – allocates one buffer for overlapping tests
+// ---------------------------------------------------------------------------
+template <typename T>
+T* setup_single()
+{
+    clear();
+
+    void* mem = std::malloc(N * sizeof(T));
+
+    HPX_TEST(mem);
+
+    T* ptr = static_cast<T*>(mem);
+
+    HPX_TEST(T::made.size() == 0);
+    HPX_TEST(T::moved == 0);
+    HPX_TEST(T::destroyed == 0);
+
+    for (int i = 0; i < N; i++)
+    {
+        hpx::construct_at(ptr + i, i);
+    }
+
+    // N objects constructed
+    HPX_TEST(T::made.size() == N);
+
+    return ptr;
+}

--- a/libs/core/algorithms/tests/unit/algorithms/uninitialized_relocate_test_utils.hpp
+++ b/libs/core/algorithms/tests/unit/algorithms/uninitialized_relocate_test_utils.hpp
@@ -52,7 +52,7 @@ void simple_mutex_operation(F&& f)
 }
 
 // ---------------------------------------------------------------------------
-// counted_struct – tracks constructions, moves, and destructions
+// counted_struct - tracks constructions, moves, and destructions
 // ---------------------------------------------------------------------------
 enum relocation_category
 {
@@ -173,7 +173,7 @@ static_assert(!is_trivially_relocatable_v<
     non_trivially_relocatable_struct_throwing_overlapping>);
 
 // ---------------------------------------------------------------------------
-// clear() – resets all static state between tests
+// clear() - resets all static state between tests
 // ---------------------------------------------------------------------------
 inline void clear()
 {
@@ -203,7 +203,7 @@ inline void clear()
 }
 
 // ---------------------------------------------------------------------------
-// setup<T>() – allocates two buffers for non-overlapping tests
+// setup<T>() - allocates two buffers for non-overlapping tests
 // ---------------------------------------------------------------------------
 template <typename T>
 std::pair<T*, T*> setup()
@@ -238,7 +238,7 @@ std::pair<T*, T*> setup()
 }
 
 // ---------------------------------------------------------------------------
-// setup_single<T>() – allocates one buffer for overlapping tests
+// setup_single<T>() - allocates one buffer for overlapping tests
 // ---------------------------------------------------------------------------
 template <typename T>
 T* setup_single()

--- a/libs/core/algorithms/tests/unit/algorithms/uninitialized_relocaten.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/uninitialized_relocaten.cpp
@@ -10,206 +10,12 @@
 #include <hpx/modules/testing.hpp>
 #include <hpx/modules/type_support.hpp>
 
-#include <atomic>
+#include "uninitialized_relocate_test_utils.hpp"
+
 #include <cstddef>
-#include <random>
-#include <set>
 #include <type_traits>
-#include <utility>
 
-constexpr int N = 500;    // number of objects to construct
-constexpr int M = 200;    // number of objects to relocate
-constexpr int K = 100;    // number of objects to relocate before throwing
-
-static_assert(N > M);
-static_assert(M > K);
-
-using hpx::experimental::is_trivially_relocatable_v;
 using hpx::experimental::uninitialized_relocate_n;
-
-std::mutex m;
-
-template <typename F>
-void simple_mutex_operation(F&& f)
-{
-    std::lock_guard<std::mutex> lk(m);
-    f();
-}
-
-// enum for the different types of objects
-enum relocation_category
-{
-    trivially_relocatable,
-    non_trivially_relocatable,
-    non_trivially_relocatable_throwing
-};
-
-template <relocation_category c, bool overlapping_test = false>
-struct counted_struct
-{
-    static std::set<counted_struct<c, overlapping_test>*> made;
-    static std::atomic<int> moved;
-    static std::atomic<int> destroyed;
-    int data;
-
-    explicit counted_struct(int data)
-      : data(data)
-    {
-        // Check that we are not constructing an object on top of another
-        simple_mutex_operation([&]() {
-            HPX_TEST(!made.count(this));
-            made.insert(this);
-        });
-    }
-
-    counted_struct(counted_struct&& other) noexcept(
-        c != non_trivially_relocatable_throwing)
-      : data(other.data)
-    {
-        if constexpr (c == non_trivially_relocatable_throwing)
-        {
-            if (moved++ == K - 1)
-            {
-                throw 42;
-            }
-        }
-        else
-        {
-            moved++;
-        }
-
-        // Check that we are not constructing an object on top of another
-        simple_mutex_operation([&]() {
-            // Unless we are testing overlapping relocation
-            // we should not be move-constructing an object on top of another
-            if constexpr (!overlapping_test)
-            {
-                HPX_TEST(!made.count(this));
-            }
-            made.insert(this);
-        });
-    }
-
-    ~counted_struct()
-    {
-        destroyed++;
-
-        // Check that the object was constructed
-        // and not already destroyed
-        simple_mutex_operation([&]() {
-            HPX_TEST(made.count(this));
-            made.erase(this);
-        });
-    }
-
-    // making sure the address is never directly accessed
-    friend void operator&(counted_struct) = delete;
-};
-
-template <relocation_category c, bool overlapping_test>
-std::set<counted_struct<c, overlapping_test>*>
-    counted_struct<c, overlapping_test>::made;
-
-template <relocation_category c, bool overlapping_test>
-std::atomic<int> counted_struct<c, overlapping_test>::moved = 0;
-
-template <relocation_category c, bool overlapping_test>
-std::atomic<int> counted_struct<c, overlapping_test>::destroyed = 0;
-
-// Non overlapping relocation testing mechanisms
-using trivially_relocatable_struct = counted_struct<trivially_relocatable>;
-HPX_DECLARE_TRIVIALLY_RELOCATABLE(trivially_relocatable_struct);
-
-using non_trivially_relocatable_struct =
-    counted_struct<non_trivially_relocatable>;
-
-using non_trivially_relocatable_struct_throwing =
-    counted_struct<non_trivially_relocatable_throwing>;
-
-// Overlapping relocation testing mechanisms
-using trivially_relocatable_struct_overlapping =
-    counted_struct<trivially_relocatable, true>;
-HPX_DECLARE_TRIVIALLY_RELOCATABLE(trivially_relocatable_struct_overlapping);
-
-using non_trivially_relocatable_struct_overlapping =
-    counted_struct<non_trivially_relocatable, true>;
-
-using non_trivially_relocatable_struct_throwing_overlapping =
-    counted_struct<non_trivially_relocatable_throwing, true>;
-
-// Check that the correct types are trivially relocatable
-static_assert(is_trivially_relocatable_v<trivially_relocatable_struct>);
-static_assert(
-    is_trivially_relocatable_v<trivially_relocatable_struct_overlapping>);
-
-static_assert(!is_trivially_relocatable_v<non_trivially_relocatable_struct>);
-static_assert(
-    !is_trivially_relocatable_v<non_trivially_relocatable_struct_overlapping>);
-
-static_assert(
-    !is_trivially_relocatable_v<non_trivially_relocatable_struct_throwing>);
-static_assert(!is_trivially_relocatable_v<
-    non_trivially_relocatable_struct_throwing_overlapping>);
-
-void clear()
-{
-    // Reset for the next test
-    trivially_relocatable_struct::moved = 0;
-    trivially_relocatable_struct::destroyed = 0;
-    trivially_relocatable_struct::made.clear();
-
-    trivially_relocatable_struct_overlapping::moved = 0;
-    trivially_relocatable_struct_overlapping::destroyed = 0;
-    trivially_relocatable_struct_overlapping::made.clear();
-
-    non_trivially_relocatable_struct::moved = 0;
-    non_trivially_relocatable_struct::destroyed = 0;
-    non_trivially_relocatable_struct::made.clear();
-
-    non_trivially_relocatable_struct_overlapping::moved = 0;
-    non_trivially_relocatable_struct_overlapping::destroyed = 0;
-    non_trivially_relocatable_struct_overlapping::made.clear();
-
-    non_trivially_relocatable_struct_throwing::moved = 0;
-    non_trivially_relocatable_struct_throwing::destroyed = 0;
-    non_trivially_relocatable_struct_throwing::made.clear();
-
-    non_trivially_relocatable_struct_throwing_overlapping::moved = 0;
-    non_trivially_relocatable_struct_throwing_overlapping::destroyed = 0;
-    non_trivially_relocatable_struct_throwing_overlapping::made.clear();
-}
-
-template <typename T>
-std::pair<T*, T*> setup()
-{
-    clear();
-
-    void* mem1 = std::malloc(N * sizeof(T));
-    void* mem2 = std::malloc(N * sizeof(T));
-
-    HPX_TEST(mem1 && mem2);
-
-    T* ptr1 = static_cast<T*>(mem1);
-    T* ptr2 = static_cast<T*>(mem2);
-
-    HPX_TEST(T::made.size() == 0);
-    HPX_TEST(T::moved == 0);
-    HPX_TEST(T::destroyed == 0);
-
-    for (int i = 0; i < N; i++)
-    {
-        hpx::construct_at(ptr1 + i, i);
-    }
-
-    // fill ptr2 with 0 after M
-    std::fill(static_cast<std::byte*>(mem2) + M * sizeof(T),
-        static_cast<std::byte*>(mem2) + N * sizeof(T), std::byte{0});
-
-    // N objects constructed
-    HPX_TEST(T::made.size() == N);
-
-    return {ptr1, ptr2};
-}
 
 template <typename Ex>
 void test()
@@ -377,7 +183,7 @@ void test_overlapping()
     static_assert(M + offset <= N);
 
     {    // Overlapping trivially-relocatable
-        auto [ptr, ___] = setup<trivially_relocatable_struct_overlapping>();
+        auto ptr = setup_single<trivially_relocatable_struct_overlapping>();
 
         // Destroy the objects that will be overwritten for bookkeeping
         std::destroy(ptr, ptr + offset);
@@ -423,7 +229,7 @@ void test_overlapping()
         std::free(ptr);
     }
     {    // Overlapping non-trivially relocatable
-        auto [ptr, ___] = setup<non_trivially_relocatable_struct_overlapping>();
+        auto ptr = setup_single<non_trivially_relocatable_struct_overlapping>();
 
         // Destroy the objects that will be overwritten for bookkeeping purposes
         std::destroy(ptr, ptr + offset);
@@ -460,8 +266,8 @@ void test_overlapping()
         std::free(ptr);
     }
     {    // Overlapping non-trivially relocatable throwing
-        auto [ptr, ___] =
-            setup<non_trivially_relocatable_struct_throwing_overlapping>();
+        auto ptr = setup_single<
+            non_trivially_relocatable_struct_throwing_overlapping>();
 
         // Destroy the objects that will be overwritten for bookkeeping purposes
         std::destroy(ptr, ptr + offset);
@@ -530,7 +336,7 @@ void test_right_overlapping()
     static_assert(M + offset <= N);
 
     {    // Right-overlapping trivially-relocatable
-        auto [ptr, ___] = setup<trivially_relocatable_struct_overlapping>();
+        auto ptr = setup_single<trivially_relocatable_struct_overlapping>();
 
         // Destroy the objects in [M, M + offset) that will be overwritten
         // by the destination tail extending beyond the source range

--- a/libs/core/algorithms/tests/unit/algorithms/uninitialized_relocaten_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/uninitialized_relocaten_sender.cpp
@@ -10,207 +10,12 @@
 #include <hpx/modules/testing.hpp>
 #include <hpx/modules/type_support.hpp>
 
-#include <atomic>
-#include <random>
-#include <set>
-#include <utility>
+#include "uninitialized_relocate_test_utils.hpp"
 
-constexpr int N = 500;    // number of objects to construct
-constexpr int M = 200;    // number of objects to relocate
-constexpr int K = 100;    // number of objects to relocate before throwing
-
-static_assert(N > M);
-static_assert(M > K);
-
-using hpx::experimental::is_trivially_relocatable_v;
 using hpx::experimental::uninitialized_relocate_n;
 
 namespace ex = hpx::execution::experimental;
 namespace tt = hpx::this_thread::experimental;
-
-std::mutex m;
-
-template <typename F>
-void simple_mutex_operation(F&& f)
-{
-    std::lock_guard<std::mutex> lk(m);
-    f();
-}
-
-// enum for the different types of objects
-enum relocation_category
-{
-    trivially_relocatable,
-    non_trivially_relocatable,
-    non_trivially_relocatable_throwing
-};
-
-template <relocation_category c, bool overlapping_test = false>
-struct counted_struct
-{
-    static std::set<counted_struct<c, overlapping_test>*> made;
-    static std::atomic<int> moved;
-    static std::atomic<int> destroyed;
-    int data;
-
-    explicit counted_struct(int data)
-      : data(data)
-    {
-        // Check that we are not constructing an object on top of another
-        simple_mutex_operation([&]() {
-            HPX_TEST(!made.count(this));
-            made.insert(this);
-        });
-    }
-
-    counted_struct(counted_struct&& other) noexcept(
-        c != non_trivially_relocatable_throwing)
-      : data(other.data)
-    {
-        if constexpr (c == non_trivially_relocatable_throwing)
-        {
-            if (moved++ == K - 1)
-            {
-                throw 42;
-            }
-        }
-        else
-        {
-            moved++;
-        }
-
-        // Check that we are not constructing an object on top of another
-        simple_mutex_operation([&]() {
-            // Unless we are testing overlapping relocation
-            // we should not be move-constructing an object on top of another
-            if constexpr (!overlapping_test)
-            {
-                HPX_TEST(!made.count(this));
-            }
-            made.insert(this);
-        });
-    }
-
-    ~counted_struct()
-    {
-        destroyed++;
-
-        // Check that the object was constructed
-        // and not already destroyed
-        simple_mutex_operation([&]() {
-            HPX_TEST(made.count(this));
-            made.erase(this);
-        });
-    }
-
-    // making sure the address is never directly accessed
-    friend void operator&(counted_struct) = delete;
-};
-
-template <relocation_category c, bool overlapping_test>
-std::set<counted_struct<c, overlapping_test>*>
-    counted_struct<c, overlapping_test>::made;
-
-template <relocation_category c, bool overlapping_test>
-std::atomic<int> counted_struct<c, overlapping_test>::moved = 0;
-
-template <relocation_category c, bool overlapping_test>
-std::atomic<int> counted_struct<c, overlapping_test>::destroyed = 0;
-
-// Non overlapping relocation testing mechanisms
-using trivially_relocatable_struct = counted_struct<trivially_relocatable>;
-HPX_DECLARE_TRIVIALLY_RELOCATABLE(trivially_relocatable_struct);
-
-using non_trivially_relocatable_struct =
-    counted_struct<non_trivially_relocatable>;
-
-using non_trivially_relocatable_struct_throwing =
-    counted_struct<non_trivially_relocatable_throwing>;
-
-// Overlapping relocation testing mechanisms
-using trivially_relocatable_struct_overlapping =
-    counted_struct<trivially_relocatable, true>;
-HPX_DECLARE_TRIVIALLY_RELOCATABLE(trivially_relocatable_struct_overlapping);
-
-using non_trivially_relocatable_struct_overlapping =
-    counted_struct<non_trivially_relocatable, true>;
-
-using non_trivially_relocatable_struct_throwing_overlapping =
-    counted_struct<non_trivially_relocatable_throwing, true>;
-
-// Check that the correct types are trivially relocatable
-static_assert(is_trivially_relocatable_v<trivially_relocatable_struct>);
-static_assert(
-    is_trivially_relocatable_v<trivially_relocatable_struct_overlapping>);
-
-static_assert(!is_trivially_relocatable_v<non_trivially_relocatable_struct>);
-static_assert(
-    !is_trivially_relocatable_v<non_trivially_relocatable_struct_overlapping>);
-
-static_assert(
-    !is_trivially_relocatable_v<non_trivially_relocatable_struct_throwing>);
-static_assert(!is_trivially_relocatable_v<
-    non_trivially_relocatable_struct_throwing_overlapping>);
-
-void clear()
-{
-    // Reset for the next test
-    trivially_relocatable_struct::moved = 0;
-    trivially_relocatable_struct::destroyed = 0;
-    trivially_relocatable_struct::made.clear();
-
-    trivially_relocatable_struct_overlapping::moved = 0;
-    trivially_relocatable_struct_overlapping::destroyed = 0;
-    trivially_relocatable_struct_overlapping::made.clear();
-
-    non_trivially_relocatable_struct::moved = 0;
-    non_trivially_relocatable_struct::destroyed = 0;
-    non_trivially_relocatable_struct::made.clear();
-
-    non_trivially_relocatable_struct_overlapping::moved = 0;
-    non_trivially_relocatable_struct_overlapping::destroyed = 0;
-    non_trivially_relocatable_struct_overlapping::made.clear();
-
-    non_trivially_relocatable_struct_throwing::moved = 0;
-    non_trivially_relocatable_struct_throwing::destroyed = 0;
-    non_trivially_relocatable_struct_throwing::made.clear();
-
-    non_trivially_relocatable_struct_throwing_overlapping::moved = 0;
-    non_trivially_relocatable_struct_throwing_overlapping::destroyed = 0;
-    non_trivially_relocatable_struct_throwing_overlapping::made.clear();
-}
-
-template <typename T>
-std::pair<T*, T*> setup()
-{
-    clear();
-
-    void* mem1 = std::malloc(N * sizeof(T));
-    void* mem2 = std::malloc(N * sizeof(T));
-
-    HPX_TEST(mem1 && mem2);
-
-    T* ptr1 = static_cast<T*>(mem1);
-    T* ptr2 = static_cast<T*>(mem2);
-
-    HPX_TEST(T::made.size() == 0);
-    HPX_TEST(T::moved == 0);
-    HPX_TEST(T::destroyed == 0);
-
-    for (int i = 0; i < N; i++)
-    {
-        hpx::construct_at(ptr1 + i, i);
-    }
-
-    // fill ptr2 with 0 after M
-    std::fill(static_cast<std::byte*>(mem2) + M * sizeof(T),
-        static_cast<std::byte*>(mem2) + N * sizeof(T), std::byte{0});
-
-    // N objects constructed
-    HPX_TEST(T::made.size() == N);
-
-    return {ptr1, ptr2};
-}
 
 template <typename LnPolicy, typename ExPolicy>
 void test(LnPolicy ln_policy, ExPolicy ex_policy)
@@ -384,7 +189,7 @@ void test_overlapping(LnPolicy ln_policy, ExPolicy ex_policy)
     static_assert(M + offset <= N);
 
     {    // Overlapping trivially-relocatable
-        auto [ptr, ___] = setup<trivially_relocatable_struct_overlapping>();
+        auto ptr = setup_single<trivially_relocatable_struct_overlapping>();
 
         // Destroy the objects that will be overwritten for bookkeeping
         std::destroy(ptr, ptr + offset);
@@ -431,7 +236,7 @@ void test_overlapping(LnPolicy ln_policy, ExPolicy ex_policy)
         std::free(ptr);
     }
     {    // Overlapping non-trivially relocatable
-        auto [ptr, ___] = setup<non_trivially_relocatable_struct_overlapping>();
+        auto ptr = setup_single<non_trivially_relocatable_struct_overlapping>();
 
         // Destroy the objects that will be overwritten for bookkeeping purposes
         std::destroy(ptr, ptr + offset);
@@ -469,8 +274,8 @@ void test_overlapping(LnPolicy ln_policy, ExPolicy ex_policy)
         std::free(ptr);
     }
     {    // Overlapping non-trivially relocatable throwing
-        auto [ptr, ___] =
-            setup<non_trivially_relocatable_struct_throwing_overlapping>();
+        auto ptr = setup_single<
+            non_trivially_relocatable_struct_throwing_overlapping>();
 
         // Destroy the objects that will be overwritten for bookkeeping purposes
         std::destroy(ptr, ptr + offset);


### PR DESCRIPTION
## Summary

Fixes #7184

The `setup<T>()` helper in relocation test files allocates two buffers (`mem1`, `mem2`) and returns them as `std::pair<T*, T*>`. Non-overlapping tests correctly free both, but overlapping tests only use one buffer for in-place relocation — the second buffer was captured as a discarded binding (`___`) and **never freed**, leaking `N * sizeof(T)` bytes per overlapping test block.

## Changes

Introduced a `setup_single<T>()` helper that allocates only a single buffer for overlapping tests, then updated all overlapping test blocks to use it. This eliminates:
- The unnecessary second allocation
- The silent memory leak
- The misleading discarded binding pattern

### Affected files (6 files, 20 leak sites fixed):

| File | Leak sites |
|------|-----------|
| `uninitialized_relocate.cpp` | 4 (`test_overlapping` x 3, `test_right_overlapping` x 1) |
| `uninitialized_relocaten.cpp` | 4 (`test_overlapping` x 3, `test_right_overlapping` x 1) |
| `uninitialized_relocate_backward.cpp` | 3 (`test_overlapping` x 3) |
| `uninitialized_relocate_sender.cpp` | 3 (`test_overlapping` x 3) |
| `uninitialized_relocaten_sender.cpp` | 3 (`test_overlapping` x 3) |
| `uninitialized_relocate_backward_sender.cpp` | 3 (`test_overlapping` x 3) |

## Testing

Built and ran all 3 available relocation test targets locally (macOS, Apple Clang, Debug build):

```
$ ./bin/uninitialized_relocate_test --hpx:threads=2          # EXIT_CODE=0
$ ./bin/uninitialized_relocaten_test --hpx:threads=2         # EXIT_CODE=0
$ ./bin/uninitialized_relocate_backward_test --hpx:threads=2 # EXIT_CODE=0
```

All tests pass. The sender test targets were not available in this build configuration but the changes are structurally identical.
