### PR TITLE
Add flat-collective fallback to hierarchical_communicator for small site counts

### DIFF
--- a/libs/full/collectives/include/hpx/collectives/argument_types.hpp
+++ b/libs/full/collectives/include/hpx/collectives/argument_types.hpp
@@ -54,6 +54,7 @@ namespace hpx::collectives {
         struct root_site_tag;
         struct tag_tag;
         struct arity_tag;
+        struct flat_fallback_threshold_tag;
     }    // namespace detail
 
     /// The number of participating sites (default: all localities)
@@ -81,4 +82,12 @@ namespace hpx::collectives {
     /// The number of children each of the communication nodes is connected
     /// to (default: picked based on num_sites).
     using arity_arg = detail::argument_type<detail::arity_tag, 2>;
+
+    /// The site-count threshold below which a hierarchical_communicator
+    /// collapses to a single flat communicator spanning all sites. At small
+    /// site counts, flat collectives outperform hierarchical composition
+    /// because tree-walking overhead exceeds the synchronization-depth
+    /// benefit. Pass 0 to disable the fallback and always build a tree.
+    using flat_fallback_threshold_arg =
+        detail::argument_type<detail::flat_fallback_threshold_tag, 16>;
 }    // namespace hpx::collectives

--- a/libs/full/collectives/include/hpx/collectives/create_communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/create_communicator.hpp
@@ -136,8 +136,8 @@ namespace hpx { namespace collectives {
         this_site_arg this_site = this_site_arg(),
         arity_arg arity = arity_arg(),
         generation_arg generation = generation_arg(),
-        root_site_arg root_site = root_site_arg());
-
+        root_site_arg root_site = root_site_arg(),
+        flat_fallback_threshold_arg threshold = flat_fallback_threshold_arg());
 }}
 // clang-format on
 
@@ -279,13 +279,13 @@ namespace hpx::collectives {
 
     ///////////////////////////////////////////////////////////////////////////
     struct hierarchical_communicator;
-
     HPX_EXPORT hierarchical_communicator create_hierarchical_communicator(
         char const* basename, num_sites_arg num_sites = num_sites_arg(),
         this_site_arg this_site = this_site_arg(),
         arity_arg arity = arity_arg(),
         generation_arg generation = generation_arg(),
-        root_site_arg root_site = root_site_arg());
+        root_site_arg root_site = root_site_arg(),
+        flat_fallback_threshold_arg threshold = flat_fallback_threshold_arg());
 
     struct hierarchical_communicator
     {
@@ -305,7 +305,8 @@ namespace hpx::collectives {
         friend HPX_EXPORT hierarchical_communicator
         create_hierarchical_communicator(char const* basename,
             num_sites_arg num_sites, this_site_arg this_site, arity_arg arity,
-            generation_arg generation, root_site_arg root_site);
+            generation_arg generation, root_site_arg root_site,
+            flat_fallback_threshold_arg threshold);
 
     public:
         hpx::tuple<communicator, this_site_arg>& operator[](std::size_t idx)

--- a/libs/full/collectives/src/create_communicator.cpp
+++ b/libs/full/collectives/src/create_communicator.cpp
@@ -429,7 +429,8 @@ namespace hpx::collectives {
 
     hierarchical_communicator create_hierarchical_communicator(
         char const* basename, num_sites_arg num_sites, this_site_arg this_site,
-        arity_arg arity, generation_arg generation, root_site_arg root_site)
+        arity_arg arity, generation_arg generation, root_site_arg root_site,
+        flat_fallback_threshold_arg threshold)
     {
         if (num_sites.is_default())
         {
@@ -447,7 +448,6 @@ namespace hpx::collectives {
         {
             this_site = this_site - root_site % num_sites;
         }
-
         HPX_ASSERT(this_site < num_sites);
         HPX_ASSERT(
             root_site != static_cast<std::size_t>(-1) && root_site < num_sites);
@@ -456,6 +456,29 @@ namespace hpx::collectives {
         if (!generation.is_default())
         {
             name += std::to_string(generation) + "/";
+        }
+
+        // Flat fallback: below the threshold, hierarchical overhead exceeds
+        // its benefit. Produce a single-level communicator spanning all N
+        // sites; the tree walking loops in the hierarchical collective
+        // overloads collapse to a single flat call when size() == 1 (this is
+        // also the code path non-leader sites take in normal tree mode). Pass
+        // threshold == 0 to disable this fallback and always build a tree.
+        if (num_sites < threshold)
+        {
+            // Name the fallback communicator the same way the tree path would
+            // name a single top-level group, to avoid basename collisions with
+            // direct flat communicators using the bare basename.
+            std::string fallback_name(name);
+            fallback_name += "0-" +
+                std::to_string(static_cast<std::size_t>(num_sites) - 1) + "/";
+
+            auto c = create_communicator(fallback_name.c_str(), num_sites,
+                this_site, generation, root_site_arg(0));
+            std::vector<hpx::tuple<communicator, this_site_arg>> communicators;
+            communicators.emplace_back(HPX_MOVE(c), this_site);
+            return hierarchical_communicator(HPX_MOVE(communicators), arity,
+                root_site, num_sites, this_site);
         }
 
         std::vector<hpx::tuple<communicator, this_site_arg>> communicators;

--- a/libs/full/collectives/tests/performance/benchmark_collectives.cpp
+++ b/libs/full/collectives/tests/performance/benchmark_collectives.cpp
@@ -10,6 +10,7 @@
 #include <hpx/config.hpp>
 
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
+#include <hpx/collectives/all_gather.hpp>
 #include <hpx/collectives/all_reduce.hpp>
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
@@ -29,6 +30,7 @@ constexpr char const* reduce_direct_basename = "/test/reduce_direct/";
 constexpr char const* broadcast_direct_basename = "/test/broadcast_direct/";
 constexpr char const* gather_direct_basename = "/test/gather_direct/";
 constexpr char const* all_reduce_direct_basename = "/test/all_reduce_direct/";
+constexpr char const* all_gather_direct_basename = "/test/all_gather_direct/";
 
 struct vector_adder
 {
@@ -164,7 +166,7 @@ void write_to_file(std::string const& collective, std::string const& type,
 ////////////////////////////////////////////////////////////////////////////////////////
 // Hierarchical collectives
 void test_scatter_hierarchical(int arity, int lpn, std::size_t iterations,
-    int test_size, std::string const& operation)
+    int test_size, std::string const& operation, int fallback_threshold)
 {
     // Get parameters
     std::size_t const num_localities =
@@ -176,7 +178,11 @@ void test_scatter_hierarchical(int arity, int lpn, std::size_t iterations,
     auto communicators =
         create_hierarchical_communicator(scatter_direct_basename,
             num_sites_arg(num_localities), this_site_arg(this_locality),
-            arity_arg(arity), generation_arg(1), root_site_arg(0));
+            arity_arg(arity), generation_arg(1), root_site_arg(0),
+            fallback_threshold < 0 ?
+                flat_fallback_threshold_arg() :
+                flat_fallback_threshold_arg(
+                    static_cast<std::size_t>(fallback_threshold)));
     // Barrier for synchronization
     char const* const barrier_test_name = "/test/barrier/hierarchical";
     hpx::distributed::barrier barrier(barrier_test_name);
@@ -223,13 +229,16 @@ void test_scatter_hierarchical(int arity, int lpn, std::size_t iterations,
 
     if (this_locality == 0)
     {
-        write_to_file(operation, "hierarchical", arity, num_localities, lpn,
+        std::string const mod_name = fallback_threshold < 0 ?
+            std::string("hierarchical") :
+            "hierarchical_t" + std::to_string(fallback_threshold);
+        write_to_file(operation, mod_name, arity, num_localities, lpn,
             test_size, iterations, result);
     }
 }
 
 void test_reduce_hierarchical(int arity, int lpn, std::size_t iterations,
-    int test_size, std::string const& operation)
+    int test_size, std::string const& operation, int fallback_threshold)
 {
     // Get parameters
     std::size_t const num_localities =
@@ -241,7 +250,11 @@ void test_reduce_hierarchical(int arity, int lpn, std::size_t iterations,
     auto communicators =
         create_hierarchical_communicator(reduce_direct_basename,
             num_sites_arg(num_localities), this_site_arg(this_locality),
-            arity_arg(arity), generation_arg(1), root_site_arg(0));
+            arity_arg(arity), generation_arg(1), root_site_arg(0),
+            fallback_threshold < 0 ?
+                flat_fallback_threshold_arg() :
+                flat_fallback_threshold_arg(
+                    static_cast<std::size_t>(fallback_threshold)));
     // Barrier for synchronization
     char const* const barrier_test_name = "/test/barrier/hierarchical";
     hpx::distributed::barrier barrier(barrier_test_name);
@@ -289,13 +302,16 @@ void test_reduce_hierarchical(int arity, int lpn, std::size_t iterations,
 
     if (this_locality == 0)
     {
-        write_to_file(operation, "hierarchical", arity, num_localities, lpn,
+        std::string const mod_name = fallback_threshold < 0 ?
+            std::string("hierarchical") :
+            "hierarchical_t" + std::to_string(fallback_threshold);
+        write_to_file(operation, mod_name, arity, num_localities, lpn,
             test_size, iterations, result);
     }
 }
 
 void test_broadcast_hierarchical(int arity, int lpn, std::size_t iterations,
-    int test_size, std::string const& operation)
+    int test_size, std::string const& operation, int fallback_threshold)
 {
     // Get parameters
     std::size_t const num_localities =
@@ -307,7 +323,11 @@ void test_broadcast_hierarchical(int arity, int lpn, std::size_t iterations,
     auto communicators =
         create_hierarchical_communicator(broadcast_direct_basename,
             num_sites_arg(num_localities), this_site_arg(this_locality),
-            arity_arg(arity), generation_arg(1), root_site_arg(0));
+            arity_arg(arity), generation_arg(1), root_site_arg(0),
+            fallback_threshold < 0 ?
+                flat_fallback_threshold_arg() :
+                flat_fallback_threshold_arg(
+                    static_cast<std::size_t>(fallback_threshold)));
     // Barrier for synchronization
     char const* const barrier_test_name = "/test/barrier/hierarchical";
     hpx::distributed::barrier barrier(barrier_test_name);
@@ -353,13 +373,16 @@ void test_broadcast_hierarchical(int arity, int lpn, std::size_t iterations,
 
     if (this_locality == 0)
     {
-        write_to_file(operation, "hierarchical", arity, num_localities, lpn,
+        std::string const mod_name = fallback_threshold < 0 ?
+            std::string("hierarchical") :
+            "hierarchical_t" + std::to_string(fallback_threshold);
+        write_to_file(operation, mod_name, arity, num_localities, lpn,
             test_size, iterations, result);
     }
 }
 
 void test_gather_hierarchical(int arity, int lpn, std::size_t iterations,
-    int test_size, std::string const& operation)
+    int test_size, std::string const& operation, int fallback_threshold)
 {
     // Get parameters
     std::size_t const num_localities =
@@ -371,7 +394,11 @@ void test_gather_hierarchical(int arity, int lpn, std::size_t iterations,
     auto communicators =
         create_hierarchical_communicator(gather_direct_basename,
             num_sites_arg(num_localities), this_site_arg(this_locality),
-            arity_arg(arity), generation_arg(1), root_site_arg(0));
+            arity_arg(arity), generation_arg(1), root_site_arg(0),
+            fallback_threshold < 0 ?
+                flat_fallback_threshold_arg() :
+                flat_fallback_threshold_arg(
+                    static_cast<std::size_t>(fallback_threshold)));
     // Barrier for synchronization
     char const* const barrier_test_name = "/test/barrier/hierarchical";
     hpx::distributed::barrier barrier(barrier_test_name);
@@ -421,13 +448,16 @@ void test_gather_hierarchical(int arity, int lpn, std::size_t iterations,
 
     if (this_locality == 0)
     {
-        write_to_file(operation, "hierarchical", arity, num_localities, lpn,
+        std::string const mod_name = fallback_threshold < 0 ?
+            std::string("hierarchical") :
+            "hierarchical_t" + std::to_string(fallback_threshold);
+        write_to_file(operation, mod_name, arity, num_localities, lpn,
             test_size, iterations, result);
     }
 }
 
 void test_all_reduce_hierarchical(int arity, int lpn, std::size_t iterations,
-    int test_size, std::string const& operation)
+    int test_size, std::string const& operation, int fallback_threshold)
 {
     // Get parameters
     std::size_t const num_localities =
@@ -439,7 +469,11 @@ void test_all_reduce_hierarchical(int arity, int lpn, std::size_t iterations,
     auto communicators =
         create_hierarchical_communicator(all_reduce_direct_basename,
             num_sites_arg(num_localities), this_site_arg(this_locality),
-            arity_arg(arity), generation_arg(1), root_site_arg(0));
+            arity_arg(arity), generation_arg(1), root_site_arg(0),
+            fallback_threshold < 0 ?
+                flat_fallback_threshold_arg() :
+                flat_fallback_threshold_arg(
+                    static_cast<std::size_t>(fallback_threshold)));
     // Barrier for synchronization
     char const* const barrier_test_name = "/test/barrier/hierarchical";
     hpx::distributed::barrier barrier(barrier_test_name);
@@ -472,7 +506,10 @@ void test_all_reduce_hierarchical(int arity, int lpn, std::size_t iterations,
 
     if (this_locality == 0)
     {
-        write_to_file(operation, "hierarchical", arity, num_localities, lpn,
+        std::string const mod_name = fallback_threshold < 0 ?
+            std::string("hierarchical") :
+            "hierarchical_t" + std::to_string(fallback_threshold);
+        write_to_file(operation, mod_name, arity, num_localities, lpn,
             test_size, iterations, result);
     }
 }
@@ -1079,6 +1116,158 @@ void test_multiple_use_with_generation_all_reduce(int lpn,
     }
 }
 
+void test_all_gather_hierarchical(int arity, int lpn, std::size_t iterations,
+    int test_size, std::string const& operation, int fallback_threshold)
+{
+    // Get parameters
+    std::size_t const num_localities =
+        hpx::get_num_localities(hpx::launch::sync);
+    std::size_t const this_locality = hpx::get_locality_id();
+    // Ensure at least two localities
+    HPX_TEST_LTE(static_cast<std::size_t>(2), num_localities);
+    // Create hierarchical communicators with optional threshold override
+    auto communicators =
+        create_hierarchical_communicator(all_gather_direct_basename,
+            num_sites_arg(num_localities), this_site_arg(this_locality),
+            arity_arg(arity), generation_arg(1), root_site_arg(0),
+            fallback_threshold < 0 ?
+                flat_fallback_threshold_arg() :
+                flat_fallback_threshold_arg(
+                    static_cast<std::size_t>(fallback_threshold)));
+    // Barrier for synchronization
+    char const* const barrier_test_name = "/test/barrier/hierarchical";
+    hpx::distributed::barrier barrier(barrier_test_name);
+    // Result vector
+    std::vector<double> result(iterations, 0.0);
+    // Data
+    std::vector<int> send_data;
+    std::vector<std::vector<int>> recv_data;
+    for (std::size_t i = 0; i != iterations; ++i)
+    {
+        send_data =
+            std::vector<int>(test_size, static_cast<int>(i + this_locality));
+        // Time collective
+        hpx::chrono::high_resolution_timer const timer;
+        // NOLINTNEXTLINE(bugprone-use-after-move)
+        hpx::future<std::vector<std::vector<int>>> ft_data =
+            all_gather(communicators, std::move(send_data),
+                this_site_arg(this_locality), generation_arg(i + 1));
+        recv_data = ft_data.get();
+        // Synchronize
+        barrier.wait();
+        // Write runtime into vector
+        result[i] = timer.elapsed();
+        // Check for correctness: every site contributed (i + site), so
+        // recv_data[j][0] must equal (i + j) at every site.
+        for (int j = 0; j < static_cast<int>(num_localities); ++j)
+        {
+            HPX_TEST_EQ(i + j, static_cast<std::size_t>(recv_data[j][0]));
+        }
+    }
+    if (this_locality == 0)
+    {
+        std::string const mod_name = fallback_threshold < 0 ?
+            std::string("hierarchical") :
+            "hierarchical_t" + std::to_string(fallback_threshold);
+        write_to_file(operation, mod_name, arity, num_localities, lpn,
+            test_size, iterations, result);
+    }
+}
+////////////////////////////////////////////////////////////////////////////////////////
+void test_one_shot_use_all_gather(int lpn, std::size_t iterations,
+    int test_size, std::string const& operation)
+{
+    // Get parameters
+    std::size_t const num_localities =
+        hpx::get_num_localities(hpx::launch::sync);
+    std::size_t const this_locality = hpx::get_locality_id();
+    // Ensure at least two localities
+    HPX_TEST_LTE(static_cast<std::size_t>(2), num_localities);
+    // Barrier for synchronization
+    char const* const barrier_test_name = "/test/barrier/single";
+    hpx::distributed::barrier barrier(barrier_test_name);
+    // Result vector
+    std::vector<double> result(iterations, 0.0);
+    // Data
+    std::vector<int> send_data;
+    std::vector<std::vector<int>> recv_data;
+    for (std::size_t i = 0; i != iterations; ++i)
+    {
+        send_data =
+            std::vector<int>(test_size, static_cast<int>(i + this_locality));
+        // Time collective
+        hpx::chrono::high_resolution_timer const timer;
+        hpx::future<std::vector<std::vector<int>>> ft_data =
+            // NOLINTNEXTLINE(bugprone-use-after-move)
+            all_gather(all_gather_direct_basename, std::move(send_data),
+                num_sites_arg(num_localities), this_site_arg(this_locality),
+                generation_arg(i + 1));
+        recv_data = ft_data.get();
+        // Synchronize
+        barrier.wait();
+        // Write runtime into vector
+        result[i] = timer.elapsed();
+        // Check for correctness
+        for (int j = 0; j < static_cast<int>(num_localities); ++j)
+        {
+            HPX_TEST_EQ(i + j, static_cast<std::size_t>(recv_data[j][0]));
+        }
+    }
+    if (this_locality == 0)
+    {
+        write_to_file(operation, "single_use", -1, num_localities, lpn,
+            test_size, iterations, result);
+    }
+}
+////////////////////////////////////////////////////////////////////////////////////////
+void test_multiple_use_with_generation_all_gather(int lpn,
+    std::size_t iterations, int test_size, std::string const& operation)
+{
+    // Get parameters
+    std::size_t const num_localities =
+        hpx::get_num_localities(hpx::launch::sync);
+    std::size_t const this_locality = hpx::get_locality_id();
+    // Ensure at least two localities
+    HPX_TEST_LTE(static_cast<std::size_t>(2), num_localities);
+    // Create communicator
+    auto const all_gather_direct_client =
+        create_communicator(all_gather_direct_basename,
+            num_sites_arg(num_localities), this_site_arg(this_locality));
+    // Barrier for synchronization
+    char const* const barrier_test_name = "/test/barrier/generation";
+    hpx::distributed::barrier barrier(barrier_test_name);
+    // Result vector
+    std::vector<double> result(iterations, 0.0);
+    // Data
+    std::vector<int> send_data;
+    std::vector<std::vector<int>> recv_data;
+    for (std::size_t i = 0; i != iterations; ++i)
+    {
+        send_data =
+            std::vector<int>(test_size, static_cast<int>(i + this_locality));
+        // Time collective
+        hpx::chrono::high_resolution_timer const timer;
+        hpx::future<std::vector<std::vector<int>>> ft_data =
+            // NOLINTNEXTLINE(bugprone-use-after-move)
+            all_gather(all_gather_direct_client, std::move(send_data),
+                generation_arg(i + 1));
+        recv_data = ft_data.get();
+        // Synchronize
+        barrier.wait();
+        // Write runtime into vector
+        result[i] = timer.elapsed();
+        // Check for correctness
+        for (int j = 0; j < static_cast<int>(num_localities); ++j)
+        {
+            HPX_TEST_EQ(i + j, static_cast<std::size_t>(recv_data[j][0]));
+        }
+    }
+    if (this_locality == 0)
+    {
+        write_to_file(operation, "multi_use", -1, num_localities, lpn,
+            test_size, iterations, result);
+    }
+}
 int hpx_main(hpx::program_options::variables_map& vm)
 {
     int const arity = vm["arity"].as<int>();
@@ -1086,6 +1275,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
     int const test_size = vm["test_size"].as<int>();
     std::string const operation = vm["operation"].as<std::string>();
     int const iterations = vm["iterations"].as<int>();
+    int const fallback_threshold = vm["fallback_threshold"].as<int>();
 
     if (hpx::get_num_localities(hpx::launch::sync) > 1)
     {
@@ -1100,8 +1290,8 @@ int hpx_main(hpx::program_options::variables_map& vm)
             }
             else
             {
-                test_scatter_hierarchical(
-                    arity, lpn, iterations, test_size, operation);
+                test_scatter_hierarchical(arity, lpn, iterations, test_size,
+                    operation, fallback_threshold);
             }
         }
         else if (operation == "reduce")
@@ -1114,8 +1304,8 @@ int hpx_main(hpx::program_options::variables_map& vm)
             }
             else
             {
-                test_reduce_hierarchical(
-                    arity, lpn, iterations, test_size, operation);
+                test_reduce_hierarchical(arity, lpn, iterations, test_size,
+                    operation, fallback_threshold);
             }
         }
         else if (operation == "broadcast")
@@ -1129,8 +1319,8 @@ int hpx_main(hpx::program_options::variables_map& vm)
             }
             else
             {
-                test_broadcast_hierarchical(
-                    arity, lpn, iterations, test_size, operation);
+                test_broadcast_hierarchical(arity, lpn, iterations, test_size,
+                    operation, fallback_threshold);
             }
         }
         else if (operation == "gather")
@@ -1143,8 +1333,8 @@ int hpx_main(hpx::program_options::variables_map& vm)
             }
             else
             {
-                test_gather_hierarchical(
-                    arity, lpn, iterations, test_size, operation);
+                test_gather_hierarchical(arity, lpn, iterations, test_size,
+                    operation, fallback_threshold);
             }
         }
         else if (operation == "all_reduce")
@@ -1158,8 +1348,23 @@ int hpx_main(hpx::program_options::variables_map& vm)
             }
             else
             {
-                test_all_reduce_hierarchical(
-                    arity, lpn, iterations, test_size, operation);
+                test_all_reduce_hierarchical(arity, lpn, iterations, test_size,
+                    operation, fallback_threshold);
+            }
+        }
+        else if (operation == "all_gather")
+        {
+            if (arity == -1)
+            {
+                test_one_shot_use_all_gather(
+                    lpn, iterations, test_size, operation);
+                test_multiple_use_with_generation_all_gather(
+                    lpn, iterations, test_size, operation);
+            }
+            else
+            {
+                test_all_gather_hierarchical(arity, lpn, iterations, test_size,
+                    operation, fallback_threshold);
             }
         }
     }
@@ -1182,7 +1387,12 @@ int main(int argc, char* argv[])
         ("iterations", value<int>()->default_value(10),
             "Number of Iteration the collective is executed")
         ("operation", value<std::string>()->default_value("scatter"),
-            "Collective Operation (scatter, reduce, broadcast, gather, all_reduce)");
+            "Collective Operation (scatter, reduce, broadcast, gather, "
+            "all_reduce, all_gather)")
+        ("fallback_threshold", value<int>()->default_value(-1),
+            "Flat fallback threshold for hierarchical mode. -1 uses library "
+            "default (16). Set to 0 to force tree construction. Only meaningful "
+            "with hierarchical mode.");
     // clang-format on
 
     std::vector<std::string> const cfg = {"hpx.run_hpx_main!=1"};

--- a/libs/full/collectives/tests/unit/CMakeLists.txt
+++ b/libs/full/collectives/tests/unit/CMakeLists.txt
@@ -34,6 +34,7 @@ if(HPX_WITH_NETWORKING)
       gather
       gather_hierarchical
       gather_sync
+      hierarchical_flat_fallback
       inclusive_scan_
       inclusive_scan_sync
       reduce

--- a/libs/full/collectives/tests/unit/hierarchical_flat_fallback.cpp
+++ b/libs/full/collectives/tests/unit/hierarchical_flat_fallback.cpp
@@ -1,0 +1,135 @@
+//  Copyright (c) 2026 Anshuman Agrawal
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/modules/collectives.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace hpx::collectives;
+
+// Distributed test (multi-locality): verifies that the fallback path produces
+// size() == 1 and correct collective results, and that threshold == 0 forces
+// the tree path with the same results.
+void test_distributed_fallback()
+{
+    std::uint32_t const this_locality = hpx::get_locality_id();
+    std::uint32_t const num_localities =
+        hpx::get_num_localities(hpx::launch::sync);
+    HPX_TEST_LTE(static_cast<std::uint32_t>(2), num_localities);
+
+    // Force the fallback path by setting threshold above num_localities.
+    auto const fb_clients = create_hierarchical_communicator(
+        "/test/hflback_dist_fb/", num_sites_arg(num_localities),
+        this_site_arg(this_locality), arity_arg(2), generation_arg(),
+        root_site_arg(0), flat_fallback_threshold_arg(1024));
+
+    HPX_TEST_EQ(fb_clients.size(), static_cast<std::size_t>(1));
+
+    std::uint32_t const value = this_locality + 1;
+    std::uint32_t const fb_result =
+        all_reduce(fb_clients, std::uint32_t(value), std::plus<std::uint32_t>{},
+            this_site_arg(this_locality), generation_arg(1))
+            .get();
+
+    std::uint32_t expected = 0;
+    for (std::uint32_t j = 0; j != num_localities; ++j)
+    {
+        expected += (j + 1);
+    }
+    HPX_TEST_EQ(fb_result, expected);
+
+    // Force the tree path by setting threshold to 0; results must match.
+    auto const tree_clients = create_hierarchical_communicator(
+        "/test/hflback_dist_tree/", num_sites_arg(num_localities),
+        this_site_arg(this_locality), arity_arg(2), generation_arg(),
+        root_site_arg(0), flat_fallback_threshold_arg(0));
+
+    std::uint32_t const tree_result = all_reduce(tree_clients,
+        std::uint32_t(value), std::plus<std::uint32_t>{},
+        this_site_arg(this_locality), generation_arg(1))
+                                          .get();
+
+    HPX_TEST_EQ(tree_result, expected);
+}
+
+// Local test (single-process, multi-thread sites): verifies that the fallback
+// works for a range of site counts below the default threshold, exercised
+// from locality 0 only.
+void test_local_fallback(std::uint32_t num_sites)
+{
+    std::vector<hpx::future<void>> sites;
+    sites.reserve(num_sites);
+
+    for (std::uint32_t site = 0; site != num_sites; ++site)
+    {
+        sites.push_back(hpx::async([=]() {
+            auto const clients = create_hierarchical_communicator(
+                "/test/hflback_local/", num_sites_arg(num_sites),
+                this_site_arg(site), arity_arg(2), generation_arg(),
+                root_site_arg(0), flat_fallback_threshold_arg(1024));
+
+            HPX_TEST_EQ(clients.size(), static_cast<std::size_t>(1));
+
+            std::uint32_t const value = site + 1;
+            std::uint32_t const result = all_reduce(clients,
+                std::uint32_t(value), std::plus<std::uint32_t>{},
+                this_site_arg(site), generation_arg(1))
+                                             .get();
+
+            std::uint32_t expected = 0;
+            for (std::uint32_t j = 0; j != num_sites; ++j)
+            {
+                expected += (j + 1);
+            }
+            HPX_TEST_EQ(result, expected);
+        }));
+    }
+
+    hpx::wait_all(std::move(sites));
+}
+
+int hpx_main()
+{
+#if defined(HPX_HAVE_NETWORKING)
+    if (hpx::get_num_localities(hpx::launch::sync) > 1)
+    {
+        test_distributed_fallback();
+    }
+#endif
+
+    if (hpx::get_locality_id() == 0)
+    {
+        for (std::uint32_t n : {2u, 4u, 8u})
+        {
+            test_local_fallback(n);
+        }
+    }
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> const cfg = {"hpx.run_hpx_main!=1"};
+
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ(hpx::init(argc, argv, init_args), 0);
+    return hpx::util::report_errors();
+}
+
+#endif


### PR DESCRIPTION
## Summary

Adds a flat fallback to the `hierarchical_communicator` factory for site counts below a configurable threshold. Addresses the follow-up question from @hkaiser on #7160:

> Should we fall back to the flat collectives if the number of connected sites is less than 16? This would require more measurements, but might be worth investigating.

## Benchmark context

Benchmark data from the parent PR #7160, measured on a DGX H100 compute
node with `benchmark_collectives_test`, single int, 100 iterations, one
HPX thread per locality:

| Procs | Flat multi_use (μs) | Hier arity=2 (μs) | Hier arity=4 (μs) |
|---:|---:|---:|---:|
| 4  | 50  | 101 | —     |
| 8  | 98  | 139 | 141   |
| 16 | 166 | 198 | 849   |
| 32 | 465 | 346 | 1,120 |

Hierarchical arity=2 overtakes flat at 32 processes (1.34x speedup).
Arity=4 regresses at P≥16 and is tracked separately; this PR uses
arity=2 as the recommended default for ≥16 ranks. Default threshold
set to 16 per the suggestion in #7160. The exact optimal value likely
depends on node topology and interconnect, so the threshold is kept
configurable and flagged in "open items" below.

## Design

The fallback lives entirely in `create_hierarchical_communicator`. When `num_sites < threshold`, the factory returns a `hierarchical_communicator` whose underlying `std::vector<tuple<communicator, this_site_arg>>` contains a single entry: a flat communicator spanning all N sites.

The tree-walking loops in the existing hierarchical overloads of `reduce_here`/`reduce_there`, `broadcast_to`/`broadcast_from`, `gather_here`/`gather_there` all collapse correctly when `size() == 1`. This is the **same code path non-leader sites already take** in normal tree mode (a leaf-only site has exactly one communicator in its vector), so this fallback is not a new state for the collective code — it's a state the collectives already handle in production.

This means **zero changes to `all_reduce.hpp`, `all_gather.hpp`, `reduce.hpp`, `broadcast.hpp`, `gather.hpp`, or `scatter.hpp`**. All correctness follows from the factory change.

## API change

A new `flat_fallback_threshold_arg` (default `16`) is added as the last parameter of `create_hierarchical_communicator`:

```cpp
auto comm = create_hierarchical_communicator(
    basename, num_sites, this_site, arity, generation, root_site,
    flat_fallback_threshold_arg(16));  // default
```

Pass `flat_fallback_threshold_arg(0)` to disable the fallback and always build a tree (useful for testing the tree path directly).

All existing callers use default arguments, so this is source-compatible.

## Testing

New test `hierarchical_flat_fallback` verifies:

1. **Structural invariant**: when `num_sites < threshold`, the returned `hierarchical_communicator` has `size() == 1`
2. **Correctness under fallback**: `all_reduce` on the fallback communicator produces the correct result
3. **Correctness under forced tree mode**: passing `flat_fallback_threshold_arg(0)` produces the same result
4. **Local-mode coverage**: the fallback works when multiple sites run as threads within a single process

Tested locally at 1 and 2 localities over the TCP parcelport on macOS. All existing hierarchical tests continue to pass without modification.

## Open items for discussion

- **Default threshold value.** I set it to 16 to match the suggestion in #7160, but the benchmark data above suggests a value of 24–32 may be closer to optimal on the DGX node tested. I'd appreciate input on whether to change the default or leave it at 16 pending multi-node measurements.
- **Preserving coverage of the tree path in existing tests.** I did not modify the existing hierarchical unit tests (`all_reduce_hierarchical`, etc.) to pass `flat_fallback_threshold_arg(0)`. With the default threshold of 16, those tests now exercise the fallback path for site counts 2–8 and the tree path only for 16+. If preserving tree-path coverage at small site counts is important, I can update those tests in a follow-up commit — happy to do either.
- **Multi-node validation.** I don't have multi-node cluster access at the moment. Once I do, I'd like to rerun the benchmark at 2+ nodes over InfiniBand to confirm the threshold holds.

## Follow-ups

After this merges, the same pattern generalizes naturally to `all_to_all` once that collective is implemented hierarchically.