### PR TITLE
ci: pin VS 2022 workflows to windows-2022 runner

### DIFF
--- a/.github/workflows/msvc_analysis.yml
+++ b/.github/workflows/msvc_analysis.yml
@@ -33,7 +33,7 @@ jobs:
       actions: read             # only required for a private repository by github/codeql-action/upload-sarif
                                 # to get the Action run status
     name: Analyze
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/windows_clang_debug.yml
+++ b/.github/workflows/windows_clang_debug.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/windows_clang_release.yml
+++ b/.github/workflows/windows_clang_release.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/windows_debug_vs2022.yml
+++ b/.github/workflows/windows_debug_vs2022.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/windows_debug_vs2022_fetch_boost.yml
+++ b/.github/workflows/windows_debug_vs2022_fetch_boost.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/windows_debug_vs2022_fetch_hwloc.yml
+++ b/.github/workflows/windows_debug_vs2022_fetch_hwloc.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/windows_debug_vs2022_local_runtime.yml
+++ b/.github/workflows/windows_debug_vs2022_local_runtime.yml
@@ -10,7 +10,7 @@ on: [pull_request]
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/windows_debug_vs2022_modules.yml
+++ b/.github/workflows/windows_debug_vs2022_modules.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/windows_debug_vs2022_tracy.yml
+++ b/.github/workflows/windows_debug_vs2022_tracy.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/windows_release_2022.yml
+++ b/.github/workflows/windows_release_2022.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/windows_release_gcc_mingw.yml
+++ b/.github/workflows/windows_release_gcc_mingw.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/windows_release_static.yml
+++ b/.github/workflows/windows_release_static.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
## Why this change is needed

GitHub Actions recently promoted `windows-latest` to point at **Windows Server 2025** (runner label `windows-2025`). That new image ships **Visual Studio 17.14**, which no longer includes the `"Visual Studio 17 2022"` CMake generator entry or the `-T clangcl` toolset that the affected jobs rely on.

As a result, every workflow that passes `-G "Visual Studio 17 2022"` (or `-T clangcl`) to CMake started failing immediately after the promotion because CMake cannot locate the generator on the new image.

## What this PR does

Pins the ten affected workflow jobs from `windows-latest` to `windows-2022` (Windows Server 2022). That image is guaranteed by GitHub to carry the full Visual Studio Build Tools 17 2022 suite, including the CMake generator and the clang-cl toolset, so all existing CMake invocations continue to work without any other changes.

The two-character diff per file is:

```diff
-    runs-on: windows-latest
+    runs-on: windows-2022
