### PR TITLE
serialization: add reflection tests for static member function name e…

### DIFF
--- a/libs/core/serialization/tests/unit/refl/CMakeLists.txt
+++ b/libs/core/serialization/tests/unit/refl/CMakeLists.txt
@@ -14,6 +14,7 @@ set(tests
     reflection_nested_object
     reflection_nested_templ_object
     reflection_function_names
+    reflection_static_member_functions
     reflection_qualified_name_of
 )
 

--- a/libs/core/serialization/tests/unit/refl/reflection_static_member_functions.cpp
+++ b/libs/core/serialization/tests/unit/refl/reflection_static_member_functions.cpp
@@ -1,0 +1,84 @@
+//  Copyright (c) 2026 Priyanshi Sharma
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#include <hpx/modules/serialization.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <string>
+
+namespace app {
+    struct compute_server
+    {
+        static int compute(double x, double y)
+        {
+            return (int) (x + y);
+        }
+        static void broadcast(int n) noexcept
+        {
+            (void) n;
+        }
+    };
+}    // namespace app
+
+namespace app::nested {
+    struct rpc_server
+    {
+        static double transform(float x, int n)
+        {
+            return x * n;
+        }
+    };
+}    // namespace app::nested
+
+namespace outer::inner {
+    struct helper_server
+    {
+        static int process(int x) noexcept
+        {
+            return x * 2;
+        }
+    };
+}    // namespace outer::inner
+
+int main()
+{
+    using hpx::serialization::detail::scope_builder;
+
+    // Static member function in simple namespace
+    {
+        constexpr auto name =
+            scope_builder<^^app::compute_server::compute>::value;
+        HPX_TEST_EQ(std::string(name.data, name.size),
+            std::string("app::compute_server::compute"));
+    }
+
+    // Void return noexcept static member function
+    {
+        constexpr auto name =
+            scope_builder<^^app::compute_server::broadcast>::value;
+        HPX_TEST_EQ(std::string(name.data, name.size),
+            std::string("app::compute_server::broadcast"));
+    }
+
+    // Static member function in nested inline namespace
+    {
+        constexpr auto name =
+            scope_builder<^^app::nested::rpc_server::transform>::value;
+        HPX_TEST_EQ(std::string(name.data, name.size),
+            std::string("app::nested::rpc_server::transform"));
+    }
+
+    // Static member function in traditional nested namespace
+    {
+        constexpr auto name =
+            scope_builder<^^outer::inner::helper_server::process>::value;
+        HPX_TEST_EQ(std::string(name.data, name.size),
+            std::string("outer::inner::helper_server::process"));
+    }
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
## Summary

Adds `reflection_static_member_functions.cpp` to test `scope_builder<^^F>` 
with static member functions — extending the free function tests in 
`reflection_function_names.cpp` to cover the class member case.

## Tests Added

- Static member functions in simple namespaces
- Void return noexcept static member functions
- Inline nested namespaces (`app::nested::rpc_server::transform`)
- Traditional nested namespaces (`outer::inner::helper_server::process`)

## Context

In HPX, actions are commonly defined as static member functions of 
server classes (e.g., `compute_server::compute`). This PR verifies 
that `scope_builder` correctly extracts fully qualified names for 
this pattern, which is directly used by `reflect_action` for the 
upcoming C++26 reflection-based action system.

## Checklist
- [x] I have added a new feature and have added tests to go along with it.