### PR TITLE
Unified tracing API: merge ITT/Tracy instrumentation

### DIFF
--- a/.github/workflows/configure-test-combination.yml
+++ b/.github/workflows/configure-test-combination.yml
@@ -82,6 +82,23 @@ jobs:
               -DHPX_WITH_EXAMPLES=On
           rm -rf *
 
+      - name: Running CMake with invalid tracing combination (should fail)
+        working-directory: build
+        run: |
+          if cmake \
+              .. \
+              -G "Ninja" \
+              -DHPX_WITH_MALLOC=system \
+              -DHPX_WITH_FETCH_ASIO=Off \
+              -DHPX_WITH_APEX=On \
+              -DHPX_WITH_FETCH_APEX=ON \
+              -DHPX_TRACY_WITH_TRACY=On \
+              -DHPX_TRACY_WITH_FETCH_TRACY=ON; then
+            echo "CMake succeeded when it should have failed!"
+            exit 1
+          fi
+          echo "CMake failed as expected."
+          rm -rf *
       - name: Upload build directory
         uses: actions/upload-artifact@v7
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1207,6 +1207,14 @@ if(HPX_WITH_APEX AND NOT HPX_WITH_DISTRIBUTED_RUNTIME)
   hpx_error("HPX_WITH_DISTRIBUTED_RUNTIME=OFF requires HPX_WITH_APEX=OFF")
 endif()
 
+if(HPX_WITH_APEX AND HPX_WITH_ITTNOTIFY)
+  hpx_error("HPX_WITH_APEX=ON requires HPX_WITH_ITTNOTIFY=OFF")
+endif()
+
+if(HPX_TRACY_WITH_TRACY AND HPX_WITH_ITTNOTIFY)
+  hpx_error("HPX_TRACY_WITH_TRACY=ON and HPX_WITH_ITTNOTIFY=ON are mutually exclusive. Only one tracing backend can be active.")
+endif()
+
 if(HPX_WITH_NETWORKING)
   hpx_add_config_define(HPX_HAVE_NETWORKING)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1207,15 +1207,25 @@ if(HPX_WITH_APEX AND NOT HPX_WITH_DISTRIBUTED_RUNTIME)
   hpx_error("HPX_WITH_DISTRIBUTED_RUNTIME=OFF requires HPX_WITH_APEX=OFF")
 endif()
 
-if(HPX_WITH_APEX AND HPX_WITH_ITTNOTIFY)
-  hpx_error("HPX_WITH_APEX=ON requires HPX_WITH_ITTNOTIFY=OFF")
+set(_hpx_tracing_backends "")
+if(HPX_WITH_APEX)
+  list(APPEND _hpx_tracing_backends "HPX_WITH_APEX")
+endif()
+if(HPX_WITH_ITTNOTIFY)
+  list(APPEND _hpx_tracing_backends "HPX_WITH_ITTNOTIFY")
+endif()
+if(HPX_TRACY_WITH_TRACY)
+  list(APPEND _hpx_tracing_backends "HPX_TRACY_WITH_TRACY")
 endif()
 
-if(HPX_TRACY_WITH_TRACY AND HPX_WITH_ITTNOTIFY)
+list(LENGTH _hpx_tracing_backends _hpx_tracing_backends_count)
+if(_hpx_tracing_backends_count GREATER 1)
   hpx_error(
-    "HPX_TRACY_WITH_TRACY=ON and HPX_WITH_ITTNOTIFY=ON are mutually exclusive. Only one tracing backend can be active."
+    "Only one tracing backend can be active. Disable all but one of: HPX_WITH_APEX, HPX_WITH_ITTNOTIFY, HPX_TRACY_WITH_TRACY."
   )
 endif()
+unset(_hpx_tracing_backends)
+unset(_hpx_tracing_backends_count)
 
 if(HPX_WITH_NETWORKING)
   hpx_add_config_define(HPX_HAVE_NETWORKING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1212,7 +1212,9 @@ if(HPX_WITH_APEX AND HPX_WITH_ITTNOTIFY)
 endif()
 
 if(HPX_TRACY_WITH_TRACY AND HPX_WITH_ITTNOTIFY)
-  hpx_error("HPX_TRACY_WITH_TRACY=ON and HPX_WITH_ITTNOTIFY=ON are mutually exclusive. Only one tracing backend can be active.")
+  hpx_error(
+    "HPX_TRACY_WITH_TRACY=ON and HPX_WITH_ITTNOTIFY=ON are mutually exclusive. Only one tracing backend can be active."
+  )
 endif()
 
 if(HPX_WITH_NETWORKING)

--- a/libs/core/thread_pools/include/hpx/thread_pools/scheduling_loop.hpp
+++ b/libs/core/thread_pools/include/hpx/thread_pools/scheduling_loop.hpp
@@ -203,8 +203,7 @@ namespace hpx::threads::detail {
                                             is_active = false;
                                         });
 
-                                hpx::tracing::itt_task_region itt_task(
-                                    itt_ctx,
+                                hpx::tracing::itt_task_region itt_task(itt_ctx,
                                     threads::get_thread_region_init_data(
                                         thrdptr));
                                 hpx::tracing::region rctx(

--- a/libs/core/thread_pools/include/hpx/thread_pools/scheduling_loop.hpp
+++ b/libs/core/thread_pools/include/hpx/thread_pools/scheduling_loop.hpp
@@ -82,7 +82,7 @@ namespace hpx::threads::detail {
         scheduling_counters& counters, scheduling_callbacks& params)
     {
         std::atomic<hpx::state>& this_state = scheduler.get_state(num_thread);
-        hpx::tracing::itt_loop_context itt_ctx;
+        hpx::tracing::loop_context trace_ctx;
 
         std::int64_t& idle_loop_count = counters.idle_loop_count_;
         std::int64_t& busy_loop_count = counters.busy_loop_count_;
@@ -203,10 +203,7 @@ namespace hpx::threads::detail {
                                             is_active = false;
                                         });
 
-                                hpx::tracing::itt_task_region itt_task(itt_ctx,
-                                    threads::get_thread_region_init_data(
-                                        thrdptr));
-                                hpx::tracing::region rctx(
+                                hpx::tracing::region rctx(trace_ctx,
                                     threads::get_region_init_data(thrdptr),
                                     num_thread);
 

--- a/libs/core/thread_pools/include/hpx/thread_pools/scheduling_loop.hpp
+++ b/libs/core/thread_pools/include/hpx/thread_pools/scheduling_loop.hpp
@@ -18,11 +18,6 @@
 #include <hpx/thread_pools/detail/scheduling_counters.hpp>
 #include <hpx/thread_pools/detail/scheduling_log.hpp>
 
-#if defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0 &&                  \
-    !defined(HPX_HAVE_APEX)
-#include <hpx/modules/itt_notify.hpp>
-#endif
-
 #include <atomic>
 #include <cstddef>
 #include <cstdint>
@@ -87,16 +82,7 @@ namespace hpx::threads::detail {
         scheduling_counters& counters, scheduling_callbacks& params)
     {
         std::atomic<hpx::state>& this_state = scheduler.get_state(num_thread);
-
-#if defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0 &&                  \
-    !defined(HPX_HAVE_APEX)
-        util::itt::stack_context ctx;    // helper for itt support
-        util::itt::thread_domain const thread_domain;
-        util::itt::id threadid(thread_domain, &scheduler);
-        util::itt::string_handle const task_id("task_id");
-        util::itt::string_handle const task_phase("task_phase");
-        // util::itt::frame_context fctx(thread_domain);
-#endif
+        hpx::tracing::itt_loop_context itt_ctx;
 
         std::int64_t& idle_loop_count = counters.idle_loop_count_;
         std::int64_t& busy_loop_count = counters.busy_loop_count_;
@@ -217,18 +203,10 @@ namespace hpx::threads::detail {
                                             is_active = false;
                                         });
 
-#if defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0 &&                  \
-    !defined(HPX_HAVE_APEX)
-                                util::itt::caller_context cctx(
-                                    ctx, !thrdptr->is_stackless());
-                                // util::itt::undo_frame_context undoframe(fctx);
-                                util::itt::task task =
-                                    thrdptr->get_description().get_task_itt(
-                                        thread_domain);
-                                task.add_metadata(task_id, thrdptr);
-                                task.add_metadata(
-                                    task_phase, thrdptr->get_thread_phase());
-#endif
+                                hpx::tracing::itt_task_region itt_task(
+                                    itt_ctx,
+                                    threads::get_thread_region_init_data(
+                                        thrdptr));
                                 hpx::tracing::region rctx(
                                     threads::get_region_init_data(thrdptr),
                                     num_thread);

--- a/libs/core/threading_base/include/hpx/threading_base/thread_data.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_data.hpp
@@ -671,7 +671,9 @@ namespace hpx::threads {
         return static_cast<thread_data*>(tid.get());
     }
 
-#if defined(HPX_HAVE_MODULE_TRACY)
+#if defined(HPX_HAVE_MODULE_TRACY) ||                                          \
+    (defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0 &&                 \
+        !defined(HPX_HAVE_APEX))
     HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT tracing::region_init_data
     get_region_init_data(thread_data const* thrdptr);
 
@@ -686,18 +688,6 @@ namespace hpx::threads {
 
     HPX_CXX_CORE_EXPORT constexpr tracing::fiber_region_init_data
     get_fiber_region_init_data(thread_data const*) noexcept
-    {
-        return {};
-    }
-#endif
-
-#if defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0 &&                  \
-    !defined(HPX_HAVE_APEX)
-    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT tracing::thread_region_init_data
-    get_thread_region_init_data(thread_data const* thrdptr);
-#else
-    HPX_CXX_CORE_EXPORT constexpr tracing::thread_region_init_data
-    get_thread_region_init_data(thread_data const*) noexcept
     {
         return {};
     }

--- a/libs/core/threading_base/include/hpx/threading_base/thread_data.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_data.hpp
@@ -691,7 +691,7 @@ namespace hpx::threads {
     }
 #endif
 
-#if defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0 &&                 \
+#if defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0 &&                  \
     !defined(HPX_HAVE_APEX)
     HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT tracing::thread_region_init_data
     get_thread_region_init_data(thread_data const* thrdptr);

--- a/libs/core/threading_base/include/hpx/threading_base/thread_data.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_data.hpp
@@ -690,6 +690,18 @@ namespace hpx::threads {
         return {};
     }
 #endif
+
+#if defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0 &&                 \
+    !defined(HPX_HAVE_APEX)
+    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT tracing::thread_region_init_data
+    get_thread_region_init_data(thread_data const* thrdptr);
+#else
+    HPX_CXX_CORE_EXPORT constexpr tracing::thread_region_init_data
+    get_thread_region_init_data(thread_data const*) noexcept
+    {
+        return {};
+    }
+#endif
 }    // namespace hpx::threads
 
 #include <hpx/config/warnings_suffix.hpp>

--- a/libs/core/threading_base/include/hpx/threading_base/thread_data.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_data.hpp
@@ -671,14 +671,21 @@ namespace hpx::threads {
         return static_cast<thread_data*>(tid.get());
     }
 
-#if defined(HPX_HAVE_MODULE_TRACY) ||                                          \
-    (defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0 &&                 \
-        !defined(HPX_HAVE_APEX))
+#if defined(HPX_HAVE_MODULE_TRACY)
     HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT tracing::region_init_data
     get_region_init_data(thread_data const* thrdptr);
 
     HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT tracing::fiber_region_init_data
     get_fiber_region_init_data(thread_data const* thrdptr);
+#elif defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0
+    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT tracing::region_init_data
+    get_region_init_data(thread_data const* thrdptr);
+
+    HPX_CXX_CORE_EXPORT constexpr tracing::fiber_region_init_data
+    get_fiber_region_init_data(thread_data const*) noexcept
+    {
+        return {};
+    }
 #else
     HPX_CXX_CORE_EXPORT constexpr tracing::region_init_data
     get_region_init_data(thread_data const*) noexcept

--- a/libs/core/threading_base/src/thread_data.cpp
+++ b/libs/core/threading_base/src/thread_data.cpp
@@ -556,4 +556,22 @@ namespace hpx::threads {
     }
 #endif
 
+#if defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0 &&                 \
+    !defined(HPX_HAVE_APEX)
+    tracing::thread_region_init_data get_thread_region_init_data(
+        thread_data const* thrdptr)
+    {
+        threads::thread_description const desc = thrdptr->get_description();
+        if (desc.kind() ==
+            threads::thread_description::data_type::description)
+        {
+            return {desc.get_description(), thrdptr->get_thread_phase(),
+                thrdptr, thrdptr->is_stackless(), 0, false,
+                desc.get_description_itt().handle_};
+        }
+        return {"address", thrdptr->get_thread_phase(), thrdptr,
+            thrdptr->is_stackless(), desc.get_address(), true, nullptr};
+    }
+#endif
+
 }    // namespace hpx::threads

--- a/libs/core/threading_base/src/thread_data.cpp
+++ b/libs/core/threading_base/src/thread_data.cpp
@@ -554,8 +554,7 @@ namespace hpx::threads {
         return {thrdptr->get_description().get_description(),
             thrdptr->get_tracy_fiber_name(), thrdptr->is_stackless()};
     }
-#elif defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0 &&                \
-    !defined(HPX_HAVE_APEX)
+#elif defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0
     tracing::region_init_data get_region_init_data(thread_data const* thrdptr)
     {
         threads::thread_description const desc = thrdptr->get_description();
@@ -567,12 +566,6 @@ namespace hpx::threads {
         }
         return {"address", thrdptr->get_thread_phase(), thrdptr,
             thrdptr->is_stackless(), desc.get_address(), true, nullptr};
-    }
-
-    tracing::fiber_region_init_data get_fiber_region_init_data(
-        thread_data const*)
-    {
-        return {};
     }
 #endif
 

--- a/libs/core/threading_base/src/thread_data.cpp
+++ b/libs/core/threading_base/src/thread_data.cpp
@@ -556,14 +556,13 @@ namespace hpx::threads {
     }
 #endif
 
-#if defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0 &&                 \
+#if defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0 &&                  \
     !defined(HPX_HAVE_APEX)
     tracing::thread_region_init_data get_thread_region_init_data(
         thread_data const* thrdptr)
     {
         threads::thread_description const desc = thrdptr->get_description();
-        if (desc.kind() ==
-            threads::thread_description::data_type::description)
+        if (desc.kind() == threads::thread_description::data_type::description)
         {
             return {desc.get_description(), thrdptr->get_thread_phase(),
                 thrdptr, thrdptr->is_stackless(), 0, false,

--- a/libs/core/threading_base/src/thread_data.cpp
+++ b/libs/core/threading_base/src/thread_data.cpp
@@ -554,12 +554,9 @@ namespace hpx::threads {
         return {thrdptr->get_description().get_description(),
             thrdptr->get_tracy_fiber_name(), thrdptr->is_stackless()};
     }
-#endif
-
-#if defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0 &&                  \
+#elif defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0 &&                \
     !defined(HPX_HAVE_APEX)
-    tracing::thread_region_init_data get_thread_region_init_data(
-        thread_data const* thrdptr)
+    tracing::region_init_data get_region_init_data(thread_data const* thrdptr)
     {
         threads::thread_description const desc = thrdptr->get_description();
         if (desc.kind() == threads::thread_description::data_type::description)
@@ -570,6 +567,12 @@ namespace hpx::threads {
         }
         return {"address", thrdptr->get_thread_phase(), thrdptr,
             thrdptr->is_stackless(), desc.get_address(), true, nullptr};
+    }
+
+    tracing::fiber_region_init_data get_fiber_region_init_data(
+        thread_data const*)
+    {
+        return {};
     }
 #endif
 

--- a/libs/core/tracing/CMakeLists.txt
+++ b/libs/core/tracing/CMakeLists.txt
@@ -12,6 +12,9 @@ set(tracing_module_dependencies hpx_config)
 if(HPX_TRACY_WITH_TRACY)
   list(APPEND tracing_module_dependencies hpx_tracy)
 endif()
+if(HPX_WITH_ITTNOTIFY)
+  list(APPEND tracing_module_dependencies hpx_itt_notify)
+endif()
 
 include(HPX_AddModule)
 add_hpx_module(

--- a/libs/core/tracing/include/hpx/tracing/tracing.hpp
+++ b/libs/core/tracing/include/hpx/tracing/tracing.hpp
@@ -99,8 +99,7 @@ namespace hpx::tracing {
 
 }    // namespace hpx::tracing
 
-#elif defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0 &&                \
-    !defined(HPX_HAVE_APEX)
+#elif defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0
 #include <hpx/modules/itt_notify.hpp>
 
 namespace hpx::tracing {

--- a/libs/core/tracing/include/hpx/tracing/tracing.hpp
+++ b/libs/core/tracing/include/hpx/tracing/tracing.hpp
@@ -10,6 +10,23 @@
 #include <hpx/config.hpp>
 
 #include <cstddef>
+#include <memory>
+
+namespace hpx::tracing {
+
+    ////////////////////////////////////////////////////////////////////////////
+    HPX_CXX_CORE_EXPORT struct thread_region_init_data
+    {
+        char const* name = nullptr;
+        std::size_t thread_phase = 0;
+        void const* thread_ptr = nullptr;
+        bool is_stackless = false;
+        std::size_t address = 0;
+        bool is_address_type = false;
+        void* itt_string_handle = nullptr;
+    };
+
+}    // namespace hpx::tracing
 
 #if defined(HPX_HAVE_MODULE_TRACY)
 #include <hpx/modules/tracy.hpp>
@@ -82,8 +99,111 @@ namespace hpx::tracing {
     };
 
     ////////////////////////////////////////////////////////////////////////////
+    HPX_CXX_CORE_EXPORT struct HPX_CORE_EXPORT [[maybe_unused]] itt_loop_context
+    {
+        constexpr explicit itt_loop_context() noexcept {}
+
+        ~itt_loop_context() = default;
+
+        itt_loop_context(itt_loop_context const&) = delete;
+        itt_loop_context& operator=(itt_loop_context const&) = delete;
+    };
+
+    ////////////////////////////////////////////////////////////////////////////
+    HPX_CXX_CORE_EXPORT struct HPX_CORE_EXPORT [[maybe_unused]] itt_task_region
+    {
+        constexpr explicit itt_task_region(
+            itt_loop_context&, thread_region_init_data const&) noexcept
+        {
+        }
+
+        ~itt_task_region() = default;
+
+        itt_task_region(itt_task_region const&) = delete;
+        itt_task_region& operator=(itt_task_region const&) = delete;
+    };
+
+    ////////////////////////////////////////////////////////////////////////////
     HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void set_thread_name(
         char const* name) noexcept;
+
+}    // namespace hpx::tracing
+
+#elif defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0 &&               \
+    !defined(HPX_HAVE_APEX)
+
+namespace hpx::tracing {
+
+    ////////////////////////////////////////////////////////////////////////////
+    HPX_CXX_CORE_EXPORT struct region_init_data
+    {
+    };
+
+    HPX_CXX_CORE_EXPORT struct [[maybe_unused]] region
+    {
+        constexpr explicit region(region_init_data const&, std::size_t) noexcept
+        {
+        }
+    };
+
+    ////////////////////////////////////////////////////////////////////////////
+    HPX_CXX_CORE_EXPORT struct [[maybe_unused]] mark_event
+    {
+        constexpr explicit mark_event(char const*) noexcept {}
+    };
+
+    ////////////////////////////////////////////////////////////////////////////
+    HPX_CXX_CORE_EXPORT struct fiber_region_init_data
+    {
+    };
+
+    HPX_CXX_CORE_EXPORT struct [[maybe_unused]] fiber_region
+    {
+        constexpr explicit fiber_region(
+            fiber_region_init_data const&, std::size_t) noexcept
+        {
+        }
+    };
+
+    ////////////////////////////////////////////////////////////////////////////
+    HPX_CXX_CORE_EXPORT struct [[maybe_unused]] fiber_suspend_region
+    {
+        constexpr explicit fiber_suspend_region(char const*) noexcept {}
+    };
+
+    ////////////////////////////////////////////////////////////////////////////
+    HPX_CXX_CORE_EXPORT struct HPX_CORE_EXPORT itt_loop_context
+    {
+        explicit itt_loop_context();
+        ~itt_loop_context();
+
+        itt_loop_context(itt_loop_context const&) = delete;
+        itt_loop_context& operator=(itt_loop_context const&) = delete;
+
+    private:
+        struct impl;
+        std::unique_ptr<impl> impl_;
+
+        friend struct itt_task_region;
+    };
+
+    ////////////////////////////////////////////////////////////////////////////
+    HPX_CXX_CORE_EXPORT struct HPX_CORE_EXPORT itt_task_region
+    {
+        explicit itt_task_region(
+            itt_loop_context& ctx, thread_region_init_data const& data);
+        ~itt_task_region();
+
+        itt_task_region(itt_task_region const&) = delete;
+        itt_task_region& operator=(itt_task_region const&) = delete;
+
+    private:
+        struct impl;
+        std::unique_ptr<impl> impl_;
+    };
+
+    ////////////////////////////////////////////////////////////////////////////
+    HPX_CXX_CORE_EXPORT constexpr void set_thread_name(char const*) noexcept {}
 
 }    // namespace hpx::tracing
 
@@ -126,6 +246,31 @@ namespace hpx::tracing {
     HPX_CXX_CORE_EXPORT struct [[maybe_unused]] fiber_suspend_region
     {
         constexpr explicit fiber_suspend_region(char const*) noexcept {}
+    };
+
+    ////////////////////////////////////////////////////////////////////////////
+    HPX_CXX_CORE_EXPORT struct [[maybe_unused]] itt_loop_context
+    {
+        constexpr explicit itt_loop_context() noexcept {}
+
+        ~itt_loop_context() = default;
+
+        itt_loop_context(itt_loop_context const&) = delete;
+        itt_loop_context& operator=(itt_loop_context const&) = delete;
+    };
+
+    ////////////////////////////////////////////////////////////////////////////
+    HPX_CXX_CORE_EXPORT struct [[maybe_unused]] itt_task_region
+    {
+        constexpr explicit itt_task_region(
+            itt_loop_context&, thread_region_init_data const&) noexcept
+        {
+        }
+
+        ~itt_task_region() = default;
+
+        itt_task_region(itt_task_region const&) = delete;
+        itt_task_region& operator=(itt_task_region const&) = delete;
     };
 
     ////////////////////////////////////////////////////////////////////////////

--- a/libs/core/tracing/include/hpx/tracing/tracing.hpp
+++ b/libs/core/tracing/include/hpx/tracing/tracing.hpp
@@ -129,7 +129,7 @@ namespace hpx::tracing {
 
 }    // namespace hpx::tracing
 
-#elif defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0 &&               \
+#elif defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0 &&                \
     !defined(HPX_HAVE_APEX)
 
 namespace hpx::tracing {

--- a/libs/core/tracing/include/hpx/tracing/tracing.hpp
+++ b/libs/core/tracing/include/hpx/tracing/tracing.hpp
@@ -10,23 +10,6 @@
 #include <hpx/config.hpp>
 
 #include <cstddef>
-#include <memory>
-
-namespace hpx::tracing {
-
-    ////////////////////////////////////////////////////////////////////////////
-    HPX_CXX_CORE_EXPORT struct thread_region_init_data
-    {
-        char const* name = nullptr;
-        std::size_t thread_phase = 0;
-        void const* thread_ptr = nullptr;
-        bool is_stackless = false;
-        std::size_t address = 0;
-        bool is_address_type = false;
-        void* itt_string_handle = nullptr;
-    };
-
-}    // namespace hpx::tracing
 
 #if defined(HPX_HAVE_MODULE_TRACY)
 #include <hpx/modules/tracy.hpp>
@@ -41,10 +24,22 @@ namespace hpx::tracing {
         bool is_stackless = false;
     };
 
+    ////////////////////////////////////////////////////////////////////////////
+    HPX_CXX_CORE_EXPORT struct HPX_CORE_EXPORT [[maybe_unused]] loop_context
+    {
+        constexpr explicit loop_context() noexcept {}
+
+        ~loop_context() = default;
+
+        loop_context(loop_context const&) = delete;
+        loop_context& operator=(loop_context const&) = delete;
+    };
+
+    ////////////////////////////////////////////////////////////////////////////
     HPX_CXX_CORE_EXPORT struct HPX_CORE_EXPORT region
     {
-        explicit region(
-            region_init_data const& init_data, std::size_t num_thread) noexcept;
+        explicit region(loop_context&, region_init_data const& init_data,
+            std::size_t num_thread) noexcept;
 
         ~region();
 
@@ -99,31 +94,6 @@ namespace hpx::tracing {
     };
 
     ////////////////////////////////////////////////////////////////////////////
-    HPX_CXX_CORE_EXPORT struct HPX_CORE_EXPORT [[maybe_unused]] itt_loop_context
-    {
-        constexpr explicit itt_loop_context() noexcept {}
-
-        ~itt_loop_context() = default;
-
-        itt_loop_context(itt_loop_context const&) = delete;
-        itt_loop_context& operator=(itt_loop_context const&) = delete;
-    };
-
-    ////////////////////////////////////////////////////////////////////////////
-    HPX_CXX_CORE_EXPORT struct HPX_CORE_EXPORT [[maybe_unused]] itt_task_region
-    {
-        constexpr explicit itt_task_region(
-            itt_loop_context&, thread_region_init_data const&) noexcept
-        {
-        }
-
-        ~itt_task_region() = default;
-
-        itt_task_region(itt_task_region const&) = delete;
-        itt_task_region& operator=(itt_task_region const&) = delete;
-    };
-
-    ////////////////////////////////////////////////////////////////////////////
     HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void set_thread_name(
         char const* name) noexcept;
 
@@ -131,19 +101,53 @@ namespace hpx::tracing {
 
 #elif defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0 &&                \
     !defined(HPX_HAVE_APEX)
+#include <hpx/modules/itt_notify.hpp>
 
 namespace hpx::tracing {
 
     ////////////////////////////////////////////////////////////////////////////
     HPX_CXX_CORE_EXPORT struct region_init_data
     {
+        char const* name = nullptr;
+        std::size_t thread_phase = 0;
+        void const* thread_ptr = nullptr;
+        bool is_stackless = false;
+        std::size_t address = 0;
+        bool is_address_type = false;
+        void* itt_string_handle = nullptr;
     };
 
-    HPX_CXX_CORE_EXPORT struct [[maybe_unused]] region
+    ////////////////////////////////////////////////////////////////////////////
+    HPX_CXX_CORE_EXPORT struct HPX_CORE_EXPORT loop_context
     {
-        constexpr explicit region(region_init_data const&, std::size_t) noexcept
-        {
-        }
+        explicit loop_context() noexcept;
+        ~loop_context();
+
+        loop_context(loop_context const&) = delete;
+        loop_context& operator=(loop_context const&) = delete;
+
+        util::itt::stack_context stack_ctx;
+        util::itt::thread_domain thread_domain;
+        util::itt::string_handle task_id;
+        util::itt::string_handle task_phase;
+    };
+
+    ////////////////////////////////////////////////////////////////////////////
+    HPX_CXX_CORE_EXPORT struct HPX_CORE_EXPORT region
+    {
+        explicit region(
+            loop_context& ctx, region_init_data const& data, std::size_t);
+        ~region();
+
+        region(region const&) = delete;
+        region& operator=(region const&) = delete;
+
+    private:
+        static util::itt::task make_task(
+            loop_context& ctx, region_init_data const& data);
+
+        util::itt::caller_context cctx;
+        util::itt::task task;
     };
 
     ////////////////////////////////////////////////////////////////////////////
@@ -169,37 +173,6 @@ namespace hpx::tracing {
     HPX_CXX_CORE_EXPORT struct [[maybe_unused]] fiber_suspend_region
     {
         constexpr explicit fiber_suspend_region(char const*) noexcept {}
-    };
-
-    ////////////////////////////////////////////////////////////////////////////
-    HPX_CXX_CORE_EXPORT struct HPX_CORE_EXPORT itt_loop_context
-    {
-        explicit itt_loop_context();
-        ~itt_loop_context();
-
-        itt_loop_context(itt_loop_context const&) = delete;
-        itt_loop_context& operator=(itt_loop_context const&) = delete;
-
-    private:
-        struct impl;
-        std::unique_ptr<impl> impl_;
-
-        friend struct itt_task_region;
-    };
-
-    ////////////////////////////////////////////////////////////////////////////
-    HPX_CXX_CORE_EXPORT struct HPX_CORE_EXPORT itt_task_region
-    {
-        explicit itt_task_region(
-            itt_loop_context& ctx, thread_region_init_data const& data);
-        ~itt_task_region();
-
-        itt_task_region(itt_task_region const&) = delete;
-        itt_task_region& operator=(itt_task_region const&) = delete;
-
-    private:
-        struct impl;
-        std::unique_ptr<impl> impl_;
     };
 
     ////////////////////////////////////////////////////////////////////////////
@@ -216,9 +189,22 @@ namespace hpx::tracing {
     {
     };
 
+    ////////////////////////////////////////////////////////////////////////////
+    HPX_CXX_CORE_EXPORT struct [[maybe_unused]] loop_context
+    {
+        constexpr explicit loop_context() noexcept {}
+
+        ~loop_context() = default;
+
+        loop_context(loop_context const&) = delete;
+        loop_context& operator=(loop_context const&) = delete;
+    };
+
+    ////////////////////////////////////////////////////////////////////////////
     HPX_CXX_CORE_EXPORT struct [[maybe_unused]] region
     {
-        constexpr explicit region(region_init_data const&, std::size_t) noexcept
+        constexpr explicit region(
+            loop_context&, region_init_data const&, std::size_t) noexcept
         {
         }
     };
@@ -246,31 +232,6 @@ namespace hpx::tracing {
     HPX_CXX_CORE_EXPORT struct [[maybe_unused]] fiber_suspend_region
     {
         constexpr explicit fiber_suspend_region(char const*) noexcept {}
-    };
-
-    ////////////////////////////////////////////////////////////////////////////
-    HPX_CXX_CORE_EXPORT struct [[maybe_unused]] itt_loop_context
-    {
-        constexpr explicit itt_loop_context() noexcept {}
-
-        ~itt_loop_context() = default;
-
-        itt_loop_context(itt_loop_context const&) = delete;
-        itt_loop_context& operator=(itt_loop_context const&) = delete;
-    };
-
-    ////////////////////////////////////////////////////////////////////////////
-    HPX_CXX_CORE_EXPORT struct [[maybe_unused]] itt_task_region
-    {
-        constexpr explicit itt_task_region(
-            itt_loop_context&, thread_region_init_data const&) noexcept
-        {
-        }
-
-        ~itt_task_region() = default;
-
-        itt_task_region(itt_task_region const&) = delete;
-        itt_task_region& operator=(itt_task_region const&) = delete;
     };
 
     ////////////////////////////////////////////////////////////////////////////

--- a/libs/core/tracing/src/tracing.cpp
+++ b/libs/core/tracing/src/tracing.cpp
@@ -8,7 +8,6 @@
 #include <hpx/tracing/tracing.hpp>
 
 #include <cstddef>
-#include <memory>
 
 #if defined(HPX_HAVE_MODULE_TRACY)
 
@@ -25,8 +24,8 @@ namespace hpx::tracing {
             data.name, num_thread, data.thread_phase, enabled);
     }
 
-    region::region(
-        region_init_data const& data, std::size_t const num_thread) noexcept
+    region::region(loop_context&, region_init_data const& data,
+        std::size_t const num_thread) noexcept
       : impl(create_tracy_region(data, num_thread))
     {
     }
@@ -88,74 +87,52 @@ namespace hpx::tracing {
 
 }    // namespace hpx::tracing
 
-#endif
-
-#if !defined(HPX_HAVE_MODULE_TRACY) && defined(HPX_HAVE_ITTNOTIFY) &&          \
-    HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
-#include <hpx/modules/itt_notify.hpp>
+#elif defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0 &&                \
+    !defined(HPX_HAVE_APEX)
 
 namespace hpx::tracing {
 
-    struct itt_loop_context::impl
-    {
-        util::itt::stack_context stack_ctx;
-        util::itt::thread_domain thread_domain;
-        util::itt::string_handle task_id;
-        util::itt::string_handle task_phase;
+    ////////////////////////////////////////////////////////////////////////////
+    // loop_context
 
-        impl()
-          : task_id("task_id")
-          , task_phase("task_phase")
-        {
-        }
-    };
-
-    itt_loop_context::itt_loop_context()
-      : impl_(std::make_unique<impl>())
+    loop_context::loop_context() noexcept
+      : task_id("task_id")
+      , task_phase("task_phase")
     {
     }
 
-    itt_loop_context::~itt_loop_context() = default;
+    loop_context::~loop_context() = default;
 
-    struct itt_task_region::impl
+    ////////////////////////////////////////////////////////////////////////////
+    // region
+
+    util::itt::task region::make_task(
+        loop_context& ctx, region_init_data const& data)
     {
-        util::itt::caller_context cctx;
-        util::itt::task task;
-
-        static util::itt::task make_task(
-            itt_loop_context::impl& ctx, thread_region_init_data const& data)
+        if (data.is_address_type)
         {
-            if (data.is_address_type)
-            {
-                return util::itt::task(ctx.thread_domain,
-                    util::itt::string_handle("address"), data.address);
-            }
-            if (data.itt_string_handle != nullptr)
-            {
-                return util::itt::task(ctx.thread_domain,
-                    util::itt::string_handle(static_cast<___itt_string_handle*>(
-                        data.itt_string_handle)));
-            }
-            return util::itt::task(
-                ctx.thread_domain, util::itt::string_handle(data.name));
+            return util::itt::task(ctx.thread_domain,
+                util::itt::string_handle("address"), data.address);
         }
-
-        impl(itt_loop_context::impl& ctx, thread_region_init_data const& data)
-          : cctx(ctx.stack_ctx, !data.is_stackless)
-          , task(make_task(ctx, data))
+        if (data.itt_string_handle != nullptr)
         {
-            task.add_metadata(ctx.task_id, data.thread_ptr);
-            task.add_metadata(ctx.task_phase, data.thread_phase);
+            return util::itt::task(ctx.thread_domain,
+                util::itt::string_handle(static_cast<___itt_string_handle*>(
+                    data.itt_string_handle)));
         }
-    };
-
-    itt_task_region::itt_task_region(
-        itt_loop_context& ctx, thread_region_init_data const& data)
-      : impl_(std::make_unique<impl>(*ctx.impl_, data))
-    {
+        return util::itt::task(
+            ctx.thread_domain, util::itt::string_handle(data.name));
     }
 
-    itt_task_region::~itt_task_region() = default;
+    region::region(loop_context& ctx, region_init_data const& data, std::size_t)
+      : cctx(ctx.stack_ctx, !data.is_stackless)
+      , task(make_task(ctx, data))
+    {
+        task.add_metadata(ctx.task_id, data.thread_ptr);
+        task.add_metadata(ctx.task_phase, data.thread_phase);
+    }
+
+    region::~region() = default;
 
 }    // namespace hpx::tracing
 

--- a/libs/core/tracing/src/tracing.cpp
+++ b/libs/core/tracing/src/tracing.cpp
@@ -8,6 +8,7 @@
 #include <hpx/tracing/tracing.hpp>
 
 #include <cstddef>
+#include <memory>
 
 #if defined(HPX_HAVE_MODULE_TRACY)
 
@@ -84,6 +85,79 @@ namespace hpx::tracing {
     {
         hpx::tracy::set_thread_name(name);
     }
+
+}    // namespace hpx::tracing
+
+#endif
+
+#if !defined(HPX_HAVE_MODULE_TRACY) && defined(HPX_HAVE_ITTNOTIFY) &&         \
+    HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
+#include <hpx/modules/itt_notify.hpp>
+
+namespace hpx::tracing {
+
+    struct itt_loop_context::impl
+    {
+        util::itt::stack_context stack_ctx;
+        util::itt::thread_domain thread_domain;
+        util::itt::string_handle task_id;
+        util::itt::string_handle task_phase;
+
+        impl()
+          : task_id("task_id")
+          , task_phase("task_phase")
+        {
+        }
+    };
+
+    itt_loop_context::itt_loop_context()
+      : impl_(std::make_unique<impl>())
+    {
+    }
+
+    itt_loop_context::~itt_loop_context() = default;
+
+    struct itt_task_region::impl
+    {
+        util::itt::caller_context cctx;
+        util::itt::task task;
+
+        static util::itt::task make_task(
+            itt_loop_context::impl& ctx,
+            thread_region_init_data const& data)
+        {
+            if (data.is_address_type)
+            {
+                return util::itt::task(ctx.thread_domain,
+                    util::itt::string_handle("address"), data.address);
+            }
+            if (data.itt_string_handle != nullptr)
+            {
+                return util::itt::task(ctx.thread_domain,
+                    util::itt::string_handle(
+                        static_cast<___itt_string_handle*>(
+                            data.itt_string_handle)));
+            }
+            return util::itt::task(
+                ctx.thread_domain, util::itt::string_handle(data.name));
+        }
+
+        impl(itt_loop_context::impl& ctx, thread_region_init_data const& data)
+          : cctx(ctx.stack_ctx, !data.is_stackless)
+          , task(make_task(ctx, data))
+        {
+            task.add_metadata(ctx.task_id, data.thread_ptr);
+            task.add_metadata(ctx.task_phase, data.thread_phase);
+        }
+    };
+
+    itt_task_region::itt_task_region(
+        itt_loop_context& ctx, thread_region_init_data const& data)
+      : impl_(std::make_unique<impl>(*ctx.impl_, data))
+    {
+    }
+
+    itt_task_region::~itt_task_region() = default;
 
 }    // namespace hpx::tracing
 

--- a/libs/core/tracing/src/tracing.cpp
+++ b/libs/core/tracing/src/tracing.cpp
@@ -87,8 +87,7 @@ namespace hpx::tracing {
 
 }    // namespace hpx::tracing
 
-#elif defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0 &&                \
-    !defined(HPX_HAVE_APEX)
+#elif defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0
 
 namespace hpx::tracing {
 

--- a/libs/core/tracing/src/tracing.cpp
+++ b/libs/core/tracing/src/tracing.cpp
@@ -90,7 +90,7 @@ namespace hpx::tracing {
 
 #endif
 
-#if !defined(HPX_HAVE_MODULE_TRACY) && defined(HPX_HAVE_ITTNOTIFY) &&         \
+#if !defined(HPX_HAVE_MODULE_TRACY) && defined(HPX_HAVE_ITTNOTIFY) &&          \
     HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
 #include <hpx/modules/itt_notify.hpp>
 
@@ -123,8 +123,7 @@ namespace hpx::tracing {
         util::itt::task task;
 
         static util::itt::task make_task(
-            itt_loop_context::impl& ctx,
-            thread_region_init_data const& data)
+            itt_loop_context::impl& ctx, thread_region_init_data const& data)
         {
             if (data.is_address_type)
             {
@@ -134,9 +133,8 @@ namespace hpx::tracing {
             if (data.itt_string_handle != nullptr)
             {
                 return util::itt::task(ctx.thread_domain,
-                    util::itt::string_handle(
-                        static_cast<___itt_string_handle*>(
-                            data.itt_string_handle)));
+                    util::itt::string_handle(static_cast<___itt_string_handle*>(
+                        data.itt_string_handle)));
             }
             return util::itt::task(
                 ctx.thread_domain, util::itt::string_handle(data.name));


### PR DESCRIPTION

## Proposed Changes

  - Replace inline ITT instrumentation in the scheduling loop with `hpx::tracing` abstractions.
  - Add unified tracing API types and ITT backend implementation under libs/core/tracing.
  - Provide thread init-data helpers to drive ITT task metadata from thread descriptions.

## Any background context you want to provide?

This intentionally enforces a single active backend at compile time (Tracy > ITT > none). Previously, ITT and Tracy instrumentation were separate and uncoordinated, so “both on” was incidental rather than a supported dual-profiler feature. The unified tracing layer is designed as a single entry point with compile-time dispatch, avoiding double instrumentation overhead and aligning with typical workflows where only one profiler is used at a time. Is this decision appropriate?

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.