### PR TITLE
Fix iteration mismatch in collective tests local timing

### DIFF
--- a/libs/full/collectives/tests/unit/all_gather_hierarchical.cpp
+++ b/libs/full/collectives/tests/unit/all_gather_hierarchical.cpp
@@ -99,7 +99,7 @@ void test_local_use(std::uint32_t num_sites, int arity = 2)
             if (site == 0)
             {
                 std::cout << "local timing (" << num_sites << "/" << arity
-                          << "): " << elapsed / (10 * ITERATIONS) << "[s]\n"
+                          << "): " << elapsed / ITERATIONS << "[s]\n"
                           << std::flush;
             }
         }));

--- a/libs/full/collectives/tests/unit/all_reduce_hierarchical.cpp
+++ b/libs/full/collectives/tests/unit/all_reduce_hierarchical.cpp
@@ -100,7 +100,7 @@ void test_local_use(std::uint32_t num_sites, int arity = 2)
             if (site == 0)
             {
                 std::cout << "local timing (" << num_sites << "/" << arity
-                          << "): " << elapsed / (10 * ITERATIONS) << "[s]\n"
+                          << "): " << elapsed / ITERATIONS << "[s]\n"
                           << std::flush;
             }
         }));

--- a/libs/full/collectives/tests/unit/reduce.cpp
+++ b/libs/full/collectives/tests/unit/reduce.cpp
@@ -187,7 +187,7 @@ void test_local_use(std::uint32_t num_sites)
             auto const elapsed = t.elapsed();
             if (site == 0)
             {
-                std::cout << "local timing: " << elapsed / (10 * ITERATIONS)
+                std::cout << "local timing: " << elapsed / ITERATIONS
                           << "[s]\n";
             }
         }));

--- a/libs/full/collectives/tests/unit/reduce_hierarchical.cpp
+++ b/libs/full/collectives/tests/unit/reduce_hierarchical.cpp
@@ -164,7 +164,7 @@ void test_local_use(std::uint32_t num_sites, int arity = 2)
             if (site == 0)
             {
                 std::cout << "local timing (" << num_sites << "/" << arity
-                          << "): " << elapsed / (10 * ITERATIONS) << "[s]\n"
+                          << "): " << elapsed / ITERATIONS << "[s]\n"
                           << std::flush;
             }
         }));

--- a/libs/full/collectives/tests/unit/reduce_sync.cpp
+++ b/libs/full/collectives/tests/unit/reduce_sync.cpp
@@ -229,7 +229,7 @@ void test_local_use()
             auto const elapsed = t.elapsed();
             if (site == 0)
             {
-                std::cout << "local timing: " << elapsed / (10 * ITERATIONS)
+                std::cout << "local timing: " << elapsed / ITERATIONS
                           << "[s]\n";
             }
         }));
@@ -282,7 +282,7 @@ void test_local_use_sync()
             auto const elapsed = t.elapsed();
             if (site == 0)
             {
-                std::cout << "local timing: " << elapsed / (10 * ITERATIONS)
+                std::cout << "local timing: " << elapsed / ITERATIONS
                           << "[s]\n";
             }
         }));

--- a/libs/full/collectives/tests/unit/scatter.cpp
+++ b/libs/full/collectives/tests/unit/scatter.cpp
@@ -182,7 +182,7 @@ void test_local_use(std::uint32_t num_sites)
             auto const elapsed = t.elapsed();
             if (site == 0)
             {
-                std::cout << "local timing: " << elapsed / (10 * ITERATIONS)
+                std::cout << "local timing: " << elapsed / ITERATIONS
                           << "[s]\n";
             }
         }));

--- a/libs/full/collectives/tests/unit/scatter_hierarchical.cpp
+++ b/libs/full/collectives/tests/unit/scatter_hierarchical.cpp
@@ -159,7 +159,7 @@ void test_local_use(std::uint32_t num_sites, int arity = 2)
             if (site == 0)
             {
                 std::cout << "local timing (" << num_sites << "/" << arity
-                          << "): " << elapsed / (10 * ITERATIONS) << "[s]\n"
+                          << "): " << elapsed / ITERATIONS << "[s]\n"
                           << std::flush;
             }
         }));

--- a/libs/full/collectives/tests/unit/scatter_sync.cpp
+++ b/libs/full/collectives/tests/unit/scatter_sync.cpp
@@ -184,7 +184,7 @@ void test_local_use()
             auto const elapsed = t.elapsed();
             if (site == 0)
             {
-                std::cout << "local timing: " << elapsed / (10 * ITERATIONS)
+                std::cout << "local timing: " << elapsed / ITERATIONS
                           << "[s]\n";
             }
         }));


### PR DESCRIPTION
While writing `barrier_hierarchical.cpp` for PR #7210, several collective tests ran for `ITERATIONS` but reported timing divided by `10 * ITERATIONS`. This PR fixes those test files so the reported latency matches the actual measurement.