### PR TITLE
Deduplicate Windows tests.examples exclusions

### DIFF
--- a/.github/ci-scripts/generate_ctest_exclude_regex.ps1
+++ b/.github/ci-scripts/generate_ctest_exclude_regex.ps1
@@ -1,0 +1,17 @@
+# Copyright (c) 2026 Arpit Singh
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$Path
+)
+
+$resolved_path = Resolve-Path -Path $Path -ErrorAction Stop
+$exclude_targets = Get-Content -Path $resolved_path |
+    Where-Object { $_ -notmatch '^\s*(#|$)' } |
+    ForEach-Object { $_.Trim() }
+
+[System.String]::Join('|', $exclude_targets)

--- a/.github/workflows/windows_clang_debug.yml
+++ b/.github/workflows/windows_clang_debug.yml
@@ -58,12 +58,11 @@ jobs:
           cmake --install build --config Debug
     - name: Test
       run: |
-          Set-Alias -Name grep -Value 'C:\Program Files\Git\usr\bin\grep.exe'
-          Set-Alias -Name sed -Value 'C:\Program Files\Git\usr\bin\sed.exe'
+          $exclude_regex = & "$env:GITHUB_WORKSPACE/.github/ci-scripts/generate_ctest_exclude_regex.ps1" `
+            "$env:GITHUB_WORKSPACE/.github/workflows/tests.examples.targets"
           cd build
           ctest `
           --output-on-failure `
             --build-config Debug `
             --tests-regex tests.examples `
-            --exclude-regex `
-                 $(grep -v  -e ^# -e ^$ D:/a/hpx/hpx/.github/workflows/tests.examples.targets | sed ':b;N;$!bb;s/\n/|/g')
+            --exclude-regex $exclude_regex

--- a/.github/workflows/windows_clang_release.yml
+++ b/.github/workflows/windows_clang_release.yml
@@ -55,12 +55,11 @@ jobs:
           cmake --install build --config Release
     - name: Test
       run: |
-          Set-Alias -Name grep -Value "C:\Program Files\Git\usr\bin\grep.exe"
-          Set-Alias -Name sed -Value "C:\Program Files\Git\usr\bin\sed.exe"
+          $exclude_regex = & "$env:GITHUB_WORKSPACE/.github/ci-scripts/generate_ctest_exclude_regex.ps1" `
+            "$env:GITHUB_WORKSPACE/.github/workflows/tests.examples.targets"
           cd build
           ctest `
           --output-on-failure `
             --build-config Release `
             --tests-regex tests.examples `
-            --exclude-regex `
-                 $(grep -v  -e ^# -e ^$ D:/a/hpx/hpx/.github/workflows/tests.examples.targets | sed ':b;N;$!bb;s/\n/|/g')
+            --exclude-regex $exclude_regex

--- a/.github/workflows/windows_debug_vs2022.yml
+++ b/.github/workflows/windows_debug_vs2022.yml
@@ -59,12 +59,11 @@ jobs:
           cmake --install build --config Debug
     - name: Test
       run: |
-          Set-Alias -Name grep -Value 'C:\Program Files\Git\usr\bin\grep.exe'
-          Set-Alias -Name sed -Value 'C:\Program Files\Git\usr\bin\sed.exe'
+          $exclude_regex = & "$env:GITHUB_WORKSPACE/.github/ci-scripts/generate_ctest_exclude_regex.ps1" `
+            "$env:GITHUB_WORKSPACE/.github/workflows/tests.examples.targets"
           cd build
           ctest `
           --output-on-failure `
             --build-config Debug `
             --tests-regex tests.examples `
-            --exclude-regex `
-                 $(grep -v  -e ^# -e ^$ D:/a/hpx/hpx/.github/workflows/tests.examples.targets | sed ':b;N;$!bb;s/\n/|/g')
+            --exclude-regex $exclude_regex

--- a/.github/workflows/windows_debug_vs2022_fetch_boost.yml
+++ b/.github/workflows/windows_debug_vs2022_fetch_boost.yml
@@ -56,12 +56,11 @@ jobs:
             cmake --install build --config Debug
       - name: Test
         run: |
-            Set-Alias -Name grep -Value 'C:\Program Files\Git\usr\bin\grep.exe'
-            Set-Alias -Name sed -Value 'C:\Program Files\Git\usr\bin\sed.exe'
+            $exclude_regex = & "$env:GITHUB_WORKSPACE/.github/ci-scripts/generate_ctest_exclude_regex.ps1" `
+              "$env:GITHUB_WORKSPACE/.github/workflows/tests.examples.targets"
             cd build
             ctest `
-            --output-on-failure `
+              --output-on-failure `
               --build-config Debug `
               --tests-regex tests.examples `
-              --exclude-regex `
-                  $(grep -v  -e ^# -e ^$ D:/a/hpx/hpx/.github/workflows/tests.examples.targets | sed ':b;N;$!bb;s/\n/|/g')
+              --exclude-regex $exclude_regex

--- a/.github/workflows/windows_debug_vs2022_fetch_hwloc.yml
+++ b/.github/workflows/windows_debug_vs2022_fetch_hwloc.yml
@@ -59,12 +59,11 @@ jobs:
           cmake --install build --config Debug
     - name: Test
       run: |
-          Set-Alias -Name grep -Value 'C:\Program Files\Git\usr\bin\grep.exe'
-          Set-Alias -Name sed -Value 'C:\Program Files\Git\usr\bin\sed.exe'
+          $exclude_regex = & "$env:GITHUB_WORKSPACE/.github/ci-scripts/generate_ctest_exclude_regex.ps1" `
+            "$env:GITHUB_WORKSPACE/.github/workflows/tests.examples.targets"
           cd build
           ctest `
           --output-on-failure `
             --build-config Debug `
             --tests-regex tests.examples `
-            --exclude-regex `
-                 $(grep -v  -e ^# -e ^$ D:/a/hpx/hpx/.github/workflows/tests.examples.targets | sed ':b;N;$!bb;s/\n/|/g')
+            --exclude-regex $exclude_regex

--- a/.github/workflows/windows_debug_vs2022_local_runtime.yml
+++ b/.github/workflows/windows_debug_vs2022_local_runtime.yml
@@ -56,12 +56,11 @@ jobs:
           cmake --install build --config Debug
     - name: Test
       run: |
-          Set-Alias -Name grep -Value 'C:\Program Files\Git\usr\bin\grep.exe'
-          Set-Alias -Name sed -Value 'C:\Program Files\Git\usr\bin\sed.exe'
+          $exclude_regex = & "$env:GITHUB_WORKSPACE/.github/ci-scripts/generate_ctest_exclude_regex.ps1" `
+            "$env:GITHUB_WORKSPACE/.github/workflows/tests.examples.targets"
           cd build
           ctest `
           --output-on-failure `
             --build-config Debug `
             --tests-regex tests.examples `
-            --exclude-regex `
-                 $(grep -v  -e ^# -e ^$ D:/a/hpx/hpx/.github/workflows/tests.examples.targets | sed ':b;N;$!bb;s/\n/|/g')
+            --exclude-regex $exclude_regex

--- a/.github/workflows/windows_debug_vs2022_modules.yml
+++ b/.github/workflows/windows_debug_vs2022_modules.yml
@@ -60,12 +60,11 @@ jobs:
           cmake --install build --config Debug
     - name: Test
       run: |
-          Set-Alias -Name grep -Value 'C:\Program Files\Git\usr\bin\grep.exe'
-          Set-Alias -Name sed -Value 'C:\Program Files\Git\usr\bin\sed.exe'
+          $exclude_regex = & "$env:GITHUB_WORKSPACE/.github/ci-scripts/generate_ctest_exclude_regex.ps1" `
+            "$env:GITHUB_WORKSPACE/.github/workflows/tests.examples.targets"
           cd build
           ctest `
           --output-on-failure `
             --build-config Debug `
             --tests-regex tests.examples `
-            --exclude-regex `
-                 $(grep -v  -e ^# -e ^$ D:/a/hpx/hpx/.github/workflows/tests.examples.targets | sed ':b;N;$!bb;s/\n/|/g')
+            --exclude-regex $exclude_regex

--- a/.github/workflows/windows_debug_vs2022_tracy.yml
+++ b/.github/workflows/windows_debug_vs2022_tracy.yml
@@ -61,12 +61,11 @@ jobs:
           cmake --install build --config Debug
     - name: Test
       run: |
-          Set-Alias -Name grep -Value 'C:\Program Files\Git\usr\bin\grep.exe'
-          Set-Alias -Name sed -Value 'C:\Program Files\Git\usr\bin\sed.exe'
+          $exclude_regex = & "$env:GITHUB_WORKSPACE/.github/ci-scripts/generate_ctest_exclude_regex.ps1" `
+            "$env:GITHUB_WORKSPACE/.github/workflows/tests.examples.targets"
           cd build
           ctest `
           --output-on-failure `
             --build-config Debug `
             --tests-regex tests.examples `
-            --exclude-regex `
-                 $(grep -v  -e ^# -e ^$ D:/a/hpx/hpx/.github/workflows/tests.examples.targets | sed ':b;N;$!bb;s/\n/|/g')
+            --exclude-regex $exclude_regex

--- a/.github/workflows/windows_release_2022.yml
+++ b/.github/workflows/windows_release_2022.yml
@@ -54,12 +54,11 @@ jobs:
           cmake --install build --config Release
     - name: Test
       run: |
-          Set-Alias -Name grep -Value "C:\Program Files\Git\usr\bin\grep.exe"
-          Set-Alias -Name sed -Value "C:\Program Files\Git\usr\bin\sed.exe"
+          $exclude_regex = & "$env:GITHUB_WORKSPACE/.github/ci-scripts/generate_ctest_exclude_regex.ps1" `
+            "$env:GITHUB_WORKSPACE/.github/workflows/tests.examples.targets"
           cd build
           ctest `
           --output-on-failure `
             --build-config Release `
             --tests-regex tests.examples `
-            --exclude-regex `
-                 $(grep -v  -e ^# -e ^$ D:/a/hpx/hpx/.github/workflows/tests.examples.targets | sed ':b;N;$!bb;s/\n/|/g')
+            --exclude-regex $exclude_regex

--- a/.github/workflows/windows_release_static.yml
+++ b/.github/workflows/windows_release_static.yml
@@ -56,12 +56,11 @@ jobs:
           cmake --install build --config Release
     - name: Test
       run: |
-          Set-Alias -Name grep -Value "C:\Program Files\Git\usr\bin\grep.exe"
-          Set-Alias -Name sed -Value "C:\Program Files\Git\usr\bin\sed.exe"
+          $exclude_regex = & "$env:GITHUB_WORKSPACE/.github/ci-scripts/generate_ctest_exclude_regex.ps1" `
+            "$env:GITHUB_WORKSPACE/.github/workflows/tests.examples.targets"
           cd build
           ctest `
           --output-on-failure `
             --build-config Release `
             --tests-regex tests.examples `
-            --exclude-regex `
-                 $(grep -v  -e ^# -e ^$ D:/a/hpx/hpx/.github/workflows/tests.examples.targets | sed ':b;N;$!bb;s/\n/|/g')
+            --exclude-regex $exclude_regex


### PR DESCRIPTION
## Summary

  This PR deduplicates the Windows-specific logic for generating the `ctest --exclude-regex` value used for `tests.examples`.

  Closes #7199.

  ## What changed

  - Added `.github/ci-scripts/generate_ctest_exclude_regex.ps1`
  - Updated the affected Windows workflows to call the helper script instead of repeating:
    - PowerShell alias setup for `grep` and `sed`
    - reading `.github/workflows/tests.examples.targets`
    - converting the file contents into a single regex inline

  ## Result

  - `.github/workflows/tests.examples.targets` remains the source of truth
  - Windows workflows no longer duplicate the same exclusion-regex generation block
  - CI behavior should remain unchanged
