### PR TITLE
ci: switch to lukka/get-cmake to resolve GitHub API rate limits

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -54,7 +54,7 @@ jobs:
         queries: security-and-quality
 
     - name: Install CMake
-      uses: jwlawson/actions-setup-cmake@v2.2
+      uses: lukka/get-cmake@latest
 
     - name: Install Ninja
       uses: seanmiddleditch/gha-setup-ninja@master

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -54,7 +54,7 @@ jobs:
         queries: security-and-quality
 
     - name: Install CMake
-      uses: lukka/get-cmake@v4
+      uses: lukka/get-cmake@v4.3.0
 
     - name: Install Ninja
       uses: seanmiddleditch/gha-setup-ninja@master

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -54,7 +54,7 @@ jobs:
         queries: security-and-quality
 
     - name: Install CMake
-      uses: lukka/get-cmake@latest
+      uses: lukka/get-cmake@v4
 
     - name: Install Ninja
       uses: seanmiddleditch/gha-setup-ninja@master

--- a/.github/workflows/windows_clang_debug.yml
+++ b/.github/workflows/windows_clang_debug.yml
@@ -19,9 +19,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - uses: jwlawson/actions-setup-cmake@v2.2
-      with:
-        github-api-token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: lukka/get-cmake@latest
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/windows_clang_debug.yml
+++ b/.github/workflows/windows_clang_debug.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - uses: lukka/get-cmake@v4
+    - uses: lukka/get-cmake@v4.3.0
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/windows_clang_debug.yml
+++ b/.github/workflows/windows_clang_debug.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - uses: lukka/get-cmake@latest
+    - uses: lukka/get-cmake@v4
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/windows_clang_release.yml
+++ b/.github/workflows/windows_clang_release.yml
@@ -19,9 +19,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - uses: jwlawson/actions-setup-cmake@v2.2
-      with:
-        github-api-token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: lukka/get-cmake@latest
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/windows_clang_release.yml
+++ b/.github/workflows/windows_clang_release.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - uses: lukka/get-cmake@v4
+    - uses: lukka/get-cmake@v4.3.0
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/windows_clang_release.yml
+++ b/.github/workflows/windows_clang_release.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - uses: lukka/get-cmake@latest
+    - uses: lukka/get-cmake@v4
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/windows_debug_vs2022.yml
+++ b/.github/workflows/windows_debug_vs2022.yml
@@ -19,9 +19,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - uses: jwlawson/actions-setup-cmake@v2.2
-      with:
-        github-api-token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: lukka/get-cmake@latest
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/windows_debug_vs2022.yml
+++ b/.github/workflows/windows_debug_vs2022.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - uses: lukka/get-cmake@v4
+    - uses: lukka/get-cmake@v4.3.0
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/windows_debug_vs2022.yml
+++ b/.github/workflows/windows_debug_vs2022.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - uses: lukka/get-cmake@latest
+    - uses: lukka/get-cmake@v4
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/windows_debug_vs2022_fetch_boost.yml
+++ b/.github/workflows/windows_debug_vs2022_fetch_boost.yml
@@ -18,9 +18,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: jwlawson/actions-setup-cmake@v2.2
-        with:
-          github-api-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: lukka/get-cmake@latest
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/windows_debug_vs2022_fetch_boost.yml
+++ b/.github/workflows/windows_debug_vs2022_fetch_boost.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: lukka/get-cmake@v4
+      - uses: lukka/get-cmake@v4.3.0
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/windows_debug_vs2022_fetch_boost.yml
+++ b/.github/workflows/windows_debug_vs2022_fetch_boost.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v6
-      - uses: lukka/get-cmake@latest
+      - uses: lukka/get-cmake@v4
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/windows_debug_vs2022_fetch_hwloc.yml
+++ b/.github/workflows/windows_debug_vs2022_fetch_hwloc.yml
@@ -19,9 +19,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - uses: jwlawson/actions-setup-cmake@v2.2
-      with:
-        github-api-token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: lukka/get-cmake@latest
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/windows_debug_vs2022_fetch_hwloc.yml
+++ b/.github/workflows/windows_debug_vs2022_fetch_hwloc.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - uses: lukka/get-cmake@v4
+    - uses: lukka/get-cmake@v4.3.0
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/windows_debug_vs2022_fetch_hwloc.yml
+++ b/.github/workflows/windows_debug_vs2022_fetch_hwloc.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - uses: lukka/get-cmake@latest
+    - uses: lukka/get-cmake@v4
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/windows_debug_vs2022_local_runtime.yml
+++ b/.github/workflows/windows_debug_vs2022_local_runtime.yml
@@ -14,9 +14,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - uses: jwlawson/actions-setup-cmake@v2.2
-      with:
-        github-api-token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: lukka/get-cmake@latest
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/windows_debug_vs2022_local_runtime.yml
+++ b/.github/workflows/windows_debug_vs2022_local_runtime.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - uses: lukka/get-cmake@v4
+    - uses: lukka/get-cmake@v4.3.0
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/windows_debug_vs2022_local_runtime.yml
+++ b/.github/workflows/windows_debug_vs2022_local_runtime.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - uses: lukka/get-cmake@latest
+    - uses: lukka/get-cmake@v4
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/windows_debug_vs2022_modules.yml
+++ b/.github/workflows/windows_debug_vs2022_modules.yml
@@ -19,9 +19,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - uses: jwlawson/actions-setup-cmake@v2.2
-      with:
-        github-api-token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: lukka/get-cmake@latest
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/windows_debug_vs2022_modules.yml
+++ b/.github/workflows/windows_debug_vs2022_modules.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - uses: lukka/get-cmake@v4
+    - uses: lukka/get-cmake@v4.3.0
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/windows_debug_vs2022_modules.yml
+++ b/.github/workflows/windows_debug_vs2022_modules.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - uses: lukka/get-cmake@latest
+    - uses: lukka/get-cmake@v4
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/windows_debug_vs2022_tracy.yml
+++ b/.github/workflows/windows_debug_vs2022_tracy.yml
@@ -19,9 +19,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - uses: jwlawson/actions-setup-cmake@v2.2
-      with:
-        github-api-token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: lukka/get-cmake@latest
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/windows_debug_vs2022_tracy.yml
+++ b/.github/workflows/windows_debug_vs2022_tracy.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - uses: lukka/get-cmake@v4
+    - uses: lukka/get-cmake@v4.3.0
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/windows_debug_vs2022_tracy.yml
+++ b/.github/workflows/windows_debug_vs2022_tracy.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - uses: lukka/get-cmake@latest
+    - uses: lukka/get-cmake@v4
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/windows_release_2022.yml
+++ b/.github/workflows/windows_release_2022.yml
@@ -18,9 +18,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - uses: jwlawson/actions-setup-cmake@v2.2
-      with:
-        github-api-token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: lukka/get-cmake@latest
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/windows_release_2022.yml
+++ b/.github/workflows/windows_release_2022.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - uses: lukka/get-cmake@v4
+    - uses: lukka/get-cmake@v4.3.0
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/windows_release_2022.yml
+++ b/.github/workflows/windows_release_2022.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - uses: lukka/get-cmake@latest
+    - uses: lukka/get-cmake@v4
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/windows_release_gcc_mingw.yml
+++ b/.github/workflows/windows_release_gcc_mingw.yml
@@ -18,9 +18,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - uses: jwlawson/actions-setup-cmake@v2.2
-      with:
-        github-api-token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: lukka/get-cmake@latest
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/windows_release_gcc_mingw.yml
+++ b/.github/workflows/windows_release_gcc_mingw.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - uses: lukka/get-cmake@v4
+    - uses: lukka/get-cmake@v4.3.0
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/windows_release_gcc_mingw.yml
+++ b/.github/workflows/windows_release_gcc_mingw.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - uses: lukka/get-cmake@latest
+    - uses: lukka/get-cmake@v4
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/windows_release_static.yml
+++ b/.github/workflows/windows_release_static.yml
@@ -19,9 +19,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - uses: jwlawson/actions-setup-cmake@v2.2
-      with:
-        github-api-token: ${{ secrets.GITHUB_TOKEN }}
+    - uses: lukka/get-cmake@latest
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/windows_release_static.yml
+++ b/.github/workflows/windows_release_static.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - uses: lukka/get-cmake@v4
+    - uses: lukka/get-cmake@v4.3.0
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/windows_release_static.yml
+++ b/.github/workflows/windows_release_static.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v6
-    - uses: lukka/get-cmake@latest
+    - uses: lukka/get-cmake@v4
 
     - name: Install dependencies
       run: |

--- a/cmake/HPX_CXXModules.cmake
+++ b/cmake/HPX_CXXModules.cmake
@@ -4,6 +4,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+include(HPX_AddCompileFlag)
 include(HPX_Message)
 
 macro(hpx_check_cxx_modules_support)
@@ -64,18 +65,28 @@ if(NOT HPX_WITH_CXX_MODULES)
   return()
 endif()
 
-# hpx_configure_module_producer(<producer>)
+# hpx_configure_module_producer(<producer> [MODULE_OUT_DIR <dir>])
 #
-# * Creates an interface target '<producer>_if' for consumers to link to.
-# * Sets INTERFACE_CXX_SCAN_FOR_MODULES ON so that CMake's native module
-#   dependency tracking propagates to all consumers.
-#
-# CMake 3.29+ with FILE_SET CXX_MODULES handles BMI generation and
-# -fmodule-output/-fprebuilt-module-path flags automatically. No manual compiler
-# flags are needed here.
+# * Ensures a stable module output dir for producer target
+# * Adds compiler flags to write module cache there (Clang/GCC)
+# * Creates an interface target '<producer>_if' for consumers to link to
 function(hpx_configure_module_producer producer)
   if(NOT TARGET ${producer})
     hpx_error("hpx_configure_module_producer: target '${producer}' not found")
+  endif()
+
+  # parse optional args
+  set(options)
+  set(one_value_args MODULE_OUT_DIR)
+  set(multi_value_args)
+  cmake_parse_arguments(
+    _args "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN}
+  )
+
+  if(_args_MODULE_OUT_DIR)
+    set(_moddir "${_args_MODULE_OUT_DIR}")
+  else()
+    set(_moddir "$<TARGET_FILE_DIR:${producer}>")
   endif()
 
   set(_iface "${producer}_if")
@@ -84,19 +95,49 @@ function(hpx_configure_module_producer producer)
     target_link_libraries(${_iface} INTERFACE ${producer})
   endif()
 
-  # Propagate scanning requirement to consumers via the interface target. CMake
-  # uses this to enable its native module dependency scanning for any target
-  # that links to this interface.
-  set_target_properties(${_iface} PROPERTIES INTERFACE_CXX_SCAN_FOR_MODULES ON)
+  # Set a property so consumers can query the BMI directory via
+  # get_target_property.
+  set_target_properties(
+    ${_iface} PROPERTIES INTERFACE_EXPORT_MODULE_DIR "${_moddir}"
+  )
+
+  # Make sure consumers scan for the BMI
+  set_target_properties(${_iface} PROPERTIES INTERFACE_CXX_SCAN_FOR_MODULES On)
+
+  if(MSVC)
+    # MSVC: CMake/MSVC handle IFCs automatically; create a target for
+    # convenience, consumers can link to this to get ordering and include info
+    return()
+  endif()
+
+  # Compiler-specific flags to instruct where to write module cache
+  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES
+                                              "AppleClang"
+  )
+    # Clang common flags
+    target_compile_options(${producer} PRIVATE "-fmodule-output=${_moddir}")
+  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    # GCC: modern flags
+    hpx_add_target_compile_option_if_available(
+      ${producer} PRIVATE "-fmodule-output=${_moddir}" RESULT ok
+    )
+    if(NOT ok)
+      hpx_error(
+        "hpx_configure_module_producer: the used version of gcc does not support '-fmodule-output'"
+      )
+    endif()
+  else()
+    hpx_warn(
+      "hpx_configure_module_producer: unknown compiler '${CMAKE_CXX_COMPILER_ID}'; "
+      "exposing EXPORT_MODULE_DIR='${_moddir}' for manual handling"
+    )
+  endif()
 endfunction()
 
-# hpx_configure_module_consumer(<consumer> <producer>)
+# hpx_configure_module_consumer(<consumer> <producer>])
 #
-# * Links the consumer to the producer interface target.
-# * Enables CMake's native module scanning on the consumer.
-#
-# CMake 3.29+ automatically resolves the BMI location from the FILE_SET
-# CXX_MODULES declared on the producer. No -fprebuilt-module-path needed.
+# * propagates module-related properties from producer interface target
+# * sets necessary consumer compiler flags for clang and gcc
 function(hpx_configure_module_consumer consumer producer)
   if(NOT TARGET ${consumer})
     hpx_error("hpx_configure_module_consumer: target '${consumer}' not found")
@@ -106,20 +147,40 @@ function(hpx_configure_module_consumer consumer producer)
   endif()
 
   target_link_libraries(${consumer} PRIVATE ${producer})
-
   get_target_property(_scan ${producer} INTERFACE_CXX_SCAN_FOR_MODULES)
   if(_scan)
     set_target_properties(${consumer} PROPERTIES CXX_SCAN_FOR_MODULES ${_scan})
   endif()
 
-  # Clang emits DWARF-5 when compiling with C++20 modules, which requires lld.
-  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES
-                                              "AppleClang"
-  )
-    get_target_property(_type ${consumer} TYPE)
-    if((_type STREQUAL "SHARED_LIBRARY") OR (_type STREQUAL "EXECUTABLE"))
-      target_link_options(${consumer} PRIVATE "-fuse-ld=lld")
-      target_link_options(${consumer} PRIVATE "-Wl,--error-limit=0")
+  get_target_property(_module_dir ${producer} INTERFACE_EXPORT_MODULE_DIR)
+  if(_module_dir)
+    if(MSVC)
+      return()
+    elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID
+                                                    MATCHES "AppleClang"
+    )
+      target_compile_options(
+        ${consumer} PRIVATE "-fprebuilt-module-path=${_module_dir}"
+      )
+      get_target_property(_type ${consumer} TYPE)
+      if((_type STREQUAL "SHARED_LIBRARY") OR (_type STREQUAL "EXECUTABLE"))
+        target_link_options(${consumer} PRIVATE "-fuse-ld=lld")
+        target_link_options(${consumer} PRIVATE "-Wl,--error-limit=0")
+      endif()
+    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+      hpx_add_target_compile_option_if_available(
+        ${consumer} PRIVATE "-fprebuilt-module-path=${_module_dir}" RESULT ok
+      )
+      if(NOT ok)
+        hpx_error(
+          "hpx_configure_module_consumer: the used version of gcc does not "
+          "support '-fprebuilt-module-path='"
+        )
+      endif()
+    else()
+      hpx_warn(
+        "hpx_configure_module_consumer: unknown compiler '${CMAKE_CXX_COMPILER_ID}'"
+      )
     endif()
   endif()
 endfunction()

--- a/cmake/HPX_CXXModules.cmake
+++ b/cmake/HPX_CXXModules.cmake
@@ -4,7 +4,6 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-include(HPX_AddCompileFlag)
 include(HPX_Message)
 
 macro(hpx_check_cxx_modules_support)
@@ -65,28 +64,18 @@ if(NOT HPX_WITH_CXX_MODULES)
   return()
 endif()
 
-# hpx_configure_module_producer(<producer> [MODULE_OUT_DIR <dir>])
+# hpx_configure_module_producer(<producer>)
 #
-# * Ensures a stable module output dir for producer target
-# * Adds compiler flags to write module cache there (Clang/GCC)
-# * Creates an interface target '<producer>_if' for consumers to link to
+# * Creates an interface target '<producer>_if' for consumers to link to.
+# * Sets INTERFACE_CXX_SCAN_FOR_MODULES ON so that CMake's native module
+#   dependency tracking propagates to all consumers.
+#
+# CMake 3.29+ with FILE_SET CXX_MODULES handles BMI generation and
+# -fmodule-output/-fprebuilt-module-path flags automatically. No manual compiler
+# flags are needed here.
 function(hpx_configure_module_producer producer)
   if(NOT TARGET ${producer})
     hpx_error("hpx_configure_module_producer: target '${producer}' not found")
-  endif()
-
-  # parse optional args
-  set(options)
-  set(one_value_args MODULE_OUT_DIR)
-  set(multi_value_args)
-  cmake_parse_arguments(
-    _args "${options}" "${one_value_args}" "${multi_value_args}" ${ARGN}
-  )
-
-  if(_args_MODULE_OUT_DIR)
-    set(_moddir "${_args_MODULE_OUT_DIR}")
-  else()
-    set(_moddir "$<TARGET_FILE_DIR:${producer}>")
   endif()
 
   set(_iface "${producer}_if")
@@ -95,49 +84,19 @@ function(hpx_configure_module_producer producer)
     target_link_libraries(${_iface} INTERFACE ${producer})
   endif()
 
-  # Set a property so consumers can query the BMI directory via
-  # get_target_property.
-  set_target_properties(
-    ${_iface} PROPERTIES INTERFACE_EXPORT_MODULE_DIR "${_moddir}"
-  )
-
-  # Make sure consumers scan for the BMI
-  set_target_properties(${_iface} PROPERTIES INTERFACE_CXX_SCAN_FOR_MODULES On)
-
-  if(MSVC)
-    # MSVC: CMake/MSVC handle IFCs automatically; create a target for
-    # convenience, consumers can link to this to get ordering and include info
-    return()
-  endif()
-
-  # Compiler-specific flags to instruct where to write module cache
-  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES
-                                              "AppleClang"
-  )
-    # Clang common flags
-    target_compile_options(${producer} PRIVATE "-fmodule-output=${_moddir}")
-  elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-    # GCC: modern flags
-    hpx_add_target_compile_option_if_available(
-      ${producer} PRIVATE "-fmodule-output=${_moddir}" RESULT ok
-    )
-    if(NOT ok)
-      hpx_error(
-        "hpx_configure_module_producer: the used version of gcc does not support '-fmodule-output'"
-      )
-    endif()
-  else()
-    hpx_warn(
-      "hpx_configure_module_producer: unknown compiler '${CMAKE_CXX_COMPILER_ID}'; "
-      "exposing EXPORT_MODULE_DIR='${_moddir}' for manual handling"
-    )
-  endif()
+  # Propagate scanning requirement to consumers via the interface target. CMake
+  # uses this to enable its native module dependency scanning for any target
+  # that links to this interface.
+  set_target_properties(${_iface} PROPERTIES INTERFACE_CXX_SCAN_FOR_MODULES ON)
 endfunction()
 
-# hpx_configure_module_consumer(<consumer> <producer>])
+# hpx_configure_module_consumer(<consumer> <producer>)
 #
-# * propagates module-related properties from producer interface target
-# * sets necessary consumer compiler flags for clang and gcc
+# * Links the consumer to the producer interface target.
+# * Enables CMake's native module scanning on the consumer.
+#
+# CMake 3.29+ automatically resolves the BMI location from the FILE_SET
+# CXX_MODULES declared on the producer. No -fprebuilt-module-path needed.
 function(hpx_configure_module_consumer consumer producer)
   if(NOT TARGET ${consumer})
     hpx_error("hpx_configure_module_consumer: target '${consumer}' not found")
@@ -147,40 +106,20 @@ function(hpx_configure_module_consumer consumer producer)
   endif()
 
   target_link_libraries(${consumer} PRIVATE ${producer})
+
   get_target_property(_scan ${producer} INTERFACE_CXX_SCAN_FOR_MODULES)
   if(_scan)
     set_target_properties(${consumer} PROPERTIES CXX_SCAN_FOR_MODULES ${_scan})
   endif()
 
-  get_target_property(_module_dir ${producer} INTERFACE_EXPORT_MODULE_DIR)
-  if(_module_dir)
-    if(MSVC)
-      return()
-    elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID
-                                                    MATCHES "AppleClang"
-    )
-      target_compile_options(
-        ${consumer} PRIVATE "-fprebuilt-module-path=${_module_dir}"
-      )
-      get_target_property(_type ${consumer} TYPE)
-      if((_type STREQUAL "SHARED_LIBRARY") OR (_type STREQUAL "EXECUTABLE"))
-        target_link_options(${consumer} PRIVATE "-fuse-ld=lld")
-        target_link_options(${consumer} PRIVATE "-Wl,--error-limit=0")
-      endif()
-    elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-      hpx_add_target_compile_option_if_available(
-        ${consumer} PRIVATE "-fprebuilt-module-path=${_module_dir}" RESULT ok
-      )
-      if(NOT ok)
-        hpx_error(
-          "hpx_configure_module_consumer: the used version of gcc does not "
-          "support '-fprebuilt-module-path='"
-        )
-      endif()
-    else()
-      hpx_warn(
-        "hpx_configure_module_consumer: unknown compiler '${CMAKE_CXX_COMPILER_ID}'"
-      )
+  # Clang emits DWARF-5 when compiling with C++20 modules, which requires lld.
+  if(CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID MATCHES
+                                              "AppleClang"
+  )
+    get_target_property(_type ${consumer} TYPE)
+    if((_type STREQUAL "SHARED_LIBRARY") OR (_type STREQUAL "EXECUTABLE"))
+      target_link_options(${consumer} PRIVATE "-fuse-ld=lld")
+      target_link_options(${consumer} PRIVATE "-Wl,--error-limit=0")
     endif()
   endif()
 endfunction()


### PR DESCRIPTION
This PR replaces the deprecated **jwlawson/actions-setup-cmake** with **lukka/get-cmake@v4.3.0** across all relevant GitHub Action workflows to stabilize the CI build process.

### **Summary of Changes:**
- **Action Migration:** Replaced `jwlawson/actions-setup-cmake@v2.2` with `lukka/get-cmake@v4.3.0` in 12 workflow files.
- **Precise Version Pinning:** Pinned the action to the exact latest release tag `@v4.3.0` to ensure deterministic builds and resolve previous version resolution errors.
- **Cleanup:** Removed the redundant `github-api-token: ${{ secrets.GITHUB_TOKEN }}` block from all workflows.

### **Rationale:**
- **Reliability:** The previous action frequently failed with **"Error: Unable to find version matching"** because it hit GitHub API rate limits during version discovery. `lukka/get-cmake` is a more robust alternative that avoids this issue.
- **Security & Stability:** Pinning to a specific release tag prevents unexpected behavior changes and ensures the CI environment remains consistent.
- **Log Hygiene:** `lukka/get-cmake` does not recognize the `github-api-token` input. Removing it prevents "unexpected input" warnings in the CI logs, keeping the job summaries clean.
- **Focused Fix:** This PR is now strictly isolated to CI infrastructure updates. Unrelated changes to the C++20 modules build configuration have been reverted as requested.
