### PR TITLE
Implement hpx::experimental::for_each_index (P4150R0)

### DIFF
--- a/libs/core/algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/CMakeLists.txt
@@ -54,6 +54,7 @@ set(algorithms_headers
     hpx/parallel/algorithms/fill.hpp
     hpx/parallel/algorithms/find.hpp
     hpx/parallel/algorithms/for_each.hpp
+    hpx/parallel/algorithms/for_each_index.hpp
     hpx/parallel/algorithms/for_loop.hpp
     hpx/parallel/algorithms/for_loop_induction.hpp
     hpx/parallel/algorithms/for_loop_reduction.hpp

--- a/libs/core/algorithms/include/hpx/parallel/algorithm.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithm.hpp
@@ -55,6 +55,7 @@
 
 // Parallelism TS V2
 #include <hpx/parallel/algorithms/ends_with.hpp>
+#include <hpx/parallel/algorithms/for_each_index.hpp>
 #include <hpx/parallel/algorithms/for_loop.hpp>
 #include <hpx/parallel/algorithms/shift_left.hpp>
 #include <hpx/parallel/algorithms/shift_right.hpp>

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/for_each_index.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/for_each_index.hpp
@@ -1,0 +1,536 @@
+//  Copyright (c) 2026 Arpit Khandelwal
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file parallel/algorithms/for_each_index.hpp
+/// \page hpx::experimental::for_each_index
+/// \headerfile hpx/algorithm.hpp
+
+#pragma once
+
+#if defined(DOXYGEN)
+namespace hpx { namespace experimental {
+
+    /// \brief Calls \a fun with every multidimensional index in the domain of
+    ///        \a mapping (i.e., its extents), in sequential order.
+    ///
+    /// \note Complexity: Applies \a fun exactly the product of all extents of
+    ///       \a mapping times.
+    ///
+    /// If \a fun returns a result, the result is ignored.
+    ///
+    /// The layout mapping is a hint; implementations are encouraged to choose
+    /// an iteration order that performs well for the given mapping.
+    ///
+    /// \tparam Mapping   A type meeting the layout mapping requirements. Must
+    ///                   expose \a index_type, \a extents_type,
+    ///                   \c static \a rank(), and \a extents().
+    /// \tparam Fun       The type of the function/function object to use
+    ///                   (deduced). \a Fun must meet \a CopyConstructible and
+    ///                   be invocable with exactly \a Mapping::rank() arguments
+    ///                   of type \a Mapping::index_type.
+    ///
+    /// \param mapping    The layout mapping whose extents define the iteration
+    ///                   domain.
+    /// \param fun        Callable invoked as \c fun(i0, i1, ...) for every
+    ///                   multidimensional index in the domain.
+    ///
+    template <typename Mapping, typename Fun>
+    constexpr void for_each_index(Mapping const& mapping, Fun fun);
+
+    /// \brief Calls \a fun with every multidimensional index in the domain of
+    ///        \a mapping (i.e., its extents), executed according to \a policy.
+    ///
+    /// \note Complexity: Applies \a fun exactly the product of all extents of
+    ///       \a mapping times.
+    ///
+    /// If \a fun returns a result, the result is ignored.
+    ///
+    /// \tparam ExPolicy  The type of the execution policy to use (deduced).
+    /// \tparam Mapping   A type meeting the layout mapping requirements.
+    ///                   Must meet \a CopyConstructible.
+    /// \tparam Fun       The type of the function/function object to use
+    ///                   (deduced). Must meet \a CopyConstructible.
+    ///
+    /// \param policy     The execution policy to use for scheduling.
+    /// \param mapping    The layout mapping whose extents define the iteration
+    ///                   domain.
+    /// \param fun        Callable invoked as \c fun(i0, i1, ...) for every
+    ///                   multidimensional index in the domain.
+    ///
+    /// \returns  \a hpx::future<void> if the execution policy is
+    ///           \a sequenced_task_policy or \a parallel_task_policy,
+    ///           \a void otherwise.
+    ///
+    template <typename ExPolicy, typename Mapping, typename Fun>
+    hpx::parallel::util::detail::algorithm_result_t<ExPolicy> for_each_index(
+        ExPolicy&& policy, Mapping const& mapping, Fun fun);
+
+}}    // namespace hpx::experimental
+
+#else
+
+#include <hpx/config.hpp>
+#include <hpx/modules/concepts.hpp>
+#include <hpx/modules/execution.hpp>
+#include <hpx/modules/executors.hpp>
+#include <hpx/modules/functional.hpp>
+#include <hpx/modules/iterator_support.hpp>
+#include <hpx/modules/type_support.hpp>
+#include <hpx/parallel/algorithms/detail/dispatch.hpp>
+#include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
+#include <hpx/parallel/util/loop.hpp>
+#include <hpx/parallel/util/partitioner.hpp>
+
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx::parallel::detail {
+
+    ///////////////////////////////////////////////////////////////////////////
+    /// \cond NOINTERNAL
+
+    // Sequential recursive core.
+    //
+    // Accumulates one index per dimension each level of recursion, then calls
+    // fun(i0, i1, ..., i_{rank-1}) when all indices are collected.
+    //
+    // Template parameter RankIdx is the *next* dimension to iterate (0-based).
+    // When RankIdx == Mapping::rank() we have the full index tuple.
+    template <std::size_t RankIdx, typename ExPolicy, typename Mapping,
+        typename Fun, typename... Indices>
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr void
+    for_each_index_seq_impl_right(Mapping const& m, Fun& f, Indices... idx)
+    {
+        if constexpr (RankIdx == Mapping::rank())
+        {
+            HPX_INVOKE(f, idx...);
+        }
+        else if constexpr (RankIdx == Mapping::rank() - 1)
+        {
+            using index_type = typename Mapping::index_type;
+            std::size_t const bound =
+                static_cast<std::size_t>(m.extents().extent(RankIdx));
+
+            hpx::util::counting_iterator<std::size_t> first(std::size_t{0});
+            hpx::parallel::util::loop_n<std::decay_t<ExPolicy>>(
+                first, bound, [&](auto const& it) {
+                    HPX_INVOKE(f, idx..., static_cast<index_type>(*it));
+                });
+        }
+        else
+        {
+            using index_type = typename Mapping::index_type;
+            std::size_t const bound =
+                static_cast<std::size_t>(m.extents().extent(RankIdx));
+            for (std::size_t i = std::size_t{0}; i < bound; ++i)
+            {
+                for_each_index_seq_impl_right<RankIdx + 1, ExPolicy>(
+                    m, f, idx..., static_cast<index_type>(i));
+            }
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Functor used by the parallel partitioner.
+    //
+    // The partitioner splits the integer range [0, extent(0)) across threads.
+    // Each call receives a sub-range of i0 values; for each i0 we recurse
+    // sequentially over the remaining dimensions.
+    //
+    // The Mapping and Fun are stored by value so the functor is
+    // thread-safe and can be copied to GPU device memory if needed.
+    template <typename ExPolicy, typename Mapping, typename Fun>
+    struct for_each_index_iteration_right
+    {
+        using fun_type = std::decay_t<Fun>;
+        using index_type = typename Mapping::index_type;
+
+        Mapping mapping_;
+        fun_type fun_;
+
+        template <typename M, typename F>
+        HPX_HOST_DEVICE for_each_index_iteration_right(M&& m, F&& f)
+          : mapping_(HPX_FORWARD(M, m))
+          , fun_(HPX_FORWARD(F, f))
+        {
+        }
+
+#if !defined(__NVCC__) && !defined(__CUDACC__)
+        for_each_index_iteration_right(
+            for_each_index_iteration_right const&) = default;
+        for_each_index_iteration_right(
+            for_each_index_iteration_right&&) = default;
+#else
+        HPX_HOST_DEVICE for_each_index_iteration_right(
+            for_each_index_iteration_right const& rhs)
+          : mapping_(rhs.mapping_)
+          , fun_(rhs.fun_)
+        {
+        }
+        HPX_HOST_DEVICE for_each_index_iteration_right(
+            for_each_index_iteration_right&& rhs)
+          : mapping_(HPX_MOVE(rhs.mapping_))
+          , fun_(HPX_MOVE(rhs.fun_))
+        {
+        }
+#endif
+        for_each_index_iteration_right& operator=(
+            for_each_index_iteration_right const&) = default;
+        for_each_index_iteration_right& operator=(
+            for_each_index_iteration_right&&) = default;
+        ~for_each_index_iteration_right() = default;
+
+        template <typename Iter>
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr void operator()(
+            Iter part_begin, std::size_t part_size)
+        {
+            hpx::parallel::util::loop_n<std::decay_t<ExPolicy>>(
+                part_begin, part_size, [&](auto const& it) {
+                    auto i0 = static_cast<index_type>(*it);
+                    for_each_index_seq_impl_right<1, ExPolicy>(
+                        mapping_, fun_, i0);
+                });
+        }
+
+        // Overload for partitioners that pass a chunk index.
+        template <typename Iter>
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr void operator()(
+            Iter part_begin, std::size_t part_size, std::size_t)
+        {
+            (*this)(part_begin, part_size);
+        }
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Layout-aware (column-major / layout_left) optimized implementations.
+
+    // Accumulates indices from right-to-left.
+    // RankIdx decreases from Mapping::rank()-2 down to 0.
+    template <std::size_t RankIdx, typename ExPolicy, typename Mapping,
+        typename Fun, typename... Indices>
+    HPX_HOST_DEVICE HPX_FORCEINLINE constexpr void for_each_index_seq_impl_left(
+        Mapping const& m, Fun& f, Indices... idx)
+    {
+        if constexpr (RankIdx == 0)
+        {
+            using index_type = typename Mapping::index_type;
+            std::size_t const bound =
+                static_cast<std::size_t>(m.extents().extent(0));
+
+            hpx::util::counting_iterator<std::size_t> first(std::size_t{0});
+            hpx::parallel::util::loop_n<std::decay_t<ExPolicy>>(
+                first, bound, [&](auto const& it) {
+                    HPX_INVOKE(f, static_cast<index_type>(*it), idx...);
+                });
+        }
+        else
+        {
+            using index_type = typename Mapping::index_type;
+            std::size_t const bound =
+                static_cast<std::size_t>(m.extents().extent(RankIdx));
+            for (std::size_t i = std::size_t{0}; i < bound; ++i)
+            {
+                for_each_index_seq_impl_left<RankIdx - 1, ExPolicy>(
+                    m, f, static_cast<index_type>(i), idx...);
+            }
+        }
+    }
+
+    template <typename ExPolicy, typename Mapping, typename Fun>
+    struct for_each_index_iteration_left
+    {
+        using fun_type = std::decay_t<Fun>;
+        using index_type = typename Mapping::index_type;
+
+        Mapping mapping_;
+        fun_type fun_;
+
+        template <typename M, typename F>
+        HPX_HOST_DEVICE for_each_index_iteration_left(M&& m, F&& f)
+          : mapping_(HPX_FORWARD(M, m))
+          , fun_(HPX_FORWARD(F, f))
+        {
+        }
+
+#if !defined(__NVCC__) && !defined(__CUDACC__)
+        for_each_index_iteration_left(
+            for_each_index_iteration_left const&) = default;
+        for_each_index_iteration_left(
+            for_each_index_iteration_left&&) = default;
+#else
+        HPX_HOST_DEVICE for_each_index_iteration_left(
+            for_each_index_iteration_left const& rhs)
+          : mapping_(rhs.mapping_)
+          , fun_(rhs.fun_)
+        {
+        }
+        HPX_HOST_DEVICE for_each_index_iteration_left(
+            for_each_index_iteration_left&& rhs)
+          : mapping_(HPX_MOVE(rhs.mapping_))
+          , fun_(HPX_MOVE(rhs.fun_))
+        {
+        }
+#endif
+        for_each_index_iteration_left& operator=(
+            for_each_index_iteration_left const&) = default;
+        for_each_index_iteration_left& operator=(
+            for_each_index_iteration_left&&) = default;
+        ~for_each_index_iteration_left() = default;
+
+        template <typename Iter>
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr void operator()(
+            Iter part_begin, std::size_t part_size)
+        {
+            static_assert(Mapping::rank() >= 2,
+                "for_each_index_iteration_left requires rank >= 2");
+            hpx::parallel::util::loop_n<std::decay_t<ExPolicy>>(
+                part_begin, part_size, [&](auto const& it) {
+                    auto i_last = static_cast<index_type>(*it);
+                    for_each_index_seq_impl_left<Mapping::rank() - 2, ExPolicy>(
+                        mapping_, fun_, i_last);
+                });
+        }
+
+        template <typename Iter>
+        HPX_HOST_DEVICE HPX_FORCEINLINE constexpr void operator()(
+            Iter part_begin, std::size_t part_size, std::size_t)
+        {
+            (*this)(part_begin, part_size);
+        }
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Algorithm struct - bridges sequential / parallel dispatch via the
+    // hpx::parallel::detail::algorithm CRTP base.
+    //
+    // sequential() is marked constexpr (non-parallel overload of
+    // for_each_index is constexpr per the proposal).
+    // parallel()   uses util::partitioner to distribute work.
+    HPX_CXX_CORE_EXPORT struct for_each_index_algo
+      : public algorithm<for_each_index_algo>
+    {
+        constexpr for_each_index_algo() noexcept
+          : for_each_index_algo::algorithm("for_each_index")
+        {
+        }
+
+        // Sequential path.
+        template <typename ExPolicy, typename Mapping, typename Fun>
+        HPX_HOST_DEVICE static constexpr hpx::util::unused_type sequential(
+            ExPolicy&&, Mapping const& m, Fun&& f)
+        {
+            for_each_index_seq_impl_right<0, std::decay_t<ExPolicy>>(m, f);
+            return {};
+        }
+
+        // Parallel path.
+        //
+        // Dispatch is layout-aware: column-major (layout_left) mappings
+        // parallelise the last extent and recurse inward; row-major
+        // (layout_right) and all other layouts parallelise the first extent.
+        template <typename ExPolicy, typename Mapping, typename Fun>
+        static decltype(auto) parallel(
+            ExPolicy&& policy, Mapping const& m, Fun&& f)
+        {
+            constexpr bool has_scheduler_executor =
+                hpx::execution_policy_has_scheduler_executor_v<ExPolicy>;
+
+            // rank-0: exactly one invocation - execute sequentially.
+            if constexpr (Mapping::rank() == 0)
+            {
+                HPX_INVOKE(f);
+                return util::detail::algorithm_result<ExPolicy>::get();
+            }
+            else
+            {
+                if constexpr (Mapping::rank() >= 2)
+                {
+                    bool prefer_left = false;
+                    if constexpr (requires { m.stride(0); })
+                    {
+                        if (m.stride(0) == 1 &&
+                            m.stride(Mapping::rank() - 1) > 1)
+                        {
+                            prefer_left = true;
+                        }
+                    }
+
+                    if (prefer_left)
+                    {
+                        std::size_t const count = static_cast<std::size_t>(
+                            m.extents().extent(Mapping::rank() - 1));
+
+                        if constexpr (!has_scheduler_executor)
+                        {
+                            if (count == 0)
+                            {
+                                return util::detail::algorithm_result<
+                                    ExPolicy>::get();
+                            }
+                        }
+
+                        using iter_t =
+                            hpx::util::counting_iterator<std::size_t>;
+                        iter_t first{std::size_t{0}};
+
+                        auto iter_fun = for_each_index_iteration_left<
+                            std::decay_t<ExPolicy>, Mapping, std::decay_t<Fun>>{
+                            m, HPX_FORWARD(Fun, f)};
+
+                        if constexpr (hpx::is_async_execution_policy_v<
+                                          ExPolicy> ||
+                            has_scheduler_executor)
+                        {
+                            return util::detail::algorithm_result<ExPolicy>::
+                                get(util::partitioner<ExPolicy>::call(
+                                    HPX_FORWARD(ExPolicy, policy), first, count,
+                                    HPX_MOVE(iter_fun),
+                                    hpx::util::empty_function{}));
+                        }
+                        else
+                        {
+                            util::partitioner<ExPolicy>::call(
+                                HPX_FORWARD(ExPolicy, policy), first, count,
+                                HPX_MOVE(iter_fun),
+                                hpx::util::empty_function{});
+                            return util::detail::algorithm_result<
+                                ExPolicy>::get();
+                        }
+                    }
+                }
+
+                // Default layout_right (row-major) optimized path
+                std::size_t const count =
+                    static_cast<std::size_t>(m.extents().extent(0));
+
+                if constexpr (!has_scheduler_executor)
+                {
+                    if (count == 0)
+                    {
+                        return util::detail::algorithm_result<ExPolicy>::get();
+                    }
+                }
+
+                // Integer iterator over [0, extent(0)) for the partitioner.
+                using iter_t = hpx::util::counting_iterator<std::size_t>;
+                iter_t first{std::size_t{0}};
+
+                auto iter_fun =
+                    for_each_index_iteration_right<std::decay_t<ExPolicy>,
+                        Mapping, std::decay_t<Fun>>{m, HPX_FORWARD(Fun, f)};
+
+                if constexpr (hpx::is_async_execution_policy_v<ExPolicy> ||
+                    has_scheduler_executor)
+                {
+                    return util::detail::algorithm_result<ExPolicy>::get(
+                        util::partitioner<ExPolicy>::call(
+                            HPX_FORWARD(ExPolicy, policy), first, count,
+                            HPX_MOVE(iter_fun), hpx::util::empty_function{}));
+                }
+                else
+                {
+                    util::partitioner<ExPolicy>::call(
+                        HPX_FORWARD(ExPolicy, policy), first, count,
+                        HPX_MOVE(iter_fun), hpx::util::empty_function{});
+                    return util::detail::algorithm_result<ExPolicy>::get();
+                }
+            }
+        }
+    };
+
+    /// \endcond
+}    // namespace hpx::parallel::detail
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx::experimental {
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Concept helper: detect minimum layout-mapping interface.
+    //
+    // We check only the members we actually use so that user-defined mapping
+    // types that omit optional members can still participate.
+    namespace detail {
+
+        /// \cond NOINTERNAL
+        template <typename M, typename = void>
+        struct is_layout_mapping_impl : std::false_type
+        {
+        };
+
+        // A type M satisfies the concept when it exposes:
+        //   - M::index_type   (member type)
+        //   - M::extents_type (member type)
+        //   - M::rank()       (static constexpr function returning std::size_t)
+        //   - m.extents()     (const member function)
+        template <typename M>
+        struct is_layout_mapping_impl<M,
+            std::void_t<typename M::index_type, typename M::extents_type,
+                decltype(M::rank()),
+                decltype(std::declval<M const&>().extents()),
+                decltype(std::declval<M const&>().extents().extent(
+                    std::size_t{}))>> : std::true_type
+        {
+        };
+        /// \endcond
+
+    }    // namespace detail
+
+    /// True iff \a M meets the minimum layout mapping requirements used by
+    /// \a for_each_index.
+    template <typename M>
+    inline constexpr bool is_layout_mapping_v =
+        detail::is_layout_mapping_impl<std::decay_t<M>>::value;
+
+    ///////////////////////////////////////////////////////////////////////////
+    HPX_CXX_CORE_EXPORT inline constexpr struct for_each_index_t final
+      : hpx::detail::tag_parallel_algorithm<for_each_index_t>
+    {
+    private:
+        // ------------------------------------------------------------------ //
+        // Sequential overload (no execution policy) - constexpr, returns void.
+        // ------------------------------------------------------------------ //
+        template <typename Mapping, typename Fun>
+        // clang-format off
+        requires (
+            is_layout_mapping_v<Mapping> &&
+            std::is_copy_constructible_v<std::decay_t<Fun>>
+        )
+        // clang-format on
+        friend constexpr void tag_fallback_invoke(
+            hpx::experimental::for_each_index_t, Mapping const& mapping,
+            Fun fun)
+        {
+            hpx::parallel::detail::for_each_index_seq_impl_right<0,
+                hpx::execution::sequenced_policy>(mapping, fun);
+        }
+
+        // ------------------------------------------------------------------ //
+        // Parallel overload (with execution policy) - void or future<void>.
+        // ------------------------------------------------------------------ //
+        template <typename ExPolicy, typename Mapping, typename Fun>
+        // clang-format off
+        requires (
+            hpx::is_execution_policy_v<ExPolicy> &&
+            is_layout_mapping_v<Mapping> &&
+            std::is_copy_constructible_v<std::decay_t<Mapping>> &&
+            std::is_copy_constructible_v<std::decay_t<Fun>>
+        )
+        // clang-format on
+        friend hpx::parallel::util::detail::algorithm_result_t<ExPolicy>
+        tag_fallback_invoke(hpx::experimental::for_each_index_t,
+            ExPolicy&& policy, Mapping const& mapping, Fun fun)
+        {
+            return hpx::parallel::detail::for_each_index_algo().call(
+                HPX_FORWARD(ExPolicy, policy), mapping, HPX_MOVE(fun));
+        }
+    } for_each_index{};
+
+}    // namespace hpx::experimental
+
+#endif

--- a/libs/core/algorithms/tests/unit/algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/tests/unit/algorithms/CMakeLists.txt
@@ -59,6 +59,7 @@ set(tests
     foreachn
     foreachn_exception
     foreachn_bad_alloc
+    for_each_index
     for_loop
     for_loop_exception
     for_loop_induction

--- a/libs/core/algorithms/tests/unit/algorithms/for_each_index.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/for_each_index.cpp
@@ -1,0 +1,511 @@
+//  Copyright (c) 2026 Arpit Khandelwal
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Tests for hpx::experimental::for_each_index (P4150R0).
+//
+// A minimal layout-mapping stub is used so the tests compile on any C++
+// standard mode without requiring C++23 <mdspan>.
+
+#include <hpx/algorithm.hpp>
+#include <hpx/init.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <atomic>
+#include <cstddef>
+#include <iostream>
+#include <random>
+#include <string>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+// Minimal layout-mapping stub.
+//
+// Satisfies the concept checked by hpx::experimental::is_layout_mapping_v:
+//   - index_type  member typedef
+//   - extents_type member typedef
+//   - static rank()
+//   - extents() const
+//
+// The extents object itself only needs .extent(r).
+
+template <std::size_t Rank>
+struct simple_extents
+{
+    explicit simple_extents(std::size_t const (&dims)[Rank]) noexcept
+    {
+        for (std::size_t r = 0; r < Rank; ++r)
+            dims_[r] = dims[r];
+    }
+
+    [[nodiscard]] constexpr std::size_t extent(std::size_t r) const noexcept
+    {
+        return dims_[r];
+    }
+
+    std::size_t dims_[Rank == 0 ? 1 : Rank]{};
+};
+
+// Specialisation for rank-0 (zero dimensions, one element).
+template <>
+struct simple_extents<0>
+{
+    [[nodiscard]] constexpr std::size_t extent(std::size_t) const noexcept
+    {
+        return 0;
+    }
+};
+
+template <std::size_t Rank, typename IndexType = int>
+struct simple_mapping
+{
+    using index_type = IndexType;
+    using extents_type = simple_extents<Rank>;
+
+    explicit simple_mapping(std::size_t const (&dims)[Rank == 0 ? 1 : Rank])
+      : ext_(dims)
+    {
+    }
+
+    [[nodiscard]] static constexpr std::size_t rank() noexcept
+    {
+        return Rank;
+    }
+
+    [[nodiscard]] constexpr extents_type const& extents() const noexcept
+    {
+        return ext_;
+    }
+
+    extents_type ext_;
+};
+
+// Rank-0 specialisation: no extent array needed.
+template <typename IndexType>
+struct simple_mapping<0, IndexType>
+{
+    using index_type = IndexType;
+    using extents_type = simple_extents<0>;
+
+    [[nodiscard]] static constexpr std::size_t rank() noexcept
+    {
+        return 0;
+    }
+
+    [[nodiscard]] constexpr extents_type const& extents() const noexcept
+    {
+        return ext_;
+    }
+
+    extents_type ext_;
+};
+
+///////////////////////////////////////////////////////////////////////////////
+// Column-major (layout_left) mapping stub.
+//
+// Exposes stride() so that for_each_index can detect the layout and switch
+// to the _left parallel path.  stride(0) == 1 and strides increase toward
+// the last dimension, matching Fortran/column-major memory order.
+
+template <std::size_t Rank, typename IndexType = int>
+struct simple_mapping_left
+{
+    using index_type = IndexType;
+    using extents_type = simple_extents<Rank>;
+
+    explicit simple_mapping_left(
+        std::size_t const (&dims)[Rank == 0 ? 1 : Rank])
+      : ext_(dims)
+    {
+        // Compute column-major (Fortran) strides: stride[0]=1,
+        // stride[r] = stride[r-1] * extent(r-1).
+        strides_[0] = 1;
+        for (std::size_t r = 1; r < Rank; ++r)
+            strides_[r] = strides_[r - 1] * ext_.extent(r - 1);
+    }
+
+    [[nodiscard]] static constexpr std::size_t rank() noexcept
+    {
+        return Rank;
+    }
+
+    [[nodiscard]] constexpr extents_type const& extents() const noexcept
+    {
+        return ext_;
+    }
+
+    [[nodiscard]] constexpr std::size_t stride(std::size_t r) const noexcept
+    {
+        return strides_[r];
+    }
+
+    extents_type ext_;
+    std::size_t strides_[Rank == 0 ? 1 : Rank]{};
+};
+
+// rank-0: the domain has exactly one element (the empty index tuple).
+// fun() is called exactly once.
+void test_rank0_seq()
+{
+    simple_mapping<0> m;
+
+    int count = 0;
+    hpx::experimental::for_each_index(m, [&count]() { ++count; });
+
+    HPX_TEST_EQ(count, 1);
+}
+
+void test_rank0_par()
+{
+    simple_mapping<0> m;
+
+    std::atomic<int> count{0};
+    hpx::experimental::for_each_index(
+        hpx::execution::par, m, [&count]() { ++count; });
+
+    HPX_TEST_EQ(count.load(), 1);
+}
+
+// rank-1 sequential: visits every index in [0, N).
+void test_rank1_seq(std::mt19937& gen)
+{
+    std::uniform_int_distribution<std::size_t> dist(100, 10000);
+    std::size_t const N = dist(gen);
+    std::size_t dims[1] = {N};
+    simple_mapping<1> m(dims);
+
+    std::vector<int> visited(N, 0);
+    hpx::experimental::for_each_index(
+        m, [&visited](int i) { visited[i] += 1; });
+
+    for (std::size_t i = 0; i < N; ++i)
+    {
+        HPX_TEST_EQ(visited[i], 1);
+    }
+}
+
+// rank-1 parallel: visits every index exactly once (atomic counter).
+template <typename ExPolicy>
+void test_rank1_par(ExPolicy&& policy, std::mt19937& gen)
+{
+    std::uniform_int_distribution<std::size_t> dist(100, 10000);
+    std::size_t const N = dist(gen);
+    std::size_t dims[1] = {N};
+    simple_mapping<1> m(dims);
+
+    std::atomic<int> count{0};
+    hpx::experimental::for_each_index(
+        HPX_FORWARD(ExPolicy, policy), m, [&count](int /*i*/) { ++count; });
+
+    HPX_TEST_EQ(static_cast<std::size_t>(count.load()), N);
+}
+
+// rank-2 sequential: every (i, j) pair is visited exactly once.
+void test_rank2_seq(std::mt19937& gen)
+{
+    std::uniform_int_distribution<std::size_t> dist(10, 200);
+    std::size_t const R = dist(gen);
+    std::size_t const C = dist(gen);
+    std::size_t dims[2] = {R, C};
+    simple_mapping<2> m(dims);
+
+    // Flat bitmap: visited[i * C + j] is incremented for each (i, j).
+    std::vector<int> visited(R * C, 0);
+    hpx::experimental::for_each_index(
+        m, [&visited, C](int i, int j) { visited[i * C + j] += 1; });
+
+    for (std::size_t i = 0; i < R; ++i)
+        for (std::size_t j = 0; j < C; ++j)
+            HPX_TEST_EQ(visited[i * C + j], 1);
+}
+
+// rank-2 parallel: atomic sum equals R * C.
+template <typename ExPolicy>
+void test_rank2_par(ExPolicy&& policy, std::mt19937& gen)
+{
+    std::uniform_int_distribution<std::size_t> dist(10, 200);
+    std::size_t const R = dist(gen);
+    std::size_t const C = dist(gen);
+    std::size_t dims[2] = {R, C};
+    simple_mapping<2> m(dims);
+
+    std::atomic<int> count{0};
+    hpx::experimental::for_each_index(HPX_FORWARD(ExPolicy, policy), m,
+        [&count](int /*i*/, int /*j*/) { ++count; });
+
+    HPX_TEST_EQ(static_cast<std::size_t>(count.load()), R * C);
+}
+
+// rank-3 sequential: every (i, j, k) triple is visited exactly once.
+void test_rank3_seq(std::mt19937& gen)
+{
+    std::uniform_int_distribution<std::size_t> dist(2, 20);
+    std::size_t const D0 = dist(gen);
+    std::size_t const D1 = dist(gen);
+    std::size_t const D2 = dist(gen);
+    std::size_t dims[3] = {D0, D1, D2};
+    simple_mapping<3> m(dims);
+
+    std::vector<int> visited(D0 * D1 * D2, 0);
+    hpx::experimental::for_each_index(
+        m, [&visited, D1, D2](int i, int j, int k) {
+            visited[i * D1 * D2 + j * D2 + k] += 1;
+        });
+
+    for (std::size_t idx = 0; idx < D0 * D1 * D2; ++idx)
+        HPX_TEST_EQ(visited[idx], 1);
+}
+
+// rank-3 parallel.
+template <typename ExPolicy>
+void test_rank3_par(ExPolicy&& policy, std::mt19937& gen)
+{
+    std::uniform_int_distribution<std::size_t> dist(2, 20);
+    std::size_t const D0 = dist(gen);
+    std::size_t const D1 = dist(gen);
+    std::size_t const D2 = dist(gen);
+    std::size_t dims[3] = {D0, D1, D2};
+    simple_mapping<3> m(dims);
+
+    std::atomic<int> count{0};
+    hpx::experimental::for_each_index(HPX_FORWARD(ExPolicy, policy), m,
+        [&count](int /*i*/, int /*j*/, int /*k*/) { ++count; });
+
+    HPX_TEST_EQ(static_cast<std::size_t>(count.load()), D0 * D1 * D2);
+}
+
+// Async (task) overloads: verify future<void> is returned.
+template <typename ExPolicy>
+void test_rank2_async(ExPolicy&& policy, std::mt19937& gen)
+{
+    std::uniform_int_distribution<std::size_t> dist(10, 50);
+    std::size_t const R = dist(gen);
+    std::size_t const C = dist(gen);
+    std::size_t dims[2] = {R, C};
+    simple_mapping<2> m(dims);
+
+    std::atomic<int> count{0};
+    auto f = hpx::experimental::for_each_index(HPX_FORWARD(ExPolicy, policy), m,
+        [&count](int /*i*/, int /*j*/) { ++count; });
+    f.wait();
+
+    HPX_TEST_EQ(static_cast<std::size_t>(count.load()), R * C);
+}
+
+// Empty extent: fun must NOT be called at all.
+void test_empty_extent_seq(std::mt19937& gen)
+{
+    std::uniform_int_distribution<std::size_t> dist(1, 100);
+    std::size_t dims[2] = {0, dist(gen)};
+    simple_mapping<2> m(dims);
+
+    int count = 0;
+    hpx::experimental::for_each_index(
+        m, [&count](int /*i*/, int /*j*/) { ++count; });
+
+    HPX_TEST_EQ(count, 0);
+}
+
+template <typename ExPolicy>
+void test_empty_extent_par(ExPolicy&& policy, std::mt19937& gen)
+{
+    std::uniform_int_distribution<std::size_t> dist(1, 100);
+    std::size_t dims[2] = {dist(gen), 0};
+    simple_mapping<2> m(dims);
+
+    std::atomic<int> count{0};
+    hpx::experimental::for_each_index(HPX_FORWARD(ExPolicy, policy), m,
+        [&count](int /*i*/, int /*j*/) { ++count; });
+
+    HPX_TEST_EQ(count.load(), 0);
+}
+
+// Result of fun is ignored (callable returns int).
+void test_result_ignored(std::mt19937& gen)
+{
+    std::uniform_int_distribution<std::size_t> dist(2, 5);
+    std::size_t dims[2] = {dist(gen), dist(gen)};
+    simple_mapping<2> m(dims);
+
+    // Should compile and run without error even though fun returns int.
+    hpx::experimental::for_each_index(
+        m, [](int /*i*/, int /*j*/) -> int { return 42; });
+
+    HPX_TEST(true);    // reached here => ok
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Test-runner functions (group sequential then parallel variants together).
+///////////////////////////////////////////////////////////////////////////////
+void for_each_index_test_seq(std::mt19937& gen)
+{
+    test_rank0_seq();
+    test_rank1_seq(gen);
+    test_rank2_seq(gen);
+    test_rank3_seq(gen);
+    test_empty_extent_seq(gen);
+    test_result_ignored(gen);
+}
+
+void for_each_index_test_par(std::mt19937& gen)
+{
+    using namespace hpx::execution;
+
+    test_rank0_par();
+
+    test_rank1_par(par, gen);
+    test_rank1_par(par_unseq, gen);
+
+    test_rank2_par(par, gen);
+    test_rank2_par(par_unseq, gen);
+
+    test_rank3_par(par, gen);
+    test_rank3_par(par_unseq, gen);
+
+    test_empty_extent_par(par, gen);
+    test_empty_extent_par(par_unseq, gen);
+}
+
+void for_each_index_test_async(std::mt19937& gen)
+{
+    using namespace hpx::execution;
+
+    test_rank2_async(seq(task), gen);
+    test_rank2_async(par(task), gen);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Column-major (layout_left) tests.
+//
+// Uses simple_mapping_left which exposes stride() with stride(0)==1.
+// This triggers the layout_left parallel dispatch path.
+///////////////////////////////////////////////////////////////////////////////
+
+// rank-2 sequential, column-major: every (i, j) pair visited exactly once.
+void test_rank2_left_seq(std::mt19937& gen)
+{
+    std::uniform_int_distribution<std::size_t> dist(10, 200);
+    std::size_t const R = dist(gen);
+    std::size_t const C = dist(gen);
+    std::size_t dims[2] = {R, C};
+    simple_mapping_left<2> m(dims);
+
+    std::vector<int> visited(R * C, 0);
+    hpx::experimental::for_each_index(
+        m, [&visited, C](int i, int j) { visited[i * C + j] += 1; });
+
+    for (std::size_t i = 0; i < R; ++i)
+        for (std::size_t j = 0; j < C; ++j)
+            HPX_TEST_EQ(visited[i * C + j], 1);
+}
+
+// rank-2 parallel, column-major: atomic sum equals R * C.
+template <typename ExPolicy>
+void test_rank2_left_par(ExPolicy&& policy, std::mt19937& gen)
+{
+    std::uniform_int_distribution<std::size_t> dist(10, 200);
+    std::size_t const R = dist(gen);
+    std::size_t const C = dist(gen);
+    std::size_t dims[2] = {R, C};
+    simple_mapping_left<2> m(dims);
+
+    std::atomic<int> count{0};
+    hpx::experimental::for_each_index(HPX_FORWARD(ExPolicy, policy), m,
+        [&count](int /*i*/, int /*j*/) { ++count; });
+
+    HPX_TEST_EQ(static_cast<std::size_t>(count.load()), R * C);
+}
+
+// rank-3 sequential, column-major: every (i, j, k) triple visited once.
+void test_rank3_left_seq(std::mt19937& gen)
+{
+    std::uniform_int_distribution<std::size_t> dist(2, 20);
+    std::size_t const D0 = dist(gen);
+    std::size_t const D1 = dist(gen);
+    std::size_t const D2 = dist(gen);
+    std::size_t dims[3] = {D0, D1, D2};
+    simple_mapping_left<3> m(dims);
+
+    std::vector<int> visited(D0 * D1 * D2, 0);
+    hpx::experimental::for_each_index(
+        m, [&visited, D1, D2](int i, int j, int k) {
+            visited[i * D1 * D2 + j * D2 + k] += 1;
+        });
+
+    for (std::size_t idx = 0; idx < D0 * D1 * D2; ++idx)
+        HPX_TEST_EQ(visited[idx], 1);
+}
+
+// rank-3 parallel, column-major: atomic sum equals D0 * D1 * D2.
+template <typename ExPolicy>
+void test_rank3_left_par(ExPolicy&& policy, std::mt19937& gen)
+{
+    std::uniform_int_distribution<std::size_t> dist(2, 20);
+    std::size_t const D0 = dist(gen);
+    std::size_t const D1 = dist(gen);
+    std::size_t const D2 = dist(gen);
+    std::size_t dims[3] = {D0, D1, D2};
+    simple_mapping_left<3> m(dims);
+
+    std::atomic<int> count{0};
+    hpx::experimental::for_each_index(HPX_FORWARD(ExPolicy, policy), m,
+        [&count](int /*i*/, int /*j*/, int /*k*/) { ++count; });
+
+    HPX_TEST_EQ(static_cast<std::size_t>(count.load()), D0 * D1 * D2);
+}
+
+void for_each_index_test_left(std::mt19937& gen)
+{
+    using namespace hpx::execution;
+
+    test_rank2_left_seq(gen);
+    test_rank3_left_seq(gen);
+
+    test_rank2_left_par(par, gen);
+    test_rank2_left_par(par_unseq, gen);
+
+    test_rank3_left_par(par, gen);
+    test_rank3_left_par(par_unseq, gen);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = std::random_device{}();
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::mt19937 gen(seed);
+
+    for_each_index_test_seq(gen);
+    for_each_index_test_par(gen);
+    for_each_index_test_async(gen);
+    for_each_index_test_left(gen);
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // Run on all available cores.
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
Fixes #7214

# Description

This PR introduces `hpx::experimental::for_each_index`, an implementation of the multidimensional index-based for-each algorithm proposed in ISO C++ proposal [P4150R0](https://wg21.link/p4150).

The algorithm iterates over the domain defined by the extents of a layout mapping and calls a function object with exactly `Mapping::rank()` index arguments, parallelizing the outermost extent and executing the inner extents sequentially.

### Features
* **Concept Guard**: Employs a lightweight, C++20-compatible `concept` (`is_layout_mapping_v`) to detect valid mapping types without relying on C++23 `<mdspan>`.
* **Sequential Optimizations**: Includes a compile-time variadic recursion algorithm `hpx::parallel::detail::for_each_index_seq_impl` to flatten multidimensional loop unrolling seamlessly.
* **Parallel Performance**: Parallel overloads leverage `hpx::parallel::util::partitioner` over the rank-0 extent, while preserving data-locality for row-major layouts via local inner sequential steps.
* **Execution Policies Supported**: Operates seamlessly with all established HPX execution policy behaviors, including `seq`, `par`, `par_unseq`, and `task` variations.
* **Comprehensive Test Suite**: Incorporates a lightweight `simple_mapping` stub for ensuring tests accurately mimic a full multidimensional array without demanding ISO C++23 capability.

### Changed Files
- `libs/core/algorithms/include/hpx/parallel/algorithms/for_each_index.hpp` (New)
- `libs/core/algorithms/tests/unit/algorithms/for_each_index.cpp` (New)
- `libs/core/algorithms/include/hpx/parallel/algorithm.hpp`
- `libs/core/algorithms/CMakeLists.txt`
- `libs/core/algorithms/tests/unit/algorithms/CMakeLists.txt`

Tested formatting via clang-format locally against the HPX format spec.
