### PR TITLE
tracing: add hpx::tracing::set_thread_name abstraction

### DIFF
--- a/libs/core/thread_support/CMakeLists.txt
+++ b/libs/core/thread_support/CMakeLists.txt
@@ -36,6 +36,6 @@ add_hpx_module(
   HEADERS ${thread_support_headers}
   COMPAT_HEADERS ${thread_support_compat_headers}
   MODULE_DEPENDENCIES ${additional_dependencies} hpx_assertion hpx_config
-                      hpx_concepts hpx_type_support
+                      hpx_concepts hpx_tracing hpx_type_support
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/core/thread_support/CMakeLists.txt
+++ b/libs/core/thread_support/CMakeLists.txt
@@ -22,11 +22,6 @@ set(thread_support_compat_headers
 
 set(thread_support_sources set_thread_name.cpp spinlock.cpp)
 
-set(additionaldependencies)
-if(HPX_TRACY_WITH_TRACY)
-  set(additional_dependencies ${additional_dependencies} hpx_tracy)
-endif()
-
 include(HPX_AddModule)
 add_hpx_module(
   core thread_support
@@ -35,7 +30,7 @@ add_hpx_module(
   SOURCES ${thread_support_sources}
   HEADERS ${thread_support_headers}
   COMPAT_HEADERS ${thread_support_compat_headers}
-  MODULE_DEPENDENCIES ${additional_dependencies} hpx_assertion hpx_config
+  MODULE_DEPENDENCIES hpx_assertion hpx_config
                       hpx_concepts hpx_tracing hpx_type_support
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/core/thread_support/CMakeLists.txt
+++ b/libs/core/thread_support/CMakeLists.txt
@@ -30,7 +30,7 @@ add_hpx_module(
   SOURCES ${thread_support_sources}
   HEADERS ${thread_support_headers}
   COMPAT_HEADERS ${thread_support_compat_headers}
-  MODULE_DEPENDENCIES hpx_assertion hpx_config
-                      hpx_concepts hpx_tracing hpx_type_support
+  MODULE_DEPENDENCIES hpx_assertion hpx_config hpx_concepts hpx_tracing
+                      hpx_type_support
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/core/thread_support/src/set_thread_name.cpp
+++ b/libs/core/thread_support/src/set_thread_name.cpp
@@ -89,7 +89,7 @@ namespace hpx::util {
     void set_thread_name(char const* thread_name) noexcept
     {
         detail::set_thread_name(thread_name);
-        hpx::tracing::set_thread_name{thread_name};
+        hpx::tracing::set_thread_name(thread_name);
     }
 }    // namespace hpx::util
 
@@ -101,7 +101,7 @@ namespace hpx::util {
     void set_thread_name(char const* thread_name) noexcept
     {
         pthread_setname_np(pthread_self(), thread_name);
-        hpx::tracing::set_thread_name{thread_name};
+        hpx::tracing::set_thread_name(thread_name);
     }
 }    // namespace hpx::util
 
@@ -111,7 +111,7 @@ namespace hpx::util {
 
     void set_thread_name(char const* thread_name) noexcept
     {
-        hpx::tracing::set_thread_name{thread_name};
+        hpx::tracing::set_thread_name(thread_name);
     }
 }    // namespace hpx::util
 

--- a/libs/core/thread_support/src/set_thread_name.cpp
+++ b/libs/core/thread_support/src/set_thread_name.cpp
@@ -8,14 +8,11 @@
 //      http://msdn.microsoft.com/en-us/library/xcb2z8hs.aspx
 
 #include <hpx/config.hpp>
+#include <hpx/modules/tracing.hpp>
 #include <hpx/thread_support/set_thread_name.hpp>
 
 #include <cstddef>
 #include <string>
-
-#if defined(HPX_HAVE_MODULE_TRACY)
-#include <hpx/modules/tracy.hpp>
-#endif
 
 #if (defined(WIN32) || defined(_WIN32) || defined(__WIN32__)) &&               \
     !defined(HPX_MINGW)
@@ -92,9 +89,7 @@ namespace hpx::util {
     void set_thread_name(char const* thread_name) noexcept
     {
         detail::set_thread_name(thread_name);
-#if defined(HPX_HAVE_MODULE_TRACY)
-        hpx::tracy::set_thread_name(thread_name);
-#endif
+        hpx::tracing::set_thread_name{thread_name};
     }
 }    // namespace hpx::util
 
@@ -106,9 +101,7 @@ namespace hpx::util {
     void set_thread_name(char const* thread_name) noexcept
     {
         pthread_setname_np(pthread_self(), thread_name);
-#if defined(HPX_HAVE_MODULE_TRACY)
-        hpx::tracy::set_thread_name(thread_name);
-#endif
+        hpx::tracing::set_thread_name{thread_name};
     }
 }    // namespace hpx::util
 
@@ -116,11 +109,9 @@ namespace hpx::util {
 
 namespace hpx::util {
 
-    void set_thread_name([[maybe_unused]] char const* thread_name) noexcept
+    void set_thread_name(char const* thread_name) noexcept
     {
-#if defined(HPX_HAVE_MODULE_TRACY)
-        hpx::tracy::set_thread_name(thread_name);
-#endif
+        hpx::tracing::set_thread_name{thread_name};
     }
 }    // namespace hpx::util
 

--- a/libs/core/tracing/include/hpx/tracing/tracing.hpp
+++ b/libs/core/tracing/include/hpx/tracing/tracing.hpp
@@ -81,6 +81,13 @@ namespace hpx::tracing {
         hpx::tracy::fiber_suspend_region impl;
     };
 
+    ////////////////////////////////////////////////////////////////////////////
+    HPX_CXX_CORE_EXPORT struct HPX_CORE_EXPORT set_thread_name
+    {
+        explicit set_thread_name(char const* name) noexcept;
+        ~set_thread_name();
+    };
+
 }    // namespace hpx::tracing
 
 #else
@@ -122,6 +129,12 @@ namespace hpx::tracing {
     HPX_CXX_CORE_EXPORT struct [[maybe_unused]] fiber_suspend_region
     {
         constexpr explicit fiber_suspend_region(char const*) noexcept {}
+    };
+
+    ////////////////////////////////////////////////////////////////////////////
+    HPX_CXX_CORE_EXPORT struct [[maybe_unused]] set_thread_name
+    {
+        constexpr explicit set_thread_name(char const*) noexcept {}
     };
 
 }    // namespace hpx::tracing

--- a/libs/core/tracing/include/hpx/tracing/tracing.hpp
+++ b/libs/core/tracing/include/hpx/tracing/tracing.hpp
@@ -82,11 +82,8 @@ namespace hpx::tracing {
     };
 
     ////////////////////////////////////////////////////////////////////////////
-    HPX_CXX_CORE_EXPORT struct HPX_CORE_EXPORT set_thread_name
-    {
-        explicit set_thread_name(char const* name) noexcept;
-        ~set_thread_name();
-    };
+    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void set_thread_name(
+        char const* name) noexcept;
 
 }    // namespace hpx::tracing
 
@@ -132,10 +129,7 @@ namespace hpx::tracing {
     };
 
     ////////////////////////////////////////////////////////////////////////////
-    HPX_CXX_CORE_EXPORT struct [[maybe_unused]] set_thread_name
-    {
-        constexpr explicit set_thread_name(char const*) noexcept {}
-    };
+    HPX_CXX_CORE_EXPORT constexpr void set_thread_name(char const*) noexcept {}
 
 }    // namespace hpx::tracing
 

--- a/libs/core/tracing/src/tracing.cpp
+++ b/libs/core/tracing/src/tracing.cpp
@@ -80,12 +80,10 @@ namespace hpx::tracing {
     ////////////////////////////////////////////////////////////////////////////
     // set_thread_name
 
-    set_thread_name::set_thread_name(char const* name) noexcept
+    void set_thread_name(char const* name) noexcept
     {
         hpx::tracy::set_thread_name(name);
     }
-
-    set_thread_name::~set_thread_name() = default;
 
 }    // namespace hpx::tracing
 

--- a/libs/core/tracing/src/tracing.cpp
+++ b/libs/core/tracing/src/tracing.cpp
@@ -77,6 +77,16 @@ namespace hpx::tracing {
 
     fiber_suspend_region::~fiber_suspend_region() = default;
 
+    ////////////////////////////////////////////////////////////////////////////
+    // set_thread_name
+
+    set_thread_name::set_thread_name(char const* name) noexcept
+    {
+        hpx::tracy::set_thread_name(name);
+    }
+
+    set_thread_name::~set_thread_name() = default;
+
 }    // namespace hpx::tracing
 
 #endif


### PR DESCRIPTION
## Proposed Changes
- Add `hpx::tracing::set_thread_name` to the tracing abstraction layer
  following the same pattern as `fiber_suspend_region` from #7058
- Remove `#ifdef HPX_HAVE_MODULE_TRACY` guards from all three platform
  branches in `set_thread_name.cpp`
- Replace direct `hpx::tracy::set_thread_name` calls with
  `hpx::tracing::set_thread_name`
- Add `hpx_tracing` as a dependency of `hpx_thread_support`

## Any background context you want to provide?
`set_thread_name.cpp` had three platform-specific branches (Windows,
pthreads, fallback) each with their own `#ifdef HPX_HAVE_MODULE_TRACY`
guard. This follows the ongoing effort to route all Tracy instrumentation
through `hpx::tracing` so call sites are backend-agnostic.

## Checklist
- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.