### PR TITLE
Add unit tests for hierarchical all_reduce and all_gather

### DIFF
--- a/libs/full/collectives/tests/unit/CMakeLists.txt
+++ b/libs/full/collectives/tests/unit/CMakeLists.txt
@@ -32,6 +32,8 @@ if(HPX_WITH_NETWORKING)
       exclusive_scan_
       exclusive_scan_sync
       gather
+      all_gather_hierarchical
+      all_reduce_hierarchical
       gather_hierarchical
       gather_sync
       inclusive_scan_

--- a/libs/full/collectives/tests/unit/CMakeLists.txt
+++ b/libs/full/collectives/tests/unit/CMakeLists.txt
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-
 set(tests
     all_gather
     all_gather_sync
@@ -23,17 +22,16 @@ set(tests
     reduce_direct
     remote_latch
 )
-
 if(HPX_WITH_NETWORKING)
   set(tests
       ${tests}
+      all_gather_hierarchical
+      all_reduce_hierarchical
       broadcast_direct
       concurrent_collectives
       exclusive_scan_
       exclusive_scan_sync
       gather
-      all_gather_hierarchical
-      all_reduce_hierarchical
       gather_hierarchical
       gather_sync
       inclusive_scan_
@@ -45,17 +43,13 @@ if(HPX_WITH_NETWORKING)
       scatter_hierarchical
       scatter_sync
   )
-
   foreach(test ${tests})
     set(${test}_PARAMETERS LOCALITIES 2)
   endforeach()
 endif()
-
 foreach(test ${tests})
   set(sources ${test}.cpp)
-
   source_group("Source Files" FILES ${sources})
-
   # add example executable
   add_hpx_executable(
     ${test}_test INTERNAL_FLAGS
@@ -64,6 +58,5 @@ foreach(test ${tests})
     HPX_PREFIX ${HPX_BUILD_PREFIX}
     FOLDER "Tests/Unit/Modules/Full/Collectives"
   )
-
   add_hpx_unit_test("modules.collectives" ${test} ${${test}_PARAMETERS})
 endforeach()

--- a/libs/full/collectives/tests/unit/all_gather_hierarchical.cpp
+++ b/libs/full/collectives/tests/unit/all_gather_hierarchical.cpp
@@ -60,8 +60,8 @@ void test_multiple_use_with_generation(int arity = 2)
     auto const elapsed = t.elapsed();
     if (this_locality == 0)
     {
-        std::cout << "remote timing (with generation): "
-                  << elapsed / ITERATIONS << "[s]\n"
+        std::cout << "remote timing (with generation): " << elapsed / ITERATIONS
+                  << "[s]\n"
                   << std::flush;
     }
 }
@@ -88,8 +88,7 @@ void test_local_use(std::uint32_t num_sites, int arity = 2)
                         this_site_arg(site), generation_arg(i + 1));
 
                 auto result = overall_result.get();
-                HPX_TEST_EQ(
-                    result.size(), static_cast<std::size_t>(num_sites));
+                HPX_TEST_EQ(result.size(), static_cast<std::size_t>(num_sites));
                 for (std::uint32_t j = 0; j != num_sites; ++j)
                 {
                     HPX_TEST_EQ(result[j], j + i);

--- a/libs/full/collectives/tests/unit/all_gather_hierarchical.cpp
+++ b/libs/full/collectives/tests/unit/all_gather_hierarchical.cpp
@@ -1,0 +1,155 @@
+//  Copyright (c) 2019-2025 Hartmut Kaiser
+//  Copyright (c) 2026 Anshuman Agrawal
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/modules/collectives.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace hpx::collectives;
+
+constexpr char const* all_gather_direct_basename =
+    "/test/all_gather_hierarchical/";
+#if defined(HPX_DEBUG)
+constexpr int ITERATIONS = 50;
+#else
+constexpr int ITERATIONS = 500;
+#endif
+
+void test_multiple_use_with_generation(int arity = 2)
+{
+    std::uint32_t const this_locality = hpx::get_locality_id();
+    std::uint32_t const num_localities =
+        hpx::get_num_localities(hpx::launch::sync);
+    HPX_TEST_LTE(static_cast<std::uint32_t>(2), num_localities);
+
+    auto const all_gather_clients = create_hierarchical_communicator(
+        all_gather_direct_basename, num_sites_arg(num_localities),
+        this_site_arg(this_locality), arity_arg(arity));
+
+    hpx::chrono::high_resolution_timer const t;
+
+    for (int i = 0; i != ITERATIONS; ++i)
+    {
+        std::uint32_t value = this_locality + i;
+        hpx::future<std::vector<std::uint32_t>> overall_result =
+            all_gather(all_gather_clients, std::move(value),
+                this_site_arg(this_locality), generation_arg(i + 1));
+
+        auto result = overall_result.get();
+        HPX_TEST_EQ(result.size(), static_cast<std::size_t>(num_localities));
+        for (std::uint32_t j = 0; j != num_localities; ++j)
+        {
+            HPX_TEST_EQ(result[j], j + i);
+        }
+    }
+
+    auto const elapsed = t.elapsed();
+    if (this_locality == 0)
+    {
+        std::cout << "remote timing (with generation): "
+                  << elapsed / ITERATIONS << "[s]\n"
+                  << std::flush;
+    }
+}
+
+void test_local_use(std::uint32_t num_sites, int arity = 2)
+{
+    std::vector<hpx::future<void>> sites;
+    sites.reserve(num_sites);
+
+    for (std::uint32_t site = 0; site != num_sites; ++site)
+    {
+        sites.push_back(hpx::async([=]() {
+            auto const all_gather_clients = create_hierarchical_communicator(
+                all_gather_direct_basename, num_sites_arg(num_sites),
+                this_site_arg(site), arity_arg(arity));
+
+            hpx::chrono::high_resolution_timer const t;
+
+            for (int i = 0; i != ITERATIONS; ++i)
+            {
+                std::uint32_t value = site + i;
+                hpx::future<std::vector<std::uint32_t>> overall_result =
+                    all_gather(all_gather_clients, std::move(value),
+                        this_site_arg(site), generation_arg(i + 1));
+
+                auto result = overall_result.get();
+                HPX_TEST_EQ(
+                    result.size(), static_cast<std::size_t>(num_sites));
+                for (std::uint32_t j = 0; j != num_sites; ++j)
+                {
+                    HPX_TEST_EQ(result[j], j + i);
+                }
+            }
+
+            auto const elapsed = t.elapsed();
+            if (site == 0)
+            {
+                std::cout << "local timing (" << num_sites << "/" << arity
+                          << "): " << elapsed / (10 * ITERATIONS) << "[s]\n"
+                          << std::flush;
+            }
+        }));
+    }
+
+    hpx::wait_all(std::move(sites));
+}
+
+int hpx_main()
+{
+#if defined(HPX_HAVE_NETWORKING)
+    if (hpx::get_num_localities(hpx::launch::sync) > 1)
+    {
+        test_multiple_use_with_generation();
+    }
+#endif
+
+    if (hpx::get_locality_id() == 0)
+    {
+        for (auto num_localities : {2, 4, 8, 16, 32, 64})
+        {
+            test_local_use(num_localities, 2);
+            if (num_localities >= 4)
+            {
+                test_local_use(num_localities, 4);
+                if (num_localities >= 8)
+                {
+                    test_local_use(num_localities, 8);
+                    if (num_localities >= 16)
+                    {
+                        test_local_use(num_localities, 16);
+                    }
+                }
+            }
+        }
+    }
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> const cfg = {"hpx.run_hpx_main!=1"};
+
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ(hpx::init(argc, argv, init_args), 0);
+    return hpx::util::report_errors();
+}
+
+#endif

--- a/libs/full/collectives/tests/unit/all_reduce_hierarchical.cpp
+++ b/libs/full/collectives/tests/unit/all_reduce_hierarchical.cpp
@@ -1,0 +1,156 @@
+//  Copyright (c) 2019-2025 Hartmut Kaiser
+//  Copyright (c) 2026 Anshuman Agrawal
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/modules/collectives.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace hpx::collectives;
+
+constexpr char const* all_reduce_direct_basename =
+    "/test/all_reduce_hierarchical/";
+#if defined(HPX_DEBUG)
+constexpr int ITERATIONS = 50;
+#else
+constexpr int ITERATIONS = 500;
+#endif
+
+void test_multiple_use_with_generation(int arity = 2)
+{
+    std::uint32_t const this_locality = hpx::get_locality_id();
+    std::uint32_t const num_localities =
+        hpx::get_num_localities(hpx::launch::sync);
+    HPX_TEST_LTE(static_cast<std::uint32_t>(2), num_localities);
+
+    auto const all_reduce_clients = create_hierarchical_communicator(
+        all_reduce_direct_basename, num_sites_arg(num_localities),
+        this_site_arg(this_locality), arity_arg(arity));
+
+    hpx::chrono::high_resolution_timer const t;
+
+    for (int i = 0; i != ITERATIONS; ++i)
+    {
+        std::uint32_t value = this_locality + i;
+        hpx::future<std::uint32_t> overall_result =
+            all_reduce(all_reduce_clients, std::move(value),
+                std::plus<std::uint32_t>{}, this_site_arg(this_locality),
+                generation_arg(i + 1));
+
+        std::uint32_t sum = 0;
+        for (std::uint32_t j = 0; j != num_localities; ++j)
+        {
+            sum += j + i;
+        }
+        HPX_TEST_EQ(sum, overall_result.get());
+    }
+
+    auto const elapsed = t.elapsed();
+    if (this_locality == 0)
+    {
+        std::cout << "remote timing (with generation): "
+                  << elapsed / ITERATIONS << "[s]\n"
+                  << std::flush;
+    }
+}
+
+void test_local_use(std::uint32_t num_sites, int arity = 2)
+{
+    std::vector<hpx::future<void>> sites;
+    sites.reserve(num_sites);
+
+    for (std::uint32_t site = 0; site != num_sites; ++site)
+    {
+        sites.push_back(hpx::async([=]() {
+            auto const all_reduce_clients = create_hierarchical_communicator(
+                all_reduce_direct_basename, num_sites_arg(num_sites),
+                this_site_arg(site), arity_arg(arity));
+
+            hpx::chrono::high_resolution_timer const t;
+
+            for (int i = 0; i != ITERATIONS; ++i)
+            {
+                std::uint32_t value = site + i;
+                hpx::future<std::uint32_t> overall_result =
+                    all_reduce(all_reduce_clients, std::move(value),
+                        std::plus<std::uint32_t>{}, this_site_arg(site),
+                        generation_arg(i + 1));
+
+                std::uint32_t sum = 0;
+                for (std::uint32_t j = 0; j != num_sites; ++j)
+                {
+                    sum += j + i;
+                }
+                HPX_TEST_EQ(sum, overall_result.get());
+            }
+
+            auto const elapsed = t.elapsed();
+            if (site == 0)
+            {
+                std::cout << "local timing (" << num_sites << "/" << arity
+                          << "): " << elapsed / (10 * ITERATIONS) << "[s]\n"
+                          << std::flush;
+            }
+        }));
+    }
+
+    hpx::wait_all(std::move(sites));
+}
+
+int hpx_main()
+{
+#if defined(HPX_HAVE_NETWORKING)
+    if (hpx::get_num_localities(hpx::launch::sync) > 1)
+    {
+        test_multiple_use_with_generation();
+    }
+#endif
+
+    if (hpx::get_locality_id() == 0)
+    {
+        for (auto num_localities : {2, 4, 8, 16, 32, 64})
+        {
+            test_local_use(num_localities, 2);
+            if (num_localities >= 4)
+            {
+                test_local_use(num_localities, 4);
+                if (num_localities >= 8)
+                {
+                    test_local_use(num_localities, 8);
+                    if (num_localities >= 16)
+                    {
+                        test_local_use(num_localities, 16);
+                    }
+                }
+            }
+        }
+    }
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> const cfg = {"hpx.run_hpx_main!=1"};
+
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ(hpx::init(argc, argv, init_args), 0);
+    return hpx::util::report_errors();
+}
+
+#endif

--- a/libs/full/collectives/tests/unit/all_reduce_hierarchical.cpp
+++ b/libs/full/collectives/tests/unit/all_reduce_hierarchical.cpp
@@ -45,10 +45,9 @@ void test_multiple_use_with_generation(int arity = 2)
     for (int i = 0; i != ITERATIONS; ++i)
     {
         std::uint32_t value = this_locality + i;
-        hpx::future<std::uint32_t> overall_result =
-            all_reduce(all_reduce_clients, std::move(value),
-                std::plus<std::uint32_t>{}, this_site_arg(this_locality),
-                generation_arg(i + 1));
+        hpx::future<std::uint32_t> overall_result = all_reduce(
+            all_reduce_clients, std::move(value), std::plus<std::uint32_t>{},
+            this_site_arg(this_locality), generation_arg(i + 1));
 
         std::uint32_t sum = 0;
         for (std::uint32_t j = 0; j != num_localities; ++j)
@@ -61,8 +60,8 @@ void test_multiple_use_with_generation(int arity = 2)
     auto const elapsed = t.elapsed();
     if (this_locality == 0)
     {
-        std::cout << "remote timing (with generation): "
-                  << elapsed / ITERATIONS << "[s]\n"
+        std::cout << "remote timing (with generation): " << elapsed / ITERATIONS
+                  << "[s]\n"
                   << std::flush;
     }
 }


### PR DESCRIPTION
Tests verify correctness of the reduce+broadcast and gather+broadcast compositions at varying site counts (2-64) and arities (2, 4, 8, 16). Both local (single-locality, multi-threaded) and distributed (multi-locality) configurations are covered.

Follows the same pattern as the existing `reduce_hierarchical`, `gather_hierarchical`, `broadcast_hierarchical`, and `scatter_hierarchical` tests.

Companion to #7160 which added the hierarchical all_reduce and all_gather implementations.

## Proposed Changes

  - Add `all_reduce_hierarchical.cpp` unit test
  - Add `all_gather_hierarchical.cpp` unit test
  - Register both in `CMakeLists.txt` under the networking test suite

## Any background context you want to provide?

The hierarchical all_reduce and all_gather were merged in #7160 but without dedicated unit tests. These tests fill that gap.

## Checklist

- [x] I have added a new feature and have added tests to go along with it.