### PR TITLE
Adapting HPX to C++ modules

### DIFF
--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -585,6 +585,8 @@ with section("parse"):
     'hpx_extract_includes_from_file': { 'kwargs': { 'SOURCE': 1,
                                                     'INCLUDE_DIRS': '+',
                                                     'FOUND_HEADERS': 1},
+                          'pargs': { 'flags': [], 'nargs': '1+'}},
+    'hpx_configure_module_producer': { 'kwargs': { 'MODULE_OUT_DIR': 1},
                           'pargs': { 'flags': [], 'nargs': '1+'}}
   }
 

--- a/.github/ci-scripts/generate_test_matrix.py
+++ b/.github/ci-scripts/generate_test_matrix.py
@@ -66,15 +66,24 @@ def generate_matrix(ctest_output, num_buckets):
             bucket_targets.append(target)
 
         unique_targets = sorted(list(set(bucket_targets)))
-        targets_str = " ".join(unique_targets)
+        if len(unique_targets) != 0:
+            first_name_parts = unique_targets[0].split('.')
+            last_name_parts = unique_targets[-1].split('.')
 
-        matrix["include"].append({
-            "id": i + 1,
-            "name": f"tests-{i+1:02d}",
-            "tests": test_regex,
-            "targets": targets_str,
-            "count": len(bucket_tests)
-        })
+            first_name_index = -2 if len(first_name_parts) > 1 else -1
+            last_name_index = -2 if len(last_name_parts) > 1 else -1
+
+            first_name = first_name_parts[first_name_index]
+            last_name = last_name_parts[last_name_index]
+
+            targets_str = " ".join(unique_targets)
+            matrix["include"].append({
+                "id": i + 1,
+                "name": f"{i+1:02d}-{first_name}-{last_name}",
+                "tests": test_regex,
+                "targets": targets_str,
+                "count": len(bucket_tests)
+            })
 
     return matrix
 

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -83,24 +83,24 @@ jobs:
       - name: core_local (Building Core Local)
         shell: bash
         working-directory: build
-        run: ninja -j"$(nproc)" -k 0 hpx_core
+        run: ninja -k 0 hpx_core
 
       - name: core (Building Core)
         shell: bash
         working-directory: build
-        run: ninja -j"$(nproc)" -k 0 core
+        run: ninja -k 0 core
 
       - name: Components (Building Components)
         shell: bash
         working-directory: build
-        run: ninja -j"$(nproc)" -k 0 components
+        run: ninja -k 0 components
 
       - name: Generate Test Matrix
         id: gen_matrix
         shell: bash
         working-directory: build
         run: |
-          ctest -N | python3 ../.github/ci-scripts/generate_test_matrix.py 18 > test_matrix.json
+          ctest -N | python3 ../.github/ci-scripts/generate_test_matrix.py 20 > test_matrix.json
           printf 'matrix=%s\n' "$(cat test_matrix.json)" >> "$GITHUB_OUTPUT"
 
       - name: Package Build Artifacts

--- a/.github/workflows/linux_debug_modules.yml
+++ b/.github/workflows/linux_debug_modules.yml
@@ -43,7 +43,7 @@ jobs:
       shell: bash
       run: |
           cmake --build build --target all
-          # cmake --build build --target tests -- -k 0
+          cmake --build build --target tests -- -k 0
     - name: Test
       shell: bash
       run: |

--- a/components/component_storage/include/hpx/components/component_storage/server/component_storage.hpp
+++ b/components/component_storage/include/hpx/components/component_storage/server/component_storage.hpp
@@ -8,9 +8,8 @@
 
 #include <hpx/config.hpp>
 #include <hpx/actions/transfer_action.hpp>
-#include <hpx/actions_base/basic_action.hpp>
-#include <hpx/actions_base/component_action.hpp>
 #include <hpx/async_distributed/transfer_continuation_action.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/naming_base.hpp>
 #include <hpx/modules/synchronization.hpp>
 

--- a/components/component_storage/src/component_module.cpp
+++ b/components/component_storage/src/component_module.cpp
@@ -5,8 +5,8 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/basic_action.hpp>
 #include <hpx/async_distributed/transfer_continuation_action.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/runtime_components/component_factory.hpp>
 

--- a/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_component_decl.hpp
+++ b/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_component_decl.hpp
@@ -18,9 +18,9 @@
 
 #include <hpx/config.hpp>
 #include <hpx/actions/transfer_action.hpp>
-#include <hpx/actions_base/component_action.hpp>
 #include <hpx/async_distributed/transfer_continuation_action.hpp>
 #include <hpx/components/client_base.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/preprocessor.hpp>

--- a/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_decl.hpp
+++ b/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_decl.hpp
@@ -10,11 +10,11 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/traits/is_distribution_policy.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/components/client_base.hpp>
 #include <hpx/distribution_policies/container_distribution_policy.hpp>
 #include <hpx/distribution_policies/explicit_container_distribution_policy.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/async_combinators.hpp>
 #include <hpx/modules/functional.hpp>

--- a/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_impl.hpp
+++ b/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_impl.hpp
@@ -8,11 +8,11 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/traits/is_distribution_policy.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/components/get_ptr.hpp>
 #include <hpx/distribution_policies/container_distribution_policy.hpp>
 #include <hpx/distribution_policies/explicit_container_distribution_policy.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/async_combinators.hpp>
 #include <hpx/modules/async_distributed.hpp>

--- a/components/containers/partitioned_vector/tests/unit/serialization_partitioned_vector.cpp
+++ b/components/containers/partitioned_vector/tests/unit/serialization_partitioned_vector.cpp
@@ -11,9 +11,9 @@
 #include <hpx/include/parallel_fill.hpp>
 #include <hpx/include/partitioned_vector.hpp>
 
+#include <hpx/modules/naming.hpp>
 #include <hpx/modules/serialization.hpp>
 #include <hpx/modules/testing.hpp>
-#include <hpx/naming/detail/preprocess_gid_types.hpp>
 
 #include <cstddef>
 #include <numeric>

--- a/components/containers/unordered/include/hpx/components/containers/unordered/partition_unordered_map_component.hpp
+++ b/components/containers/unordered/include/hpx/components/containers/unordered/partition_unordered_map_component.hpp
@@ -18,13 +18,11 @@
 
 #include <hpx/config.hpp>
 #include <hpx/actions/transfer_action.hpp>
-#include <hpx/actions_base/basic_action.hpp>
-#include <hpx/actions_base/component_action.hpp>
-#include <hpx/actions_base/plain_action.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/async_distributed/transfer_continuation_action.hpp>
 #include <hpx/components/client_base.hpp>
 #include <hpx/components/get_ptr.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/collectives.hpp>
 #include <hpx/modules/components_base.hpp>

--- a/components/containers/unordered/include/hpx/components/containers/unordered/unordered_map.hpp
+++ b/components/containers/unordered/include/hpx/components/containers/unordered/unordered_map.hpp
@@ -9,11 +9,11 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/traits/is_distribution_policy.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/components/client_base.hpp>
 #include <hpx/components/get_ptr.hpp>
 #include <hpx/distribution_policies/container_distribution_policy.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_combinators.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/functional.hpp>

--- a/components/iostreams/include/hpx/components/iostreams/server/output_stream.hpp
+++ b/components/iostreams/include/hpx/components/iostreams/server/output_stream.hpp
@@ -9,8 +9,8 @@
 
 #include <hpx/config.hpp>
 #include <hpx/actions/transfer_action.hpp>
-#include <hpx/actions_base/component_action.hpp>
 #include <hpx/async_distributed/transfer_continuation_action.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/serialization.hpp>
 

--- a/components/iostreams/src/component_module.cpp
+++ b/components/iostreams/src/component_module.cpp
@@ -11,8 +11,8 @@
 #include <hpx/components/iostreams/server/output_stream.hpp>
 #include <hpx/components/iostreams/standard_streams.hpp>
 
-#include <hpx/actions_base/basic_action.hpp>
 #include <hpx/async_distributed/transfer_continuation_action.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/runtime_local.hpp>

--- a/components/iostreams/src/standard_streams.cpp
+++ b/components/iostreams/src/standard_streams.cpp
@@ -10,8 +10,8 @@
 #include <hpx/components/iostreams/ostream.hpp>
 #include <hpx/components/iostreams/standard_streams.hpp>
 
-#include <hpx/actions_base/plain_action.hpp>
 #include <hpx/async_distributed/base_lco_with_value.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/errors.hpp>

--- a/components/parcel_plugins/binary_filter/bzip2/src/bzip2_serialization_filter.cpp
+++ b/components/parcel_plugins/binary_filter/bzip2/src/bzip2_serialization_filter.cpp
@@ -13,8 +13,7 @@
 #include <hpx/modules/iostream.hpp>
 
 #include <hpx/binary_filter/bzip2_serialization_filter.hpp>
-#include <hpx/plugin_factories/binary_filter_factory.hpp>
-#include <hpx/plugin_factories/plugin_registry.hpp>
+#include <hpx/modules/plugin_factories.hpp>
 
 #include <algorithm>
 #include <cstddef>

--- a/components/parcel_plugins/binary_filter/snappy/src/snappy_serialization_filter.cpp
+++ b/components/parcel_plugins/binary_filter/snappy/src/snappy_serialization_filter.cpp
@@ -10,10 +10,9 @@
 #include <snappy.h>
 
 #include <hpx/modules/errors.hpp>
+#include <hpx/modules/plugin_factories.hpp>
 
 #include <hpx/binary_filter/snappy_serialization_filter.hpp>
-#include <hpx/plugin_factories/binary_filter_factory.hpp>
-#include <hpx/plugin_factories/plugin_registry.hpp>
 
 #include <algorithm>
 #include <cstddef>

--- a/components/parcel_plugins/binary_filter/zlib/src/zlib_serialization_filter.cpp
+++ b/components/parcel_plugins/binary_filter/zlib/src/zlib_serialization_filter.cpp
@@ -13,8 +13,7 @@
 #include <hpx/modules/iostream.hpp>
 
 #include <hpx/binary_filter/zlib_serialization_filter.hpp>
-#include <hpx/plugin_factories/binary_filter_factory.hpp>
-#include <hpx/plugin_factories/plugin_registry.hpp>
+#include <hpx/modules/plugin_factories.hpp>
 
 #include <algorithm>
 #include <cstddef>

--- a/components/parcel_plugins/coalescing/src/coalescing_message_handler.cpp
+++ b/components/parcel_plugins/coalescing/src/coalescing_message_handler.cpp
@@ -25,9 +25,9 @@
 #include <hpx/modules/timing.hpp>
 #include <hpx/modules/util.hpp>
 
+#include <hpx/modules/plugin_factories.hpp>
 #include <hpx/parcel_coalescing/counter_registry.hpp>
 #include <hpx/parcel_coalescing/message_handler.hpp>
-#include <hpx/plugin_factories/message_handler_factory.hpp>
 
 #include <chrono>
 #include <cstddef>

--- a/components/process/include/hpx/components/process/server/child.hpp
+++ b/components/process/include/hpx/components/process/server/child.hpp
@@ -8,9 +8,8 @@
 
 #include <hpx/config.hpp>
 #include <hpx/actions/transfer_action.hpp>
-#include <hpx/actions_base/actions_base_support.hpp>
-#include <hpx/actions_base/component_action.hpp>
 #include <hpx/async_distributed/transfer_continuation_action.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 
 #include <hpx/components/process/export_definitions.hpp>

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -342,7 +342,10 @@ foreach(lib ${HPX_LIBS})
     set_target_properties(
       hpx_${lib}_module PROPERTIES POSITION_INDEPENDENT_CODE ON
     )
-    hpx_configure_module_producer(hpx_${lib}_module)
+    hpx_configure_module_producer(
+      hpx_${lib}_module
+      MODULE_OUT_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/${HPX_PACKAGE_NAME}/${lib}
+    )
 
     target_link_libraries(
       hpx_${lib}_module
@@ -448,9 +451,9 @@ foreach(lib ${HPX_LIBS})
       ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR} COMPONENT runtime
       RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR} COMPONENT runtime
       FILE_SET hpx_${lib}_public_sources
-          DESTINATION ${CMAKE_INSTALL_LIBDIR}/cxx
+          DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${HPX_PACKAGE_NAME}/${lib}
       CXX_MODULES_BMI
-          DESTINATION ${CMAKE_INSTALL_LIBDIR}/cxx
+          DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${HPX_PACKAGE_NAME}/${lib}
           COMPONENT runtime
     )
     hpx_export_internal_targets(hpx_${lib}_module hpx_${lib}_module_if)

--- a/libs/core/concurrency/include/hpx/concurrency/concurrent_queue.hpp
+++ b/libs/core/concurrency/include/hpx/concurrency/concurrent_queue.hpp
@@ -13,7 +13,7 @@
 
 namespace hpx::concurrent {
 
-    template <typename T, typename Allocator = std::allocator<T>>
+    HPX_CXX_CORE_EXPORT template <typename T,
+        typename Allocator = std::allocator<T>>
     using concurrent_queue = hpx::lockfree::queue<T, Allocator>;
-
 }    // namespace hpx::concurrent

--- a/libs/core/concurrency/include/hpx/concurrency/concurrent_unordered_map.hpp
+++ b/libs/core/concurrency/include/hpx/concurrency/concurrent_unordered_map.hpp
@@ -395,5 +395,4 @@ namespace hpx::concurrent {
             map_.reserve(count);
         }
     };
-
 }    // namespace hpx::concurrent

--- a/libs/core/concurrency/include/hpx/concurrency/concurrent_unordered_set.hpp
+++ b/libs/core/concurrency/include/hpx/concurrency/concurrent_unordered_set.hpp
@@ -296,5 +296,4 @@ namespace hpx::concurrent {
             set_.reserve(count);
         }
     };
-
 }    // namespace hpx::concurrent

--- a/libs/core/concurrency/include/hpx/concurrency/concurrent_vector.hpp
+++ b/libs/core/concurrency/include/hpx/concurrency/concurrent_vector.hpp
@@ -251,5 +251,4 @@ namespace hpx::concurrent {
             return old_size;
         }
     };
-
 }    // namespace hpx::concurrent

--- a/libs/core/executors/include/hpx/executors/fork_join_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/fork_join_executor.hpp
@@ -1398,7 +1398,7 @@ namespace hpx::execution::experimental {
         }
     }    // namespace detail
 
-    template <typename Policy, bool HierarchicalSpawning>
+    HPX_CXX_CORE_EXPORT template <typename Policy, bool HierarchicalSpawning>
     decltype(auto) fork_join_executor_from(
         hpx::execution::parallel_policy_executor<Policy, HierarchicalSpawning>&
             exec)
@@ -1406,7 +1406,7 @@ namespace hpx::execution::experimental {
         return detail::fork_join_executor_from(exec);
     }
 
-    template <typename Policy, bool HierarchicalSpawning>
+    HPX_CXX_CORE_EXPORT template <typename Policy, bool HierarchicalSpawning>
     decltype(auto) fork_join_executor_from(
         hpx::execution::parallel_policy_executor<Policy,
             HierarchicalSpawning> const& exec)
@@ -1414,7 +1414,7 @@ namespace hpx::execution::experimental {
         return detail::fork_join_executor_from(exec);
     }
 
-    template <typename Policy, bool HierarchicalSpawning>
+    HPX_CXX_CORE_EXPORT template <typename Policy, bool HierarchicalSpawning>
     decltype(auto) fork_join_executor_from(
         hpx::execution::parallel_policy_executor<Policy, HierarchicalSpawning>&&
             exec)
@@ -1423,7 +1423,7 @@ namespace hpx::execution::experimental {
     }
 
     // fallback for everything but parallel_executor
-    template <typename Executor>
+    HPX_CXX_CORE_EXPORT template <typename Executor>
     decltype(auto) fork_join_executor_from(Executor&& exec)
     {
         return HPX_FORWARD(Executor, exec);

--- a/libs/core/plugin/CMakeLists.txt
+++ b/libs/core/plugin/CMakeLists.txt
@@ -12,7 +12,7 @@ set(plugin_headers
     hpx/plugin/concrete_factory.hpp
     hpx/plugin/config.hpp
     hpx/plugin/dll.hpp
-    hpx/plugin/export_plugin.hpp
+    hpx/plugin/macros.hpp
     hpx/plugin/plugin_factory.hpp
     hpx/plugin/plugin_wrapper.hpp
     hpx/plugin/virtual_constructor.hpp
@@ -21,7 +21,7 @@ set(plugin_headers
     hpx/plugin/traits/plugin_config_data.hpp
 )
 
-set(plugin_macro_headers hpx/plugin/export_plugin.hpp)
+set(plugin_macro_headers hpx/plugin/macros.hpp)
 
 # Default location is $HPX_ROOT/libs/plugin/include_compatibility
 # cmake-format: off

--- a/libs/core/plugin/include/hpx/plugin/macros.hpp
+++ b/libs/core/plugin/include/hpx/plugin/macros.hpp
@@ -12,14 +12,14 @@
 #include <hpx/config.hpp>
 #include <hpx/plugin/config.hpp>
 #include <hpx/plugin/config/defines.hpp>
-#include <hpx/modules/datastructures.hpp>
+//#include <hpx/modules/datastructures.hpp>
 #include <hpx/modules/preprocessor.hpp>
 
-#if !defined(HPX_HAVE_CXX_MODULES) || defined(HPX_CORE_EXPORTS) ||             \
-    (defined(HPX_COMPILE_BMI) && defined(HPX_COMPILE_CORE_WITH_MODULES))
-#include <hpx/plugin/abstract_factory.hpp>
-#include <hpx/plugin/concrete_factory.hpp>
-#endif
+//#if !defined(HPX_HAVE_CXX_MODULES) || defined(HPX_CORE_EXPORTS) ||             \
+//    (defined(HPX_COMPILE_BMI) && defined(HPX_COMPILE_CORE_WITH_MODULES))
+//#include <hpx/plugin/abstract_factory.hpp>
+//#include <hpx/plugin/concrete_factory.hpp>
+//#endif
 
 #include <algorithm>
 #include <cctype>

--- a/libs/core/plugin/include/hpx/plugin/plugin_factory.hpp
+++ b/libs/core/plugin/include/hpx/plugin/plugin_factory.hpp
@@ -14,7 +14,7 @@
 #include <hpx/modules/functional.hpp>
 #include <hpx/plugin/abstract_factory.hpp>
 #include <hpx/plugin/dll.hpp>
-#include <hpx/plugin/export_plugin.hpp>
+#include <hpx/plugin/macros.hpp>
 #include <hpx/plugin/virtual_constructor.hpp>
 
 #include <algorithm>

--- a/libs/full/actions/include/hpx/actions/action_support.hpp
+++ b/libs/full/actions/include/hpx/actions/action_support.hpp
@@ -10,4 +10,4 @@
 
 #pragma once
 
-#include <hpx/actions_base/actions_base_support.hpp>
+#include <hpx/modules/actions_base.hpp>

--- a/libs/full/actions/include/hpx/actions/actions_fwd.hpp
+++ b/libs/full/actions/include/hpx/actions/actions_fwd.hpp
@@ -9,7 +9,7 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_NETWORKING)
-#include <hpx/actions_base/actions_base_fwd.hpp>
+#include <hpx/modules/actions_base.hpp>
 
 namespace hpx::actions {
 

--- a/libs/full/actions/include/hpx/actions/base_action.hpp
+++ b/libs/full/actions/include/hpx/actions/base_action.hpp
@@ -22,10 +22,7 @@
 #endif
 
 #include <hpx/actions/actions_fwd.hpp>
-#include <hpx/actions_base/actions_base_fwd.hpp>
-#include <hpx/actions_base/actions_base_support.hpp>
-#include <hpx/actions_base/detail/action_factory.hpp>
-#include <hpx/actions_base/traits/action_continuation.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/naming_base.hpp>
 #include <hpx/modules/parcelset_base.hpp>

--- a/libs/full/actions/include/hpx/actions/invoke_function.hpp
+++ b/libs/full/actions/include/hpx/actions/invoke_function.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/basic_action.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/tag_invoke.hpp>
 
 #include <utility>

--- a/libs/full/actions/include/hpx/actions/post_helper.hpp
+++ b/libs/full/actions/include/hpx/actions/post_helper.hpp
@@ -9,11 +9,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/actions/post_helper_fwd.hpp>
-#include <hpx/actions_base/actions_base_support.hpp>
-#include <hpx/actions_base/traits/action_continuation.hpp>
-#include <hpx/actions_base/traits/action_decorate_continuation.hpp>
-#include <hpx/actions_base/traits/action_schedule_thread.hpp>
-#include <hpx/actions_base/traits/action_select_direct_execution.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/coroutines.hpp>
 #include <hpx/modules/naming_base.hpp>

--- a/libs/full/actions/include/hpx/actions/post_helper_fwd.hpp
+++ b/libs/full/actions/include/hpx/actions/post_helper_fwd.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/traits/action_select_direct_execution.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/coroutines.hpp>
 #include <hpx/modules/naming_base.hpp>
 #include <hpx/modules/threading_base.hpp>

--- a/libs/full/actions/include/hpx/actions/register_action.hpp
+++ b/libs/full/actions/include/hpx/actions/register_action.hpp
@@ -9,9 +9,8 @@
 
 #include <hpx/config.hpp>
 #include <hpx/actions/actions_fwd.hpp>
-#include <hpx/actions_base/actions_base_support.hpp>
-#include <hpx/actions_base/detail/action_factory.hpp>
 #include <hpx/assert.hpp>
+#include <hpx/modules/actions_base.hpp>
 
 #if defined(HPX_HAVE_NETWORKING)
 

--- a/libs/full/actions/include/hpx/actions/transfer_action.hpp
+++ b/libs/full/actions/include/hpx/actions/transfer_action.hpp
@@ -15,7 +15,7 @@
 #include <hpx/actions/post_helper.hpp>
 #include <hpx/actions/register_action.hpp>
 #include <hpx/actions/transfer_base_action.hpp>
-#include <hpx/actions_base/actions_base_support.hpp>
+#include <hpx/modules/actions_base.hpp>
 
 #if defined(HPX_HAVE_NETWORKING)
 #include <hpx/modules/async_base.hpp>

--- a/libs/full/actions/include/hpx/actions/transfer_base_action.hpp
+++ b/libs/full/actions/include/hpx/actions/transfer_base_action.hpp
@@ -15,15 +15,7 @@
 #include <hpx/actions/actions_fwd.hpp>
 #include <hpx/actions/base_action.hpp>
 #include <hpx/actions/register_action.hpp>
-#include <hpx/actions_base/actions_base_support.hpp>
-#include <hpx/actions_base/detail/invocation_count_registry.hpp>
-#include <hpx/actions_base/traits/action_continuation.hpp>
-#include <hpx/actions_base/traits/action_does_termination_detection.hpp>
-#include <hpx/actions_base/traits/action_priority.hpp>
-#include <hpx/actions_base/traits/action_schedule_thread.hpp>
-#include <hpx/actions_base/traits/action_stacksize.hpp>
-#include <hpx/actions_base/traits/action_trigger_continuation_fwd.hpp>
-#include <hpx/actions_base/traits/action_was_object_migrated.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 
 #if defined(HPX_HAVE_NETWORKING)
@@ -348,7 +340,7 @@ namespace hpx::actions {
 
 #if defined(HPX_HAVE_PARCELPORT_COUNTERS) &&                                   \
     defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
-#include <hpx/actions_base/detail/per_action_data_counter_registry.hpp>
+#include <hpx/modules/actions_base.hpp>
 
 /// \cond NOINTERNAL
 template <typename Action>

--- a/libs/full/actions_base/CMakeLists.txt
+++ b/libs/full/actions_base/CMakeLists.txt
@@ -23,6 +23,7 @@ set(actions_base_headers
     hpx/actions_base/detail/invocation_count_registry.hpp
     hpx/actions_base/detail/per_action_data_counter_registry.hpp
     hpx/actions_base/lambda_to_action.hpp
+    hpx/actions_base/macros.hpp
     hpx/actions_base/plain_action.hpp
     hpx/actions_base/preassigned_action_id.hpp
     hpx/actions_base/traits/action_continuation.hpp
@@ -42,6 +43,8 @@ set(actions_base_headers
     hpx/actions_base/traits/is_distribution_policy.hpp
     hpx/actions_base/traits/is_valid_action.hpp
 )
+
+set(actions_base_macro_headers hpx/actions_base/macros.hpp)
 
 # Default location is $HPX_ROOT/libs/actions_base/include_compatibility
 # cmake-format: off
@@ -86,8 +89,10 @@ include(HPX_AddModule)
 add_hpx_module(
   full actions_base
   GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_MODULE_GEN ON
   SOURCES ${actions_base_sources}
   HEADERS ${actions_base_headers}
+  MACRO_HEADERS ${actions_base_macro_headers}
   COMPAT_HEADERS ${actions_base_compat_headers}
   MODULE_DEPENDENCIES hpx_components_base hpx_naming_base
   DEPENDENCIES hpx_core

--- a/libs/full/actions_base/include/hpx/actions_base/action_priority.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/action_priority.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2023 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -7,13 +7,14 @@
 
 #pragma once
 
+#include <hpx/config.hpp>
 #include <hpx/actions_base/traits/action_priority.hpp>
 #include <hpx/actions_base/traits/extract_action.hpp>
 #include <hpx/modules/coroutines.hpp>
 
 namespace hpx::actions {
 
-    template <typename Action>
+    HPX_CXX_EXPORT template <typename Action>
     constexpr threads::thread_priority action_priority() noexcept
     {
         //  The mapping to 'normal' is now done at the last possible moment in

--- a/libs/full/actions_base/include/hpx/actions_base/action_stacksize.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/action_stacksize.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2023 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -7,13 +7,14 @@
 
 #pragma once
 
+#include <hpx/config.hpp>
 #include <hpx/actions_base/traits/action_stacksize.hpp>
 #include <hpx/actions_base/traits/extract_action.hpp>
 #include <hpx/modules/coroutines.hpp>
 
 namespace hpx::actions {
 
-    template <typename Action>
+    HPX_CXX_EXPORT template <typename Action>
     constexpr threads::thread_stacksize action_stacksize() noexcept
     {
         //  The mapping to 'normal' is now done at the last possible moment in

--- a/libs/full/actions_base/include/hpx/actions_base/actions_base_fwd.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/actions_base_fwd.hpp
@@ -19,8 +19,7 @@ namespace hpx::actions {
     ///////////////////////////////////////////////////////////////////////////
     /// The type of the action defines whether this action will be executed
     /// directly or by an HPX-threads
-    enum class action_flavor
-    {
+    HPX_CXX_EXPORT enum class action_flavor : std::uint8_t {
         plain_action = 0,    ///< The action will be executed by a newly created
                              ///< thread
         direct_action = 1    ///< The action needs to be executed directly
@@ -29,11 +28,11 @@ namespace hpx::actions {
     /// The \a base_action class is an abstract class used as the base class
     /// for all action types. It's main purpose is to allow polymorphic
     /// serialization of action instances through a unique_ptr.
-    struct HPX_EXPORT base_action;
+    HPX_CXX_EXPORT struct HPX_EXPORT base_action;
 
     namespace detail {
 
-        HPX_EXPORT std::uint32_t get_action_id_from_name(
+        HPX_CXX_EXPORT HPX_EXPORT std::uint32_t get_action_id_from_name(
             char const* action_name);
     }    // namespace detail
 

--- a/libs/full/actions_base/include/hpx/actions_base/actions_base_support.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/actions_base_support.hpp
@@ -29,7 +29,7 @@ namespace hpx::actions::detail {
     // Figure out what priority the action has to be associated with a
     // dynamically specified default priority results in using the static
     // Priority.
-    template <threads::thread_priority Priority>
+    HPX_CXX_EXPORT template <threads::thread_priority Priority>
     struct thread_priority
     {
         constexpr static threads::thread_priority call(
@@ -61,7 +61,7 @@ namespace hpx::actions::detail {
     // Figure out what stacksize the action has to be associated with a
     // dynamically specified default stacksize results in using the static
     // Stacksize.
-    template <threads::thread_stacksize Stacksize>
+    HPX_CXX_EXPORT template <threads::thread_stacksize Stacksize>
     struct thread_stacksize
     {
         constexpr static threads::thread_stacksize call(
@@ -88,7 +88,7 @@ namespace hpx::actions::detail {
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Action>
+    HPX_CXX_EXPORT template <typename Action>
     std::uint32_t get_action_id()
     {
         static std::uint32_t id =

--- a/libs/full/actions_base/include/hpx/actions_base/basic_action.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/basic_action.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2025 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //  Copyright (c)      2011 Thomas Heller
 //
@@ -19,6 +19,7 @@
 #include <hpx/actions_base/detail/action_factory.hpp>
 #include <hpx/actions_base/detail/invocation_count_registry.hpp>
 #include <hpx/actions_base/detail/per_action_data_counter_registry.hpp>
+#include <hpx/actions_base/macros.hpp>
 #include <hpx/actions_base/preassigned_action_id.hpp>
 #include <hpx/actions_base/traits/action_continuation.hpp>
 #include <hpx/actions_base/traits/action_priority.hpp>
@@ -71,7 +72,7 @@ namespace hpx::actions {
             naming::component_type comptype;
 
             template <typename... Ts>
-            HPX_FORCEINLINE typename Action::internal_result_type operator()(
+            HPX_FORCEINLINE Action::internal_result_type operator()(
                 Ts&&... vs) const
             {
                 return Action::invoke(lva, comptype, HPX_FORWARD(Ts, vs)...);
@@ -147,7 +148,7 @@ namespace hpx::actions {
             hpx::id_type target_;
             naming::address_type lva_;
             naming::component_type comptype_;
-            typename Action::arguments_type args_;
+            Action::arguments_type args_;
         };
 
         ///////////////////////////////////////////////////////////////////////
@@ -157,9 +158,8 @@ namespace hpx::actions {
         public:
             template <typename... Ts>
             explicit continuation_thread_function(hpx::id_type&& target,
-                typename Action::continuation_type&& cont,
-                naming::address_type lva, naming::component_type comptype,
-                Ts&&... vs)
+                Action::continuation_type&& cont, naming::address_type lva,
+                naming::component_type comptype, Ts&&... vs)
               : target_(HPX_MOVE(target))
               , cont_(HPX_MOVE(cont))
               , lva_(lva)
@@ -188,10 +188,10 @@ namespace hpx::actions {
         private:
             // This holds the target alive, if necessary.
             hpx::id_type target_;
-            typename Action::continuation_type cont_;
+            Action::continuation_type cont_;
             naming::address_type lva_;
             naming::component_type comptype_;
-            typename Action::arguments_type args_;
+            Action::arguments_type args_;
         };
 
         ///////////////////////////////////////////////////////////////////////
@@ -210,7 +210,7 @@ namespace hpx::actions {
         }
     }    // namespace detail
 
-    template <typename Component, typename R, typename... Args,
+    HPX_CXX_EXPORT template <typename Component, typename R, typename... Args,
         typename Derived>
     struct basic_action<Component, R(Args...), Derived>
     {
@@ -234,18 +234,17 @@ namespace hpx::actions {
         using derived_type = Derived;
 
         // result_type represents the type returned when invoking operator()
-        using result_type = typename traits::promise_local_result<R>::type;
+        using result_type = traits::promise_local_result<R>::type;
 
         // The remote_result_type is the remote type for the type_continuation
-        using remote_result_type =
-            typename traits::action_remote_result<R>::type;
+        using remote_result_type = traits::action_remote_result<R>::type;
 
         // The local_result_type is the local type for the type_continuation
         using local_result_type =
-            typename traits::promise_local_result<remote_result_type>::type;
+            traits::promise_local_result<remote_result_type>::type;
 
         using continuation_type =
-            typename traits::action_continuation<basic_action>::type;
+            traits::action_continuation<basic_action>::type;
 
         static constexpr std::size_t arity = sizeof...(Args);
 
@@ -444,7 +443,7 @@ namespace hpx::actions {
 
     namespace detail {
 
-        template <typename Action>
+        HPX_CXX_EXPORT template <typename Action>
         void register_local_action_invocation_count(
             invocation_count_registry& registry)
         {
@@ -457,29 +456,29 @@ namespace hpx::actions {
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
 
-        template <typename Action, typename Derived = void>
+        HPX_CXX_EXPORT template <typename Action, typename Derived = void>
         struct action_type
         {
             using type = Derived;
         };
 
-        template <typename Action>
+        HPX_CXX_EXPORT template <typename Action>
         struct action_type<Action, void>
         {
             using type = Action;
         };
 
-        template <typename Action, typename Derived>
-        using action_type_t = typename action_type<Action, Derived>::type;
+        HPX_CXX_EXPORT template <typename Action, typename Derived>
+        using action_type_t = action_type<Action, Derived>::type;
 
     }    // namespace detail
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename TF, TF F, typename Derived = void>
+    HPX_CXX_EXPORT template <typename TF, TF F, typename Derived = void>
     struct action;
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename TF, TF F, typename Derived = void>
+    HPX_CXX_EXPORT template <typename TF, TF F, typename Derived = void>
     // NOLINTNEXTLINE(bugprone-crtp-constructor-accessibility)
     struct direct_action
       : action<TF, F,
@@ -500,31 +499,30 @@ namespace hpx::actions {
     // Base template allowing to generate a concrete action type from a function
     // pointer. It is instantiated only if the supplied pointer is not a
     // supported function pointer.
-    template <typename TF, TF F, typename Derived = void,
+    HPX_CXX_EXPORT template <typename TF, TF F, typename Derived = void,
         typename Direct = std::false_type>
     struct make_action
     {
         using type = action<TF, F, Derived>;
     };
 
-    template <typename TF, TF F, typename Derived>
+    HPX_CXX_EXPORT template <typename TF, TF F, typename Derived>
     struct make_action<TF, F, Derived, std::true_type>
     {
         using type = direct_action<TF, F, Derived>;
     };
 
-    template <typename TF, TF F, typename Derived = void,
+    HPX_CXX_EXPORT template <typename TF, TF F, typename Derived = void,
         typename Direct = std::false_type>
-    using make_action_t = typename make_action<TF, F, Derived, Direct>::type;
+    using make_action_t = make_action<TF, F, Derived, Direct>::type;
 
-    template <typename TF, TF F, typename Derived = void>
+    HPX_CXX_EXPORT template <typename TF, TF F, typename Derived = void>
     struct make_direct_action : make_action<TF, F, Derived, std::true_type>
     {
     };
 
-    template <typename TF, TF F, typename Derived>
-    using make_direct_action_t =
-        typename make_direct_action<TF, F, Derived>::type;
+    HPX_CXX_EXPORT template <typename TF, TF F, typename Derived>
+    using make_direct_action_t = make_direct_action<TF, F, Derived>::type;
 
     /// \endcond
 }    // namespace hpx::actions
@@ -533,281 +531,3 @@ namespace hpx::actions {
 #include <hpx/config/warnings_suffix.hpp>
 
 /// \cond NOINTERNAL
-
-// Macros usable to refer to an action given the function to expose
-#define HPX_MAKE_ACTION(func)                                                  \
-    hpx::actions::make_action<decltype(&func), &func> /**/ /**/
-#define HPX_MAKE_DIRECT_ACTION(func)                                           \
-    hpx::actions::make_direct_action<decltype(&func), &func> /**/ /**/
-
-///////////////////////////////////////////////////////////////////////////////
-/// \def HPX_DECLARE_ACTION(func, name)
-/// \brief Declares an action type
-///
-#define HPX_DECLARE_ACTION(...)                                                \
-    HPX_DECLARE_ACTION_(__VA_ARGS__)                                           \
-    /**/
-
-/// \cond NOINTERNAL
-
-#define HPX_DECLARE_DIRECT_ACTION(...)                                         \
-    HPX_DECLARE_ACTION(__VA_ARGS__)                                            \
-    /**/
-
-#define HPX_DECLARE_ACTION_(...)                                               \
-    HPX_PP_EXPAND(HPX_PP_CAT(HPX_DECLARE_ACTION_, HPX_PP_NARGS(__VA_ARGS__))(  \
-        __VA_ARGS__))                                                          \
-    /**/
-
-#define HPX_DECLARE_ACTION_1(func)                                             \
-    HPX_DECLARE_ACTION_2(func, HPX_PP_CAT(func, _action))                      \
-    /**/
-
-#define HPX_DECLARE_ACTION_2(func, name)                                       \
-    struct name;                                                               \
-    /**/
-
-///////////////////////////////////////////////////////////////////////////////
-#define HPX_REGISTER_ACTION_(...)                                              \
-    HPX_PP_EXPAND(HPX_PP_CAT(HPX_REGISTER_ACTION_, HPX_PP_NARGS(__VA_ARGS__))( \
-        __VA_ARGS__))                                                          \
-/**/
-#define HPX_REGISTER_ACTION_1(action)                                          \
-    HPX_REGISTER_ACTION_2(action, action)                                      \
-    /**/
-
-#if !defined(HPX_HAVE_NETWORKING)
-
-#define HPX_DEFINE_GET_ACTION_NAME(action) /**/
-#if defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0 &&                  \
-    !defined(HPX_HAVE_APEX)
-#define HPX_DEFINE_GET_ACTION_NAME_ITT(action, actionname) /**/
-#endif
-#define HPX_REGISTER_ACTION_EXTERN_DECLARATION(action) /**/
-
-#define HPX_REGISTER_ACTION_2(action, actionname)                              \
-    HPX_REGISTER_ACTION_INVOCATION_COUNT(action)                               \
-    HPX_REGISTER_PER_ACTION_DATA_COUNTER_TYPES(action)                         \
-    /**/
-
-#define HPX_REGISTER_ACTION_DECLARATION_2(action, actionname) /**/
-
-#endif
-
-///////////////////////////////////////////////////////////////////////////////
-#if defined(HPX_COMPUTE_DEVICE_CODE)
-#define HPX_ACTION_USES_STACK(action, size)  /**/
-#define HPX_ACTION_USES_SMALL_STACK(action)  /**/
-#define HPX_ACTION_USES_MEDIUM_STACK(action) /**/
-#define HPX_ACTION_USES_LARGE_STACK(action)  /**/
-#define HPX_ACTION_USES_HUGE_STACK(action)   /**/
-#else
-#define HPX_ACTION_USES_STACK(action, size)                                    \
-    namespace hpx::traits {                                                    \
-        template <>                                                            \
-        struct action_stacksize<action>                                        \
-        {                                                                      \
-            static constexpr threads::thread_stacksize value = size;           \
-        };                                                                     \
-    }                                                                          \
-    /**/
-
-#define HPX_ACTION_USES_SMALL_STACK(action)                                    \
-    HPX_ACTION_USES_STACK(action, threads::thread_stacksize::small_)           \
-/**/
-#define HPX_ACTION_USES_MEDIUM_STACK(action)                                   \
-    HPX_ACTION_USES_STACK(action, threads::thread_stacksize::medium)           \
-/**/
-#define HPX_ACTION_USES_LARGE_STACK(action)                                    \
-    HPX_ACTION_USES_STACK(action, threads::thread_stacksize::large)            \
-/**/
-#define HPX_ACTION_USES_HUGE_STACK(action)                                     \
-    HPX_ACTION_USES_STACK(action, threads::thread_stacksize::huge)             \
-/**/
-#endif
-
-///////////////////////////////////////////////////////////////////////////////
-#if defined(HPX_COMPUTE_DEVICE_CODE)
-#define HPX_ACTION_HAS_PRIORITY(action, priority)      /**/
-#define HPX_ACTION_HAS_LOW_PRIORITY(action)            /**/
-#define HPX_ACTION_HAS_NORMAL_PRIORITY(action)         /**/
-#define HPX_ACTION_HAS_HIGH_PRIORITY(action)           /**/
-#define HPX_ACTION_HAS_HIGH_RECURSIVE_PRIORITY(action) /**/
-// obsolete, kept for compatibility
-#define HPX_ACTION_HAS_CRITICAL_PRIORITY(action) /**/
-#else
-///////////////////////////////////////////////////////////////////////////////
-#define HPX_ACTION_HAS_PRIORITY(action, priority)                              \
-    namespace hpx::traits {                                                    \
-        template <>                                                            \
-        struct action_priority<action>                                         \
-        {                                                                      \
-            static constexpr threads::thread_priority value = priority;        \
-        };                                                                     \
-        /* make sure the action is not executed directly */                    \
-        template <>                                                            \
-        struct has_decorates_action<action> : std::true_type                   \
-        {                                                                      \
-        };                                                                     \
-    }                                                                          \
-    /**/
-
-#define HPX_ACTION_HAS_LOW_PRIORITY(action)                                    \
-    HPX_ACTION_HAS_PRIORITY(action, threads::thread_priority::low)             \
-/**/
-#define HPX_ACTION_HAS_NORMAL_PRIORITY(action)                                 \
-    HPX_ACTION_HAS_PRIORITY(action, threads::thread_priority::normal)          \
-/**/
-#define HPX_ACTION_HAS_HIGH_PRIORITY(action)                                   \
-    HPX_ACTION_HAS_PRIORITY(action, threads::thread_priority::high)            \
-/**/
-#define HPX_ACTION_HAS_HIGH_RECURSIVE_PRIORITY(action)                         \
-    HPX_ACTION_HAS_PRIORITY(action, threads::thread_priority::high_recursive)  \
-/**/
-
-// obsolete, kept for compatibility
-#define HPX_ACTION_HAS_CRITICAL_PRIORITY(action)                               \
-    HPX_ACTION_HAS_PRIORITY(action, threads::thread_priority::high_recursive)  \
-/**/
-#endif
-
-/// \endcond
-
-/// \def HPX_REGISTER_ACTION_DECLARATION(action)
-///
-/// \brief Declare the necessary component action boilerplate code.
-///
-/// The macro \a HPX_REGISTER_ACTION_DECLARATION can be used to declare all the
-/// boilerplate code which is required for proper functioning of component
-/// actions in the context of HPX.
-///
-/// The parameter \a action is the type of the action to declare the
-/// boilerplate for.
-///
-/// This macro can be invoked with an optional second parameter. This parameter
-/// specifies a unique name of the action to be used for serialization purposes.
-/// The second parameter has to be specified if the first parameter is not
-/// usable as a plain (non-qualified) C++ identifier, i.e. the first parameter
-/// contains special characters which cannot be part of a C++ identifier, such
-/// as '<', '>', or ':'.
-///
-/// \par Example:
-///
-/// \code
-///      namespace app
-///      {
-///          // Define a simple component exposing one action 'print_greeting'
-///          class HPX_COMPONENT_EXPORT server
-///            : public hpx::components::component_base<server>
-///          {
-///              void print_greeting ()
-///              {
-///                  hpx::cout << "Hey, how are you?\n" << std::flush;
-///              }
-///
-///              // Component actions need to be declared, this also defines the
-///              // type 'print_greeting_action' representing the action.
-///              HPX_DEFINE_COMPONENT_ACTION(server,
-///                  print_greeting, print_greeting_action);
-///          };
-///      }
-///
-///      // Declare boilerplate code required for each of the component actions.
-///      HPX_REGISTER_ACTION_DECLARATION(app::server::print_greeting_action)
-/// \endcode
-///
-/// \note This macro has to be used once for each of the component actions
-/// defined using one of the \a HPX_DEFINE_COMPONENT_ACTION macros. It has to
-/// be visible in all translation units using the action, thus it is
-/// recommended to place it into the header file defining the component.
-#if defined(HPX_COMPUTE_DEVICE_CODE)
-#define HPX_REGISTER_ACTION_DECLARATION(...) /**/
-#else
-#define HPX_REGISTER_ACTION_DECLARATION(...)                                   \
-    HPX_REGISTER_ACTION_DECLARATION_(__VA_ARGS__)                              \
-    /**/
-
-#define HPX_REGISTER_ACTION_DECLARATION_(...)                                  \
-    HPX_PP_EXPAND(HPX_PP_CAT(HPX_REGISTER_ACTION_DECLARATION_,                 \
-        HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))                               \
-/**/
-#define HPX_REGISTER_ACTION_DECLARATION_1(action)                              \
-    HPX_REGISTER_ACTION_DECLARATION_2(action, action)                          \
-/**/
-#endif
-
-/// \def HPX_REGISTER_ACTION(action)
-///
-/// \brief Define the necessary component action boilerplate code.
-///
-/// The macro \a HPX_REGISTER_ACTION can be used to define all the
-/// boilerplate code which is required for proper functioning of component
-/// actions in the context of HPX.
-///
-/// The parameter \a action is the type of the action to define the
-/// boilerplate for.
-///
-/// This macro can be invoked with an optional second parameter. This parameter
-/// specifies a unique name of the action to be used for serialization purposes.
-/// The second parameter has to be specified if the first parameter is not
-/// usable as a plain (non-qualified) C++ identifier, i.e. the first parameter
-/// contains special characters which cannot be part of a C++ identifier, such
-/// as '<', '>', or ':'.
-///
-/// \note This macro has to be used once for each of the component actions
-/// defined using one of the \a HPX_DEFINE_COMPONENT_ACTION or
-/// \a HPX_DEFINE_PLAIN_ACTION macros. It has to occur exactly once for each of
-/// the actions, thus it is recommended to place it into the source file defining
-/// the component.
-///
-/// \note Only one of the forms of this macro \a HPX_REGISTER_ACTION or
-///       \a HPX_REGISTER_ACTION_ID should be used for a particular action,
-///       never both.
-///
-#if defined(HPX_COMPUTE_DEVICE_CODE)
-#define HPX_REGISTER_ACTION(...) /**/
-#else
-#define HPX_REGISTER_ACTION(...)                                               \
-    HPX_REGISTER_ACTION_(__VA_ARGS__)                                          \
-/**/
-#endif
-
-/// \def HPX_REGISTER_ACTION_ID(action, actionname, actionid)
-///
-/// \brief Define the necessary component action boilerplate code and assign a
-///        predefined unique id to the action.
-///
-/// The macro \a HPX_REGISTER_ACTION can be used to define all the
-/// boilerplate code which is required for proper functioning of component
-/// actions in the context of HPX.
-///
-/// The parameter \a action is the type of the action to define the
-/// boilerplate for.
-///
-/// The parameter \a actionname specifies an unique name of the action to be
-/// used for serialization purposes.
-/// The second parameter has to be usable as a plain (non-qualified) C++
-/// identifier, it should not contain special characters which cannot be part
-/// of a C++ identifier, such as '<', '>', or ':'.
-///
-/// The parameter \a actionid specifies an unique integer value which will be
-/// used to represent the action during serialization.
-///
-/// \note This macro has to be used once for each of the component actions
-/// defined using one of the \a HPX_DEFINE_COMPONENT_ACTION or global actions
-/// \a HPX_DEFINE_PLAIN_ACTION macros. It has to occur exactly once for each of
-/// the actions, thus it is recommended to place it into the source file defining
-/// the component.
-///
-/// \note Only one of the forms of this macro \a HPX_REGISTER_ACTION or
-///       \a HPX_REGISTER_ACTION_ID should be used for a particular action,
-///       never both.
-///
-#if defined(HPX_COMPUTE_DEVICE_CODE)
-#define HPX_REGISTER_ACTION_ID(action, actionname, actionid) /**/
-#else
-#define HPX_REGISTER_ACTION_ID(action, actionname, actionid)                   \
-    HPX_REGISTER_ACTION_2(action, actionname)                                  \
-    HPX_REGISTER_ACTION_FACTORY_ID(actionname, actionid)                       \
-/**/
-#endif

--- a/libs/full/actions_base/include/hpx/actions_base/basic_action_fwd.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/basic_action_fwd.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2024 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //  Copyright (c)      2011 Thomas Heller
 //
@@ -8,12 +8,15 @@
 
 #pragma once
 
+#include <hpx/config.hpp>
+
 namespace hpx::actions {
 
     ///////////////////////////////////////////////////////////////////////////
     /// \tparam Component         component type
     /// \tparam Signature         return type and arguments
     /// \tparam Derived           derived action class
-    template <typename Component, typename Signature, typename Derived>
+    HPX_CXX_EXPORT template <typename Component, typename Signature,
+        typename Derived>
     struct basic_action;
 }    // namespace hpx::actions

--- a/libs/full/actions_base/include/hpx/actions_base/component_action.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/component_action.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2024 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -12,6 +12,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/actions_base/basic_action.hpp>
+#include <hpx/actions_base/macros.hpp>
 #include <hpx/actions_base/traits/is_client.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/format.hpp>
@@ -199,109 +200,5 @@ namespace hpx::actions {
     };
     /// \endcond
 }    // namespace hpx::actions
-
-/// \def HPX_DEFINE_COMPONENT_ACTION(component, func, action_type)
-///
-/// \brief Registers a  member function of a component as an action type
-/// with HPX
-///
-/// The macro \a HPX_DEFINE_COMPONENT_ACTION can be used to register a
-/// member function of a component as an action type named \a action_type.
-///
-/// The parameter \a component is the type of the component exposing the
-/// member function \a func which should be associated with the newly defined
-/// action type. The parameter \p action_type is the name of the action type to
-/// register with HPX.
-///
-/// \par Example:
-///
-/// \code
-///       namespace app
-///       {
-///           // Define a simple component exposing one action 'print_greeting'
-///           class HPX_COMPONENT_EXPORT server
-///             : public hpx::components::component_base<server>
-///           {
-///               void print_greeting() const
-///               {
-///                   hpx::cout << "Hey, how are you?\n" << std::flush;
-///               }
-///
-///               // Component actions need to be declared, this also defines the
-///               // type 'print_greeting_action' representing the action.
-///               HPX_DEFINE_COMPONENT_ACTION(server, print_greeting,
-///                   print_greeting_action);
-///           };
-///       }
-/// \endcode
-///
-/// The first argument must provide the type name of the component the
-/// action is defined for.
-///
-/// The second argument must provide the member function name the action
-/// should wrap.
-///
-/// \note The macro \a HPX_DEFINE_COMPONENT_ACTION can be used with 2 or
-/// 3 arguments. The third argument is optional.
-///
-/// The default value for the third argument (the typename of the defined
-/// action) is derived from the name of the function (as passed as the second
-/// argument) by appending '_action'. The third argument can be omitted only
-/// if the second argument with an appended suffix '_action' resolves to a valid,
-/// unqualified C++ type name.
-///
-#if defined(HPX_COMPUTE_DEVICE_CODE)
-#define HPX_DEFINE_COMPONENT_ACTION(...)                            /**/
-#define HPX_DEFINE_COMPONENT_ACTION_3(component, func, name)        /**/
-#define HPX_DEFINE_COMPONENT_ACTION_2(component, func)              /**/
-#define HPX_DEFINE_COMPONENT_DIRECT_ACTION(...)                     /**/
-#define HPX_DEFINE_COMPONENT_DIRECT_ACTION_3(component, func, name) /**/
-#define HPX_DEFINE_COMPONENT_DIRECT_ACTION_2(component, func)       /**/
-#else
-#define HPX_DEFINE_COMPONENT_ACTION(...)                                       \
-    HPX_DEFINE_COMPONENT_ACTION_(__VA_ARGS__)                                  \
-    /**/
-
-/// \cond NOINTERNAL
-#define HPX_DEFINE_COMPONENT_ACTION_(...)                                      \
-    HPX_PP_EXPAND(HPX_PP_CAT(                                                  \
-        HPX_DEFINE_COMPONENT_ACTION_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__)) \
-    /**/
-
-#define HPX_DEFINE_COMPONENT_ACTION_3(component, func, name)                   \
-    struct name                                                                \
-      : hpx::actions::make_action_t<decltype(&component::func),                \
-            &component::func, name>                                            \
-    {                                                                          \
-    }; /**/
-#define HPX_DEFINE_COMPONENT_ACTION_2(component, func)                         \
-    HPX_DEFINE_COMPONENT_ACTION_3(component, func, HPX_PP_CAT(func, _action))  \
-    /**/
-/// \endcond
-
-/// \cond NOINTERNAL
-#define HPX_DEFINE_COMPONENT_DIRECT_ACTION(...)                                \
-    HPX_DEFINE_COMPONENT_DIRECT_ACTION_(__VA_ARGS__)                           \
-    /**/
-
-#define HPX_DEFINE_COMPONENT_DIRECT_ACTION_(...)                               \
-    HPX_PP_EXPAND(HPX_PP_CAT(HPX_DEFINE_COMPONENT_DIRECT_ACTION_,              \
-        HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))                               \
-    /**/
-
-#define HPX_DEFINE_COMPONENT_DIRECT_ACTION_3(component, func, name)            \
-    struct name                                                                \
-      : hpx::actions::make_direct_action_t<decltype(&component::func),         \
-            &component::func, name>                                            \
-    {                                                                          \
-    };                                                                         \
-    /**/
-
-#define HPX_DEFINE_COMPONENT_DIRECT_ACTION_2(component, func)                  \
-    HPX_DEFINE_COMPONENT_DIRECT_ACTION_3(                                      \
-        component, func, HPX_PP_CAT(func, _action))                            \
-    /**/
-/// \endcond
-#endif
 
 #include <hpx/config/warnings_suffix.hpp>

--- a/libs/full/actions_base/include/hpx/actions_base/detail/action_factory.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/detail/action_factory.hpp
@@ -11,6 +11,7 @@
 #if defined(HPX_HAVE_NETWORKING)
 #include <hpx/actions_base/actions_base_fwd.hpp>
 #include <hpx/actions_base/actions_base_support.hpp>
+#include <hpx/actions_base/macros.hpp>
 #include <hpx/modules/preprocessor.hpp>
 
 #include <cstdint>
@@ -21,7 +22,7 @@
 
 namespace hpx::actions::detail {
 
-    struct action_registry
+    HPX_CXX_EXPORT struct action_registry
     {
         action_registry(action_registry const&) = delete;
         action_registry(action_registry&&) = delete;
@@ -62,10 +63,10 @@ namespace hpx::actions::detail {
         cache_t cache_;
     };
 
-    template <std::uint32_t Id>
+    HPX_CXX_EXPORT template <std::uint32_t Id>
     HPX_ALWAYS_EXPORT std::string get_action_name_id();
 
-    template <std::uint32_t Id>
+    HPX_CXX_EXPORT template <std::uint32_t Id>
     struct add_constant_entry
     {
         add_constant_entry(add_constant_entry const&) = delete;
@@ -89,20 +90,5 @@ namespace hpx::actions::detail {
             get_action_name_id<Id>(), Id);
     }
 }    // namespace hpx::actions::detail
-
-#define HPX_REGISTER_ACTION_FACTORY_ID(Name, Id)                               \
-    namespace hpx::actions::detail {                                           \
-        template <>                                                            \
-        HPX_ALWAYS_EXPORT std::string get_action_name_id<Id>()                 \
-        {                                                                      \
-            return HPX_PP_STRINGIZE(Name);                                     \
-        }                                                                      \
-        template add_constant_entry<Id> add_constant_entry<Id>::instance;      \
-    }                                                                          \
-    /**/
-
-#else
-
-#define HPX_REGISTER_ACTION_FACTORY_ID(Name, Id) /**/
 
 #endif

--- a/libs/full/actions_base/include/hpx/actions_base/detail/invocation_count_registry.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/detail/invocation_count_registry.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2015-2025 Hartmut Kaiser
+//  Copyright (c) 2015-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/actions_base/macros.hpp>
 #include <hpx/modules/hashing.hpp>
 #include <hpx/modules/type_support.hpp>
 
@@ -18,7 +19,7 @@
 
 namespace hpx::actions::detail {
 
-    class HPX_EXPORT invocation_count_registry
+    HPX_CXX_EXPORT class HPX_EXPORT invocation_count_registry
     {
     public:
         using get_invocation_count_type = std::int64_t (*)(bool);
@@ -63,17 +64,17 @@ namespace hpx::actions::detail {
         map_type map_;
     };
 
-    template <typename Action>
+    HPX_CXX_EXPORT template <typename Action>
     void register_local_action_invocation_count(
         invocation_count_registry& registry);
 
 #if defined(HPX_HAVE_NETWORKING)
-    template <typename Action>
+    HPX_CXX_EXPORT template <typename Action>
     void register_remote_action_invocation_count(
         invocation_count_registry& registry);
 #endif
 
-    template <typename Action>
+    HPX_CXX_EXPORT template <typename Action>
     struct register_action_invocation_count
     {
         register_action_invocation_count()
@@ -94,12 +95,5 @@ namespace hpx::actions::detail {
     register_action_invocation_count<Action>
         register_action_invocation_count<Action>::instance;
 }    // namespace hpx::actions::detail
-
-#define HPX_REGISTER_ACTION_INVOCATION_COUNT(Action)                           \
-    namespace hpx::actions::detail {                                           \
-        template register_action_invocation_count<Action>                      \
-            register_action_invocation_count<Action>::instance;                \
-    }                                                                          \
-    /**/
 
 #include <hpx/config/warnings_suffix.hpp>

--- a/libs/full/actions_base/include/hpx/actions_base/detail/per_action_data_counter_registry.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/detail/per_action_data_counter_registry.hpp
@@ -96,17 +96,6 @@ namespace hpx::actions::detail {
         register_per_action_data_counters<Action>::instance;
 }    // namespace hpx::actions::detail
 
-#define HPX_REGISTER_PER_ACTION_DATA_COUNTER_TYPES(Action)                     \
-    namespace hpx::actions::detail {                                           \
-        template register_per_action_data_counters<Action>                     \
-            register_per_action_data_counters<Action>::instance;               \
-    }                                                                          \
-    /**/
-
 #include <hpx/config/warnings_suffix.hpp>
-
-#else
-
-#define HPX_REGISTER_PER_ACTION_DATA_COUNTER_TYPES(Action)
 
 #endif

--- a/libs/full/actions_base/include/hpx/actions_base/lambda_to_action.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/lambda_to_action.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <hpx/config.hpp>
 #include <hpx/actions_base/plain_action.hpp>
 
 #include <string>
@@ -94,7 +95,7 @@ namespace hpx::actions {
         };
     }    // namespace detail
 
-    template <typename F>
+    HPX_CXX_EXPORT template <typename F>
     constexpr auto lambda_to_action(F&& f) noexcept
         -> decltype(hpx::actions::detail::action_maker() +=
             true ? nullptr : hpx::actions::detail::addr_add() + f)

--- a/libs/full/actions_base/include/hpx/actions_base/macros.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/macros.hpp
@@ -1,0 +1,690 @@
+//  Copyright (c) 2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/modules/preprocessor.hpp>
+
+#include <string>
+#include <type_traits>
+
+///////////////////////////////////////////////////////////////////////////////
+// from hpx/actions_base/detail/invocation_count_registry.hpp
+
+#if defined(HPX_HAVE_PARCELPORT_COUNTERS) &&                                   \
+    defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS) &&                            \
+    defined(HPX_HAVE_NETWORKING)
+
+#define HPX_REGISTER_ACTION_INVOCATION_COUNT(Action)                           \
+    namespace hpx::actions::detail {                                           \
+        template register_action_invocation_count<Action>                      \
+            register_action_invocation_count<Action>::instance;                \
+    }                                                                          \
+    /**/
+
+#define HPX_REGISTER_PER_ACTION_DATA_COUNTER_TYPES(Action)                     \
+    namespace hpx::actions::detail {                                           \
+        template register_per_action_data_counters<Action>                     \
+            register_per_action_data_counters<Action>::instance;               \
+    }                                                                          \
+    /**/
+#else
+
+#define HPX_REGISTER_ACTION_INVOCATION_COUNT(Action)
+#define HPX_REGISTER_PER_ACTION_DATA_COUNTER_TYPES(Action)
+
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
+// from hpx/actions_base/basic_action.hpp
+
+// Macros usable to refer to an action given the function to expose
+#define HPX_MAKE_ACTION(func)                                                  \
+    hpx::actions::make_action<decltype(&func), &func> /**/ /**/
+#define HPX_MAKE_DIRECT_ACTION(func)                                           \
+    hpx::actions::make_direct_action<decltype(&func), &func> /**/ /**/
+
+///////////////////////////////////////////////////////////////////////////////
+/// \def HPX_DECLARE_ACTION(func, name)
+/// \brief Declares an action type
+///
+#define HPX_DECLARE_ACTION(...)                                                \
+    HPX_DECLARE_ACTION_(__VA_ARGS__)                                           \
+    /**/
+
+/// \cond NOINTERNAL
+
+#define HPX_DECLARE_DIRECT_ACTION(...)                                         \
+    HPX_DECLARE_ACTION(__VA_ARGS__)                                            \
+    /**/
+
+#define HPX_DECLARE_ACTION_(...)                                               \
+    HPX_PP_EXPAND(HPX_PP_CAT(HPX_DECLARE_ACTION_, HPX_PP_NARGS(__VA_ARGS__))(  \
+        __VA_ARGS__))                                                          \
+    /**/
+
+#define HPX_DECLARE_ACTION_1(func)                                             \
+    HPX_DECLARE_ACTION_2(func, HPX_PP_CAT(func, _action))                      \
+    /**/
+
+#define HPX_DECLARE_ACTION_2(func, name)                                       \
+    struct name;                                                               \
+    /**/
+
+///////////////////////////////////////////////////////////////////////////////
+#define HPX_REGISTER_ACTION_(...)                                              \
+    HPX_PP_EXPAND(HPX_PP_CAT(HPX_REGISTER_ACTION_, HPX_PP_NARGS(__VA_ARGS__))( \
+        __VA_ARGS__))                                                          \
+/**/
+#define HPX_REGISTER_ACTION_1(action)                                          \
+    HPX_REGISTER_ACTION_2(action, action)                                      \
+    /**/
+
+#if !defined(HPX_HAVE_NETWORKING)
+
+#define HPX_DEFINE_GET_ACTION_NAME(action) /**/
+#if defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0 &&                  \
+    !defined(HPX_HAVE_APEX)
+#define HPX_DEFINE_GET_ACTION_NAME_ITT(action, actionname) /**/
+#endif
+#define HPX_REGISTER_ACTION_EXTERN_DECLARATION(action) /**/
+
+#define HPX_REGISTER_ACTION_2(action, actionname)                              \
+    HPX_REGISTER_ACTION_INVOCATION_COUNT(action)                               \
+    HPX_REGISTER_PER_ACTION_DATA_COUNTER_TYPES(action)                         \
+    /**/
+
+#define HPX_REGISTER_ACTION_DECLARATION_2(action, actionname) /**/
+
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+#define HPX_ACTION_USES_STACK(action, size)  /**/
+#define HPX_ACTION_USES_SMALL_STACK(action)  /**/
+#define HPX_ACTION_USES_MEDIUM_STACK(action) /**/
+#define HPX_ACTION_USES_LARGE_STACK(action)  /**/
+#define HPX_ACTION_USES_HUGE_STACK(action)   /**/
+#else
+#define HPX_ACTION_USES_STACK(action, size)                                    \
+    namespace hpx::traits {                                                    \
+        template <>                                                            \
+        struct action_stacksize<action>                                        \
+        {                                                                      \
+            static constexpr threads::thread_stacksize value = size;           \
+        };                                                                     \
+    }                                                                          \
+    /**/
+
+#define HPX_ACTION_USES_SMALL_STACK(action)                                    \
+    HPX_ACTION_USES_STACK(action, threads::thread_stacksize::small_)           \
+/**/
+#define HPX_ACTION_USES_MEDIUM_STACK(action)                                   \
+    HPX_ACTION_USES_STACK(action, threads::thread_stacksize::medium)           \
+/**/
+#define HPX_ACTION_USES_LARGE_STACK(action)                                    \
+    HPX_ACTION_USES_STACK(action, threads::thread_stacksize::large)            \
+/**/
+#define HPX_ACTION_USES_HUGE_STACK(action)                                     \
+    HPX_ACTION_USES_STACK(action, threads::thread_stacksize::huge)             \
+/**/
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+#define HPX_ACTION_HAS_PRIORITY(action, priority)      /**/
+#define HPX_ACTION_HAS_LOW_PRIORITY(action)            /**/
+#define HPX_ACTION_HAS_NORMAL_PRIORITY(action)         /**/
+#define HPX_ACTION_HAS_HIGH_PRIORITY(action)           /**/
+#define HPX_ACTION_HAS_HIGH_RECURSIVE_PRIORITY(action) /**/
+// obsolete, kept for compatibility
+#define HPX_ACTION_HAS_CRITICAL_PRIORITY(action) /**/
+#else
+///////////////////////////////////////////////////////////////////////////////
+#define HPX_ACTION_HAS_PRIORITY(action, priority)                              \
+    namespace hpx::traits {                                                    \
+        template <>                                                            \
+        struct action_priority<action>                                         \
+        {                                                                      \
+            static constexpr threads::thread_priority value = priority;        \
+        };                                                                     \
+        /* make sure the action is not executed directly */                    \
+        template <>                                                            \
+        struct has_decorates_action<action> : std::true_type                   \
+        {                                                                      \
+        };                                                                     \
+    }                                                                          \
+    /**/
+
+#define HPX_ACTION_HAS_LOW_PRIORITY(action)                                    \
+    HPX_ACTION_HAS_PRIORITY(action, threads::thread_priority::low)             \
+/**/
+#define HPX_ACTION_HAS_NORMAL_PRIORITY(action)                                 \
+    HPX_ACTION_HAS_PRIORITY(action, threads::thread_priority::normal)          \
+/**/
+#define HPX_ACTION_HAS_HIGH_PRIORITY(action)                                   \
+    HPX_ACTION_HAS_PRIORITY(action, threads::thread_priority::high)            \
+/**/
+#define HPX_ACTION_HAS_HIGH_RECURSIVE_PRIORITY(action)                         \
+    HPX_ACTION_HAS_PRIORITY(action, threads::thread_priority::high_recursive)  \
+/**/
+
+// obsolete, kept for compatibility
+#define HPX_ACTION_HAS_CRITICAL_PRIORITY(action)                               \
+    HPX_ACTION_HAS_PRIORITY(action, threads::thread_priority::high_recursive)  \
+/**/
+#endif
+
+/// \endcond
+
+/// \def HPX_REGISTER_ACTION_DECLARATION(action)
+///
+/// \brief Declare the necessary component action boilerplate code.
+///
+/// The macro \a HPX_REGISTER_ACTION_DECLARATION can be used to declare all the
+/// boilerplate code which is required for proper functioning of component
+/// actions in the context of HPX.
+///
+/// The parameter \a action is the type of the action to declare the
+/// boilerplate for.
+///
+/// This macro can be invoked with an optional second parameter. This parameter
+/// specifies a unique name of the action to be used for serialization purposes.
+/// The second parameter has to be specified if the first parameter is not
+/// usable as a plain (nonqualified) C++ identifier, i.e. the first parameter
+/// contains special characters which cannot be part of a C++ identifier, such
+/// as '<', '>', or ':'.
+///
+/// \par Example:
+///
+/// \code
+///      namespace app
+///      {
+///          // Define a simple component exposing one action 'print_greeting'
+///          class HPX_COMPONENT_EXPORT server
+///            : public hpx::components::component_base<server>
+///          {
+///              void print_greeting ()
+///              {
+///                  hpx::cout << "Hey, how are you?\n" << std::flush;
+///              }
+///
+///              // Component actions need to be declared, this also defines the
+///              // type 'print_greeting_action' representing the action.
+///              HPX_DEFINE_COMPONENT_ACTION(server,
+///                  print_greeting, print_greeting_action);
+///          };
+///      }
+///
+///      // Declare boilerplate code required for each of the component actions.
+///      HPX_REGISTER_ACTION_DECLARATION(app::server::print_greeting_action)
+/// \endcode
+///
+/// \note This macro has to be used once for each of the component actions
+/// defined using one of the \a HPX_DEFINE_COMPONENT_ACTION macros. It has to
+/// be visible in all translation units using the action, thus it is
+/// recommended to place it into the header file defining the component.
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+#define HPX_REGISTER_ACTION_DECLARATION(...) /**/
+#else
+#define HPX_REGISTER_ACTION_DECLARATION(...)                                   \
+    HPX_REGISTER_ACTION_DECLARATION_(__VA_ARGS__)                              \
+    /**/
+
+#define HPX_REGISTER_ACTION_DECLARATION_(...)                                  \
+    HPX_PP_EXPAND(HPX_PP_CAT(HPX_REGISTER_ACTION_DECLARATION_,                 \
+        HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))                               \
+/**/
+#define HPX_REGISTER_ACTION_DECLARATION_1(action)                              \
+    HPX_REGISTER_ACTION_DECLARATION_2(action, action)                          \
+/**/
+#endif
+
+/// \def HPX_REGISTER_ACTION(action)
+///
+/// \brief Define the necessary component action boilerplate code.
+///
+/// The macro \a HPX_REGISTER_ACTION can be used to define all the
+/// boilerplate code which is required for proper functioning of component
+/// actions in the context of HPX.
+///
+/// The parameter \a action is the type of the action to define the
+/// boilerplate for.
+///
+/// This macro can be invoked with an optional second parameter. This parameter
+/// specifies a unique name of the action to be used for serialization purposes.
+/// The second parameter has to be specified if the first parameter is not
+/// usable as a plain (nonqualified) C++ identifier, i.e. the first parameter
+/// contains special characters which cannot be part of a C++ identifier, such
+/// as '<', '>', or ':'.
+///
+/// \note This macro has to be used once for each of the component actions
+/// defined using one of the \a HPX_DEFINE_COMPONENT_ACTION or
+/// \a HPX_DEFINE_PLAIN_ACTION macros. It has to occur exactly once for each of
+/// the actions, thus it is recommended to place it into the source file defining
+/// the component.
+///
+/// \note Only one of the forms of this macro \a HPX_REGISTER_ACTION or
+///       \a HPX_REGISTER_ACTION_ID should be used for a particular action,
+///       never both.
+///
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+#define HPX_REGISTER_ACTION(...) /**/
+#else
+#define HPX_REGISTER_ACTION(...)                                               \
+    HPX_REGISTER_ACTION_(__VA_ARGS__)                                          \
+/**/
+#endif
+
+/// \def HPX_REGISTER_ACTION_ID(action, actionname, actionid)
+///
+/// \brief Define the necessary component action boilerplate code and assign a
+///        predefined unique id to the action.
+///
+/// The macro \a HPX_REGISTER_ACTION can be used to define all the
+/// boilerplate code which is required for proper functioning of component
+/// actions in the context of HPX.
+///
+/// The parameter \a action is the type of the action to define the
+/// boilerplate for.
+///
+/// The parameter \a actionname specifies an unique name of the action to be
+/// used for serialization purposes.
+/// The second parameter has to be usable as a plain (nonqualified) C++
+/// identifier, it should not contain special characters which cannot be part
+/// of a C++ identifier, such as '<', '>', or ':'.
+///
+/// The parameter \a actionid specifies a unique integer value which will be
+/// used to represent the action during serialization.
+///
+/// \note This macro has to be used once for each of the component actions
+/// defined using one of the \a HPX_DEFINE_COMPONENT_ACTION or global actions
+/// \a HPX_DEFINE_PLAIN_ACTION macros. It has to occur exactly once for each of
+/// the actions, thus it is recommended to place it into the source file defining
+/// the component.
+///
+/// \note Only one of the forms of this macro \a HPX_REGISTER_ACTION or
+///       \a HPX_REGISTER_ACTION_ID should be used for a particular action,
+///       never both.
+///
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+#define HPX_REGISTER_ACTION_ID(action, actionname, actionid) /**/
+#else
+#define HPX_REGISTER_ACTION_ID(action, actionname, actionid)                   \
+    HPX_REGISTER_ACTION_2(action, actionname)                                  \
+    HPX_REGISTER_ACTION_FACTORY_ID(actionname, actionid)                       \
+    /**/
+
+#endif
+
+////////////////////////////////////////////////////////////////////////////////
+// from hpx/actions_base/component_action.hpp
+
+/// \def HPX_DEFINE_COMPONENT_ACTION(component, func, action_type)
+///
+/// \brief Registers a  member function of a component as an action type
+/// with HPX
+///
+/// The macro \a HPX_DEFINE_COMPONENT_ACTION can be used to register a
+/// member function of a component as an action type named \a action_type.
+///
+/// The parameter \a component is the type of the component exposing the
+/// member function \a func which should be associated with the newly defined
+/// action type. The parameter \p action_type is the name of the action type to
+/// register with HPX.
+///
+/// \par Example:
+///
+/// \code
+///       namespace app
+///       {
+///           // Define a simple component exposing one action 'print_greeting'
+///           class HPX_COMPONENT_EXPORT server
+///             : public hpx::components::component_base<server>
+///           {
+///               void print_greeting() const
+///               {
+///                   hpx::cout << "Hey, how are you?\n" << std::flush;
+///               }
+///
+///               // Component actions need to be declared, this also defines the
+///               // type 'print_greeting_action' representing the action.
+///               HPX_DEFINE_COMPONENT_ACTION(server, print_greeting,
+///                   print_greeting_action);
+///           };
+///       }
+/// \endcode
+///
+/// The first argument must provide the type name of the component the
+/// action is defined for.
+///
+/// The second argument must provide the member function name the action
+/// should wrap.
+///
+/// \note The macro \a HPX_DEFINE_COMPONENT_ACTION can be used with 2 or
+/// 3 arguments. The third argument is optional.
+///
+/// The default value for the third argument (the typename of the defined
+/// action) is derived from the name of the function (as passed as the second
+/// argument) by appending '_action'. The third argument can be omitted only
+/// if the second argument with an appended suffix '_action' resolves to a valid,
+/// unqualified C++ type name.
+///
+#if defined(HPX_COMPUTE_DEVICE_CODE)
+#define HPX_DEFINE_COMPONENT_ACTION(...)                            /**/
+#define HPX_DEFINE_COMPONENT_ACTION_3(component, func, name)        /**/
+#define HPX_DEFINE_COMPONENT_ACTION_2(component, func)              /**/
+#define HPX_DEFINE_COMPONENT_DIRECT_ACTION(...)                     /**/
+#define HPX_DEFINE_COMPONENT_DIRECT_ACTION_3(component, func, name) /**/
+#define HPX_DEFINE_COMPONENT_DIRECT_ACTION_2(component, func)       /**/
+#else
+#define HPX_DEFINE_COMPONENT_ACTION(...)                                       \
+    HPX_DEFINE_COMPONENT_ACTION_(__VA_ARGS__)                                  \
+    /**/
+
+/// \cond NOINTERNAL
+#define HPX_DEFINE_COMPONENT_ACTION_(...)                                      \
+    HPX_PP_EXPAND(HPX_PP_CAT(                                                  \
+        HPX_DEFINE_COMPONENT_ACTION_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__)) \
+    /**/
+
+#define HPX_DEFINE_COMPONENT_ACTION_3(component, func, name)                   \
+    struct name                                                                \
+      : hpx::actions::make_action_t<decltype(&component::func),                \
+            &component::func, name>                                            \
+    {                                                                          \
+    }; /**/
+#define HPX_DEFINE_COMPONENT_ACTION_2(component, func)                         \
+    HPX_DEFINE_COMPONENT_ACTION_3(component, func, HPX_PP_CAT(func, _action))  \
+    /**/
+/// \endcond
+
+/// \cond NOINTERNAL
+#define HPX_DEFINE_COMPONENT_DIRECT_ACTION(...)                                \
+    HPX_DEFINE_COMPONENT_DIRECT_ACTION_(__VA_ARGS__)                           \
+    /**/
+
+#define HPX_DEFINE_COMPONENT_DIRECT_ACTION_(...)                               \
+    HPX_PP_EXPAND(HPX_PP_CAT(HPX_DEFINE_COMPONENT_DIRECT_ACTION_,              \
+        HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))                               \
+    /**/
+
+#define HPX_DEFINE_COMPONENT_DIRECT_ACTION_3(component, func, name)            \
+    struct name                                                                \
+      : hpx::actions::make_direct_action_t<decltype(&component::func),         \
+            &component::func, name>                                            \
+    {                                                                          \
+    };                                                                         \
+    /**/
+
+#define HPX_DEFINE_COMPONENT_DIRECT_ACTION_2(component, func)                  \
+    HPX_DEFINE_COMPONENT_DIRECT_ACTION_3(                                      \
+        component, func, HPX_PP_CAT(func, _action))                            \
+    /**/
+/// \endcond
+
+#endif
+
+////////////////////////////////////////////////////////////////////////////////
+// from hpx/actions_base/plain_action.hpp
+
+/// \def HPX_DEFINE_PLAIN_ACTION(func, name)
+/// \brief Defines a plain action type
+///
+/// \par Example:
+///
+/// \code
+///       namespace app
+///       {
+///           void some_global_function(double d)
+///           {
+///               cout << d;
+///           }
+///
+///           // This will define the action type 'app::some_global_action' which
+///           // represents the function 'app::some_global_function'.
+///           HPX_DEFINE_PLAIN_ACTION(some_global_function, some_global_action);
+///       }
+/// \endcode
+///
+/// \note Usually this macro will not be used in user code unless the intent is
+/// to avoid defining the action_type in global namespace. Normally, the use of
+/// the macro \a HPX_PLAIN_ACTION is recommended.
+///
+/// \note The macro \a HPX_DEFINE_PLAIN_ACTION can be used with 1 or 2
+/// arguments. The second argument is optional. The default value for the
+/// second argument (the typename of the defined action) is derived from the
+/// name of the function (as passed as the first argument) by appending '_action'.
+/// The second argument can be omitted only if the first argument with an
+/// appended suffix '_action' resolves to a valid, unqualified C++ type name.
+///
+#define HPX_DEFINE_PLAIN_ACTION(...)                                           \
+    HPX_DEFINE_PLAIN_ACTION_(__VA_ARGS__)                                      \
+    /**/
+
+/// \cond NOINTERNAL
+
+#define HPX_DEFINE_PLAIN_DIRECT_ACTION(...)                                    \
+    HPX_DEFINE_PLAIN_DIRECT_ACTION_(__VA_ARGS__)                               \
+    /**/
+
+#define HPX_DEFINE_PLAIN_ACTION_(...)                                          \
+    HPX_PP_EXPAND(HPX_PP_CAT(                                                  \
+        HPX_DEFINE_PLAIN_ACTION_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))     \
+    /**/
+
+#define HPX_DEFINE_PLAIN_DIRECT_ACTION_(...)                                   \
+    HPX_PP_EXPAND(HPX_PP_CAT(HPX_DEFINE_PLAIN_DIRECT_ACTION_,                  \
+        HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))                               \
+    /**/
+
+#define HPX_DEFINE_PLAIN_ACTION_1(func)                                        \
+    HPX_DEFINE_PLAIN_ACTION_2(func, HPX_PP_CAT(func, _action))                 \
+    /**/
+
+#if defined(__NVCC__) || defined(__CUDACC__)
+#define HPX_DEFINE_PLAIN_ACTION_2(func, name)                                  \
+    struct name                                                                \
+      : hpx::actions::make_action<                                             \
+            typename std::add_pointer<                                         \
+                typename std::remove_pointer<decltype(&func)>::type>::type,    \
+            &func, name>::type                                                 \
+    {                                                                          \
+    } /**/
+#else
+#define HPX_DEFINE_PLAIN_ACTION_2(func, name)                                  \
+    struct name : hpx::actions::make_action_t<decltype(&func), &func, name>    \
+    {                                                                          \
+    } /**/
+#endif
+
+#define HPX_DEFINE_PLAIN_DIRECT_ACTION_1(func)                                 \
+    HPX_DEFINE_PLAIN_DIRECT_ACTION_2(func, HPX_PP_CAT(func, _action))          \
+    /**/
+
+#define HPX_DEFINE_PLAIN_DIRECT_ACTION_2(func, name)                           \
+    struct name                                                                \
+      : hpx::actions::make_direct_action_t<decltype(&func), &func, name>       \
+    {                                                                          \
+    } /**/
+
+/// \endcond
+
+///////////////////////////////////////////////////////////////////////////////
+/// \def HPX_DECLARE_PLAIN_ACTION(func, name)
+/// \brief Declares a plain action type
+///
+#define HPX_DECLARE_PLAIN_ACTION(...)                                          \
+    HPX_DECLARE_ACTION(__VA_ARGS__)                                            \
+/**/
+
+/// \def HPX_PLAIN_ACTION(func, name)
+///
+/// \brief Defines a plain action type based on the given function
+/// \a func and registers it with HPX.
+///
+/// The macro \a HPX_PLAIN_ACTION can be used to define a plain action (e.g. an
+/// action encapsulating a global or free function) based on the given function
+/// \a func. It defines the action type \a name representing the given function.
+/// This macro additionally registers the newly define action type with HPX.
+///
+/// The parameter \p func is a global or free (non-member) function which should
+/// be encapsulated into a plain action. The parameter \p name is the name of
+/// the action type defined by this macro.
+///
+/// \par Example:
+///
+/// \code
+///     namespace app {
+///         void some_global_function(double d) {
+///             cout << d;
+///         }
+///     }
+///
+///     // This will define the action type 'some_global_action' which
+///     // represents the function 'app::some_global_function'.
+///     HPX_PLAIN_ACTION(app::some_global_function, some_global_action)
+/// \endcode
+///
+/// \note The macro \a HPX_PLAIN_ACTION has to be used at global namespace even
+/// if the wrapped function is located in some other namespace. The newly
+/// defined action type is placed into the global namespace as well.
+///
+/// \note The macro \a HPX_PLAIN_ACTION_ID can be used with 1, 2, or 3
+///       arguments. The second and third arguments are optional. The default
+///       value for the second argument (the typename of the defined action) is
+///       derived from the name of the function (as passed as the first
+///       argument) by appending '_action'. The second argument can be omitted
+///       only if the first argument with an appended suffix '_action' resolves
+///       to a valid, unqualified C++ type name. The default value for the third
+///       argument is \a hpx::components::factory_state::check.
+///
+/// \note Only one of the forms of this macro \a HPX_PLAIN_ACTION or
+///       \a HPX_PLAIN_ACTION_ID should be used for a particular action,
+///       never both.
+///
+#define HPX_PLAIN_ACTION(...)                                                  \
+    HPX_PLAIN_ACTION_(__VA_ARGS__)                                             \
+/**/
+
+/// \def HPX_PLAIN_ACTION_ID(func, actionname, actionid)
+///
+/// \brief Defines a plain action type based on the given function \a func and
+///   registers it with HPX.
+///
+/// The macro \a HPX_PLAIN_ACTION_ID can be used to define a plain action (e.g.
+/// an action encapsulating a global or free function) based on the given
+/// function \a func. It defines the action type \a actionname representing the
+/// given function.
+///
+/// The parameter \a actionid specifies a unique integer value which will be
+/// used to represent the action during serialization.
+///
+/// The parameter \p func is a global or free (non-member) function which should
+/// be encapsulated into a plain action. The parameter \p name is the name of
+/// the action type defined by this macro.
+///
+/// The second parameter has to be usable as a plain (non-qualified) C++
+/// identifier, it should not contain special characters which cannot be part of
+/// a C++ identifier, such as '<', '>', or ':'.
+///
+/// \par Example:
+///
+/// \code
+///     namespace app {
+///         void some_global_function(double d) {
+///             cout << d;
+///         }
+///     }
+///
+///     // This will define the action type 'some_global_action' which
+///     // represents the function 'app::some_global_function'.
+///     HPX_PLAIN_ACTION_ID(app::some_global_function, some_global_action,
+///         some_unique_id);
+/// \endcode
+///
+/// \note The macro \a HPX_PLAIN_ACTION_ID has to be used at global namespace
+///       even if the wrapped function is located in some other namespace. The
+///       newly defined action type is placed into the global namespace as well.
+///
+/// \note Only one of the forms of this macro \a HPX_PLAIN_ACTION or
+///       \a HPX_PLAIN_ACTION_ID should be used for a particular action,
+///       never both.
+///
+#define HPX_PLAIN_ACTION_ID(func, name, id)                                    \
+    HPX_DEFINE_PLAIN_ACTION(func, name);                                       \
+    HPX_REGISTER_ACTION_DECLARATION(name, name)                                \
+    HPX_REGISTER_ACTION_ID(name, name, id)                                     \
+    /**/
+
+/// \cond NOINTERNAL
+
+#define HPX_PLAIN_DIRECT_ACTION(...)                                           \
+    HPX_PLAIN_DIRECT_ACTION_(__VA_ARGS__)                                      \
+/**/
+
+/// \endcond
+
+/// \cond NOINTERNAL
+
+//
+// macros for plain actions
+#define HPX_PLAIN_ACTION_(...)                                                 \
+    HPX_PP_EXPAND(                                                             \
+        HPX_PP_CAT(HPX_PLAIN_ACTION_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__)) \
+/**/
+#define HPX_PLAIN_ACTION_2(func, name)                                         \
+    HPX_DEFINE_PLAIN_ACTION(func, name);                                       \
+    HPX_REGISTER_ACTION_DECLARATION(name, name)                                \
+    HPX_REGISTER_ACTION(name, name)                                            \
+/**/
+#define HPX_PLAIN_ACTION_1(func)                                               \
+    HPX_PLAIN_ACTION_2(func, HPX_PP_CAT(func, _action))                        \
+/**/
+
+// same for direct actions
+#define HPX_PLAIN_DIRECT_ACTION_(...)                                          \
+    HPX_PP_EXPAND(HPX_PP_CAT(                                                  \
+        HPX_PLAIN_DIRECT_ACTION_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))     \
+/**/
+#define HPX_PLAIN_DIRECT_ACTION_2(func, name)                                  \
+    HPX_DEFINE_PLAIN_DIRECT_ACTION(func, name);                                \
+    HPX_REGISTER_ACTION_DECLARATION(name, name)                                \
+    HPX_REGISTER_ACTION(name, name)                                            \
+/**/
+#define HPX_PLAIN_DIRECT_ACTION_1(func)                                        \
+    HPX_PLAIN_DIRECT_ACTION_2(func, HPX_PP_CAT(func, _action))                 \
+/**/
+#define HPX_PLAIN_DIRECT_ACTION_ID(func, name, id)                             \
+    HPX_DEFINE_PLAIN_DIRECT_ACTION(func, name);                                \
+    HPX_REGISTER_ACTION_DECLARATION(name, name)                                \
+    HPX_REGISTER_ACTION_ID(name, name, id)                                     \
+    /**/
+
+/// \endcond
+
+////////////////////////////////////////////////////////////////////////////////
+// from hpx/actions_base/detail/action_factory.hpp
+
+#if defined(HPX_HAVE_NETWORKING)
+
+#define HPX_REGISTER_ACTION_FACTORY_ID(Name, Id)                               \
+    namespace hpx::actions::detail {                                           \
+        template <>                                                            \
+        HPX_ALWAYS_EXPORT std::string get_action_name_id<Id>()                 \
+        {                                                                      \
+            return HPX_PP_STRINGIZE(Name);                                     \
+        }                                                                      \
+        template add_constant_entry<Id> add_constant_entry<Id>::instance;      \
+    }                                                                          \
+    /**/
+
+#else
+
+#define HPX_REGISTER_ACTION_FACTORY_ID(Name, Id)
+
+#endif

--- a/libs/full/actions_base/include/hpx/actions_base/plain_action.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/plain_action.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2024 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c) 2011      Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -11,6 +11,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/actions_base/basic_action.hpp>
+#include <hpx/actions_base/macros.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/format.hpp>
@@ -54,7 +55,8 @@ namespace hpx::actions {
     //  Specialized generic plain (free) action types allowing to hold a
     //  different number of arguments
     ///////////////////////////////////////////////////////////////////////////
-    template <typename R, typename... Ps, R (*F)(Ps...), typename Derived>
+    HPX_CXX_EXPORT template <typename R, typename... Ps, R (*F)(Ps...),
+        typename Derived>
     struct action<R (*)(Ps...), F, Derived>
       : basic_action<detail::plain_function, R(Ps...),
             detail::action_type_t<action<R (*)(Ps...), F, Derived>, Derived>>
@@ -79,7 +81,7 @@ namespace hpx::actions {
         }
     };
 
-    template <typename R, typename... Ps, R (*F)(Ps...) noexcept,
+    HPX_CXX_EXPORT template <typename R, typename... Ps, R (*F)(Ps...) noexcept,
         typename Derived>
     struct action<R (*)(Ps...) noexcept, F, Derived>
       : basic_action<detail::plain_function, R(Ps...),
@@ -129,239 +131,5 @@ namespace hpx::traits {
     // clang-format on
     /// \endcond
 }    // namespace hpx::traits
-
-/// \def HPX_DEFINE_PLAIN_ACTION(func, name)
-/// \brief Defines a plain action type
-///
-/// \par Example:
-///
-/// \code
-///       namespace app
-///       {
-///           void some_global_function(double d)
-///           {
-///               cout << d;
-///           }
-///
-///           // This will define the action type 'app::some_global_action' which
-///           // represents the function 'app::some_global_function'.
-///           HPX_DEFINE_PLAIN_ACTION(some_global_function, some_global_action);
-///       }
-/// \endcode
-///
-/// \note Usually this macro will not be used in user code unless the intent is
-/// to avoid defining the action_type in global namespace. Normally, the use of
-/// the macro \a HPX_PLAIN_ACTION is recommended.
-///
-/// \note The macro \a HPX_DEFINE_PLAIN_ACTION can be used with 1 or 2
-/// arguments. The second argument is optional. The default value for the
-/// second argument (the typename of the defined action) is derived from the
-/// name of the function (as passed as the first argument) by appending '_action'.
-/// The second argument can be omitted only if the first argument with an
-/// appended suffix '_action' resolves to a valid, unqualified C++ type name.
-///
-#define HPX_DEFINE_PLAIN_ACTION(...)                                           \
-    HPX_DEFINE_PLAIN_ACTION_(__VA_ARGS__)                                      \
-    /**/
-
-/// \cond NOINTERNAL
-
-#define HPX_DEFINE_PLAIN_DIRECT_ACTION(...)                                    \
-    HPX_DEFINE_PLAIN_DIRECT_ACTION_(__VA_ARGS__)                               \
-    /**/
-
-#define HPX_DEFINE_PLAIN_ACTION_(...)                                          \
-    HPX_PP_EXPAND(HPX_PP_CAT(                                                  \
-        HPX_DEFINE_PLAIN_ACTION_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))     \
-    /**/
-
-#define HPX_DEFINE_PLAIN_DIRECT_ACTION_(...)                                   \
-    HPX_PP_EXPAND(HPX_PP_CAT(HPX_DEFINE_PLAIN_DIRECT_ACTION_,                  \
-        HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))                               \
-    /**/
-
-#define HPX_DEFINE_PLAIN_ACTION_1(func)                                        \
-    HPX_DEFINE_PLAIN_ACTION_2(func, HPX_PP_CAT(func, _action))                 \
-    /**/
-
-#if defined(__NVCC__) || defined(__CUDACC__)
-#define HPX_DEFINE_PLAIN_ACTION_2(func, name)                                  \
-    struct name                                                                \
-      : hpx::actions::make_action<                                             \
-            typename std::add_pointer<                                         \
-                typename std::remove_pointer<decltype(&func)>::type>::type,    \
-            &func, name>::type                                                 \
-    {                                                                          \
-    } /**/
-#else
-#define HPX_DEFINE_PLAIN_ACTION_2(func, name)                                  \
-    struct name : hpx::actions::make_action_t<decltype(&func), &func, name>    \
-    {                                                                          \
-    } /**/
-#endif
-
-#define HPX_DEFINE_PLAIN_DIRECT_ACTION_1(func)                                 \
-    HPX_DEFINE_PLAIN_DIRECT_ACTION_2(func, HPX_PP_CAT(func, _action))          \
-    /**/
-
-#define HPX_DEFINE_PLAIN_DIRECT_ACTION_2(func, name)                           \
-    struct name                                                                \
-      : hpx::actions::make_direct_action_t<decltype(&func), &func, name>       \
-    {                                                                          \
-    } /**/
-
-/// \endcond
-
-///////////////////////////////////////////////////////////////////////////////
-/// \def HPX_DECLARE_PLAIN_ACTION(func, name)
-/// \brief Declares a plain action type
-///
-#define HPX_DECLARE_PLAIN_ACTION(...)                                          \
-    HPX_DECLARE_ACTION(__VA_ARGS__)                                            \
-/**/
-
-/// \def HPX_PLAIN_ACTION(func, name)
-///
-/// \brief Defines a plain action type based on the given function
-/// \a func and registers it with HPX.
-///
-/// The macro \a HPX_PLAIN_ACTION can be used to define a plain action (e.g. an
-/// action encapsulating a global or free function) based on the given function
-/// \a func. It defines the action type \a name representing the given function.
-/// This macro additionally registers the newly define action type with HPX.
-///
-/// The parameter \p func is a global or free (non-member) function which should
-/// be encapsulated into a plain action. The parameter \p name is the name of
-/// the action type defined by this macro.
-///
-/// \par Example:
-///
-/// \code
-///     namespace app {
-///         void some_global_function(double d) {
-///             cout << d;
-///         }
-///     }
-///
-///     // This will define the action type 'some_global_action' which
-///     // represents the function 'app::some_global_function'.
-///     HPX_PLAIN_ACTION(app::some_global_function, some_global_action)
-/// \endcode
-///
-/// \note The macro \a HPX_PLAIN_ACTION has to be used at global namespace even
-/// if the wrapped function is located in some other namespace. The newly
-/// defined action type is placed into the global namespace as well.
-///
-/// \note The macro \a HPX_PLAIN_ACTION_ID can be used with 1, 2, or 3
-///       arguments. The second and third arguments are optional. The default
-///       value for the second argument (the typename of the defined action) is
-///       derived from the name of the function (as passed as the first
-///       argument) by appending '_action'. The second argument can be omitted
-///       only if the first argument with an appended suffix '_action' resolves
-///       to a valid, unqualified C++ type name. The default value for the third
-///       argument is \a hpx::components::factory_state::check.
-///
-/// \note Only one of the forms of this macro \a HPX_PLAIN_ACTION or
-///       \a HPX_PLAIN_ACTION_ID should be used for a particular action,
-///       never both.
-///
-#define HPX_PLAIN_ACTION(...)                                                  \
-    HPX_PLAIN_ACTION_(__VA_ARGS__)                                             \
-/**/
-
-/// \def HPX_PLAIN_ACTION_ID(func, actionname, actionid)
-///
-/// \brief Defines a plain action type based on the given function \a func and
-///   registers it with HPX.
-///
-/// The macro \a HPX_PLAIN_ACTION_ID can be used to define a plain action (e.g.
-/// an action encapsulating a global or free function) based on the given
-/// function \a func. It defines the action type \a actionname representing the
-/// given function.
-///
-/// The parameter \a actionid specifies a unique integer value which will be
-/// used to represent the action during serialization.
-///
-/// The parameter \p func is a global or free (non-member) function which should
-/// be encapsulated into a plain action. The parameter \p name is the name of
-/// the action type defined by this macro.
-///
-/// The second parameter has to be usable as a plain (non-qualified) C++
-/// identifier, it should not contain special characters which cannot be part of
-/// a C++ identifier, such as '<', '>', or ':'.
-///
-/// \par Example:
-///
-/// \code
-///     namespace app {
-///         void some_global_function(double d) {
-///             cout << d;
-///         }
-///     }
-///
-///     // This will define the action type 'some_global_action' which
-///     // represents the function 'app::some_global_function'.
-///     HPX_PLAIN_ACTION_ID(app::some_global_function, some_global_action,
-///         some_unique_id);
-/// \endcode
-///
-/// \note The macro \a HPX_PLAIN_ACTION_ID has to be used at global namespace
-///       even if the wrapped function is located in some other namespace. The
-///       newly defined action type is placed into the global namespace as well.
-///
-/// \note Only one of the forms of this macro \a HPX_PLAIN_ACTION or
-///       \a HPX_PLAIN_ACTION_ID should be used for a particular action,
-///       never both.
-///
-#define HPX_PLAIN_ACTION_ID(func, name, id)                                    \
-    HPX_DEFINE_PLAIN_ACTION(func, name);                                       \
-    HPX_REGISTER_ACTION_DECLARATION(name, name)                                \
-    HPX_REGISTER_ACTION_ID(name, name, id)                                     \
-    /**/
-
-/// \cond NOINTERNAL
-
-#define HPX_PLAIN_DIRECT_ACTION(...)                                           \
-    HPX_PLAIN_DIRECT_ACTION_(__VA_ARGS__)                                      \
-/**/
-
-/// \endcond
-
-/// \cond NOINTERNAL
-
-// macros for plain actions
-#define HPX_PLAIN_ACTION_(...)                                                 \
-    HPX_PP_EXPAND(                                                             \
-        HPX_PP_CAT(HPX_PLAIN_ACTION_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__)) \
-/**/
-#define HPX_PLAIN_ACTION_2(func, name)                                         \
-    HPX_DEFINE_PLAIN_ACTION(func, name);                                       \
-    HPX_REGISTER_ACTION_DECLARATION(name, name)                                \
-    HPX_REGISTER_ACTION(name, name)                                            \
-/**/
-#define HPX_PLAIN_ACTION_1(func)                                               \
-    HPX_PLAIN_ACTION_2(func, HPX_PP_CAT(func, _action))                        \
-/**/
-
-// same for direct actions
-#define HPX_PLAIN_DIRECT_ACTION_(...)                                          \
-    HPX_PP_EXPAND(HPX_PP_CAT(                                                  \
-        HPX_PLAIN_DIRECT_ACTION_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))     \
-/**/
-#define HPX_PLAIN_DIRECT_ACTION_2(func, name)                                  \
-    HPX_DEFINE_PLAIN_DIRECT_ACTION(func, name);                                \
-    HPX_REGISTER_ACTION_DECLARATION(name, name)                                \
-    HPX_REGISTER_ACTION(name, name)                                            \
-/**/
-#define HPX_PLAIN_DIRECT_ACTION_1(func)                                        \
-    HPX_PLAIN_DIRECT_ACTION_2(func, HPX_PP_CAT(func, _action))                 \
-/**/
-#define HPX_PLAIN_DIRECT_ACTION_ID(func, name, id)                             \
-    HPX_DEFINE_PLAIN_DIRECT_ACTION(func, name);                                \
-    HPX_REGISTER_ACTION_DECLARATION(name, name)                                \
-    HPX_REGISTER_ACTION_ID(name, name, id)                                     \
-    /**/
-
-/// \endcond
 
 #include <hpx/config/warnings_suffix.hpp>

--- a/libs/full/actions_base/include/hpx/actions_base/preassigned_action_id.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/preassigned_action_id.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2024 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //  Copyright (c)      2011 Thomas Heller
 //
@@ -10,11 +10,12 @@
 
 #pragma once
 
+#include <hpx/config.hpp>
+
 namespace hpx::actions {
 
     /// \cond NOINTERNAL
-    enum preassigned_action_id
-    {
+    HPX_CXX_EXPORT enum preassigned_action_id {
         register_worker_action_id = 0,
         notify_worker_action_id,
         allocate_action_id,

--- a/libs/full/actions_base/include/hpx/actions_base/traits/action_continuation.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/traits/action_continuation.hpp
@@ -6,9 +6,11 @@
 
 #pragma once
 
+#include <hpx/config.hpp>
+
 namespace hpx::actions {
 
-    template <typename Result, typename RemoteResult = Result>
+    HPX_CXX_EXPORT template <typename Result, typename RemoteResult = Result>
     struct typed_continuation;
 }    // namespace hpx::actions
 
@@ -16,7 +18,7 @@ namespace hpx::traits {
 
     ///////////////////////////////////////////////////////////////////////////
     // Trait to determine the continuation type for an action
-    template <typename Action, typename Enable = void>
+    HPX_CXX_EXPORT template <typename Action, typename Enable = void>
     struct action_continuation
     {
         using type =
@@ -24,6 +26,6 @@ namespace hpx::traits {
                 typename Action::remote_result_type>;
     };
 
-    template <typename Action>
+    HPX_CXX_EXPORT template <typename Action>
     using action_continuation_t = typename action_continuation<Action>::type;
 }    // namespace hpx::traits

--- a/libs/full/actions_base/include/hpx/actions_base/traits/action_decorate_continuation.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/traits/action_decorate_continuation.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2024 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -6,13 +6,14 @@
 
 #pragma once
 
+#include <hpx/config.hpp>
 #include <hpx/actions_base/traits/action_continuation.hpp>
 
 namespace hpx::traits {
 
     ///////////////////////////////////////////////////////////////////////////
     // Customization point for action capabilities
-    template <typename Action, typename Enable = void>
+    HPX_CXX_EXPORT template <typename Action, typename Enable = void>
     struct action_decorate_continuation
     {
         using continuation_type =

--- a/libs/full/actions_base/include/hpx/actions_base/traits/action_does_termination_detection.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/traits/action_does_termination_detection.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2024 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -6,11 +6,13 @@
 
 #pragma once
 
+#include <hpx/config.hpp>
+
 namespace hpx::traits {
 
     ///////////////////////////////////////////////////////////////////////////
     // Customization point for Action::does_termination_detection
-    template <typename Action, typename Enable = void>
+    HPX_CXX_EXPORT template <typename Action, typename Enable = void>
     struct action_does_termination_detection
     {
         static constexpr bool call() noexcept

--- a/libs/full/actions_base/include/hpx/actions_base/traits/action_is_target_valid.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/traits/action_is_target_valid.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2024 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <hpx/config.hpp>
 #include <hpx/modules/naming_base.hpp>
 #include <hpx/modules/type_support.hpp>
 
@@ -39,7 +40,7 @@ namespace hpx::traits {
         };
     }    // namespace detail
 
-    template <typename Action, typename Enable = void>
+    HPX_CXX_EXPORT template <typename Action, typename Enable = void>
     struct action_is_target_valid
     {
         static bool call(hpx::id_type const& id) noexcept

--- a/libs/full/actions_base/include/hpx/actions_base/traits/action_priority.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/traits/action_priority.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2024 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -6,20 +6,21 @@
 
 #pragma once
 
+#include <hpx/config.hpp>
 #include <hpx/modules/coroutines.hpp>
 
 namespace hpx::traits {
 
     ///////////////////////////////////////////////////////////////////////////
     // Customization point for action stack size
-    template <typename Action, typename Enable = void>
+    HPX_CXX_EXPORT template <typename Action, typename Enable = void>
     struct action_priority
     {
         static constexpr threads::thread_priority value =
             threads::thread_priority::default_;
     };
 
-    template <typename Action>
+    HPX_CXX_EXPORT template <typename Action>
     inline constexpr threads::thread_priority action_priority_v =
         action_priority<Action>::value;
 }    // namespace hpx::traits

--- a/libs/full/actions_base/include/hpx/actions_base/traits/action_remote_result.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/traits/action_remote_result.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2024 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //  Copyright (c)      2011 Thomas Heller
 //
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <hpx/config.hpp>
 #include <hpx/modules/type_support.hpp>
 
 namespace hpx::traits {
@@ -30,12 +31,12 @@ namespace hpx::traits {
     }    // namespace detail
     /// \endcond
 
-    template <typename Result>
+    HPX_CXX_EXPORT template <typename Result>
     struct action_remote_result
       : detail::action_remote_result_customization_point<Result>
     {
     };
 
-    template <typename Result>
+    HPX_CXX_EXPORT template <typename Result>
     using action_remote_result_t = typename action_remote_result<Result>::type;
 }    // namespace hpx::traits

--- a/libs/full/actions_base/include/hpx/actions_base/traits/action_schedule_thread.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/traits/action_schedule_thread.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2024 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <hpx/config.hpp>
 #include <hpx/modules/coroutines.hpp>
 #include <hpx/modules/naming_base.hpp>
 #include <hpx/modules/threading_base.hpp>
@@ -41,7 +42,7 @@ namespace hpx::traits {
         };
     }    // namespace detail
 
-    template <typename Action, typename Enable = void>
+    HPX_CXX_EXPORT template <typename Action, typename Enable = void>
     struct action_schedule_thread
     {
         static void call(naming::address_type lva,

--- a/libs/full/actions_base/include/hpx/actions_base/traits/action_select_direct_execution.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/traits/action_select_direct_execution.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2018-2024 Hartmut Kaiser
+//  Copyright (c) 2018-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <hpx/config.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/naming_base.hpp>
 #include <hpx/modules/type_support.hpp>
@@ -39,7 +40,7 @@ namespace hpx::traits {
         };
     }    // namespace detail
 
-    template <typename Action, typename Enable = void>
+    HPX_CXX_EXPORT template <typename Action, typename Enable = void>
     struct action_select_direct_execution
     {
         static constexpr launch call(launch policy, naming::address_type lva)

--- a/libs/full/actions_base/include/hpx/actions_base/traits/action_stacksize.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/traits/action_stacksize.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2024 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -6,20 +6,21 @@
 
 #pragma once
 
+#include <hpx/config.hpp>
 #include <hpx/modules/coroutines.hpp>
 
 namespace hpx::traits {
 
     ///////////////////////////////////////////////////////////////////////////
     // Customization point for action stack size
-    template <typename Action, typename Enable = void>
+    HPX_CXX_EXPORT template <typename Action, typename Enable = void>
     struct action_stacksize
     {
         static constexpr threads::thread_stacksize value =
             threads::thread_stacksize::default_;
     };
 
-    template <typename Action>
+    HPX_CXX_EXPORT template <typename Action>
     inline constexpr threads::thread_stacksize action_stacksize_v =
         action_stacksize<Action>::value;
 }    // namespace hpx::traits

--- a/libs/full/actions_base/include/hpx/actions_base/traits/action_trigger_continuation_fwd.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/traits/action_trigger_continuation_fwd.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2020-2024 Hartmut Kaiser
+//  Copyright (c) 2020-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -6,11 +6,13 @@
 
 #pragma once
 
+#include <hpx/config.hpp>
+
 namespace hpx::traits {
 
     ///////////////////////////////////////////////////////////////////////////
     // Trait to determine the continuation type for an action
-    template <typename Continuation, typename Enable = void>
+    HPX_CXX_EXPORT template <typename Continuation, typename Enable = void>
     struct action_trigger_continuation
     {
         template <typename F, typename... Ts>

--- a/libs/full/actions_base/include/hpx/actions_base/traits/action_was_object_migrated.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/traits/action_was_object_migrated.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2023 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -40,7 +40,7 @@ namespace hpx::traits {
 
     ///////////////////////////////////////////////////////////////////////////
     // Customization point for action capabilities
-    template <typename Action, typename Enable = void>
+    HPX_CXX_EXPORT template <typename Action, typename Enable = void>
     struct action_was_object_migrated
     {
         // returns whether target was migrated to another locality

--- a/libs/full/actions_base/include/hpx/actions_base/traits/extract_action.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/traits/extract_action.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2023 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -6,10 +6,12 @@
 
 #pragma once
 
+#include <hpx/config.hpp>
+
 namespace hpx::traits {
 
     // This template meta function can be used to extract the action type.
-    template <typename Action, typename Enable = void>
+    HPX_CXX_EXPORT template <typename Action, typename Enable = void>
     struct extract_action
     {
         using type = typename Action::derived_type;
@@ -18,6 +20,6 @@ namespace hpx::traits {
         using remote_result_type = typename type::remote_result_type;
     };
 
-    template <typename Action>
+    HPX_CXX_EXPORT template <typename Action>
     using extract_action_t = typename extract_action<Action>::type;
 }    // namespace hpx::traits

--- a/libs/full/actions_base/include/hpx/actions_base/traits/is_client.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/traits/is_client.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -6,36 +6,38 @@
 
 #pragma once
 
+#include <hpx/config.hpp>
+
 #include <cstddef>
 #include <type_traits>
 
 namespace hpx::traits {
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename T, typename Enable = void>
+    HPX_CXX_EXPORT template <typename T, typename Enable = void>
     struct is_client : std::false_type
     {
     };
 
-    template <typename T>
+    HPX_CXX_EXPORT template <typename T>
     inline constexpr bool is_client_v = is_client<T>::value;
 
-    template <typename T, typename Enable = void>
+    HPX_CXX_EXPORT template <typename T, typename Enable = void>
     struct is_client_or_client_array : is_client<T>
     {
     };
 
-    template <typename T>
+    HPX_CXX_EXPORT template <typename T>
     struct is_client_or_client_array<T[]> : is_client<T>
     {
     };
 
-    template <typename T, std::size_t N>
+    HPX_CXX_EXPORT template <typename T, std::size_t N>
     struct is_client_or_client_array<T[N]> : is_client<T>
     {
     };
 
-    template <typename T>
+    HPX_CXX_EXPORT template <typename T>
     inline constexpr bool is_client_or_client_array_v =
         is_client_or_client_array<T>::value;
 }    // namespace hpx::traits

--- a/libs/full/actions_base/include/hpx/actions_base/traits/is_continuation.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/traits/is_continuation.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2015 Thomas Heller
-//  Copyright (c) 2021-2024 Hartmut Kaiser
+//  Copyright (c) 2021-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -28,13 +28,13 @@ namespace hpx::traits {
         };
     }    // namespace detail
 
-    template <typename Continuation, typename Enable = void>
+    HPX_CXX_EXPORT template <typename Continuation, typename Enable = void>
     struct is_continuation
       : detail::is_continuation_impl<std::decay_t<Continuation>>
     {
     };
 
-    template <typename Continuation>
+    HPX_CXX_EXPORT template <typename Continuation>
     inline constexpr bool is_continuation_v =
         is_continuation<Continuation>::value;
 }    // namespace hpx::traits

--- a/libs/full/actions_base/include/hpx/actions_base/traits/is_distribution_policy.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/traits/is_distribution_policy.hpp
@@ -1,11 +1,13 @@
 //  Copyright (c) 2014 Bibek Ghimire
-//  Copyright (c) 2014-2024 Hartmut Kaiser
+//  Copyright (c) 2014-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #pragma once
+
+#include <hpx/config.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -14,18 +16,18 @@
 
 namespace hpx::traits {
 
-    template <typename T, typename Enable = void>
+    HPX_CXX_EXPORT template <typename T, typename Enable = void>
     struct is_distribution_policy : std::false_type
     {
     };
 
-    template <typename T>
+    HPX_CXX_EXPORT template <typename T>
     inline constexpr bool is_distribution_policy_v =
         is_distribution_policy<T>::value;
 
     // By default, the number of partitions is the same as the number of
     // localities represented by the given distribution policy.
-    template <typename Policy, typename Enable = void>
+    HPX_CXX_EXPORT template <typename Policy, typename Enable = void>
     struct num_container_partitions
     {
         static std::size_t call(Policy const& policy)
@@ -36,7 +38,7 @@ namespace hpx::traits {
 
     // By default, the sizes of the partitions are equal across the localities
     // represented by the given distribution policy.
-    template <typename Policy, typename Enable = void>
+    HPX_CXX_EXPORT template <typename Policy, typename Enable = void>
     struct container_partition_sizes
     {
         static std::vector<std::size_t> call(

--- a/libs/full/actions_base/include/hpx/actions_base/traits/is_valid_action.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/traits/is_valid_action.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2024 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -6,19 +6,22 @@
 
 #pragma once
 
+#include <hpx/config.hpp>
+
 #include <type_traits>
 
 namespace hpx::traits {
 
     // verify that given Action is actually supported by the given Component
-    template <typename Action, typename Component, typename Enable = void>
+    HPX_CXX_EXPORT template <typename Action, typename Component,
+        typename Enable = void>
     struct is_valid_action
       : std::is_same<std::decay_t<typename Action::component_type>,
             std::decay_t<Component>>
     {
     };
 
-    template <typename Action, typename Component>
+    HPX_CXX_EXPORT template <typename Action, typename Component>
     inline constexpr bool is_valid_action_v =
         is_valid_action<Action, Component>::value;
 }    // namespace hpx::traits

--- a/libs/full/agas/src/addressing_service.cpp
+++ b/libs/full/agas/src/addressing_service.cpp
@@ -8,12 +8,11 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/traits/action_priority.hpp>
-#include <hpx/actions_base/traits/action_was_object_migrated.hpp>
 #include <hpx/agas/addressing_service.hpp>
 #include <hpx/agas_base/detail/bootstrap_component_namespace.hpp>
 #include <hpx/agas_base/detail/bootstrap_locality_namespace.hpp>
 #include <hpx/assert.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/async_combinators.hpp>
 #include <hpx/modules/async_distributed.hpp>
@@ -25,6 +24,7 @@
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/lock_registration.hpp>
 #include <hpx/modules/logging.hpp>
+#include <hpx/modules/naming.hpp>
 #include <hpx/modules/runtime_configuration.hpp>
 #include <hpx/modules/runtime_local.hpp>
 #include <hpx/modules/serialization.hpp>
@@ -32,7 +32,6 @@
 #include <hpx/modules/thread_support.hpp>
 #include <hpx/modules/type_support.hpp>
 #include <hpx/modules/util.hpp>
-#include <hpx/naming/split_gid.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/libs/full/agas/src/route.cpp
+++ b/libs/full/agas/src/route.cpp
@@ -8,13 +8,13 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_NETWORKING)
-#include <hpx/actions_base/plain_action.hpp>
 #include <hpx/agas/addressing_service.hpp>
 #include <hpx/agas_base/route.hpp>
 #include <hpx/agas_base/server/primary_namespace.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/async_distributed/continuation.hpp>
 #include <hpx/async_distributed/detail/post.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/parcelset_base.hpp>

--- a/libs/full/agas_base/include/hpx/agas_base/gva.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/gva.hpp
@@ -14,6 +14,7 @@
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/naming.hpp>
 #include <hpx/modules/naming_base.hpp>
+#include <hpx/modules/serialization.hpp>
 
 #include <cstdint>
 #include <iosfwd>

--- a/libs/full/agas_base/include/hpx/agas_base/server/component_namespace.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/server/component_namespace.hpp
@@ -9,10 +9,10 @@
 
 #include <hpx/config.hpp>
 #include <hpx/actions/transfer_action.hpp>
-#include <hpx/actions_base/component_action.hpp>
 #include <hpx/agas_base/agas_fwd.hpp>
 #include <hpx/async_distributed/base_lco_with_value.hpp>
 #include <hpx/async_distributed/transfer_continuation_action.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/functional.hpp>

--- a/libs/full/agas_base/include/hpx/agas_base/server/locality_namespace.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/server/locality_namespace.hpp
@@ -10,10 +10,10 @@
 
 #include <hpx/config.hpp>
 #include <hpx/actions/transfer_action.hpp>
-#include <hpx/actions_base/component_action.hpp>
 #include <hpx/agas_base/agas_fwd.hpp>
 #include <hpx/async_distributed/base_lco_with_value.hpp>
 #include <hpx/async_distributed/transfer_continuation_action.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/naming_base.hpp>

--- a/libs/full/agas_base/include/hpx/agas_base/server/primary_namespace.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/server/primary_namespace.hpp
@@ -12,11 +12,11 @@
 
 #include <hpx/config.hpp>
 #include <hpx/actions/transfer_action.hpp>
-#include <hpx/actions_base/component_action.hpp>
 #include <hpx/agas_base/agas_fwd.hpp>
 #include <hpx/agas_base/gva.hpp>
 #include <hpx/async_distributed/base_lco_with_value.hpp>
 #include <hpx/async_distributed/transfer_continuation_action.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/allocator_support.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/datastructures.hpp>

--- a/libs/full/agas_base/include/hpx/agas_base/server/symbol_namespace.hpp
+++ b/libs/full/agas_base/include/hpx/agas_base/server/symbol_namespace.hpp
@@ -10,10 +10,10 @@
 
 #include <hpx/config.hpp>
 #include <hpx/actions/transfer_action.hpp>
-#include <hpx/actions_base/component_action.hpp>
 #include <hpx/agas_base/agas_fwd.hpp>
 #include <hpx/async_distributed/base_lco_with_value.hpp>
 #include <hpx/async_distributed/transfer_continuation_action.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/naming_base.hpp>

--- a/libs/full/agas_base/src/component_namespace.cpp
+++ b/libs/full/agas_base/src/component_namespace.cpp
@@ -6,12 +6,12 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/basic_action.hpp>
 #include <hpx/agas_base/component_namespace.hpp>
 #include <hpx/agas_base/server/component_namespace.hpp>
 #include <hpx/async_distributed/base_lco_with_value.hpp>
 #include <hpx/async_distributed/detail/post.hpp>
 #include <hpx/async_distributed/transfer_continuation_action.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/serialization.hpp>
 
 #include <hpx/config/warnings_prefix.hpp>

--- a/libs/full/agas_base/src/locality_namespace.cpp
+++ b/libs/full/agas_base/src/locality_namespace.cpp
@@ -7,10 +7,10 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/component_action.hpp>
 #include <hpx/agas_base/locality_namespace.hpp>
 #include <hpx/agas_base/server/locality_namespace.hpp>
 #include <hpx/async_distributed/base_lco_with_value.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/serialization.hpp>
 
 #include <hpx/config/warnings_prefix.hpp>

--- a/libs/full/agas_base/src/server/component_namespace_server.cpp
+++ b/libs/full/agas_base/src/server/component_namespace_server.cpp
@@ -14,9 +14,9 @@
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/format.hpp>
+#include <hpx/modules/naming.hpp>
 #include <hpx/modules/timing.hpp>
 #include <hpx/modules/util.hpp>
-#include <hpx/naming/credit_handling.hpp>
 
 #include <atomic>
 #include <cstddef>

--- a/libs/full/agas_base/src/server/locality_namespace_server.cpp
+++ b/libs/full/agas_base/src/server/locality_namespace_server.cpp
@@ -15,10 +15,10 @@
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/modules/logging.hpp>
+#include <hpx/modules/naming.hpp>
 #include <hpx/modules/serialization.hpp>
 #include <hpx/modules/timing.hpp>
 #include <hpx/modules/util.hpp>
-#include <hpx/naming/credit_handling.hpp>
 
 #include <atomic>
 #include <cstddef>

--- a/libs/full/agas_base/src/server/symbol_namespace_server.cpp
+++ b/libs/full/agas_base/src/server/symbol_namespace_server.cpp
@@ -11,11 +11,10 @@
 #include <hpx/assert.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/format.hpp>
+#include <hpx/modules/naming.hpp>
 #include <hpx/modules/thread_support.hpp>
 #include <hpx/modules/timing.hpp>
 #include <hpx/modules/util.hpp>
-#include <hpx/naming/credit_handling.hpp>
-#include <hpx/naming/split_gid.hpp>
 
 #include <atomic>
 #include <cstdint>

--- a/libs/full/agas_base/src/symbol_namespace.cpp
+++ b/libs/full/agas_base/src/symbol_namespace.cpp
@@ -9,11 +9,11 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/component_action.hpp>
 #include <hpx/agas_base/server/symbol_namespace.hpp>
 #include <hpx/agas_base/symbol_namespace.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/async_distributed/base_lco_with_value.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/errors.hpp>

--- a/libs/full/async_colocated/include/hpx/async_colocated/async_colocated.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/async_colocated.hpp
@@ -7,9 +7,6 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/actions_base_support.hpp>
-#include <hpx/actions_base/traits/extract_action.hpp>
-#include <hpx/actions_base/traits/is_continuation.hpp>
 #include <hpx/agas_base/primary_namespace.hpp>
 #include <hpx/agas_base/server/primary_namespace.hpp>
 #include <hpx/assert.hpp>
@@ -17,6 +14,7 @@
 #include <hpx/async_colocated/functional/colocated_helpers.hpp>
 #include <hpx/async_distributed/async_continue_fwd.hpp>
 #include <hpx/async_distributed/bind_action.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_local.hpp>
 #include <hpx/modules/datastructures.hpp>
 #include <hpx/modules/functional.hpp>

--- a/libs/full/async_colocated/include/hpx/async_colocated/async_colocated_callback.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/async_colocated_callback.hpp
@@ -6,13 +6,13 @@
 
 #pragma once
 
-#include <hpx/actions_base/traits/extract_action.hpp>
 #include <hpx/agas_base/primary_namespace.hpp>
 #include <hpx/agas_base/server/primary_namespace.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/async_colocated/async_colocated.hpp>
 #include <hpx/async_colocated/async_colocated_callback_fwd.hpp>
 #include <hpx/async_distributed/async_continue_callback.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/futures.hpp>
 
 #include <utility>

--- a/libs/full/async_colocated/include/hpx/async_colocated/async_colocated_callback_fwd.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/async_colocated_callback_fwd.hpp
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include <hpx/actions_base/traits/extract_action.hpp>
 #include <hpx/async_colocated/async_colocated_fwd.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/futures.hpp>
 
 namespace hpx { namespace detail {

--- a/libs/full/async_colocated/include/hpx/async_colocated/async_colocated_fwd.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/async_colocated_fwd.hpp
@@ -7,9 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/basic_action_fwd.hpp>
-#include <hpx/actions_base/traits/extract_action.hpp>
-#include <hpx/actions_base/traits/is_continuation.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_local.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/naming_base.hpp>

--- a/libs/full/async_colocated/include/hpx/async_colocated/post_colocated.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/post_colocated.hpp
@@ -9,8 +9,6 @@
 #include <hpx/config.hpp>
 
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
-#include <hpx/actions_base/actions_base_support.hpp>
-#include <hpx/actions_base/traits/is_continuation.hpp>
 #include <hpx/agas_base/primary_namespace.hpp>
 #include <hpx/agas_base/server/primary_namespace.hpp>
 #include <hpx/async_colocated/functional/colocated_helpers.hpp>
@@ -18,6 +16,7 @@
 #include <hpx/async_colocated/register_post_colocated.hpp>
 #include <hpx/async_distributed/bind_action.hpp>
 #include <hpx/async_distributed/detail/post_continue.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/functional.hpp>
 
 #include <type_traits>

--- a/libs/full/async_colocated/include/hpx/async_colocated/post_colocated_callback.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/post_colocated_callback.hpp
@@ -9,8 +9,6 @@
 #include <hpx/config.hpp>
 
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
-#include <hpx/actions_base/actions_base_support.hpp>
-#include <hpx/actions_base/traits/action_priority.hpp>
 #include <hpx/agas_base/primary_namespace.hpp>
 #include <hpx/agas_base/server/primary_namespace.hpp>
 #include <hpx/async_colocated/functional/colocated_helpers.hpp>
@@ -18,6 +16,7 @@
 #include <hpx/async_colocated/register_post_colocated.hpp>
 #include <hpx/async_distributed/bind_action.hpp>
 #include <hpx/async_distributed/detail/post_continue_callback.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/functional.hpp>
 

--- a/libs/full/async_colocated/include/hpx/async_colocated/post_colocated_callback_fwd.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/post_colocated_callback_fwd.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/actions_base_support.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/naming_base.hpp>
 
 namespace hpx { namespace detail {

--- a/libs/full/async_colocated/include/hpx/async_colocated/post_colocated_fwd.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/post_colocated_fwd.hpp
@@ -7,8 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/actions_base_support.hpp>
-#include <hpx/actions_base/traits/is_continuation.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/naming_base.hpp>
 
 #include <type_traits>

--- a/libs/full/async_colocated/src/server/destroy_component.cpp
+++ b/libs/full/async_colocated/src/server/destroy_component.cpp
@@ -5,9 +5,9 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/plain_action.hpp>
 #include <hpx/async_colocated/get_colocation_id.hpp>
 #include <hpx/async_colocated/server/destroy_component.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/logging.hpp>

--- a/libs/full/async_distributed/include/hpx/async_distributed/async.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/async.hpp
@@ -37,15 +37,12 @@ namespace hpx {
 #else
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/traits/extract_action.hpp>
-#include <hpx/actions_base/traits/is_client.hpp>
-#include <hpx/actions_base/traits/is_distribution_policy.hpp>
-#include <hpx/actions_base/traits/is_valid_action.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/async_distributed/async_continue.hpp>
 #include <hpx/async_distributed/bind_action.hpp>
 #include <hpx/async_distributed/detail/async_implementations.hpp>
 #include <hpx/components/client_base.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/async_local.hpp>
 #include <hpx/modules/execution.hpp>

--- a/libs/full/async_distributed/include/hpx/async_distributed/async_callback.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/async_callback.hpp
@@ -7,13 +7,10 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/traits/extract_action.hpp>
-#include <hpx/actions_base/traits/is_client.hpp>
-#include <hpx/actions_base/traits/is_distribution_policy.hpp>
-#include <hpx/actions_base/traits/is_valid_action.hpp>
 #include <hpx/async_distributed/async_callback_fwd.hpp>
 #include <hpx/async_distributed/detail/async_implementations_fwd.hpp>
 #include <hpx/components/client_base.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/futures.hpp>

--- a/libs/full/async_distributed/include/hpx/async_distributed/async_callback_fwd.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/async_callback_fwd.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/basic_action_fwd.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/async_local.hpp>
 #include <hpx/modules/futures.hpp>

--- a/libs/full/async_distributed/include/hpx/async_distributed/async_continue.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/async_continue.hpp
@@ -9,11 +9,9 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/actions_base_support.hpp>
-#include <hpx/actions_base/traits/extract_action.hpp>
-#include <hpx/actions_base/traits/is_distribution_policy.hpp>
 #include <hpx/async_distributed/async_continue_fwd.hpp>
 #include <hpx/async_distributed/promise.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_local.hpp>
 #include <hpx/modules/futures.hpp>
 

--- a/libs/full/async_distributed/include/hpx/async_distributed/async_continue_callback.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/async_continue_callback.hpp
@@ -8,11 +8,10 @@
 
 #pragma once
 
-#include <hpx/actions_base/traits/extract_action.hpp>
-#include <hpx/actions_base/traits/is_distribution_policy.hpp>
 #include <hpx/async_distributed/async_callback_fwd.hpp>
 #include <hpx/async_distributed/async_continue.hpp>
 #include <hpx/async_distributed/detail/post_callback.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/futures.hpp>
 
 #include <type_traits>

--- a/libs/full/async_distributed/include/hpx/async_distributed/async_continue_callback_fwd.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/async_continue_callback_fwd.hpp
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include <hpx/actions_base/traits/is_distribution_policy.hpp>
 #include <hpx/async_distributed/async_continue_fwd.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/futures.hpp>
 
 #ifndef HPX_MSVC

--- a/libs/full/async_distributed/include/hpx/async_distributed/async_continue_fwd.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/async_continue_fwd.hpp
@@ -9,10 +9,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/basic_action_fwd.hpp>
-#include <hpx/actions_base/traits/action_remote_result.hpp>
-#include <hpx/actions_base/traits/extract_action.hpp>
-#include <hpx/actions_base/traits/is_distribution_policy.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/async_local.hpp>
 #include <hpx/modules/futures.hpp>

--- a/libs/full/async_distributed/include/hpx/async_distributed/base_lco.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/base_lco.hpp
@@ -8,10 +8,9 @@
 
 #include <hpx/config.hpp>
 #include <hpx/actions/transfer_action.hpp>
-#include <hpx/actions_base/actions_base_support.hpp>
-#include <hpx/actions_base/component_action.hpp>
 #include <hpx/async_distributed/lcos_fwd.hpp>
 #include <hpx/async_distributed/transfer_continuation_action.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/naming_base.hpp>
 #include <hpx/parcelset/coalescing_message_handler_registration.hpp>

--- a/libs/full/async_distributed/include/hpx/async_distributed/base_lco_with_value.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/base_lco_with_value.hpp
@@ -9,11 +9,11 @@
 
 #include <hpx/config.hpp>
 #include <hpx/actions/transfer_action.hpp>
-#include <hpx/actions_base/component_action.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/async_distributed/base_lco.hpp>
 #include <hpx/async_distributed/lcos_fwd.hpp>
 #include <hpx/async_distributed/transfer_continuation_action.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/ini.hpp>

--- a/libs/full/async_distributed/include/hpx/async_distributed/bind_action.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/bind_action.hpp
@@ -9,9 +9,8 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/traits/extract_action.hpp>
-#include <hpx/actions_base/traits/is_continuation.hpp>
 #include <hpx/async_distributed/detail/post.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_local.hpp>
 #include <hpx/modules/datastructures.hpp>
 #include <hpx/modules/functional.hpp>

--- a/libs/full/async_distributed/include/hpx/async_distributed/continuation.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/continuation.hpp
@@ -8,13 +8,9 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/action_priority.hpp>
-#include <hpx/actions_base/basic_action_fwd.hpp>
-#include <hpx/actions_base/traits/action_continuation.hpp>
-#include <hpx/actions_base/traits/action_remote_result.hpp>
-#include <hpx/actions_base/traits/is_continuation.hpp>
 #include <hpx/async_distributed/continuation_fwd.hpp>
 #include <hpx/async_distributed/trigger_lco_fwd.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/functional.hpp>

--- a/libs/full/async_distributed/include/hpx/async_distributed/continuation_fwd.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/continuation_fwd.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/traits/action_continuation.hpp>
+#include <hpx/modules/actions_base.hpp>
 
 namespace hpx { namespace actions {
 

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/async_implementations.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/async_implementations.hpp
@@ -7,12 +7,10 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/traits/action_select_direct_execution.hpp>
-#include <hpx/actions_base/traits/action_was_object_migrated.hpp>
-#include <hpx/actions_base/traits/extract_action.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/async_distributed/detail/async_implementations_fwd.hpp>
 #include <hpx/async_distributed/packaged_action.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/allocator_support.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/components_base.hpp>

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/async_implementations_fwd.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/async_implementations_fwd.hpp
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <hpx/actions_base/traits/extract_action.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/async_local.hpp>
 #include <hpx/modules/futures.hpp>

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/async_unwrap_result_implementations.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/async_unwrap_result_implementations.hpp
@@ -7,13 +7,11 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/traits/action_select_direct_execution.hpp>
-#include <hpx/actions_base/traits/action_was_object_migrated.hpp>
-#include <hpx/actions_base/traits/extract_action.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/async_distributed/detail/async_implementations.hpp>
 #include <hpx/async_distributed/detail/async_unwrap_result_implementations_fwd.hpp>
 #include <hpx/async_distributed/detail/sync_implementations.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/naming_base.hpp>

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/async_unwrap_result_implementations_fwd.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/async_unwrap_result_implementations_fwd.hpp
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <hpx/actions_base/traits/extract_action.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_local.hpp>
 #include <hpx/modules/naming_base.hpp>
 

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/post.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/post.hpp
@@ -9,18 +9,12 @@
 
 #include <hpx/config.hpp>
 #include <hpx/actions/post_helper.hpp>
-#include <hpx/actions_base/action_priority.hpp>
-#include <hpx/actions_base/action_stacksize.hpp>
-#include <hpx/actions_base/actions_base_support.hpp>
-#include <hpx/actions_base/traits/extract_action.hpp>
-#include <hpx/actions_base/traits/is_continuation.hpp>
-#include <hpx/actions_base/traits/is_distribution_policy.hpp>
-#include <hpx/actions_base/traits/is_valid_action.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/async_distributed/continuation.hpp>
 #include <hpx/async_distributed/detail/post_implementations_fwd.hpp>
 #include <hpx/async_distributed/put_parcel_fwd.hpp>
 #include <hpx/components/client_base.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/async_local.hpp>
 #include <hpx/modules/components_base.hpp>

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/post_callback.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/post_callback.hpp
@@ -7,13 +7,8 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/traits/action_is_target_valid.hpp>
-#include <hpx/actions_base/traits/action_priority.hpp>
-#include <hpx/actions_base/traits/action_stacksize.hpp>
-#include <hpx/actions_base/traits/extract_action.hpp>
-#include <hpx/actions_base/traits/is_continuation.hpp>
-#include <hpx/actions_base/traits/is_distribution_policy.hpp>
 #include <hpx/async_distributed/detail/post.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/datastructures.hpp>

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/post_continue.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/post_continue.hpp
@@ -8,11 +8,10 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/actions_base_support.hpp>
-#include <hpx/actions_base/traits/extract_action.hpp>
 #include <hpx/async_distributed/detail/post.hpp>
 #include <hpx/async_distributed/detail/post_continue_fwd.hpp>
 #include <hpx/async_distributed/make_continuation.hpp>
+#include <hpx/modules/actions_base.hpp>
 
 #include <utility>
 

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/post_continue_callback.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/post_continue_callback.hpp
@@ -8,11 +8,10 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/actions_base_support.hpp>
-#include <hpx/actions_base/traits/extract_action.hpp>
 #include <hpx/async_distributed/detail/post.hpp>
 #include <hpx/async_distributed/detail/post_callback.hpp>
 #include <hpx/async_distributed/make_continuation.hpp>
+#include <hpx/modules/actions_base.hpp>
 
 #include <utility>
 

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/post_continue_fwd.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/post_continue_fwd.hpp
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <hpx/actions_base/actions_base_fwd.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/naming_base.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/post_implementations.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/post_implementations.hpp
@@ -7,11 +7,9 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/traits/action_is_target_valid.hpp>
-#include <hpx/actions_base/traits/action_was_object_migrated.hpp>
-#include <hpx/actions_base/traits/is_continuation.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/async_distributed/detail/post_implementations_fwd.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/naming_base.hpp>

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/post_implementations_fwd.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/post_implementations_fwd.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/traits/is_continuation.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/coroutines.hpp>

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/sync_implementations.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/sync_implementations.hpp
@@ -7,11 +7,9 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/traits/action_select_direct_execution.hpp>
-#include <hpx/actions_base/traits/action_was_object_migrated.hpp>
-#include <hpx/actions_base/traits/extract_action.hpp>
 #include <hpx/async_distributed/detail/async_implementations.hpp>
 #include <hpx/async_distributed/detail/sync_implementations_fwd.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/async_local.hpp>
 #include <hpx/modules/components_base.hpp>

--- a/libs/full/async_distributed/include/hpx/async_distributed/detail/sync_implementations_fwd.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/detail/sync_implementations_fwd.hpp
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <hpx/actions_base/traits/extract_action.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_local.hpp>
 #include <hpx/modules/naming_base.hpp>
 

--- a/libs/full/async_distributed/include/hpx/async_distributed/packaged_action.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/packaged_action.hpp
@@ -8,14 +8,12 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/traits/action_priority.hpp>
-#include <hpx/actions_base/traits/action_was_object_migrated.hpp>
-#include <hpx/actions_base/traits/extract_action.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/async_distributed/detail/post.hpp>
 #include <hpx/async_distributed/detail/post_callback.hpp>
 #include <hpx/async_distributed/detail/post_implementations_fwd.hpp>
 #include <hpx/async_distributed/promise.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/allocator_support.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/errors.hpp>

--- a/libs/full/async_distributed/include/hpx/async_distributed/put_parcel.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/put_parcel.hpp
@@ -11,19 +11,18 @@
 
 #if defined(HPX_HAVE_NETWORKING)
 #include <hpx/assert.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/errors.hpp>
+#include <hpx/modules/functional.hpp>
+#include <hpx/modules/naming.hpp>
+#include <hpx/modules/naming_base.hpp>
+#include <hpx/modules/runtime_local.hpp>
 #include <hpx/modules/type_support.hpp>
 
 #include <hpx/actions/actions_fwd.hpp>
 #include <hpx/actions/transfer_action.hpp>
-#include <hpx/actions_base/traits/is_continuation.hpp>
 #include <hpx/async_distributed/put_parcel_fwd.hpp>
 #include <hpx/async_distributed/transfer_continuation_action.hpp>
-#include <hpx/modules/functional.hpp>
-#include <hpx/modules/naming_base.hpp>
-#include <hpx/modules/runtime_local.hpp>
-#include <hpx/naming/credit_handling.hpp>
-#include <hpx/naming/split_gid.hpp>
 #include <hpx/parcelset/parcel.hpp>
 #include <hpx/parcelset/parcelhandler.hpp>
 #include <hpx/parcelset/parcelset_fwd.hpp>

--- a/libs/full/async_distributed/include/hpx/async_distributed/put_parcel_fwd.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/put_parcel_fwd.hpp
@@ -9,7 +9,7 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_NETWORKING)
-#include <hpx/actions_base/actions_base_fwd.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/naming_base.hpp>
 #include <hpx/parcelset/parcel.hpp>

--- a/libs/full/async_distributed/include/hpx/async_distributed/sync.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/sync.hpp
@@ -37,14 +37,12 @@ namespace hpx {
 #else
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/traits/extract_action.hpp>
-#include <hpx/actions_base/traits/is_client.hpp>
-#include <hpx/actions_base/traits/is_valid_action.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/async_distributed/bind_action.hpp>
 #include <hpx/async_distributed/detail/sync_implementations.hpp>
 #include <hpx/async_distributed/sync.hpp>
 #include <hpx/components/client_base.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/async_local.hpp>
 #include <hpx/modules/execution.hpp>

--- a/libs/full/async_distributed/include/hpx/async_distributed/traits/action_trigger_continuation.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/traits/action_trigger_continuation.hpp
@@ -6,9 +6,9 @@
 
 #pragma once
 
-#include <hpx/actions_base/traits/action_trigger_continuation_fwd.hpp>
 #include <hpx/async_distributed/continuation_fwd.hpp>
 #include <hpx/async_distributed/trigger.hpp>
+#include <hpx/modules/actions_base.hpp>
 
 #include <utility>
 

--- a/libs/full/async_distributed/include/hpx/async_distributed/transfer_continuation_action.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/transfer_continuation_action.hpp
@@ -16,9 +16,9 @@
 #include <hpx/actions/post_helper.hpp>
 #include <hpx/actions/register_action.hpp>
 #include <hpx/actions/transfer_base_action.hpp>
-#include <hpx/actions_base/actions_base_support.hpp>
 #include <hpx/async_distributed/continuation.hpp>
 #include <hpx/async_distributed/traits/action_trigger_continuation.hpp>
+#include <hpx/modules/actions_base.hpp>
 
 #if defined(HPX_HAVE_NETWORKING)
 #include <hpx/modules/async_base.hpp>

--- a/libs/full/async_distributed/include/hpx/async_distributed/trigger_lco.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/trigger_lco.hpp
@@ -10,14 +10,13 @@
 
 #include <hpx/config.hpp>
 #include <hpx/actions/actions_fwd.hpp>
-#include <hpx/actions_base/action_priority.hpp>
-#include <hpx/actions_base/action_stacksize.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/async_distributed/continuation_fwd.hpp>
 #include <hpx/async_distributed/detail/post_continue_fwd.hpp>
 #include <hpx/async_distributed/detail/post_implementations_fwd.hpp>
 #include <hpx/async_distributed/lcos_fwd.hpp>
 #include <hpx/async_distributed/trigger_lco_fwd.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/naming_base.hpp>
 

--- a/libs/full/async_distributed/src/base_lco.cpp
+++ b/libs/full/async_distributed/src/base_lco.cpp
@@ -6,9 +6,9 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/actions/transfer_action.hpp>
-#include <hpx/actions_base/basic_action.hpp>
 #include <hpx/async_distributed/base_lco.hpp>
 #include <hpx/async_distributed/transfer_continuation_action.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/naming_base.hpp>
 

--- a/libs/full/async_distributed/src/continuation.cpp
+++ b/libs/full/async_distributed/src/continuation.cpp
@@ -7,13 +7,12 @@
 
 #include <hpx/config.hpp>
 #include <hpx/actions/transfer_action.hpp>
-#include <hpx/actions_base/traits/action_priority.hpp>
-#include <hpx/actions_base/traits/extract_action.hpp>
 #include <hpx/async_distributed/continuation.hpp>
 #include <hpx/async_distributed/transfer_continuation_action.hpp>
 #include <hpx/async_distributed/trigger_lco.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/errors.hpp>
-#include <hpx/naming/credit_handling.hpp>
+#include <hpx/modules/naming.hpp>
 
 #include <exception>
 #include <utility>

--- a/libs/full/checkpoint/include/hpx/checkpoint/checkpoint.hpp
+++ b/libs/full/checkpoint/include/hpx/checkpoint/checkpoint.hpp
@@ -15,10 +15,10 @@
 
 #pragma once
 
-#include <hpx/actions_base/traits/is_client.hpp>
 #include <hpx/async_distributed/dataflow.hpp>
 #include <hpx/components/client_base.hpp>
 #include <hpx/components/get_ptr.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/checkpoint_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/futures.hpp>

--- a/libs/full/collectives/include/hpx/collectives/broadcast_direct.hpp
+++ b/libs/full/collectives/include/hpx/collectives/broadcast_direct.hpp
@@ -129,13 +129,12 @@ namespace hpx { namespace lcos {
 #include <hpx/config.hpp>
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/actions/transfer_action.hpp>
-#include <hpx/actions_base/plain_action.hpp>
-#include <hpx/actions_base/traits/extract_action.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/async_colocated/async_colocated.hpp>
 #include <hpx/async_colocated/post_colocated.hpp>
 #include <hpx/async_distributed/post.hpp>
 #include <hpx/async_distributed/transfer_continuation_action.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_combinators.hpp>
 #include <hpx/modules/datastructures.hpp>
 #include <hpx/modules/errors.hpp>

--- a/libs/full/collectives/include/hpx/collectives/detail/barrier_node.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/barrier_node.hpp
@@ -8,10 +8,10 @@
 
 #include <hpx/config.hpp>
 #include <hpx/actions/transfer_action.hpp>
-#include <hpx/actions_base/component_action.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/async_distributed/base_lco.hpp>
 #include <hpx/async_distributed/transfer_continuation_action.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/naming_base.hpp>

--- a/libs/full/collectives/include/hpx/collectives/detail/channel_communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/channel_communicator.hpp
@@ -10,9 +10,9 @@
 
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 
-#include <hpx/actions_base/component_action.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/components/client.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/datastructures.hpp>
 #include <hpx/modules/futures.hpp>

--- a/libs/full/collectives/include/hpx/collectives/detail/communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/communicator.hpp
@@ -10,7 +10,7 @@
 
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 
-#include <hpx/actions_base/component_action.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/datastructures.hpp>

--- a/libs/full/collectives/include/hpx/collectives/detail/latch.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/latch.hpp
@@ -8,9 +8,9 @@
 
 #include <hpx/config.hpp>
 #include <hpx/actions/transfer_action.hpp>
-#include <hpx/actions_base/component_action.hpp>
 #include <hpx/async_distributed/base_lco_with_value.hpp>
 #include <hpx/async_distributed/transfer_continuation_action.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/runtime_local.hpp>

--- a/libs/full/collectives/include/hpx/collectives/fold.hpp
+++ b/libs/full/collectives/include/hpx/collectives/fold.hpp
@@ -159,11 +159,10 @@ namespace hpx { namespace lcos {
 
 #include <hpx/config.hpp>
 #include <hpx/actions/transfer_action.hpp>
-#include <hpx/actions_base/actions_base_support.hpp>
-#include <hpx/actions_base/traits/extract_action.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/async_colocated/async_colocated.hpp>
 #include <hpx/async_distributed/transfer_continuation_action.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_combinators.hpp>
 #include <hpx/modules/datastructures.hpp>
 #include <hpx/modules/futures.hpp>

--- a/libs/full/collectives/include/hpx/collectives/reduce_direct.hpp
+++ b/libs/full/collectives/include/hpx/collectives/reduce_direct.hpp
@@ -75,11 +75,10 @@ namespace hpx { namespace lcos {
 
 #include <hpx/config.hpp>
 #include <hpx/actions/transfer_action.hpp>
-#include <hpx/actions_base/actions_base_support.hpp>
-#include <hpx/actions_base/traits/extract_action.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/async_colocated/async_colocated.hpp>
 #include <hpx/async_distributed/transfer_continuation_action.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_combinators.hpp>
 #include <hpx/modules/datastructures.hpp>
 #include <hpx/modules/futures.hpp>

--- a/libs/full/collectives/include/hpx/collectives/spmd_block.hpp
+++ b/libs/full/collectives/include/hpx/collectives/spmd_block.hpp
@@ -8,9 +8,9 @@
 
 #include <hpx/config.hpp>
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
-#include <hpx/actions_base/plain_action.hpp>
 #include <hpx/collectives/barrier.hpp>
 #include <hpx/collectives/broadcast_direct.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/concepts.hpp>

--- a/libs/full/collectives/src/latch.cpp
+++ b/libs/full/collectives/src/latch.cpp
@@ -5,12 +5,12 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/actions/transfer_action.hpp>
-#include <hpx/actions_base/detail/action_factory.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/async_distributed/continuation.hpp>
 #include <hpx/async_distributed/transfer_continuation_action.hpp>
 #include <hpx/collectives/latch.hpp>
 #include <hpx/components/client_base.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/runtime_local.hpp>

--- a/libs/full/components/include/hpx/components/client_base.hpp
+++ b/libs/full/components/include/hpx/components/client_base.hpp
@@ -11,10 +11,10 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/traits/is_client.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/components/basename_registration.hpp>
 #include <hpx/components/components_fwd.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/errors.hpp>

--- a/libs/full/components/include/hpx/components/make_client.hpp
+++ b/libs/full/components/include/hpx/components/make_client.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/traits/is_client.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/naming_base.hpp>
 

--- a/libs/full/components_base/include/hpx/components_base/agas_interface.hpp
+++ b/libs/full/components_base/include/hpx/components_base/agas_interface.hpp
@@ -30,7 +30,8 @@
 // FIXME: this is pulled from the main library
 namespace hpx::detail {
 
-    HPX_EXPORT naming::gid_type get_next_id(std::size_t count = 1);
+    HPX_CXX_EXPORT HPX_EXPORT naming::gid_type get_next_id(
+        std::size_t count = 1);
 }    // namespace hpx::detail
 
 namespace hpx::agas {

--- a/libs/full/compute/include/hpx/compute/host/target_distribution_policy.hpp
+++ b/libs/full/compute/include/hpx/compute/host/target_distribution_policy.hpp
@@ -15,9 +15,9 @@
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/modules/async_local.hpp>
 #endif
-#include <hpx/actions_base/traits/is_distribution_policy.hpp>
 #include <hpx/compute/detail/target_distribution_policy.hpp>
 #include <hpx/compute/host/distributed_target.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/serialization.hpp>
 #include <hpx/runtime_components/create_component_helpers.hpp>

--- a/libs/full/compute/src/get_host_targets.cpp
+++ b/libs/full/compute/src/get_host_targets.cpp
@@ -7,9 +7,9 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
-#include <hpx/actions_base/plain_action.hpp>
 #include <hpx/compute/host/distributed_target.hpp>
 #include <hpx/compute/host/get_targets.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/naming_base.hpp>

--- a/libs/full/distribution_policies/include/hpx/distribution_policies/binpacking_distribution_policy.hpp
+++ b/libs/full/distribution_policies/include/hpx/distribution_policies/binpacking_distribution_policy.hpp
@@ -9,9 +9,9 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/traits/is_distribution_policy.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/async_distributed/dataflow.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/futures.hpp>

--- a/libs/full/distribution_policies/include/hpx/distribution_policies/colocating_distribution_policy.hpp
+++ b/libs/full/distribution_policies/include/hpx/distribution_policies/colocating_distribution_policy.hpp
@@ -9,8 +9,6 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/traits/extract_action.hpp>
-#include <hpx/actions_base/traits/is_distribution_policy.hpp>
 #include <hpx/async_colocated/async_colocated.hpp>
 #include <hpx/async_colocated/async_colocated_callback.hpp>
 #include <hpx/async_colocated/post_colocated_callback_fwd.hpp>
@@ -18,6 +16,7 @@
 #include <hpx/async_distributed/detail/async_implementations.hpp>
 #include <hpx/async_distributed/detail/post.hpp>
 #include <hpx/components/client_base.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/futures.hpp>

--- a/libs/full/distribution_policies/include/hpx/distribution_policies/container_distribution_policy.hpp
+++ b/libs/full/distribution_policies/include/hpx/distribution_policies/container_distribution_policy.hpp
@@ -8,9 +8,9 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/traits/is_distribution_policy.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/distribution_policies/default_distribution_policy.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/serialization.hpp>
 

--- a/libs/full/distribution_policies/include/hpx/distribution_policies/default_distribution_policy.hpp
+++ b/libs/full/distribution_policies/include/hpx/distribution_policies/default_distribution_policy.hpp
@@ -9,12 +9,10 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/actions_base_support.hpp>
-#include <hpx/actions_base/traits/extract_action.hpp>
-#include <hpx/actions_base/traits/is_distribution_policy.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/async_distributed/dataflow.hpp>
 #include <hpx/async_distributed/detail/post.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/errors.hpp>

--- a/libs/full/distribution_policies/include/hpx/distribution_policies/explicit_container_distribution_policy.hpp
+++ b/libs/full/distribution_policies/include/hpx/distribution_policies/explicit_container_distribution_policy.hpp
@@ -7,9 +7,9 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/traits/is_distribution_policy.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/distribution_policies/default_distribution_policy.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/serialization.hpp>
 

--- a/libs/full/distribution_policies/include/hpx/distribution_policies/target_distribution_policy.hpp
+++ b/libs/full/distribution_policies/include/hpx/distribution_policies/target_distribution_policy.hpp
@@ -9,12 +9,10 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/actions_base_support.hpp>
-#include <hpx/actions_base/traits/extract_action.hpp>
-#include <hpx/actions_base/traits/is_distribution_policy.hpp>
 #include <hpx/async_distributed/dataflow.hpp>
 #include <hpx/async_distributed/detail/async_implementations_fwd.hpp>
 #include <hpx/async_distributed/detail/post_implementations_fwd.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/futures.hpp>

--- a/libs/full/distribution_policies/include/hpx/distribution_policies/unwrapping_result_policy.hpp
+++ b/libs/full/distribution_policies/include/hpx/distribution_policies/unwrapping_result_policy.hpp
@@ -9,13 +9,12 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/traits/extract_action.hpp>
-#include <hpx/actions_base/traits/is_distribution_policy.hpp>
 #include <hpx/async_distributed/detail/async_implementations.hpp>
 #include <hpx/async_distributed/detail/async_unwrap_result_implementations.hpp>
 #include <hpx/async_distributed/detail/post_implementations_fwd.hpp>
 #include <hpx/async_distributed/detail/sync_implementations.hpp>
 #include <hpx/components/client_base.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/naming_base.hpp>

--- a/libs/full/executors_distributed/CMakeLists.txt
+++ b/libs/full/executors_distributed/CMakeLists.txt
@@ -27,6 +27,6 @@ add_hpx_module(
   HEADERS ${executors_distributed_headers}
   COMPAT_HEADERS ${executors_distributed_compat_headers}
   DEPENDENCIES hpx_core
-  MODULE_DEPENDENCIES hpx_async_distributed
+  MODULE_DEPENDENCIES hpx_actions_base hpx_async_distributed
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/full/executors_distributed/include/hpx/executors_distributed/distribution_policy_executor.hpp
+++ b/libs/full/executors_distributed/include/hpx/executors_distributed/distribution_policy_executor.hpp
@@ -10,8 +10,8 @@
 
 #include <hpx/config.hpp>
 #include <hpx/actions/invoke_function.hpp>
-#include <hpx/actions_base/traits/is_distribution_policy.hpp>
 #include <hpx/async_distributed/async.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/execution_base.hpp>
 #include <hpx/modules/functional.hpp>

--- a/libs/full/include/CMakeLists.txt
+++ b/libs/full/include/CMakeLists.txt
@@ -107,6 +107,7 @@ set(include_headers
 
 if(HPX_WITH_DISTRIBUTED_RUNTIME)
   set(include_optional_module_dependencies
+      hpx_actions_base
       hpx_agas
       hpx_async_colocated
       hpx_async_distributed
@@ -119,10 +120,13 @@ if(HPX_WITH_DISTRIBUTED_RUNTIME)
   )
 endif()
 
+set(include_sources sandbox.cpp)
+
 include(HPX_AddModule)
 add_hpx_module(
   full include
   GLOBAL_HEADER_GEN OFF
+  SOURCES ${include_sources}
   HEADERS ${include_headers}
   DEPENDENCIES hpx_core
   MODULE_DEPENDENCIES hpx_command_line_handling hpx_compute hpx_naming_base

--- a/libs/full/include/include/hpx/experimental/sandbox.hpp
+++ b/libs/full/include/include/hpx/experimental/sandbox.hpp
@@ -27,19 +27,14 @@
 #pragma once
 
 #include <hpx/config.hpp>
-
-#include <hpx/modules/execution.hpp>
-#include <hpx/modules/format.hpp>
-#include <hpx/runtime_local/runtime_local_fwd.hpp>
-#include <hpx/topology/topology.hpp>
+#include <hpx/modules/runtime_local.hpp>
 
 #include <chrono>
 #include <cstddef>
 #include <cstdlib>
-#include <ostream>
+#include <iosfwd>
 #include <string>
 #include <utility>
-#include <vector>
 
 namespace hpx::experimental::sandbox {
 
@@ -57,20 +52,7 @@ namespace hpx::experimental::sandbox {
         /// \brief Print a formatted environment report.
         ///
         /// \param os  Output stream.
-        void print(std::ostream& os) const
-        {
-            hpx::util::format_to(os, "\n");
-            hpx::util::format_to(os, "=== HPX Sandbox --- Environment {}\n",
-                std::string(25, '='));
-            hpx::util::format_to(os, "  Cores:           {}\n", cores);
-            hpx::util::format_to(os, "  PUs:             {}\n", pus);
-            hpx::util::format_to(os, "  NUMA domains:    {}\n", numa_nodes);
-            hpx::util::format_to(os, "  HPX workers:     {}\n", hpx_workers);
-            hpx::util::format_to(os, "  Sandbox:         {}\n",
-                is_sandbox ? "yes (constrained environment detected)" :
-                             "no (full hardware access)");
-            hpx::util::format_to(os, "{}\n", std::string(56, '='));
-        }
+        HPX_EXPORT void print(std::ostream& os) const;
     };
 
     /// \brief Holds the results of a comparative benchmark.
@@ -87,63 +69,18 @@ namespace hpx::experimental::sandbox {
         /// \brief Print a formatted benchmark report.
         ///
         /// \param os  Output stream.
-        void print(std::ostream& os) const
-        {
-            hpx::util::format_to(os, "\n");
-            hpx::util::format_to(
-                os, "=== HPX Sandbox --- Benchmark {}\n", std::string(26, '='));
-            hpx::util::format_to(os, "  Label:           \"{}\"\n", label);
-            hpx::util::format_to(os, "  Iterations:      {}\n", iterations);
-            hpx::util::format_to(os, "  Workers:         {}\n", num_workers);
-            hpx::util::format_to(os, "{}\n", std::string(56, '-'));
-            hpx::util::format_to(
-                os, "  Sequential:      {:.3f} ms\n", seq_mean_ms);
-            hpx::util::format_to(
-                os, "  Parallel:        {:.3f} ms\n", par_mean_ms);
-            hpx::util::format_to(os, "{}\n", std::string(56, '-'));
-            hpx::util::format_to(os, "  Speedup:         {:.2f}x\n", speedup);
-            hpx::util::format_to(
-                os, "  Efficiency:      {:.1f}%\n", efficiency_pct);
-            hpx::util::format_to(os, "{}\n", std::string(56, '-'));
-
-            // Verdict
-            hpx::util::format_to(os, "  Verdict:         ");
-            if (efficiency_pct >= 80.0)
-                hpx::util::format_to(os, "Excellent scaling\n");
-            else if (efficiency_pct >= 60.0)
-                hpx::util::format_to(os, "Good scaling\n");
-            else if (efficiency_pct >= 40.0)
-                hpx::util::format_to(
-                    os, "Moderate scaling (check granularity)\n");
-            else if (speedup > 1.0)
-                hpx::util::format_to(
-                    os, "Limited scaling (overhead-dominated)\n");
-            else
-                hpx::util::format_to(
-                    os, "No speedup (work too small or contention)\n");
-            hpx::util::format_to(os, "{}\n", std::string(56, '='));
-        }
+        HPX_EXPORT void print(std::ostream& os) const;
     };
 
     // --- Environment Detection ---
-
     namespace detail {
-
-        inline bool check_sandbox_heuristic()
-        {
-            if (std::getenv("COMPILER_EXPLORER") != nullptr)
-                return true;
-            if (std::getenv("HPX_SANDBOX") != nullptr)
-                return true;
-            return false;
-        }
 
         template <typename F>
         double time_once_ms(F&& fn)
         {
-            auto start = std::chrono::high_resolution_clock::now();
+            auto const start = std::chrono::high_resolution_clock::now();
             fn();
-            auto end = std::chrono::high_resolution_clock::now();
+            auto const end = std::chrono::high_resolution_clock::now();
             return std::chrono::duration<double, std::milli>(end - start)
                 .count();
         }
@@ -152,6 +89,7 @@ namespace hpx::experimental::sandbox {
         double mean_ms(F&& fn, std::size_t iterations)
         {
             fn();    // warmup
+
             double total = 0.0;
             for (std::size_t i = 0; i < iterations; ++i)
             {
@@ -159,23 +97,12 @@ namespace hpx::experimental::sandbox {
             }
             return total / static_cast<double>(iterations);
         }
-
     }    // namespace detail
 
     // --- Public API ---
 
     /// \brief Detect and return information about the current environment.
-    inline environment_info detect_environment()
-    {
-        environment_info info;
-        auto const& topo = hpx::threads::create_topology();
-        info.cores = topo.get_number_of_cores();
-        info.pus = topo.get_number_of_pus();
-        info.numa_nodes = topo.get_number_of_numa_nodes();
-        info.hpx_workers = hpx::get_num_worker_threads();
-        info.is_sandbox = detail::check_sandbox_heuristic();
-        return info;
-    }
+    HPX_EXPORT environment_info detect_environment();
 
     /// \brief Print a formatted environment report.
     inline void describe_environment(std::ostream& os)
@@ -187,7 +114,7 @@ namespace hpx::experimental::sandbox {
     template <typename F>
     double measure(F&& fn, std::size_t iterations = 5)
     {
-        return detail::mean_ms(std::forward<F>(fn), iterations);
+        return detail::mean_ms(HPX_FORWARD(F, fn), iterations);
     }
 
     /// \brief Compare sequential and parallel execution of the same work.
@@ -196,11 +123,13 @@ namespace hpx::experimental::sandbox {
         ParFn&& par_fn, std::size_t iterations = 5)
     {
         benchmark_report report;
-        report.label = std::move(label);
+        report.label = HPX_MOVE(label);
         report.iterations = iterations;
         report.num_workers = hpx::get_num_worker_threads();
-        report.seq_mean_ms = detail::mean_ms(seq_fn, iterations);
-        report.par_mean_ms = detail::mean_ms(par_fn, iterations);
+        report.seq_mean_ms =
+            detail::mean_ms(HPX_FORWARD(SeqFn, seq_fn), iterations);
+        report.par_mean_ms =
+            detail::mean_ms(HPX_FORWARD(ParFn, par_fn), iterations);
         if (report.par_mean_ms > 0.0)
         {
             report.speedup = report.seq_mean_ms / report.par_mean_ms;
@@ -213,5 +142,4 @@ namespace hpx::experimental::sandbox {
         }
         return report;
     }
-
 }    // namespace hpx::experimental::sandbox

--- a/libs/full/include/include/hpx/include/actions.hpp
+++ b/libs/full/include/include/hpx/include/actions.hpp
@@ -9,10 +9,8 @@
 
 #include <hpx/config.hpp>
 #include <hpx/actions/transfer_action.hpp>
-#include <hpx/actions_base/component_action.hpp>
-#include <hpx/actions_base/lambda_to_action.hpp>
-#include <hpx/actions_base/plain_action.hpp>
 #include <hpx/async_distributed/base_lco_with_value.hpp>
 #include <hpx/async_distributed/continuation.hpp>
 #include <hpx/async_distributed/make_continuation.hpp>
 #include <hpx/async_distributed/transfer_continuation_action.hpp>
+#include <hpx/modules/actions_base.hpp>

--- a/libs/full/include/include/hpx/include/plain_actions.hpp
+++ b/libs/full/include/include/hpx/include/plain_actions.hpp
@@ -7,5 +7,5 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/plain_action.hpp>
 #include <hpx/async_distributed/continuation.hpp>
+#include <hpx/modules/actions_base.hpp>

--- a/libs/full/include/include/hpx/include/traits.hpp
+++ b/libs/full/include/include/hpx/include/traits.hpp
@@ -22,21 +22,7 @@
 #include <hpx/modules/timed_execution.hpp>
 #include <hpx/modules/type_support.hpp>
 
-#include <hpx/actions_base/traits/action_continuation.hpp>
-#include <hpx/actions_base/traits/action_decorate_continuation.hpp>
-#include <hpx/actions_base/traits/action_does_termination_detection.hpp>
-#include <hpx/actions_base/traits/action_is_target_valid.hpp>
-#include <hpx/actions_base/traits/action_priority.hpp>
-#include <hpx/actions_base/traits/action_remote_result.hpp>
-#include <hpx/actions_base/traits/action_schedule_thread.hpp>
-#include <hpx/actions_base/traits/action_select_direct_execution.hpp>
-#include <hpx/actions_base/traits/action_stacksize.hpp>
-#include <hpx/actions_base/traits/action_was_object_migrated.hpp>
-#include <hpx/actions_base/traits/extract_action.hpp>
-#include <hpx/actions_base/traits/is_client.hpp>
-#include <hpx/actions_base/traits/is_continuation.hpp>
-#include <hpx/actions_base/traits/is_distribution_policy.hpp>
-#include <hpx/actions_base/traits/is_valid_action.hpp>
 #include <hpx/async_distributed/traits/action_trigger_continuation.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/parcelset_base.hpp>

--- a/libs/full/include/src/sandbox.cpp
+++ b/libs/full/include/src/sandbox.cpp
@@ -1,0 +1,96 @@
+//  Copyright (c) 2020-2026 The STE||AR-Group
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+
+#include <hpx/experimental/sandbox.hpp>
+#include <hpx/modules/execution.hpp>
+#include <hpx/modules/format.hpp>
+#include <hpx/modules/runtime_local.hpp>
+#include <hpx/modules/topology.hpp>
+
+#include <chrono>
+#include <cstddef>
+#include <cstdlib>
+#include <ostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace hpx::experimental::sandbox {
+
+    void environment_info::print(std::ostream& os) const
+    {
+        hpx::util::format_to(os, "\n");
+        hpx::util::format_to(
+            os, "=== HPX Sandbox --- Environment {}\n", std::string(25, '='));
+        hpx::util::format_to(os, "  Cores:           {}\n", cores);
+        hpx::util::format_to(os, "  PUs:             {}\n", pus);
+        hpx::util::format_to(os, "  NUMA domains:    {}\n", numa_nodes);
+        hpx::util::format_to(os, "  HPX workers:     {}\n", hpx_workers);
+        hpx::util::format_to(os, "  Sandbox:         {}\n",
+            is_sandbox ? "yes (constrained environment detected)" :
+                         "no (full hardware access)");
+        hpx::util::format_to(os, "{}\n", std::string(56, '='));
+    }
+
+    void benchmark_report::print(std::ostream& os) const
+    {
+        hpx::util::format_to(os, "\n");
+        hpx::util::format_to(
+            os, "=== HPX Sandbox --- Benchmark {}\n", std::string(26, '='));
+        hpx::util::format_to(os, "  Label:           \"{}\"\n", label);
+        hpx::util::format_to(os, "  Iterations:      {}\n", iterations);
+        hpx::util::format_to(os, "  Workers:         {}\n", num_workers);
+        hpx::util::format_to(os, "{}\n", std::string(56, '-'));
+        hpx::util::format_to(os, "  Sequential:      {:.3f} ms\n", seq_mean_ms);
+        hpx::util::format_to(os, "  Parallel:        {:.3f} ms\n", par_mean_ms);
+        hpx::util::format_to(os, "{}\n", std::string(56, '-'));
+        hpx::util::format_to(os, "  Speedup:         {:.2f}x\n", speedup);
+        hpx::util::format_to(
+            os, "  Efficiency:      {:.1f}%\n", efficiency_pct);
+        hpx::util::format_to(os, "{}\n", std::string(56, '-'));
+
+        // Verdict
+        hpx::util::format_to(os, "  Verdict:         ");
+        if (efficiency_pct >= 80.0)
+            hpx::util::format_to(os, "Excellent scaling\n");
+        else if (efficiency_pct >= 60.0)
+            hpx::util::format_to(os, "Good scaling\n");
+        else if (efficiency_pct >= 40.0)
+            hpx::util::format_to(os, "Moderate scaling (check granularity)\n");
+        else if (speedup > 1.0)
+            hpx::util::format_to(os, "Limited scaling (overhead-dominated)\n");
+        else
+            hpx::util::format_to(
+                os, "No speedup (work too small or contention)\n");
+        hpx::util::format_to(os, "{}\n", std::string(56, '='));
+    }
+
+    namespace detail {
+
+        inline bool check_sandbox_heuristic()
+        {
+            if (std::getenv("COMPILER_EXPLORER") != nullptr)
+                return true;
+            if (std::getenv("HPX_SANDBOX") != nullptr)
+                return true;
+            return false;
+        }
+    }    // namespace detail
+
+    environment_info detect_environment()
+    {
+        environment_info info;
+        auto const& topo = hpx::threads::create_topology();
+        info.cores = topo.get_number_of_cores();
+        info.pus = topo.get_number_of_pus();
+        info.numa_nodes = topo.get_number_of_numa_nodes();
+        info.hpx_workers = hpx::get_num_worker_threads();
+        info.is_sandbox = detail::check_sandbox_heuristic();
+        return info;
+    }
+}    // namespace hpx::experimental::sandbox

--- a/libs/full/init_runtime/CMakeLists.txt
+++ b/libs/full/init_runtime/CMakeLists.txt
@@ -31,6 +31,7 @@ if(HPX_WITH_DISTRIBUTED_RUNTIME)
   set(init_runtime_sources ${init_runtime_sources} pre_main.cpp)
 
   set(init_runtime_optional_module_dependencies
+      hpx_actions_base
       hpx_async_distributed
       hpx_collectives
       hpx_components_base

--- a/libs/full/init_runtime/src/hpx_init.cpp
+++ b/libs/full/init_runtime/src/hpx_init.cpp
@@ -44,9 +44,9 @@
 #include <hpx/modules/mpi_base.hpp>
 #endif
 #if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
-#include <hpx/actions_base/plain_action.hpp>
 #include <hpx/async_distributed/bind_action.hpp>
 #include <hpx/init_runtime/pre_main.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/naming.hpp>

--- a/libs/full/lcos_distributed/CMakeLists.txt
+++ b/libs/full/lcos_distributed/CMakeLists.txt
@@ -31,7 +31,7 @@ add_hpx_module(
   HEADERS ${lcos_distributed_headers}
   COMPAT_HEADERS ${lcos_distributed_compat_headers}
   DEPENDENCIES hpx_core
-  MODULE_DEPENDENCIES hpx_actions hpx_async_distributed hpx_components_base
-                      hpx_naming
+  MODULE_DEPENDENCIES hpx_actions_base hpx_actions hpx_async_distributed
+                      hpx_components_base hpx_naming
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/full/lcos_distributed/include/hpx/lcos_distributed/server/channel.hpp
+++ b/libs/full/lcos_distributed/include/hpx/lcos_distributed/server/channel.hpp
@@ -8,9 +8,9 @@
 
 #include <hpx/config.hpp>
 #include <hpx/actions/transfer_action.hpp>
-#include <hpx/actions_base/component_action.hpp>
 #include <hpx/async_distributed/base_lco_with_value.hpp>
 #include <hpx/async_distributed/transfer_continuation_action.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/lcos_local.hpp>

--- a/libs/full/naming/CMakeLists.txt
+++ b/libs/full/naming/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020 The STE||AR-Group
+# Copyright (c) 2019-2026 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -28,8 +28,10 @@ include(HPX_AddModule)
 add_hpx_module(
   full naming
   GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_MODULE_GEN ON
   SOURCES ${naming_sources}
   HEADERS ${naming_headers}
+  ADD_TO_GLOBAL_HEADER "hpx/naming/detail/preprocess_gid_types.hpp"
   COMPAT_HEADERS ${naming_compat_headers}
   DEPENDENCIES hpx_core
   MODULE_DEPENDENCIES hpx_components_base hpx_naming_base

--- a/libs/full/naming/include/hpx/naming/credit_handling.hpp
+++ b/libs/full/naming/include/hpx/naming/credit_handling.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2024 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c) 2011 Bryce Lelbach
 //  Copyright (c) 2007 Richard D. Guidry Jr.
 //
@@ -20,66 +20,67 @@
 namespace hpx::naming {
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT void decrement_refcnt(gid_type const& gid);
+    HPX_CXX_EXPORT HPX_EXPORT void decrement_refcnt(gid_type const& gid);
 
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
 
         ///////////////////////////////////////////////////////////////////////
         // has side effects, can't be pure
-        HPX_EXPORT std::int64_t add_credit_to_gid(
+        HPX_CXX_EXPORT HPX_EXPORT std::int64_t add_credit_to_gid(
             gid_type& id, std::int64_t credits);
 
-        HPX_EXPORT std::int64_t remove_credit_from_gid(
+        HPX_CXX_EXPORT HPX_EXPORT std::int64_t remove_credit_from_gid(
             gid_type& id, std::int64_t debit);
 
-        HPX_EXPORT std::int64_t fill_credit_for_gid(gid_type& id,
+        HPX_CXX_EXPORT HPX_EXPORT std::int64_t fill_credit_for_gid(gid_type& id,
             std::int64_t credits = static_cast<std::int64_t>(
                 HPX_GLOBALCREDIT_INITIAL));
 
         ///////////////////////////////////////////////////////////////////////
-        HPX_EXPORT gid_type move_gid(gid_type& id);
-        HPX_EXPORT gid_type move_gid_locked(
+        HPX_CXX_EXPORT HPX_EXPORT gid_type move_gid(gid_type& id);
+        HPX_CXX_EXPORT HPX_EXPORT gid_type move_gid_locked(
             std::unique_lock<gid_type::mutex_type> l, gid_type& gid);
 
-        HPX_EXPORT std::int64_t replenish_credits(gid_type& id);
-        HPX_EXPORT std::int64_t replenish_credits_locked(
+        HPX_CXX_EXPORT HPX_EXPORT std::int64_t replenish_credits(gid_type& id);
+        HPX_CXX_EXPORT HPX_EXPORT std::int64_t replenish_credits_locked(
             std::unique_lock<gid_type::mutex_type>& l, gid_type& id);
 
         ///////////////////////////////////////////////////////////////////////
         // splits the current credit of the given id and assigns half of it to
         // the returned copy
-        HPX_EXPORT gid_type split_credits_for_gid(gid_type& id);
-        HPX_EXPORT gid_type split_credits_for_gid_locked(
+        HPX_CXX_EXPORT HPX_EXPORT gid_type split_credits_for_gid(gid_type& id);
+        HPX_CXX_EXPORT HPX_EXPORT gid_type split_credits_for_gid_locked(
             std::unique_lock<gid_type::mutex_type>& l, gid_type& id);
 
         ///////////////////////////////////////////////////////////////////////
-        HPX_EXPORT void decrement_refcnt(id_type_impl const* gid) noexcept;
+        HPX_CXX_EXPORT HPX_EXPORT void decrement_refcnt(
+            id_type_impl const* gid) noexcept;
 
         ///////////////////////////////////////////////////////////////////////
         // credit management (called during serialization), this function
         // has to be 'const' as save() above has to be 'const'.
-        void preprocess_gid(
+        HPX_CXX_EXPORT HPX_EXPORT void preprocess_gid(
             id_type_impl const&, serialization::output_archive& ar);
 
         ///////////////////////////////////////////////////////////////////////
         // serialization
-        HPX_EXPORT void save(
+        HPX_CXX_EXPORT HPX_EXPORT void save(
             serialization::output_archive& ar, id_type_impl const&, unsigned);
-        HPX_EXPORT void load(
+        HPX_CXX_EXPORT HPX_EXPORT void load(
             serialization::input_archive& ar, id_type_impl&, unsigned);
 
-        HPX_SERIALIZATION_SPLIT_FREE(id_type_impl)
+        HPX_SERIALIZATION_SPLIT_FREE(HPX_CXX_EXPORT, id_type_impl)
     }    // namespace detail
 }    // namespace hpx::naming
 
 namespace hpx {
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT void save(
+    HPX_CXX_EXPORT HPX_EXPORT void save(
         serialization::output_archive& ar, hpx::id_type const&, unsigned int);
-    HPX_EXPORT void load(
+    HPX_CXX_EXPORT HPX_EXPORT void load(
         serialization::input_archive& ar, hpx::id_type&, unsigned int);
 
-    HPX_SERIALIZATION_SPLIT_FREE(hpx::id_type)
+    HPX_SERIALIZATION_SPLIT_FREE(HPX_CXX_EXPORT, hpx::id_type)
 }    // namespace hpx

--- a/libs/full/naming/include/hpx/naming/detail/preprocess_gid_types.hpp
+++ b/libs/full/naming/include/hpx/naming/detail/preprocess_gid_types.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2015-2024 Hartmut Kaiser
+//  Copyright (c) 2015-2026 Hartmut Kaiser
 //  Copyright (c) 2015-2016 Thomas Heller
 //  Copyright (c) 2024 Hartmut Kaiser
 //
@@ -30,7 +30,7 @@ namespace hpx::serialization::detail {
     ///////////////////////////////////////////////////////////////////////////
     // This class allows to handle credit splitting for gid_types during
     // serialization.
-    class preprocess_gid_types
+    HPX_CXX_EXPORT class preprocess_gid_types
     {
         using mutex_type = hpx::spinlock;
 

--- a/libs/full/naming/include/hpx/naming/split_gid.hpp
+++ b/libs/full/naming/include/hpx/naming/split_gid.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2024 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c) 2011 Bryce Lelbach
 //  Copyright (c) 2007 Richard D. Guidry Jr.
 //
@@ -17,11 +17,13 @@
 
 namespace hpx::naming::detail {
 
-    HPX_EXPORT hpx::future_or_value<gid_type> split_gid_if_needed(gid_type& id);
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future_or_value<gid_type>
+    split_gid_if_needed(gid_type& id);
 
-    HPX_EXPORT gid_type split_gid_if_needed(
+    HPX_CXX_EXPORT HPX_EXPORT gid_type split_gid_if_needed(
         hpx::launch::sync_policy, gid_type& id);
 
-    HPX_EXPORT hpx::future_or_value<gid_type> split_gid_if_needed_locked(
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future_or_value<gid_type>
+    split_gid_if_needed_locked(
         std::unique_lock<gid_type::mutex_type>& l, gid_type& gid);
 }    // namespace hpx::naming::detail

--- a/libs/full/parcelport_gasnet/CMakeLists.txt
+++ b/libs/full/parcelport_gasnet/CMakeLists.txt
@@ -41,7 +41,7 @@ add_hpx_module(
   DEPENDENCIES hpx_core hpx_gasnet_base PkgConfig::GASNET
                ${gasnet_additional_dependencies}
   MODULE_DEPENDENCIES hpx_actions hpx_command_line_handling hpx_parcelset_base
-                      hpx_parcelset
+                      hpx_parcelset hpx_plugin_factories
   CMAKE_SUBDIRS examples tests
 )
 

--- a/libs/full/parcelport_gasnet/src/parcelport_gasnet.cpp
+++ b/libs/full/parcelport_gasnet/src/parcelport_gasnet.cpp
@@ -23,11 +23,11 @@
 #include <hpx/modules/util.hpp>
 
 #include <hpx/modules/parcelset_base.hpp>
+#include <hpx/modules/plugin_factories.hpp>
 #include <hpx/parcelport_gasnet/locality.hpp>
 #include <hpx/parcelport_gasnet/receiver.hpp>
 #include <hpx/parcelport_gasnet/sender.hpp>
 #include <hpx/parcelset/parcelport_impl.hpp>
-#include <hpx/plugin_factories/parcelport_factory.hpp>
 
 #include <atomic>
 #include <cstddef>

--- a/libs/full/parcelport_lci/CMakeLists.txt
+++ b/libs/full/parcelport_lci/CMakeLists.txt
@@ -63,7 +63,7 @@ add_hpx_module(
   COMPAT_HEADERS ${parcelport_lci_compat_headers}
   DEPENDENCIES hpx_core hpx_dependencies_boost LCI::LCI
   MODULE_DEPENDENCIES hpx_actions hpx_command_line_handling hpx_parcelset_base
-                      hpx_parcelset
+                      hpx_parcelset hpx_plugin_factories
   CMAKE_SUBDIRS examples tests
 )
 

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/sender_base.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/sender_base.hpp
@@ -19,6 +19,7 @@
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/parcelset_base.hpp>
 #include <hpx/modules/plugin.hpp>
+#include <hpx/modules/plugin_factories.hpp>
 #include <hpx/modules/resource_partitioner.hpp>
 #include <hpx/modules/runtime_configuration.hpp>
 #include <hpx/modules/runtime_local.hpp>
@@ -28,7 +29,6 @@
 #include <hpx/parcelset/parcelport_connection.hpp>
 #include <hpx/parcelset/parcelport_impl.hpp>
 #include <hpx/parcelset/parcelset_fwd.hpp>
-#include <hpx/plugin_factories/parcelport_factory.hpp>
 
 #include <hpx/modules/parcelset_base.hpp>
 #include <hpx/parcelset/parcelport_connection.hpp>

--- a/libs/full/parcelport_lci/include/hpx/parcelport_lci/sendrecv/sender_sendrecv.hpp
+++ b/libs/full/parcelport_lci/include/hpx/parcelport_lci/sendrecv/sender_sendrecv.hpp
@@ -19,6 +19,7 @@
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/parcelset_base.hpp>
 #include <hpx/modules/plugin.hpp>
+#include <hpx/modules/plugin_factories.hpp>
 #include <hpx/modules/resource_partitioner.hpp>
 #include <hpx/modules/runtime_configuration.hpp>
 #include <hpx/modules/runtime_local.hpp>
@@ -28,7 +29,6 @@
 #include <hpx/parcelset/parcelport_connection.hpp>
 #include <hpx/parcelset/parcelport_impl.hpp>
 #include <hpx/parcelset/parcelset_fwd.hpp>
-#include <hpx/plugin_factories/parcelport_factory.hpp>
 
 #include <hpx/modules/parcelset_base.hpp>
 #include <hpx/parcelset/parcelport_connection.hpp>

--- a/libs/full/parcelport_lcw/CMakeLists.txt
+++ b/libs/full/parcelport_lcw/CMakeLists.txt
@@ -58,7 +58,7 @@ add_hpx_module(
   COMPAT_HEADERS ${parcelport_lcw_compat_headers}
   DEPENDENCIES hpx_core hpx_dependencies_boost LCW::LCW LCI::LCT
   MODULE_DEPENDENCIES hpx_actions hpx_command_line_handling hpx_parcelset
-                      hpx_parcelset_base
+                      hpx_parcelset_base hpx_plugin_factories
   CMAKE_SUBDIRS examples tests
 )
 

--- a/libs/full/parcelport_lcw/include/hpx/parcelport_lcw/sender_base.hpp
+++ b/libs/full/parcelport_lcw/include/hpx/parcelport_lcw/sender_base.hpp
@@ -27,10 +27,10 @@
 #include <hpx/modules/command_line_handling.hpp>
 #include <hpx/modules/parcelset_base.hpp>
 
+#include <hpx/modules/plugin_factories.hpp>
 #include <hpx/parcelset/parcelport_connection.hpp>
 #include <hpx/parcelset/parcelport_impl.hpp>
 #include <hpx/parcelset/parcelset_fwd.hpp>
-#include <hpx/plugin_factories/parcelport_factory.hpp>
 
 #include <hpx/parcelset/parcelport_connection.hpp>
 #include <hpx/parcelset_base/detail/gatherer.hpp>

--- a/libs/full/parcelport_lcw/include/hpx/parcelport_lcw/sendrecv/sender_sendrecv.hpp
+++ b/libs/full/parcelport_lcw/include/hpx/parcelport_lcw/sendrecv/sender_sendrecv.hpp
@@ -27,10 +27,10 @@
 #include <hpx/modules/command_line_handling.hpp>
 #include <hpx/modules/parcelset_base.hpp>
 
+#include <hpx/modules/plugin_factories.hpp>
 #include <hpx/parcelset/parcelport_connection.hpp>
 #include <hpx/parcelset/parcelport_impl.hpp>
 #include <hpx/parcelset/parcelset_fwd.hpp>
-#include <hpx/plugin_factories/parcelport_factory.hpp>
 
 #include <hpx/parcelset/parcelport_connection.hpp>
 #include <hpx/parcelset_base/detail/gatherer.hpp>

--- a/libs/full/parcelport_mpi/CMakeLists.txt
+++ b/libs/full/parcelport_mpi/CMakeLists.txt
@@ -38,7 +38,7 @@ add_hpx_module(
   COMPAT_HEADERS ${parcelport_mpi_compat_headers}
   DEPENDENCIES hpx_core hpx_dependencies_boost Mpi::mpi
   MODULE_DEPENDENCIES hpx_actions hpx_command_line_handling hpx_parcelset
-                      hpx_parcelset_base
+                      hpx_parcelset_base hpx_plugin_factories
   CMAKE_SUBDIRS examples tests
 )
 

--- a/libs/full/parcelport_mpi/src/parcelport_mpi.cpp
+++ b/libs/full/parcelport_mpi/src/parcelport_mpi.cpp
@@ -16,6 +16,7 @@
 #include <hpx/modules/mpi_base.hpp>
 #include <hpx/modules/parcelset_base.hpp>
 #include <hpx/modules/plugin.hpp>
+#include <hpx/modules/plugin_factories.hpp>
 #include <hpx/modules/resource_partitioner.hpp>
 #include <hpx/modules/runtime_configuration.hpp>
 #include <hpx/modules/runtime_local.hpp>
@@ -25,7 +26,6 @@
 #include <hpx/parcelport_mpi/receiver.hpp>
 #include <hpx/parcelport_mpi/sender.hpp>
 #include <hpx/parcelset/parcelport_impl.hpp>
-#include <hpx/plugin_factories/parcelport_factory.hpp>
 
 #include <atomic>
 #include <cstddef>

--- a/libs/full/parcelport_tcp/CMakeLists.txt
+++ b/libs/full/parcelport_tcp/CMakeLists.txt
@@ -32,7 +32,7 @@ add_hpx_module(
   COMPAT_HEADERS ${parcelport_tcp_compat_headers}
   DEPENDENCIES hpx_core
   MODULE_DEPENDENCIES hpx_actions hpx_command_line_handling hpx_parcelset
-                      hpx_parcelset_base
+                      hpx_parcelset_base hpx_plugin_factories
   CMAKE_SUBDIRS examples tests
 )
 

--- a/libs/full/parcelport_tcp/src/parcelport_tcp.cpp
+++ b/libs/full/parcelport_tcp/src/parcelport_tcp.cpp
@@ -10,8 +10,8 @@
 #include <hpx/modules/plugin.hpp>
 #include <hpx/modules/resource_partitioner.hpp>
 
+#include <hpx/modules/plugin_factories.hpp>
 #include <hpx/parcelport_tcp/connection_handler.hpp>
-#include <hpx/plugin_factories/parcelport_factory.hpp>
 
 // Inject additional configuration data into the factory registry for this type.
 // This information ends up in the system wide configuration database under the

--- a/libs/full/parcelports/CMakeLists.txt
+++ b/libs/full/parcelports/CMakeLists.txt
@@ -54,5 +54,6 @@ add_hpx_module(
   SOURCES ${parcelports_sources}
   HEADERS ${parcelports_headers}
   DEPENDENCIES hpx_core
-  MODULE_DEPENDENCIES hpx_parcelset ${parcelport_module_dependencies}
+  MODULE_DEPENDENCIES hpx_parcelset hpx_plugin_factories
+                      ${parcelport_module_dependencies}
 )

--- a/libs/full/parcelports/cmake/templates/static_parcelports.hpp.in
+++ b/libs/full/parcelports/cmake/templates/static_parcelports.hpp.in
@@ -12,7 +12,7 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_NETWORKING)
-#include <hpx/plugin_factories/parcelport_factory_base.hpp>
+#include <hpx/modules/plugin_factories.hpp>
 
 #include <vector>
 

--- a/libs/full/parcelports/src/static_parcelports.cpp
+++ b/libs/full/parcelports/src/static_parcelports.cpp
@@ -7,10 +7,10 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_NETWORKING)
+#include <hpx/modules/plugin_factories.hpp>
 #include <hpx/parcelports/init_all_parcelports.hpp>
 #include <hpx/parcelports/static_parcelports.hpp>
 #include <hpx/parcelset/init_parcelports.hpp>
-#include <hpx/plugin_factories/parcelport_factory_base.hpp>
 
 #include <vector>
 

--- a/libs/full/parcelset/include/hpx/parcelset/encode_parcels.hpp
+++ b/libs/full/parcelset/include/hpx/parcelset/encode_parcels.hpp
@@ -14,16 +14,15 @@
 
 #if defined(HPX_HAVE_NETWORKING)
 #include <hpx/assert.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/logging.hpp>
+#include <hpx/modules/naming.hpp>
+#include <hpx/modules/parcelset_base.hpp>
 #include <hpx/modules/runtime_local.hpp>
 #include <hpx/modules/serialization.hpp>
 #include <hpx/modules/timing.hpp>
 
-#include <hpx/actions_base/basic_action.hpp>
-#include <hpx/modules/parcelset_base.hpp>
-#include <hpx/naming/detail/preprocess_gid_types.hpp>
-#include <hpx/naming/split_gid.hpp>
 #include <hpx/parcelset/parcel.hpp>
 #include <hpx/parcelset/parcelset_fwd.hpp>
 

--- a/libs/full/parcelset/include/hpx/parcelset/init_parcelports.hpp
+++ b/libs/full/parcelset/include/hpx/parcelset/init_parcelports.hpp
@@ -9,7 +9,7 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_NETWORKING)
-#include <hpx/plugin_factories/parcelport_factory_base.hpp>
+#include <hpx/modules/plugin_factories.hpp>
 
 #include <vector>
 

--- a/libs/full/parcelset/include/hpx/parcelset/parcelhandler.hpp
+++ b/libs/full/parcelset/include/hpx/parcelset/parcelhandler.hpp
@@ -23,8 +23,8 @@
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/naming_base.hpp>
 #include <hpx/modules/parcelset_base.hpp>
+#include <hpx/modules/plugin_factories.hpp>
 #include <hpx/parcelset/parcelset_fwd.hpp>
-#include <hpx/plugin_factories/parcelport_factory_base.hpp>
 
 #include <algorithm>
 #include <atomic>

--- a/libs/full/parcelset/src/detail/parcel_await.cpp
+++ b/libs/full/parcelset/src/detail/parcel_await.cpp
@@ -10,11 +10,11 @@
 #if defined(HPX_HAVE_NETWORKING)
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/lcos_local.hpp>
+#include <hpx/modules/naming.hpp>
+#include <hpx/modules/parcelset_base.hpp>
 #include <hpx/modules/serialization.hpp>
 
 #include <hpx/actions/actions_fwd.hpp>
-#include <hpx/modules/parcelset_base.hpp>
-#include <hpx/naming/detail/preprocess_gid_types.hpp>
 #include <hpx/parcelset/detail/parcel_await.hpp>
 #include <hpx/parcelset/parcelset_fwd.hpp>
 

--- a/libs/full/parcelset/src/parcel.cpp
+++ b/libs/full/parcelset/src/parcel.cpp
@@ -9,20 +9,20 @@
 
 #if defined(HPX_HAVE_NETWORKING)
 #include <hpx/assert.hpp>
+#include <hpx/modules/actions_base.hpp>
+#include <hpx/modules/components_base.hpp>
 #include <hpx/modules/datastructures.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/modules/itt_notify.hpp>
+#include <hpx/modules/naming.hpp>
+#include <hpx/modules/parcelset_base.hpp>
 #include <hpx/modules/runtime_local.hpp>
 #include <hpx/modules/serialization.hpp>
 #include <hpx/modules/threading_base.hpp>
 #include <hpx/modules/timing.hpp>
 
 #include <hpx/actions/transfer_action.hpp>
-#include <hpx/actions_base/detail/action_factory.hpp>
-#include <hpx/modules/components_base.hpp>
-#include <hpx/modules/parcelset_base.hpp>
-#include <hpx/naming/detail/preprocess_gid_types.hpp>
 #include <hpx/parcelset/parcel.hpp>
 #include <hpx/parcelset/parcelhandler.hpp>
 

--- a/libs/full/parcelset/src/parcelhandler.cpp
+++ b/libs/full/parcelset/src/parcelhandler.cpp
@@ -33,10 +33,10 @@
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/naming_base.hpp>
 #include <hpx/modules/parcelset_base.hpp>
+#include <hpx/modules/plugin_factories.hpp>
 #include <hpx/parcelset/init_parcelports.hpp>
 #include <hpx/parcelset/message_handler_fwd.hpp>
 #include <hpx/parcelset/parcelhandler.hpp>
-#include <hpx/plugin_factories/parcelport_factory_base.hpp>
 
 #include <asio/error.hpp>
 

--- a/libs/full/performance_counters/include/hpx/performance_counters/action_invocation_counter_discoverer.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/action_invocation_counter_discoverer.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/detail/invocation_count_registry.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/performance_counters/counters_fwd.hpp>
 
 namespace hpx { namespace performance_counters {

--- a/libs/full/performance_counters/include/hpx/performance_counters/base_performance_counter.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/base_performance_counter.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/component_action.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/runtime_local.hpp>
 #include <hpx/performance_counters/counters.hpp>

--- a/libs/full/performance_counters/include/hpx/performance_counters/per_action_data_counter_discoverer.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/per_action_data_counter_discoverer.hpp
@@ -11,7 +11,7 @@
 #if defined(HPX_HAVE_PARCELPORT_COUNTERS) &&                                   \
     defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS) &&                            \
     defined(HPX_HAVE_NETWORKING)
-#include <hpx/actions_base/detail/per_action_data_counter_registry.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/performance_counters/counters_fwd.hpp>
 
 namespace hpx { namespace performance_counters {

--- a/libs/full/performance_counters/include/hpx/performance_counters/server/base_performance_counter.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/server/base_performance_counter.hpp
@@ -8,9 +8,9 @@
 
 #include <hpx/config.hpp>
 #include <hpx/actions/transfer_action.hpp>
-#include <hpx/actions_base/component_action.hpp>
 #include <hpx/async_distributed/base_lco_with_value.hpp>
 #include <hpx/async_distributed/transfer_continuation_action.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/thread_support.hpp>
 #include <hpx/performance_counters/counters.hpp>

--- a/libs/full/performance_counters/include/hpx/performance_counters/server/component_namespace_counters.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/server/component_namespace_counters.hpp
@@ -10,8 +10,8 @@
 
 #include <hpx/config.hpp>
 #include <hpx/actions/transfer_action.hpp>
-#include <hpx/actions_base/plain_action.hpp>
 #include <hpx/async_distributed/transfer_continuation_action.hpp>
+#include <hpx/modules/actions_base.hpp>
 
 #include <string>
 

--- a/libs/full/performance_counters/include/hpx/performance_counters/server/locality_namespace_counters.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/server/locality_namespace_counters.hpp
@@ -10,8 +10,8 @@
 
 #include <hpx/config.hpp>
 #include <hpx/actions/transfer_action.hpp>
-#include <hpx/actions_base/plain_action.hpp>
 #include <hpx/async_distributed/transfer_continuation_action.hpp>
+#include <hpx/modules/actions_base.hpp>
 
 #include <string>
 

--- a/libs/full/performance_counters/include/hpx/performance_counters/server/primary_namespace_counters.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/server/primary_namespace_counters.hpp
@@ -10,8 +10,8 @@
 
 #include <hpx/config.hpp>
 #include <hpx/actions/transfer_action.hpp>
-#include <hpx/actions_base/plain_action.hpp>
 #include <hpx/async_distributed/transfer_continuation_action.hpp>
+#include <hpx/modules/actions_base.hpp>
 
 #include <string>
 

--- a/libs/full/performance_counters/include/hpx/performance_counters/server/symbol_namespace_counters.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/server/symbol_namespace_counters.hpp
@@ -10,8 +10,8 @@
 
 #include <hpx/config.hpp>
 #include <hpx/actions/transfer_action.hpp>
-#include <hpx/actions_base/plain_action.hpp>
 #include <hpx/async_distributed/transfer_continuation_action.hpp>
+#include <hpx/modules/actions_base.hpp>
 
 #include <string>
 

--- a/libs/full/performance_counters/src/action_invocation_counter_discoverer.cpp
+++ b/libs/full/performance_counters/src/action_invocation_counter_discoverer.cpp
@@ -5,7 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/detail/invocation_count_registry.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/modules/util.hpp>

--- a/libs/full/performance_counters/src/component_namespace_counters.cpp
+++ b/libs/full/performance_counters/src/component_namespace_counters.cpp
@@ -14,7 +14,7 @@
 #include <hpx/format.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/functional.hpp>
-#include <hpx/naming/credit_handling.hpp>
+#include <hpx/modules/naming.hpp>
 #include <hpx/performance_counters/agas_namespace_action_code.hpp>
 #include <hpx/performance_counters/component_namespace_counters.hpp>
 #include <hpx/performance_counters/counter_creators.hpp>

--- a/libs/full/performance_counters/src/counter_creators.cpp
+++ b/libs/full/performance_counters/src/counter_creators.cpp
@@ -6,11 +6,11 @@
 
 #include <hpx/config.hpp>
 #include <hpx/actions/transfer_action.hpp>
-#include <hpx/actions_base/plain_action.hpp>
 #include <hpx/agas/agas_fwd.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/async_distributed/async.hpp>
 #include <hpx/async_distributed/transfer_continuation_action.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/functional.hpp>

--- a/libs/full/performance_counters/src/counters.cpp
+++ b/libs/full/performance_counters/src/counters.cpp
@@ -6,11 +6,11 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/basic_action.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/async_distributed/continuation.hpp>
 #include <hpx/async_distributed/detail/post.hpp>
 #include <hpx/async_distributed/transfer_continuation_action.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/execution.hpp>

--- a/libs/full/performance_counters/src/locality_namespace_counters.cpp
+++ b/libs/full/performance_counters/src/locality_namespace_counters.cpp
@@ -14,7 +14,7 @@
 #include <hpx/format.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/functional.hpp>
-#include <hpx/naming/credit_handling.hpp>
+#include <hpx/modules/naming.hpp>
 #include <hpx/performance_counters/agas_namespace_action_code.hpp>
 #include <hpx/performance_counters/counter_creators.hpp>
 #include <hpx/performance_counters/counters.hpp>

--- a/libs/full/performance_counters/src/per_action_data_counter_discoverer.cpp
+++ b/libs/full/performance_counters/src/per_action_data_counter_discoverer.cpp
@@ -9,7 +9,7 @@
 #if defined(HPX_HAVE_PARCELPORT_COUNTERS) &&                                   \
     defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS) &&                            \
     defined(HPX_HAVE_NETWORKING)
-#include <hpx/actions_base/detail/invocation_count_registry.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/util.hpp>
 #include <hpx/performance_counters/counter_creators.hpp>

--- a/libs/full/performance_counters/src/primary_namespace_counters.cpp
+++ b/libs/full/performance_counters/src/primary_namespace_counters.cpp
@@ -14,7 +14,7 @@
 #include <hpx/format.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/functional.hpp>
-#include <hpx/naming/credit_handling.hpp>
+#include <hpx/modules/naming.hpp>
 #include <hpx/performance_counters/agas_namespace_action_code.hpp>
 #include <hpx/performance_counters/counter_creators.hpp>
 #include <hpx/performance_counters/counters.hpp>

--- a/libs/full/performance_counters/src/server/action_invocation_counter.cpp
+++ b/libs/full/performance_counters/src/server/action_invocation_counter.cpp
@@ -5,7 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/detail/invocation_count_registry.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/performance_counters/action_invocation_counter_discoverer.hpp>

--- a/libs/full/performance_counters/src/server/base_performance_counter.cpp
+++ b/libs/full/performance_counters/src/server/base_performance_counter.cpp
@@ -6,9 +6,9 @@
 
 #include <hpx/config.hpp>
 #include <hpx/actions/transfer_action.hpp>
-#include <hpx/actions_base/component_action.hpp>
 #include <hpx/async_distributed/base_lco_with_value.hpp>
 #include <hpx/async_distributed/transfer_continuation_action.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/thread_support.hpp>

--- a/libs/full/plugin_factories/CMakeLists.txt
+++ b/libs/full/plugin_factories/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2021 The STE||AR-Group
+# Copyright (c) 2019-2026 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -9,6 +9,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 set(plugin_factories_headers
     hpx/plugin_factories/binary_filter_factory.hpp
     hpx/plugin_factories/binary_filter_factory_base.hpp
+    hpx/plugin_factories/macros.hpp
     hpx/plugin_factories/message_handler_factory.hpp
     hpx/plugin_factories/message_handler_factory_base.hpp
     hpx/plugin_factories/parcelport_factory.hpp
@@ -17,6 +18,8 @@ set(plugin_factories_headers
     hpx/plugin_factories/plugin_registry.hpp
     hpx/plugin_factories/unique_plugin_name.hpp
 )
+
+set(plugin_factories_macro_headers hpx/plugin_factories/macros.hpp)
 
 # cmake-format: off
 set(plugin_factories_compat_headers
@@ -38,8 +41,10 @@ include(HPX_AddModule)
 add_hpx_module(
   full plugin_factories
   GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_MODULE_GEN ON
   SOURCES ${plugin_factories_sources}
   HEADERS ${plugin_factories_headers}
+  MACRO_HEADERS ${plugin_factories_macro_headers}
   COMPAT_HEADERS ${plugin_factories_compat_headers}
   DEPENDENCIES hpx_core
   MODULE_DEPENDENCIES hpx_command_line_handling hpx_parcelset_base

--- a/libs/full/plugin_factories/include/hpx/plugin_factories/binary_filter_factory.hpp
+++ b/libs/full/plugin_factories/include/hpx/plugin_factories/binary_filter_factory.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2024 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -8,9 +8,8 @@
 
 #include <hpx/config.hpp>
 #include <hpx/modules/ini.hpp>
-#include <hpx/modules/preprocessor.hpp>
-
 #include <hpx/plugin_factories/binary_filter_factory_base.hpp>
+#include <hpx/plugin_factories/macros.hpp>
 #include <hpx/plugin_factories/plugin_registry.hpp>
 #include <hpx/plugin_factories/unique_plugin_name.hpp>
 
@@ -25,7 +24,7 @@ namespace hpx::plugins {
     ///
     /// \tparam BinaryFilter The message handler type this factory should be
     ///                        responsible for.
-    template <typename BinaryFilter>
+    HPX_CXX_EXPORT template <typename BinaryFilter>
     struct binary_filter_factory : binary_filter_factory_base
     {
         /// \brief Construct a new factory instance
@@ -76,15 +75,3 @@ namespace hpx::plugins {
         bool isenabled_;
     };
 }    // namespace hpx::plugins
-
-///////////////////////////////////////////////////////////////////////////////
-/// This macro is used create and to register a minimal component factory with
-/// Hpx.Plugin.
-#define HPX_REGISTER_BINARY_FILTER_FACTORY(BinaryFilter, pluginname)           \
-    HPX_REGISTER_BINARY_FILTER_FACTORY_BASE(                                   \
-        hpx::plugins::binary_filter_factory<BinaryFilter>, pluginname)         \
-    HPX_DEF_UNIQUE_PLUGIN_NAME(                                                \
-        hpx::plugins::binary_filter_factory<BinaryFilter>, pluginname)         \
-    template struct hpx::plugins::binary_filter_factory<BinaryFilter>;         \
-    HPX_REGISTER_PLUGIN_REGISTRY_2(BinaryFilter, pluginname)                   \
-    /**/

--- a/libs/full/plugin_factories/include/hpx/plugin_factories/binary_filter_factory_base.hpp
+++ b/libs/full/plugin_factories/include/hpx/plugin_factories/binary_filter_factory_base.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-#include <hpx/plugin_factories/macros.hpp>2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -9,7 +9,7 @@
 #include <hpx/config.hpp>
 #include <hpx/modules/plugin.hpp>
 #include <hpx/modules/serialization.hpp>
-
+#include <hpx/plugin_factories/macros.hpp>
 #include <hpx/plugin_factories/plugin_factory_base.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -18,7 +18,8 @@ namespace hpx::plugins {
     ///////////////////////////////////////////////////////////////////////////
     /// The \a plugin_factory_base has to be used as a base class for all
     /// plugin factories.
-    struct HPX_EXPORT binary_filter_factory_base : plugin_factory_base
+    HPX_CXX_EXPORT struct HPX_EXPORT binary_filter_factory_base
+      : plugin_factory_base
     {
         ~binary_filter_factory_base() override = default;
 
@@ -30,14 +31,3 @@ namespace hpx::plugins {
             serialization::binary_filter* next_filter = nullptr) = 0;
     };
 }    // namespace hpx::plugins
-
-///////////////////////////////////////////////////////////////////////////////
-/// This macro is used to register the given binary filter factory with
-/// Hpx.Plugin. This macro has to be used for each of the binary filter
-/// factories.
-#define HPX_REGISTER_BINARY_FILTER_FACTORY_BASE(FactoryType, pluginname)       \
-    HPX_PLUGIN_EXPORT(HPX_PLUGIN_PLUGIN_PREFIX,                                \
-        hpx::plugins::plugin_factory_base, FactoryType, pluginname, factory)   \
-    HPX_INIT_REGISTRY_PLUGIN_FACTORY_STATIC(                                   \
-        HPX_PLUGIN_PLUGIN_PREFIX, pluginname, factory)                         \
-    /**/

--- a/libs/full/plugin_factories/include/hpx/plugin_factories/macros.hpp
+++ b/libs/full/plugin_factories/include/hpx/plugin_factories/macros.hpp
@@ -1,0 +1,173 @@
+//  Copyright (c) 2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/modules/preprocessor.hpp>
+#include <hpx/plugin/macros.hpp>
+#include <hpx/runtime_configuration/macros.hpp>
+
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+#define HPX_DEF_UNIQUE_PLUGIN_NAME(PluginType, name)                           \
+    namespace hpx::plugins {                                                   \
+        template <>                                                            \
+        struct unique_plugin_name<PluginType>                                  \
+        {                                                                      \
+            using type = char const*;                                          \
+                                                                               \
+            static constexpr type call(void) noexcept                          \
+            {                                                                  \
+                return HPX_PP_STRINGIZE(name);                                 \
+            }                                                                  \
+        };                                                                     \
+    }                                                                          \
+    /**/
+
+///////////////////////////////////////////////////////////////////////////////
+// from libs/plugin_factories/plugin_factory_base.hpp
+// This macro is used to register the given plugin factory with Hpx.Plugin.
+// This macro has to be used for each of the plugin factories. Ungated,
+// matching the component analog (HPX_REGISTER_COMPONENT_FACTORY).
+#define HPX_REGISTER_PLUGIN_FACTORY_BASE(FactoryType, pluginname)              \
+    HPX_PLUGIN_EXPORT(HPX_PLUGIN_PLUGIN_PREFIX,                                \
+        hpx::plugins::plugin_factory_base, FactoryType, pluginname, factory)   \
+    HPX_INIT_REGISTRY_PLUGIN_FACTORY_STATIC(                                   \
+        HPX_PLUGIN_PLUGIN_PREFIX, pluginname, factory)                         \
+/**/
+
+// This macro is used to define the required Hpx.Plugin entry points. This
+// macro has to be used in exactly one compilation unit of a plugin module.
+// Ungated: a plugin may live in a shared library, in a statically linked
+// build, or directly in the application executable.
+#define HPX_REGISTER_PLUGIN_MODULE()                                           \
+    HPX_PLUGIN_EXPORT_LIST(HPX_PLUGIN_PLUGIN_PREFIX, factory)                  \
+    HPX_REGISTER_PLUGIN_REGISTRY_MODULE()                                      \
+    /**/
+
+#define HPX_REGISTER_PLUGIN_MODULE_DYNAMIC()                                   \
+    HPX_PLUGIN_EXPORT_LIST(HPX_PLUGIN_PLUGIN_PREFIX, factory)                  \
+    HPX_REGISTER_PLUGIN_REGISTRY_MODULE_DYNAMIC()
+
+///////////////////////////////////////////////////////////////////////////////
+// from libs/plugin_factories/binary_filter_factory_base.hpp
+// This macro is used to register the given component factory with
+// Hpx.Plugin. This macro has to be used for each of the binary filter
+// factories.
+#define HPX_REGISTER_BINARY_FILTER_FACTORY_BASE(FactoryType, pluginname)       \
+    HPX_PLUGIN_EXPORT(HPX_PLUGIN_PLUGIN_PREFIX,                                \
+        hpx::plugins::plugin_factory_base, FactoryType, pluginname, factory)   \
+    HPX_INIT_REGISTRY_PLUGIN_FACTORY_STATIC(                                   \
+        HPX_PLUGIN_PLUGIN_PREFIX, pluginname, factory)                         \
+    /**/
+
+///////////////////////////////////////////////////////////////////////////////
+// from libs/plugin_factories/binary_filter_factory.hpp
+// This macro is used create and to register a minimal component factory with
+// Hpx.Plugin.
+#define HPX_REGISTER_BINARY_FILTER_FACTORY(BinaryFilter, pluginname)           \
+    HPX_REGISTER_BINARY_FILTER_FACTORY_BASE(                                   \
+        hpx::plugins::binary_filter_factory<BinaryFilter>, pluginname)         \
+    HPX_DEF_UNIQUE_PLUGIN_NAME(                                                \
+        hpx::plugins::binary_filter_factory<BinaryFilter>, pluginname)         \
+    template struct hpx::plugins::binary_filter_factory<BinaryFilter>;         \
+    HPX_REGISTER_PLUGIN_REGISTRY_2(BinaryFilter, pluginname)                   \
+    /**/
+
+///////////////////////////////////////////////////////////////////////////////
+// from libs/plugin_factories/plugin_registry.hpp
+// This macro is used create and to register a minimal plugin registry with
+// Hpx.Plugin.
+#define HPX_REGISTER_PLUGIN_REGISTRY(...)                                      \
+    HPX_REGISTER_PLUGIN_REGISTRY_(__VA_ARGS__)                                 \
+    /**/
+
+#define HPX_REGISTER_PLUGIN_REGISTRY_(...)                                     \
+    HPX_PP_EXPAND(HPX_PP_CAT(HPX_REGISTER_PLUGIN_REGISTRY_,                    \
+        HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))                               \
+    /**/
+
+#define HPX_REGISTER_PLUGIN_REGISTRY_2(PluginType, pluginname)                 \
+    HPX_REGISTER_PLUGIN_REGISTRY_5(                                            \
+        PluginType, pluginname, HPX_PLUGIN_NAME, "hpx", "hpx")                 \
+    /**/
+#define HPX_REGISTER_PLUGIN_REGISTRY_4(                                        \
+    PluginType, pluginname, pluginsection, pluginsuffix)                       \
+    HPX_REGISTER_PLUGIN_REGISTRY_5(                                            \
+        PluginType, pluginname, HPX_PLUGIN_NAME, pluginsection, pluginsuffix)  \
+    /**/
+#define HPX_REGISTER_PLUGIN_REGISTRY_5(                                        \
+    PluginType, pluginname, pluginstring, pluginsection, pluginsuffix)         \
+    inline constexpr char __##pluginname##_string[] =                          \
+        HPX_PP_STRINGIZE(pluginstring);                                        \
+    inline constexpr char __##pluginname##_section[] = pluginsection;          \
+    inline constexpr char __##pluginname##_suffix[] = pluginsuffix;            \
+    using __##pluginname##_plugin_registry_type =                              \
+        hpx::plugins::plugin_registry<PluginType, __##pluginname##_string,     \
+            __##pluginname##_section, __##pluginname##_suffix>;                \
+    HPX_REGISTER_PLUGIN_BASE_REGISTRY(                                         \
+        __##pluginname##_plugin_registry_type, pluginname)                     \
+    HPX_DEF_UNIQUE_PLUGIN_NAME(                                                \
+        __##pluginname##_plugin_registry_type, pluginname)                     \
+    template struct hpx::plugins::plugin_registry<PluginType,                  \
+        __##pluginname##_string, __##pluginname##_section,                     \
+        __##pluginname##_suffix>;                                              \
+    /**/
+
+#if defined(HPX_HAVE_NETWORKING)
+
+///////////////////////////////////////////////////////////////////////////////
+// from libs/plugin_factories/parcelport_factory.hpp
+// This macro is used create and to register a minimal parcelport factory with
+// Hpx.Plugin.
+#define HPX_REGISTER_PARCELPORT_(Parcelport, pluginname, pp)                   \
+    using HPX_PP_CAT(pluginname, _plugin_factory_type) =                       \
+        hpx::plugins::parcelport_factory<Parcelport>;                          \
+    HPX_DEF_UNIQUE_PLUGIN_NAME(                                                \
+        HPX_PP_CAT(pluginname, _plugin_factory_type), pp)                      \
+    template struct hpx::plugins::parcelport_factory<Parcelport>;              \
+    HPX_EXPORT hpx::plugins::parcelport_factory_base* HPX_PP_CAT(              \
+        pluginname, _factory_init)(                                            \
+        std::vector<hpx::plugins::parcelport_factory_base*> & factories)       \
+    {                                                                          \
+        static HPX_PP_CAT(pluginname, _plugin_factory_type)                    \
+            factory(factories);                                                \
+        return &factory;                                                       \
+    }                                                                          \
+    /**/
+
+#define HPX_REGISTER_PARCELPORT(Parcelport, pluginname)                        \
+    HPX_REGISTER_PARCELPORT_(                                                  \
+        Parcelport, HPX_PP_CAT(parcelport_, pluginname), pluginname)
+
+///////////////////////////////////////////////////////////////////////////////
+// from libs/plugin_factories/message_handler_factory_base.hpp
+// This macro is used to register the given component factory with
+// Hpx.Plugin. This macro has to be used for each of the message handler
+// factories.
+#define HPX_REGISTER_MESSAGE_HANDLER_FACTORY_BASE(FactoryType, pluginname)     \
+    HPX_PLUGIN_EXPORT(HPX_PLUGIN_PLUGIN_PREFIX,                                \
+        hpx::plugins::plugin_factory_base, FactoryType, pluginname, factory)   \
+    HPX_INIT_REGISTRY_PLUGIN_FACTORY_STATIC(                                   \
+        HPX_PLUGIN_PLUGIN_PREFIX, pluginname, factory)                         \
+    /**/
+
+///////////////////////////////////////////////////////////////////////////////
+// from libs/plugin_factories/message_handler_factory.hpp
+// This macro is used create and to register a minimal component factory with
+// Hpx.Plugin.
+#define HPX_REGISTER_MESSAGE_HANDLER_FACTORY(MessageHandler, pluginname)       \
+    HPX_REGISTER_MESSAGE_HANDLER_FACTORY_BASE(                                 \
+        hpx::plugins::message_handler_factory<MessageHandler>, pluginname)     \
+    HPX_DEF_UNIQUE_PLUGIN_NAME(                                                \
+        hpx::plugins::message_handler_factory<MessageHandler>, pluginname)     \
+    template struct hpx::plugins::message_handler_factory<MessageHandler>;     \
+    HPX_REGISTER_PLUGIN_REGISTRY_2(MessageHandler, pluginname)                 \
+    /**/
+
+#endif

--- a/libs/full/plugin_factories/include/hpx/plugin_factories/message_handler_factory.hpp
+++ b/libs/full/plugin_factories/include/hpx/plugin_factories/message_handler_factory.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2024 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -11,9 +11,8 @@
 #if defined(HPX_HAVE_NETWORKING)
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/ini.hpp>
-#include <hpx/modules/preprocessor.hpp>
-
 #include <hpx/modules/parcelset_base.hpp>
+#include <hpx/plugin_factories/macros.hpp>
 #include <hpx/plugin_factories/message_handler_factory_base.hpp>
 #include <hpx/plugin_factories/plugin_registry.hpp>
 #include <hpx/plugin_factories/unique_plugin_name.hpp>
@@ -31,7 +30,7 @@ namespace hpx::plugins {
     ///
     /// \tparam MessageHandler The message handler type this factory should be
     ///                        responsible for.
-    template <typename MessageHandler>
+    HPX_CXX_EXPORT template <typename MessageHandler>
     struct message_handler_factory : message_handler_factory_base
     {
         /// \brief Construct a new factory instance
@@ -89,17 +88,5 @@ namespace hpx::plugins {
         bool isenabled_;
     };
 }    // namespace hpx::plugins
-
-///////////////////////////////////////////////////////////////////////////////
-/// This macro is used create and to register a minimal component factory with
-/// Hpx.Plugin.
-#define HPX_REGISTER_MESSAGE_HANDLER_FACTORY(MessageHandler, pluginname)       \
-    HPX_REGISTER_MESSAGE_HANDLER_FACTORY_BASE(                                 \
-        hpx::plugins::message_handler_factory<MessageHandler>, pluginname)     \
-    HPX_DEF_UNIQUE_PLUGIN_NAME(                                                \
-        hpx::plugins::message_handler_factory<MessageHandler>, pluginname)     \
-    template struct hpx::plugins::message_handler_factory<MessageHandler>;     \
-    HPX_REGISTER_PLUGIN_REGISTRY_2(MessageHandler, pluginname)                 \
-    /**/
 
 #endif

--- a/libs/full/plugin_factories/include/hpx/plugin_factories/message_handler_factory_base.hpp
+++ b/libs/full/plugin_factories/include/hpx/plugin_factories/message_handler_factory_base.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -10,9 +10,9 @@
 
 #if defined(HPX_HAVE_NETWORKING)
 #include <hpx/modules/errors.hpp>
-#include <hpx/modules/plugin.hpp>
-
 #include <hpx/modules/parcelset_base.hpp>
+#include <hpx/modules/plugin.hpp>
+#include <hpx/plugin_factories/macros.hpp>
 #include <hpx/plugin_factories/plugin_factory_base.hpp>
 
 #include <cstddef>
@@ -23,11 +23,12 @@ namespace hpx::plugins {
     ///////////////////////////////////////////////////////////////////////////
     /// The \a plugin_factory_base has to be used as a base class for all
     /// plugin factories.
-    struct HPX_EXPORT message_handler_factory_base : plugin_factory_base
+    HPX_CXX_EXPORT struct HPX_EXPORT message_handler_factory_base
+      : plugin_factory_base
     {
         ~message_handler_factory_base() override = default;
 
-        /// Register a action for this message handler type
+        /// Register an action for this message handler type
         virtual void register_action(char const* action, error_code& ec) = 0;
 
         /// Create a new instance of a message handler
@@ -39,16 +40,5 @@ namespace hpx::plugins {
             std::size_t interval) = 0;
     };
 }    // namespace hpx::plugins
-
-///////////////////////////////////////////////////////////////////////////////
-/// This macro is used to register the given message handler factory with
-/// Hpx.Plugin. This macro has to be used for each of the message handler
-/// factories.
-#define HPX_REGISTER_MESSAGE_HANDLER_FACTORY_BASE(FactoryType, pluginname)     \
-    HPX_PLUGIN_EXPORT(HPX_PLUGIN_PLUGIN_PREFIX,                                \
-        hpx::plugins::plugin_factory_base, FactoryType, pluginname, factory)   \
-    HPX_INIT_REGISTRY_PLUGIN_FACTORY_STATIC(                                   \
-        HPX_PLUGIN_PLUGIN_PREFIX, pluginname, factory)                         \
-    /**/
 
 #endif

--- a/libs/full/plugin_factories/include/hpx/plugin_factories/parcelport_factory.hpp
+++ b/libs/full/plugin_factories/include/hpx/plugin_factories/parcelport_factory.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c)      2014 Thomas Heller
-//  Copyright (c) 2007-2025 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c)      2020 Google
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+
 #if defined(HPX_HAVE_NETWORKING)
 #include <hpx/modules/plugin.hpp>
 #include <hpx/modules/prefix.hpp>
@@ -16,7 +17,7 @@
 #include <hpx/modules/resource_partitioner.hpp>
 #include <hpx/modules/runtime_configuration.hpp>
 #include <hpx/modules/string_util.hpp>
-
+#include <hpx/plugin_factories/macros.hpp>
 #include <hpx/plugin_factories/parcelport_factory_base.hpp>
 #include <hpx/plugin_factories/plugin_factory_base.hpp>
 #include <hpx/plugin_factories/unique_plugin_name.hpp>
@@ -37,7 +38,7 @@ namespace hpx::plugins {
     ///
     /// \tparam Parcelport The parcelport type this factory should be
     ///                        responsible for.
-    template <typename Parcelport>
+    HPX_CXX_EXPORT template <typename Parcelport>
     struct parcelport_factory : parcelport_factory_base
     {
         /// \brief Construct a new factory instance
@@ -167,28 +168,5 @@ namespace hpx::plugins {
         }
     };
 }    // namespace hpx::plugins
-
-///////////////////////////////////////////////////////////////////////////////
-/// This macro is used create and to register a minimal component factory with
-/// Hpx.Plugin.
-#define HPX_REGISTER_PARCELPORT_(Parcelport, pluginname, pp)                   \
-    using HPX_PP_CAT(pluginname, _plugin_factory_type) =                       \
-        hpx::plugins::parcelport_factory<Parcelport>;                          \
-    HPX_DEF_UNIQUE_PLUGIN_NAME(                                                \
-        HPX_PP_CAT(pluginname, _plugin_factory_type), pp)                      \
-    template struct hpx::plugins::parcelport_factory<Parcelport>;              \
-    HPX_EXPORT hpx::plugins::parcelport_factory_base* HPX_PP_CAT(              \
-        pluginname, _factory_init)(                                            \
-        std::vector<hpx::plugins::parcelport_factory_base*> & factories)       \
-    {                                                                          \
-        static HPX_PP_CAT(pluginname, _plugin_factory_type)                    \
-            factory(factories);                                                \
-        return &factory;                                                       \
-    }                                                                          \
-    /**/
-
-#define HPX_REGISTER_PARCELPORT(Parcelport, pluginname)                        \
-    HPX_REGISTER_PARCELPORT_(                                                  \
-        Parcelport, HPX_PP_CAT(parcelport_, pluginname), pluginname)
 
 #endif

--- a/libs/full/plugin_factories/include/hpx/plugin_factories/parcelport_factory_base.hpp
+++ b/libs/full/plugin_factories/include/hpx/plugin_factories/parcelport_factory_base.hpp
@@ -23,7 +23,7 @@ namespace hpx::plugins {
     ///////////////////////////////////////////////////////////////////////////
     /// The \a plugin_factory_base has to be used as a base class for all
     /// plugin factories.
-    struct HPX_EXPORT parcelport_factory_base
+    HPX_CXX_EXPORT struct HPX_EXPORT parcelport_factory_base
     {
         virtual ~parcelport_factory_base() = default;
 

--- a/libs/full/plugin_factories/include/hpx/plugin_factories/plugin_factory_base.hpp
+++ b/libs/full/plugin_factories/include/hpx/plugin_factories/plugin_factory_base.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2024 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -9,9 +9,9 @@
 #include <hpx/config.hpp>
 #include <hpx/modules/ini.hpp>
 #include <hpx/modules/plugin.hpp>
-#include <hpx/modules/type_support.hpp>
-
 #include <hpx/modules/runtime_configuration.hpp>
+#include <hpx/modules/type_support.hpp>
+#include <hpx/plugin_factories/macros.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx::plugins {
@@ -19,7 +19,7 @@ namespace hpx::plugins {
     ///////////////////////////////////////////////////////////////////////////
     /// The \a plugin_factory_base has to be used as a base class for all
     /// plugin factories.
-    struct HPX_EXPORT plugin_factory_base
+    HPX_CXX_EXPORT struct HPX_EXPORT plugin_factory_base
     {
         virtual ~plugin_factory_base() = default;
     };
@@ -48,28 +48,3 @@ struct hpx::util::plugin::virtual_constructor<hpx::plugins::plugin_factory_base>
     using type = hpx::util::pack<hpx::util::section const*,
         hpx::util::section const*, bool>;
 };
-
-////////////////////////////////////////////////////////////////////////////////
-/// This macro is used to register the given plugin factory with Hpx.Plugin.
-/// This macro has to be used for each of the plugin factories. Ungated,
-/// matching the component analog (HPX_REGISTER_COMPONENT_FACTORY).
-#define HPX_REGISTER_PLUGIN_FACTORY_BASE(FactoryType, pluginname)              \
-    HPX_PLUGIN_EXPORT(HPX_PLUGIN_PLUGIN_PREFIX,                                \
-        hpx::plugins::plugin_factory_base, FactoryType, pluginname, factory)   \
-    HPX_INIT_REGISTRY_PLUGIN_FACTORY_STATIC(                                   \
-        HPX_PLUGIN_PLUGIN_PREFIX, pluginname, factory)                         \
-/**/
-
-/// This macro is used to define the required Hpx.Plugin entry points. This
-/// macro has to be used in exactly one compilation unit of a plugin module.
-/// Ungated: a plugin may live in a shared library, in a statically linked
-/// build, or directly in the application executable.
-#define HPX_REGISTER_PLUGIN_MODULE()                                           \
-    HPX_PLUGIN_EXPORT_LIST(HPX_PLUGIN_PLUGIN_PREFIX, factory)                  \
-    HPX_REGISTER_PLUGIN_REGISTRY_MODULE()                                      \
-    /**/
-
-#define HPX_REGISTER_PLUGIN_MODULE_DYNAMIC()                                   \
-    HPX_PLUGIN_EXPORT_LIST(HPX_PLUGIN_PLUGIN_PREFIX, factory)                  \
-    HPX_REGISTER_PLUGIN_REGISTRY_MODULE_DYNAMIC()                              \
-    /**/

--- a/libs/full/plugin_factories/include/hpx/plugin_factories/plugin_registry.hpp
+++ b/libs/full/plugin_factories/include/hpx/plugin_factories/plugin_registry.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -10,10 +10,9 @@
 #include <hpx/modules/ini.hpp>
 #include <hpx/modules/plugin.hpp>
 #include <hpx/modules/prefix.hpp>
-#include <hpx/modules/preprocessor.hpp>
 #include <hpx/modules/runtime_configuration.hpp>
 #include <hpx/modules/string_util.hpp>
-
+#include <hpx/plugin_factories/macros.hpp>
 #include <hpx/plugin_factories/unique_plugin_name.hpp>
 
 #include <algorithm>
@@ -25,13 +24,14 @@
 namespace hpx::plugins {
 
     ///////////////////////////////////////////////////////////////////////////
-    /// The \a plugin_registry provides a minimal implementation of a
-    /// plugin's registry. If no additional functionality is required this
-    /// type can be used to implement the full set of minimally required
-    /// functions to be exposed by a plugin's registry instance.
+    /// The \a plugin_registry provides a minimal implementation of a plugin's
+    /// registry. If no additional functionality is required this type can be
+    /// used to implement the full set of minimally required functions to be
+    /// exposed by a plugin's registry instance.
     ///
-    /// \tparam Plugin   The plugin type this registry should be responsible for.
-    template <typename Plugin, char const* const Name,
+    /// \tparam Plugin   The plugin type this registry should be responsible
+    ///                  for.
+    HPX_CXX_EXPORT template <typename Plugin, char const* const Name,
         char const* const Section, char const* const Suffix>
     struct plugin_registry : plugin_registry_base
     {
@@ -67,41 +67,3 @@ namespace hpx::plugins {
         }
     };
 }    // namespace hpx::plugins
-
-///////////////////////////////////////////////////////////////////////////////
-/// This macro is used create and to register a minimal plugin registry with
-/// Hpx.Plugin.
-#define HPX_REGISTER_PLUGIN_REGISTRY(...)                                      \
-    HPX_REGISTER_PLUGIN_REGISTRY_(__VA_ARGS__)                                 \
-    /**/
-
-#define HPX_REGISTER_PLUGIN_REGISTRY_(...)                                     \
-    HPX_PP_EXPAND(HPX_PP_CAT(HPX_REGISTER_PLUGIN_REGISTRY_,                    \
-        HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))                               \
-    /**/
-
-#define HPX_REGISTER_PLUGIN_REGISTRY_2(PluginType, pluginname)                 \
-    HPX_REGISTER_PLUGIN_REGISTRY_5(                                            \
-        PluginType, pluginname, HPX_PLUGIN_NAME, "hpx", "hpx")                 \
-    /**/
-#define HPX_REGISTER_PLUGIN_REGISTRY_4(                                        \
-    PluginType, pluginname, pluginsection, pluginsuffix)                       \
-    HPX_REGISTER_PLUGIN_REGISTRY_5(                                            \
-        PluginType, pluginname, HPX_PLUGIN_NAME, pluginsection, pluginsuffix)  \
-    /**/
-#define HPX_REGISTER_PLUGIN_REGISTRY_5(                                        \
-    PluginType, pluginname, pluginstring, pluginsection, pluginsuffix)         \
-    constexpr char __##pluginname##_string[] = HPX_PP_STRINGIZE(pluginstring); \
-    constexpr char __##pluginname##_section[] = pluginsection;                 \
-    constexpr char __##pluginname##_suffix[] = pluginsuffix;                   \
-    using __##pluginname##_plugin_registry_type =                              \
-        hpx::plugins::plugin_registry<PluginType, __##pluginname##_string,     \
-            __##pluginname##_section, __##pluginname##_suffix>;                \
-    HPX_REGISTER_PLUGIN_BASE_REGISTRY(                                         \
-        __##pluginname##_plugin_registry_type, pluginname)                     \
-    HPX_DEF_UNIQUE_PLUGIN_NAME(                                                \
-        __##pluginname##_plugin_registry_type, pluginname)                     \
-    template struct hpx::plugins::plugin_registry<PluginType,                  \
-        __##pluginname##_string, __##pluginname##_section,                     \
-        __##pluginname##_suffix>;                                              \
-    /**/

--- a/libs/full/plugin_factories/include/hpx/plugin_factories/unique_plugin_name.hpp
+++ b/libs/full/plugin_factories/include/hpx/plugin_factories/unique_plugin_name.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2011 Bryce Lelbach
-//  Copyright (c) 2013-2024 Hartmut Kaiser
+//  Copyright (c) 2013-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -7,28 +7,13 @@
 
 #pragma once
 
-#include <hpx/modules/preprocessor.hpp>
+#include <hpx/config.hpp>
 
 namespace hpx::plugins {
 
-    template <typename PluginType>
+    HPX_CXX_EXPORT template <typename PluginType>
     struct unique_plugin_name
     {
         static_assert(sizeof(PluginType) == 0, "plugin name is not defined");
     };
 }    // namespace hpx::plugins
-
-#define HPX_DEF_UNIQUE_PLUGIN_NAME(PluginType, name)                           \
-    namespace hpx::plugins {                                                   \
-        template <>                                                            \
-        struct unique_plugin_name<PluginType>                                  \
-        {                                                                      \
-            using type = char const*;                                          \
-                                                                               \
-            static constexpr type call(void) noexcept                          \
-            {                                                                  \
-                return HPX_PP_STRINGIZE(name);                                 \
-            }                                                                  \
-        };                                                                     \
-    }                                                                          \
-    /**/

--- a/libs/full/resiliency_distributed/examples/async_replay_distributed.cpp
+++ b/libs/full/resiliency_distributed/examples/async_replay_distributed.cpp
@@ -11,10 +11,10 @@
 #include <hpx/config.hpp>
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 
-#include <hpx/actions_base/plain_action.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/runtime.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/resiliency_distributed.hpp>
 #include <hpx/modules/testing.hpp>

--- a/libs/full/resiliency_distributed/examples/async_replicate_distributed.cpp
+++ b/libs/full/resiliency_distributed/examples/async_replicate_distributed.cpp
@@ -10,10 +10,10 @@
 #include <hpx/config.hpp>
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 
-#include <hpx/actions_base/plain_action.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/runtime.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/resiliency_distributed.hpp>
 #include <hpx/modules/testing.hpp>

--- a/libs/full/resiliency_distributed/tests/performance/replay/async_replay_distributed.cpp
+++ b/libs/full/resiliency_distributed/tests/performance/replay/async_replay_distributed.cpp
@@ -11,10 +11,10 @@
 #include <hpx/config.hpp>
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 
-#include <hpx/actions_base/plain_action.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/runtime.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/resiliency.hpp>
 #include <hpx/modules/resiliency_distributed.hpp>

--- a/libs/full/resiliency_distributed/tests/performance/replay/async_replay_distributed_validate.cpp
+++ b/libs/full/resiliency_distributed/tests/performance/replay/async_replay_distributed_validate.cpp
@@ -11,10 +11,10 @@
 #include <hpx/config.hpp>
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 
-#include <hpx/actions_base/plain_action.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/runtime.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/resiliency.hpp>
 #include <hpx/modules/resiliency_distributed.hpp>

--- a/libs/full/resiliency_distributed/tests/performance/replay/plain_async_distributed.cpp
+++ b/libs/full/resiliency_distributed/tests/performance/replay/plain_async_distributed.cpp
@@ -10,10 +10,10 @@
 #include <hpx/config.hpp>
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 
-#include <hpx/actions_base/plain_action.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/runtime.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/resiliency.hpp>
 #include <hpx/modules/testing.hpp>

--- a/libs/full/resiliency_distributed/tests/performance/replicate/async_replicate_distributed.cpp
+++ b/libs/full/resiliency_distributed/tests/performance/replicate/async_replicate_distributed.cpp
@@ -11,10 +11,10 @@
 #include <hpx/config.hpp>
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 
-#include <hpx/actions_base/plain_action.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/runtime.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/resiliency.hpp>
 #include <hpx/modules/resiliency_distributed.hpp>

--- a/libs/full/resiliency_distributed/tests/performance/replicate/async_replicate_distributed_validate.cpp
+++ b/libs/full/resiliency_distributed/tests/performance/replicate/async_replicate_distributed_validate.cpp
@@ -11,10 +11,10 @@
 #include <hpx/config.hpp>
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 
-#include <hpx/actions_base/plain_action.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/runtime.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/resiliency.hpp>
 #include <hpx/modules/resiliency_distributed.hpp>

--- a/libs/full/resiliency_distributed/tests/performance/replicate/async_replicate_distributed_vote.cpp
+++ b/libs/full/resiliency_distributed/tests/performance/replicate/async_replicate_distributed_vote.cpp
@@ -10,10 +10,10 @@
 #include <hpx/config.hpp>
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 
-#include <hpx/actions_base/plain_action.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/runtime.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/resiliency.hpp>
 #include <hpx/modules/resiliency_distributed.hpp>

--- a/libs/full/resiliency_distributed/tests/performance/replicate/async_replicate_distributed_vote_validate.cpp
+++ b/libs/full/resiliency_distributed/tests/performance/replicate/async_replicate_distributed_vote_validate.cpp
@@ -11,10 +11,10 @@
 #include <hpx/config.hpp>
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 
-#include <hpx/actions_base/plain_action.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/runtime.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/resiliency.hpp>
 #include <hpx/modules/resiliency_distributed.hpp>

--- a/libs/full/resiliency_distributed/tests/unit/async_replay_distributed_plain.cpp
+++ b/libs/full/resiliency_distributed/tests/unit/async_replay_distributed_plain.cpp
@@ -7,9 +7,9 @@
 #include <hpx/config.hpp>
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 
-#include <hpx/actions_base/plain_action.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/runtime.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/resiliency.hpp>
 #include <hpx/modules/resiliency_distributed.hpp>

--- a/libs/full/resiliency_distributed/tests/unit/async_replicate_distributed_plain.cpp
+++ b/libs/full/resiliency_distributed/tests/unit/async_replicate_distributed_plain.cpp
@@ -7,9 +7,9 @@
 #include <hpx/config.hpp>
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 
-#include <hpx/actions_base/plain_action.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/runtime.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/resiliency.hpp>
 #include <hpx/modules/resiliency_distributed.hpp>

--- a/libs/full/runtime_components/include/hpx/runtime_components/distributed_metadata_base.hpp
+++ b/libs/full/runtime_components/include/hpx/runtime_components/distributed_metadata_base.hpp
@@ -8,10 +8,10 @@
 
 #include <hpx/config.hpp>
 #include <hpx/actions/transfer_action.hpp>
-#include <hpx/actions_base/component_action.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/async_distributed/base_lco_with_value.hpp>
 #include <hpx/async_distributed/transfer_continuation_action.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/preprocessor.hpp>
 

--- a/libs/full/runtime_components/include/hpx/runtime_components/new.hpp
+++ b/libs/full/runtime_components/include/hpx/runtime_components/new.hpp
@@ -11,9 +11,8 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/traits/is_client.hpp>
-#include <hpx/actions_base/traits/is_distribution_policy.hpp>
 #include <hpx/components/client_base.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/futures.hpp>

--- a/libs/full/runtime_components/include/hpx/runtime_components/server/console_error_sink.hpp
+++ b/libs/full/runtime_components/include/hpx/runtime_components/server/console_error_sink.hpp
@@ -8,8 +8,8 @@
 
 #include <hpx/config.hpp>
 #include <hpx/actions/transfer_action.hpp>
-#include <hpx/actions_base/plain_action.hpp>
 #include <hpx/async_distributed/transfer_continuation_action.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 
 #include <exception>

--- a/libs/full/runtime_components/include/hpx/runtime_components/server/console_logging.hpp
+++ b/libs/full/runtime_components/include/hpx/runtime_components/server/console_logging.hpp
@@ -9,9 +9,8 @@
 
 #include <hpx/config.hpp>
 #include <hpx/actions/transfer_action.hpp>
-#include <hpx/actions_base/plain_action.hpp>
-#include <hpx/actions_base/traits/action_does_termination_detection.hpp>
 #include <hpx/async_distributed/transfer_continuation_action.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/datastructures.hpp>
 #include <hpx/modules/logging.hpp>

--- a/libs/full/runtime_components/src/server/console_error_sink_server.cpp
+++ b/libs/full/runtime_components/src/server/console_error_sink_server.cpp
@@ -7,10 +7,10 @@
 
 #include <hpx/config.hpp>
 #include <hpx/actions/transfer_action.hpp>
-#include <hpx/actions_base/basic_action.hpp>
 #include <hpx/async_distributed/base_lco_with_value.hpp>
 #include <hpx/async_distributed/continuation.hpp>
 #include <hpx/async_distributed/transfer_continuation_action.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/ini.hpp>
 #include <hpx/modules/runtime_local.hpp>

--- a/libs/full/runtime_components/tests/unit/components/action_invoke_no_more_than.hpp
+++ b/libs/full/runtime_components/tests/unit/components/action_invoke_no_more_than.hpp
@@ -9,9 +9,9 @@
 #include <hpx/config.hpp>
 
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
-#include <hpx/actions_base/traits/action_decorate_continuation.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/async_distributed/continuation.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/futures.hpp>

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/copy_component.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/copy_component.hpp
@@ -9,9 +9,9 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/plain_action.hpp>
 #include <hpx/async_colocated/async_colocated.hpp>
 #include <hpx/async_distributed/async.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/naming_base.hpp>

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/migrate_component.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/migrate_component.hpp
@@ -10,12 +10,11 @@
 
 #include <hpx/config.hpp>
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
-#include <hpx/actions_base/plain_action.hpp>
-#include <hpx/actions_base/traits/is_distribution_policy.hpp>
 #include <hpx/async_colocated/async_colocated.hpp>
 #include <hpx/async_distributed/async.hpp>
 #include <hpx/components/client_base.hpp>
 #include <hpx/distribution_policies/target_distribution_policy.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/naming_base.hpp>

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/server/copy_component.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/server/copy_component.hpp
@@ -7,8 +7,8 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/plain_action.hpp>
 #include <hpx/components/get_ptr.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/naming_base.hpp>
 #include <hpx/runtime_components/components_fwd.hpp>

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/server/migrate_component.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/server/migrate_component.hpp
@@ -7,8 +7,8 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/plain_action.hpp>
 #include <hpx/components/get_ptr.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/naming_base.hpp>
 #include <hpx/runtime_distributed/find_here.hpp>

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/server/runtime_support.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/server/runtime_support.hpp
@@ -10,20 +10,19 @@
 
 #include <hpx/config.hpp>
 #include <hpx/actions/transfer_action.hpp>
-#include <hpx/actions_base/component_action.hpp>
-#include <hpx/actions_base/traits/action_does_termination_detection.hpp>
 #include <hpx/agas/agas_fwd.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/async_distributed/transfer_continuation_action.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/parcelset_base.hpp>
 #include <hpx/modules/plugin.hpp>
+#include <hpx/modules/plugin_factories.hpp>
 #include <hpx/modules/program_options.hpp>
 #include <hpx/modules/runtime_configuration.hpp>
 #include <hpx/modules/synchronization.hpp>
 #include <hpx/performance_counters/counters.hpp>
-#include <hpx/plugin_factories/plugin_factory_base.hpp>
 #include <hpx/runtime_components/components_fwd.hpp>
 #include <hpx/runtime_distributed/find_here.hpp>
 

--- a/libs/full/runtime_distributed/src/big_boot_barrier.cpp
+++ b/libs/full/runtime_distributed/src/big_boot_barrier.cpp
@@ -9,13 +9,12 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_NETWORKING)
-#include <hpx/actions_base/actions_base_support.hpp>
-#include <hpx/actions_base/plain_action.hpp>
 #include <hpx/agas/addressing_service.hpp>
 #include <hpx/agas_base/detail/hosted_component_namespace.hpp>
 #include <hpx/agas_base/detail/hosted_locality_namespace.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/async_distributed/put_parcel.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/agas_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/errors.hpp>

--- a/libs/full/runtime_distributed/src/get_locality_name.cpp
+++ b/libs/full/runtime_distributed/src/get_locality_name.cpp
@@ -5,8 +5,8 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/plain_action.hpp>
 #include <hpx/async_distributed/async.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/runtime_distributed/get_locality_name.hpp>
 

--- a/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
+++ b/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
@@ -7,10 +7,10 @@
 
 #include <hpx/config.hpp>
 
-#include <hpx/actions_base/plain_action.hpp>
 #include <hpx/agas/addressing_service.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/async_distributed/continuation.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_combinators.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/command_line_handling.hpp>
@@ -22,6 +22,7 @@
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/ini.hpp>
 #include <hpx/modules/logging.hpp>
+#include <hpx/modules/plugin_factories.hpp>
 #include <hpx/modules/prefix.hpp>
 #include <hpx/modules/runtime_configuration.hpp>
 #include <hpx/modules/runtime_local.hpp>
@@ -33,8 +34,6 @@
 #include <hpx/modules/timing.hpp>
 #include <hpx/modules/type_support.hpp>
 #include <hpx/performance_counters/counters.hpp>
-#include <hpx/plugin_factories/binary_filter_factory_base.hpp>
-#include <hpx/plugin_factories/message_handler_factory_base.hpp>
 #include <hpx/runtime_components/console_logging.hpp>
 #include <hpx/runtime_distributed.hpp>
 #include <hpx/runtime_distributed/find_localities.hpp>

--- a/libs/full/runtime_distributed/src/stubs/runtime_support_stubs.cpp
+++ b/libs/full/runtime_distributed/src/stubs/runtime_support_stubs.cpp
@@ -6,10 +6,10 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/traits/action_was_object_migrated.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/async_colocated/post_colocated.hpp>
 #include <hpx/async_distributed/post.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/components_base.hpp>

--- a/libs/full/segmented_algorithms/CMakeLists.txt
+++ b/libs/full/segmented_algorithms/CMakeLists.txt
@@ -54,7 +54,7 @@ add_hpx_module(
   HEADERS ${segmented_algorithms_headers}
   COMPAT_HEADERS ${segmented_algorithms_compat_headers}
   DEPENDENCIES hpx_core
-  MODULE_DEPENDENCIES hpx_async_colocated hpx_async_distributed
+  MODULE_DEPENDENCIES hpx_actions_base hpx_async_colocated hpx_async_distributed
                       hpx_distribution_policies hpx_naming_base
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/dispatch.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/dispatch.hpp
@@ -8,9 +8,9 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/plain_action.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/distribution_policies/colocating_distribution_policy.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/algorithms.hpp>
 #include <hpx/modules/executors.hpp>
 #include <hpx/modules/naming_base.hpp>

--- a/tests/performance/local/future_overhead.cpp
+++ b/tests/performance/local/future_overhead.cpp
@@ -9,7 +9,7 @@
 
 #include <hpx/config.hpp>
 #if defined(HPX_HAVE_DISTRIBUTED_RUNTIME) && !defined(HPX_COMPUTE_DEVICE_CODE)
-#include <hpx/actions_base/plain_action.hpp>
+#include <hpx/modules/actions_base.hpp>
 #endif
 #include <hpx/algorithm.hpp>
 #include <hpx/execution.hpp>

--- a/tests/performance/local/spinlock_overhead1.cpp
+++ b/tests/performance/local/spinlock_overhead1.cpp
@@ -8,13 +8,14 @@
 #include <hpx/config.hpp>
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 
-#include <hpx/actions_base/plain_action.hpp>
 #include <hpx/async_distributed/continuation.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/async.hpp>
 #include <hpx/iostream.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_combinators.hpp>
 #include <hpx/modules/format.hpp>
+#include <hpx/modules/itt_notify.hpp>
 #include <hpx/modules/lock_registration.hpp>
 #include <hpx/modules/testing.hpp>
 #include <hpx/modules/timing.hpp>

--- a/tests/performance/local/spinlock_overhead2.cpp
+++ b/tests/performance/local/spinlock_overhead2.cpp
@@ -8,13 +8,14 @@
 #include <hpx/config.hpp>
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 
-#include <hpx/actions_base/plain_action.hpp>
 #include <hpx/async_distributed/continuation.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/async.hpp>
 #include <hpx/iostream.hpp>
+#include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_combinators.hpp>
 #include <hpx/modules/format.hpp>
+#include <hpx/modules/itt_notify.hpp>
 #include <hpx/modules/lock_registration.hpp>
 #include <hpx/modules/testing.hpp>
 #include <hpx/modules/timing.hpp>

--- a/tests/unit/build/CMakeLists.txt
+++ b/tests/unit/build/CMakeLists.txt
@@ -55,6 +55,12 @@ function(
   if(HPX_WITH_CLANG_CUDA)
     set(cmake_cuda_compiler -DCMAKE_CUDA_COMPILER=${CMAKE_CUDA_COMPILER})
   endif()
+  if(HPX_WITH_CXX_MODULES)
+    set(ADDITIONAL_CMAKE_OPTIONS
+        ${ADDITIONAL_CMAKE_OPTIONS} -DHPX_WITH_CXX_MODULES=ON
+        -DHPX_CMAKE_LOGLEVEL=Debug
+    )
+  endif()
   add_custom_target(
     ${name}
     COMMAND
@@ -63,7 +69,7 @@ function(
       -DHPX_DIR=${hpx_dir} -DBOOST_ROOT=${BOOST_ROOT}
       ${ADDITIONAL_CMAKE_OPTIONS} -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS_SAFE}
       -DCMAKE_BUILD_TYPE=${build_type} ${cmake_cuda_compiler} --test-command
-      "${CMAKE_CTEST_COMMAND}" --output-on-failure
+      "${CMAKE_CTEST_COMMAND}" --output-on-failure --verbose
     VERBATIM
   )
   add_dependencies(${name} hpx hpx_init hpx_wrap)

--- a/tests/unit/build/CMakeLists.txt
+++ b/tests/unit/build/CMakeLists.txt
@@ -10,6 +10,12 @@ if(NOT HPX_WITH_TESTS_EXTERNAL_BUILD)
   return()
 endif()
 
+# If C++ modules are enabled, exit now (we don't know yet how to setup a
+# dependent HPX project to use the generated BMIs).
+if(HPX_WITH_CXX_MODULES)
+  return()
+endif()
+
 # Try building an external cmake based project ...
 function(
   create_cmake_test


### PR DESCRIPTION
The following modules have been adapted by this PR:

- full/plugin_factories
- full/actions_base
- full/naming

Also:

- flyby: adding missing export statements to various symbols in core
- flyby: full compilation of all tests with C++ modules enabled
