### PR TITLE
fix(execution): correct sends_stopped in bulk and schedule_from completion signatures

### DIFF
--- a/libs/core/execution/include/hpx/execution/algorithms/bulk.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/bulk.hpp
@@ -61,7 +61,8 @@ namespace hpx::execution::experimental {
                     error_types_of_t<Sender, Env, Variant>,
                     Variant<std::exception_ptr>>;
 
-                static constexpr bool sends_stopped = false;
+                static constexpr bool sends_stopped =
+                    sends_stopped_of_v<Sender, Env>;
             };
 
             // clang-format off

--- a/libs/core/execution/include/hpx/execution/algorithms/schedule_from.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/schedule_from.hpp
@@ -61,7 +61,9 @@ namespace hpx::execution::experimental {
                     predecessor_sender_error_types<Variant>,
                     scheduler_sender_error_types<Variant>>;
 
-                static constexpr bool sends_stopped = false;
+                static constexpr bool sends_stopped =
+                    sends_stopped_of_v<Sender, Env> ||
+                    sends_stopped_of_v<scheduler_sender_type, Env>;
             };
 
             // clang-format off

--- a/libs/core/execution/tests/unit/algorithm_bulk.cpp
+++ b/libs/core/execution/tests/unit/algorithm_bulk.cpp
@@ -412,5 +412,41 @@ int main()
         HPX_TEST_EQ(custom_bulk_call_count, 3);
     }
 
+#if !defined(HPX_HAVE_STDEXEC)
+    // Completion signatures: bulk must inherit sends_stopped from its upstream.
+    // Before the fix, bulk_sender hard-coded sends_stopped = false regardless
+    // of the upstream sender. This section verifies the corrected behaviour.
+    {
+        // Upstream never sends stopped -> bulk also must not advertise stopped.
+        auto s_false = ex::bulk(ex::just(42), 5, [](int, int) {});
+        check_sends_stopped<false>(s_false);
+
+        // Upstream can send stopped -> bulk must propagate that into its
+        // completion signatures.
+        auto s_true = ex::bulk(stopped_sender_with_value_type{}, 5,
+            [](int, int) { HPX_TEST(false); });
+        check_sends_stopped<true>(s_true);
+
+        // Chained bulk: stopped propagates through every layer.
+        auto s_chain = ex::bulk(ex::bulk(stopped_sender_with_value_type{}, 5,
+                                    [](int, int) { HPX_TEST(false); }),
+            5, [](int, int) { HPX_TEST(false); });
+        check_sends_stopped<true>(s_chain);
+    }
+
+    // Runtime: set_stopped must reach the downstream receiver when the
+    // upstream sends a stopped signal through bulk.
+    {
+        std::atomic<bool> set_stopped_called{false};
+        auto s = ex::bulk(stopped_sender_with_value_type{}, 5,
+            [](int, int) { HPX_TEST(false); });
+
+        auto r = expect_stopped_receiver{set_stopped_called};
+        auto os = ex::connect(std::move(s), std::move(r));
+        ex::start(os);
+        HPX_TEST(set_stopped_called);
+    }
+#endif
+
     return hpx::util::report_errors();
 }


### PR DESCRIPTION
Problem Summary
==========================

bulk_sender and schedule_from_sender incorrectly hard-coded:

    static constexpr bool sends_stopped = false;

However, both internally propagate cancellation (set_stopped)
from upstream senders to downstream receivers.

This creates a mismatch between the static contract (completion signatures)
and runtime behavior, violating the P2300 std::execution specification
and leading to undefined behavior.


Why This Matters
==========================

Completion signatures define what signals a sender may emit.

If sends_stopped is declared false:

- Downstream receivers may NOT implement set_stopped()
- But at runtime, set_stopped() is still invoked
- This leads to calls into receivers that are not prepared

=> Undefined behavior


Fix: bulk.hpp
==========================

bulk should transparently propagate stopping behavior
from its upstream sender.

BEFORE:
static constexpr bool sends_stopped = false;

AFTER:
static constexpr bool sends_stopped =
    sends_stopped_of_v<Sender, Env>;


Fix: schedule_from.hpp
==========================

schedule_from can receive cancellation from:

1. Predecessor sender
2. Scheduler sender

So it must reflect both.

BEFORE:
static constexpr bool sends_stopped = false;

AFTER:
static constexpr bool sends_stopped =
    sends_stopped_of_v<Sender, Env> ||
    sends_stopped_of_v<scheduler_sender_type, Env>;


Not Changed
==========================

as_sender, keep_future:

These wrap HPX futures, which:
- Do NOT support cancellation
- Never call set_stopped()

So this remains correct:

static constexpr bool sends_stopped = false;


Tests Added
==========================

File:
libs/core/execution/tests/unit/algorithm_bulk.cpp


--- Static Tests ---

1. Non-stopping upstream -> remains false
static_assert(
    !check_sends_stopped<
        bulk(just(42), [](int) {})
    >()
);

2. Stopping upstream -> propagates true
static_assert(
    check_sends_stopped<
        bulk(stopped_sender_with_value_type{}, [](auto) {})
    >()
);

3. Chained bulk layers propagate correctly
static_assert(
    check_sends_stopped<
        bulk(
            bulk(
                stopped_sender_with_value_type{},
                [](auto) {}
            ),
            [](auto) {}
        )
    >()
);


--- Runtime Test ---

Ensure set_stopped is actually delivered

{
    auto sender =
        bulk(
            stopped_sender_with_value_type{},
            [](auto) {}
        );

    auto op = connect(sender, expect_stopped_receiver{});
    start(op);
}


Key Insight
==========================

Senders must NEVER lie in their completion signatures.

If set_stopped can happen at runtime,
sends_stopped MUST be true at compile time.

bulk and schedule_from are transparent propagators,
so their sends_stopped must reflect upstream behavior.