### PR TITLE
docs: update .github markdown links to new TheHPXProject organization

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -21,7 +21,7 @@ the spirit in which it's intended - a guide to make it easier to enrich all of
 us and the technical communities in which we participate.
 
 This code of conduct applies to all spaces managed by the
-[HPX](https://github.com/STEllAR-GROUP/hpx) project or
+[HPX](https://github.com/TheHPXProject/hpx) project or
 [STE||AR Group](http://stellar-group.org). This includes IRC, the mailing
 lists, the issue tracker, and any other forums created by the project team
 which the community uses for communication. In addition, violations of this

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -4,7 +4,7 @@
 <!-- Distributed under the Boost Software License, Version 1.0. (See accompanying -->
 <!-- file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)        -->
 
-This describes how you can contribute to [HPX](https://github.com/STEllAR-GROUP/hpx).
+This describes how you can contribute to [HPX](https://github.com/TheHPXProject/hpx).
 Great to have you here. There are a few ways you can help make HPX better!
 
 # How to Get Involved in Developing HPX
@@ -13,7 +13,7 @@ This page describes how you can get yourself involved with the development of
 HPX. Here are some easy things to do.
 
 All of the HPX development and the related discussions happen through the
-[Github ticket system](https://github.com/STEllAR-GROUP/hpx/issues). We are
+[Github ticket system](https://github.com/TheHPXProject/hpx/issues). We are
 looking forward to contributions submitted through the usual Github process,
 i.e. pull requests.
 
@@ -22,7 +22,7 @@ The easiest ways to get in contact with us are listed here:
 * Mailing list:    [hpx-users@stellar-group.org](email:hpx-users@stellar-group.org), [hpx-devel@stellar-group.org](email:hpx-devel@stellar-group.org)
 * Discord server:  [#ste||ar](https://discord.gg/Tn9QuzVjvy)
 * Blog:            [hpx.stellar-group.org](hpx.stellar-group.org)
-* More options:    See our [support page](https://github.com/STEllAR-GROUP/hpx/blob/master/.github/SUPPORT.md)
+* More options:    See our [support page](https://github.com/TheHPXProject/hpx/blob/master/.github/SUPPORT.md)
 
 The basic approach is to find something fun you want to fix, hack it up, and
 send a `git diff` as a mail attachment to [hpx-devel@stellar-group.org](email:hpx-devel@stellar-group.org)
@@ -54,7 +54,7 @@ cleanup that many people can help out with), then please:
 If a task has an owner without an update in a week, feel free to notify them
 that you're taking that on yourself, and of course if you realize you can't
 complete a task - please update it in the
-[ticket system](https://github.com/STEllAR-GROUP/hpx/issues).
+[ticket system](https://github.com/TheHPXProject/hpx/issues).
 
 Even if you are deeply skilled, please consider doing one little easy hack, to
 get used to the process. After that, you are invited to move on up to the more
@@ -72,7 +72,7 @@ information to get you started.
 ### Get a login on Github [here](https://github.com/) and fork the HPX repository to your Github account.
 
 All new and old bugs in HPX can be found in our
-[ticket system](https://github.com/STEllAR-GROUP/hpx/issues). Especially with
+[ticket system](https://github.com/TheHPXProject/hpx/issues). Especially with
 new incoming bugs, it is helpful to test the bug on your own computer/operating
 system and comment in the bug entry whether you can or cannot confirm the bug
 and under what circumstances it affects you.
@@ -104,7 +104,7 @@ The short version of the guidelines:
 * Exceptions for error handling instead of C-style error codes.
 
 A more elaborate description of our coding guidelines can be found
-[here](https://github.com/STEllAR-GROUP/hpx/wiki/HPX-Source-Code-Structure-and-Coding-Standards).
+[here](https://github.com/TheHPXProject/hpx/wiki/HPX-Source-Code-Structure-and-Coding-Standards).
 
 There is a `.editorconfig` file in the HPX root directory which can be used
 for almost any widely available editor. Please see

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -10,7 +10,7 @@
 
 If you believe you have found a security vulnerability in HPX, don't hesitate to _report them_.
 
- 1. Use any of the [means of contact](https://github.com/STEllAR-GROUP/hpx/blob/master/.github/SUPPORT.md).
+ 1. Use any of the [means of contact](https://github.com/TheHPXProject/hpx/blob/master/.github/SUPPORT.md).
 
     **Please do not report security vulnerabilities through public GitHub issues.**
 

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -7,7 +7,7 @@
 ## Support for deploying and using HPX
 
 Welcome to [HPX](http://stellar-group.org/libraries/hpx/)! We use GitHub for
-[tracking bugs and feature requests](https://github.com/STEllAR-GROUP/hpx/issues).
+[tracking bugs and feature requests](https://github.com/TheHPXProject/hpx/issues).
 Please see for the resources below if you are looking for the right place to
 get support for using HPX.
 
@@ -18,7 +18,7 @@ get support for using HPX.
 ### Reporting security issues and vulnerabilities
 
 Please send us an [email](info@stellar-group.org) describing the issue. See our
-[security policy](https://github.com/STEllAR-GROUP/hpx/blob/master/.github/SECURITY.md)
+[security policy](https://github.com/TheHPXProject/hpx/blob/master/.github/SECURITY.md)
 for details.
 
 ### Chat


### PR DESCRIPTION
## Summary

Updates all `STEllAR-GROUP/hpx` links in `.github` documentation 
files to point to the new `TheHPXProject/hpx` repository following 
the organization migration.

## Files updated
- `.github/CONTRIBUTING.md` (6 links)
- `.github/SECURITY.md` (1 link)
- `.github/SUPPORT.md` (2 links)
- `.github/CODE_OF_CONDUCT.md` (1 link)

## Checklist
- [x] No functional code changes — documentation links only