### PR TITLE
make_future: static_assert against silent-hang run_loop_scheduler sender

### DIFF
--- a/libs/core/execution/include/hpx/execution/algorithms/make_future.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/make_future.hpp
@@ -217,10 +217,48 @@ namespace hpx::execution::experimental {
             }
         };
 
+        // Detects whether a sender's set_value completion scheduler is
+        // run_loop_scheduler. Used by detail::make_future to reject -- at
+        // compile time -- the 1-argument form make_future(sender) when the
+        // sender's completion path runs on a run_loop scheduler. That call
+        // would silently hang at runtime because the 1-argument overload
+        // constructs a future_data that never drives loop.run().
+        template <typename Sender, typename = void>
+        struct sender_completion_is_run_loop_scheduler : std::false_type
+        {
+        };
+
+        template <typename Sender>
+        struct sender_completion_is_run_loop_scheduler<Sender,
+            std::void_t<
+                decltype(hpx::execution::experimental::get_completion_scheduler<
+                    hpx::execution::experimental::set_value_t>(hpx::execution::
+                        experimental::get_env(std::declval<Sender>())))>>
+          : std::is_same<std::decay_t<decltype(hpx::execution::experimental::
+                                 get_completion_scheduler<
+                                     hpx::execution::experimental::set_value_t>(
+                                     hpx::execution::experimental::get_env(
+                                         std::declval<Sender>())))>,
+                hpx::execution::experimental::run_loop_scheduler>
+        {
+        };
+
         ///////////////////////////////////////////////////////////////////////
         HPX_CXX_CORE_EXPORT template <typename Sender, typename Allocator>
         auto make_future(Sender&& sender, Allocator const& allocator)
         {
+            // The 1-argument make_future(sender) overload constructs a
+            // future_data that never calls loop.run(), so passing a sender
+            // whose set_value completion scheduler is a run_loop_scheduler
+            // produces a future that silently hangs. Reject at compile time
+            // and direct the user to make_future(sched, sender).
+            static_assert(!sender_completion_is_run_loop_scheduler<
+                              std::decay_t<Sender>>::value,
+                "make_future(sender) cannot drive the parent run_loop when "
+                "the sender's completion scheduler is a run_loop_scheduler. "
+                "Use make_future(loop.get_scheduler(), sender) so the "
+                "resulting future can drive the loop in its get().");
+
             using allocator_type = Allocator;
 
             using value_types = hpx::execution::experimental::value_types_of_t<


### PR DESCRIPTION
## Proposed Changes

 - Add a compile-time guard inside detail::make_future(Sender, Allocator) that rejects senders whose set_value completion scheduler is run_loop_scheduler. The 1-argument make_future(sender) overload constructs a future_data that never drives loop.run(), so passing a sender like just(42) | continues_on(loop.get_scheduler()) produces a future that silently hangs in get(). The new sender_completion_is_run_loop_scheduler trait detects this pattern and the static_assert fails compile with a clear message pointing the user at make_future(loop.get_scheduler(), sender).
 - Drop the original "take run_loop& directly" change. After #7257, get_run_loop_from_scheduler reads .loop on HPX's own run_loop::env_t (no stdexec internals), so the breaking API change from make_future(sched, sender) → make_future(loop, sender) no longer has a real justification. This PR is now scoped down to just the silent-hang guard.

## Any background context you want to provide?

## Checklist

Not all points below apply to all pull requests.

- [x] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
