### PR TITLE
Add ITTNotify CI workflow and smoke test

### DIFF
--- a/.github/workflows/linux_debug_ittnotify.yml
+++ b/.github/workflows/linux_debug_ittnotify.yml
@@ -1,0 +1,65 @@
+# Copyright (c) 2026 The STE||AR Group
+# Copyright (c) 2026 Vansh Dobhal
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+name: Linux CI (ITTNotify, Debug)
+
+on: [pull_request]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: stellargroup/build_env:17
+
+    steps:
+    - uses: actions/checkout@v6
+    - name: Install ITTNotify (ittapi)
+      shell: bash
+      run: |
+          git clone https://github.com/intel/ittapi.git
+          cmake -S ittapi -B ittapi/build -GNinja \
+              -DCMAKE_BUILD_TYPE=Release \
+              -DCMAKE_INSTALL_PREFIX=$PWD/ittapi/install
+          cmake --build ittapi/build --target install
+    - name: Configure
+      shell: bash
+      env:
+        AMPLIFIER_ROOT: ${{ github.workspace }}/ittapi/install
+      run: |
+          cmake \
+              . \
+              -Bbuild \
+              -GNinja \
+              -DCMAKE_BUILD_TYPE=Debug \
+              -DHPX_WITH_MALLOC=system \
+              -DHPX_WITH_FETCH_ASIO=ON \
+              -DHPX_WITH_ASIO_TAG=asio-1-34-2 \
+              -DHPX_WITH_EXAMPLES=ON \
+              -DHPX_WITH_TESTS=ON \
+              -DHPX_WITH_TESTS_MAX_THREADS_PER_LOCALITY=2 \
+              -DHPX_WITH_VERIFY_LOCKS=ON \
+              -DHPX_WITH_VERIFY_LOCKS_BACKTRACE=ON \
+              -DHPX_WITH_CHECK_MODULE_DEPENDENCIES=On \
+              -DHPX_WITH_ITTNOTIFY=ON
+    - name: Build
+      shell: bash
+      run: |
+          cmake --build build --target all
+          cmake --build build --target examples
+    - name: Test
+      shell: bash
+      run: |
+          export LD_LIBRARY_PATH="$GITHUB_WORKSPACE/ittapi/install/lib:$GITHUB_WORKSPACE/ittapi/install/lib64:$LD_LIBRARY_PATH"
+          cd build
+          ctest \
+            --output-on-failure \
+            --tests-regex tests.examples \
+            --exclude-regex tests.examples.transpose.transpose_block_numa \
+            --exclude-regex tests.examples.quickstart.1d_wave_equation

--- a/.github/workflows/linux_debug_ittnotify.yml
+++ b/.github/workflows/linux_debug_ittnotify.yml
@@ -28,6 +28,11 @@ jobs:
               -DCMAKE_BUILD_TYPE=Release \
               -DCMAKE_INSTALL_PREFIX=$PWD/ittapi/install
           cmake --build ittapi/build --target install
+    - name: Build ref-collector
+      shell: bash
+      run: |
+          cd ittapi/src/ittnotify_refcol
+          make CC=gcc
     - name: Configure
       shell: bash
       env:
@@ -56,10 +61,27 @@ jobs:
     - name: Test
       shell: bash
       run: |
-          export LD_LIBRARY_PATH="$GITHUB_WORKSPACE/ittapi/install/lib:$GITHUB_WORKSPACE/ittapi/install/lib64:$LD_LIBRARY_PATH"
+          export INTEL_LIBITTNOTIFY64="${GITHUB_WORKSPACE}/ittapi/src/ittnotify_refcol/libittnotify_refcol.so"
+          export INTEL_LIBITTNOTIFY_LOG_DIR="${GITHUB_WORKSPACE}/itt_logs"
+          # Enable ITT bindings at runtime so the ref-collector is loaded
+          export HPX_HAVE_ITTNOTIFY=1
+          mkdir -p $INTEL_LIBITTNOTIFY_LOG_DIR
           cd build
           ctest \
             --output-on-failure \
-            --tests-regex tests.examples \
-            --exclude-regex tests.examples.transpose.transpose_block_numa \
-            --exclude-regex tests.examples.quickstart.1d_wave_equation
+            --tests-regex tests.examples.itt_notify \
+            -j1
+    - name: Verify ITT API usage
+      shell: bash
+      run: |
+          LOG_DIR="${GITHUB_WORKSPACE}/itt_logs"
+          # Fallback to /tmp if custom dir wasn't picked up
+          if ! ls ${LOG_DIR}/libittnotify_refcol_*.log 1>/dev/null 2>&1; then
+            LOG_DIR="/tmp"
+          fi
+          
+          echo "=== ITT ref-collector log contents (from ${LOG_DIR}) ==="
+          cat ${LOG_DIR}/libittnotify_refcol_*.log
+          grep -q "__itt_domain_create" ${LOG_DIR}/libittnotify_refcol_*.log
+          grep -q "__itt_task_begin" ${LOG_DIR}/libittnotify_refcol_*.log
+          echo "ITT API verification passed."

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -29,6 +29,10 @@ set(subdirs
     transpose
 )
 
+if(HPX_WITH_ITTNOTIFY)
+  set(subdirs ${subdirs} itt_notify)
+endif()
+
 if(HPX_WITH_EXAMPLES_HDF5)
   set(subdirs ${subdirs} interpolate1d sheneos)
 endif()

--- a/examples/itt_notify/CMakeLists.txt
+++ b/examples/itt_notify/CMakeLists.txt
@@ -10,7 +10,6 @@ if(NOT HPX_WITH_ITTNOTIFY)
 endif()
 
 set(example_programs itt_notify_smoke)
-set(itt_notify_smoke_PARAMETERS "--hpx:ini=hpx.use_itt_notify=1")
 
 foreach(example_program ${example_programs})
   set(sources ${example_program}.cpp)

--- a/examples/itt_notify/CMakeLists.txt
+++ b/examples/itt_notify/CMakeLists.txt
@@ -1,0 +1,33 @@
+# Copyright (c) 2026 The STE||AR Group
+# Copyright (c) 2026 Vansh Dobhal
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+if(NOT HPX_WITH_ITTNOTIFY)
+  return()
+endif()
+
+set(example_programs itt_notify_smoke)
+set(itt_notify_smoke_PARAMETERS "--hpx:ini=hpx.use_itt_notify=1")
+
+foreach(example_program ${example_programs})
+  set(sources ${example_program}.cpp)
+
+  source_group("Source Files" FILES ${sources})
+
+  add_hpx_executable(
+    ${example_program} INTERNAL_FLAGS
+    SOURCES ${sources}
+    FOLDER "Examples/ITTNotify" ${HPX_WITH_CXX_MODULES_OPTION}
+  )
+
+  add_hpx_example_target_dependencies("itt_notify" ${example_program})
+
+  if(HPX_WITH_TESTS AND HPX_WITH_TESTS_EXAMPLES)
+    add_hpx_example_test(
+      "itt_notify" ${example_program} ${${example_program}_PARAMETERS}
+    )
+  endif()
+endforeach()

--- a/examples/itt_notify/itt_notify_smoke.cpp
+++ b/examples/itt_notify/itt_notify_smoke.cpp
@@ -5,37 +5,36 @@
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+// This smoke test verifies that HPX compiles, links, and runs correctly
+// with ITTNotify support enabled. The scheduling loop automatically
+// exercises ITT instrumentation (task regions, caller contexts) when
+// HPX_WITH_ITTNOTIFY=ON.
+
+#include <hpx/future.hpp>
 #include <hpx/init.hpp>
-#include <hpx/modules/itt_notify.hpp>
 
-int hpx_main(int, char*[])
+#include <cstddef>
+
+int hpx_main()
 {
-    int sync_obj = 0;
+    // Spawn a few tasks so the scheduler exercises its ITT instrumentation
+    constexpr std::size_t n = 8;
+    hpx::future<int> futs[n];
 
-    HPX_ITT_THREAD_SET_NAME("hpx_itt_smoke");
+    for (std::size_t i = 0; i < n; ++i)
+    {
+        futs[i] = hpx::async([i]() -> int { return static_cast<int>(i * i); });
+    }
 
-    auto* domain = HPX_ITT_DOMAIN_CREATE("hpx.itt.smoke");
-    auto* task_name = HPX_ITT_STRING_HANDLE_CREATE("smoke_task");
-
-    HPX_ITT_SYNC_CREATE(&sync_obj, "smoke_sync", "smoke_sync");
-    HPX_ITT_SYNC_PREPARE(&sync_obj);
-
-    HPX_ITT_TASK_BEGIN(domain, task_name);
-    HPX_ITT_TASK_END(domain);
-
-    HPX_ITT_SYNC_ACQUIRED(&sync_obj);
-    HPX_ITT_SYNC_RELEASED(&sync_obj);
-    HPX_ITT_SYNC_DESTROY(&sync_obj);
-
-    int mark = 0;
-    HPX_ITT_MARK_CREATE(mark, "smoke_mark");
-    HPX_ITT_MARK(mark, "smoke_event");
-    HPX_ITT_MARK_OFF(mark);
+    for (auto& f : futs)
+    {
+        f.get();
+    }
 
     return hpx::local::finalize();
 }
 
 int main(int argc, char* argv[])
 {
-    return hpx::local::init(&hpx_main, argc, argv);
+    return hpx::local::init(hpx_main, argc, argv);
 }

--- a/examples/itt_notify/itt_notify_smoke.cpp
+++ b/examples/itt_notify/itt_notify_smoke.cpp
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 The STE||AR Group
+// Copyright (c) 2026 Vansh Dobhal
+//
+// SPDX-License-Identifier: BSL-1.0
+// Distributed under the Boost Software License, Version 1.0. (See accompanying
+// file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/init.hpp>
+#include <hpx/modules/itt_notify.hpp>
+
+int hpx_main(int, char*[])
+{
+    int sync_obj = 0;
+
+    HPX_ITT_THREAD_SET_NAME("hpx_itt_smoke");
+
+    auto* domain = HPX_ITT_DOMAIN_CREATE("hpx.itt.smoke");
+    auto* task_name = HPX_ITT_STRING_HANDLE_CREATE("smoke_task");
+
+    HPX_ITT_SYNC_CREATE(&sync_obj, "smoke_sync", "smoke_sync");
+    HPX_ITT_SYNC_PREPARE(&sync_obj);
+
+    HPX_ITT_TASK_BEGIN(domain, task_name);
+    HPX_ITT_TASK_END(domain);
+
+    HPX_ITT_SYNC_ACQUIRED(&sync_obj);
+    HPX_ITT_SYNC_RELEASED(&sync_obj);
+    HPX_ITT_SYNC_DESTROY(&sync_obj);
+
+    int mark = 0;
+    HPX_ITT_MARK_CREATE(mark, "smoke_mark");
+    HPX_ITT_MARK(mark, "smoke_event");
+    HPX_ITT_MARK_OFF(mark);
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    return hpx::local::init(&hpx_main, argc, argv);
+}

--- a/examples/itt_notify/itt_notify_smoke.cpp
+++ b/examples/itt_notify/itt_notify_smoke.cpp
@@ -5,19 +5,32 @@
 // Distributed under the Boost Software License, Version 1.0. (See accompanying
 // file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// This smoke test verifies that HPX compiles, links, and runs correctly
-// with ITTNotify support enabled. The scheduling loop automatically
-// exercises ITT instrumentation (task regions, caller contexts) when
-// HPX_WITH_ITTNOTIFY=ON.
+// This smoke test verifies that HPX correctly invokes ITT API functions
+// when built with HPX_WITH_ITTNOTIFY=ON. It exercises HPX's ITT RAII
+// wrappers (domain, task, string_handle, mark_context) and spawns async
+// work so the scheduling loop also generates ITT instrumentation.
+//
+// When run with the ittapi ref-collector (INTEL_LIBITTNOTIFY64), all
+// ITT calls are logged to a file that CI can inspect for verification.
 
 #include <hpx/future.hpp>
 #include <hpx/init.hpp>
+#include <hpx/modules/itt_notify.hpp>
 
 #include <cstddef>
 
 int hpx_main()
 {
-    // Spawn a few tasks so the scheduler exercises its ITT instrumentation
+    // Exercise the ITT RAII wrappers directly
+    hpx::util::itt::domain domain("hpx.itt.smoke");
+    hpx::util::itt::string_handle task_name("smoke_task");
+    hpx::util::itt::mark_context mark("smoke_mark");
+
+    {
+        hpx::util::itt::task t(domain, task_name);
+    }
+
+    // Spawn async work so the scheduler exercises its ITT instrumentation
     constexpr std::size_t n = 8;
     hpx::future<int> futs[n];
 


### PR DESCRIPTION
## Proposed Changes

  - Add smoke test example exercising core ITT macros (task, sync, mark, thread naming)
  - Register itt_notify example subdirectory in examples/CMakeLists.txt
  - Add linux_debug_ittnotify.yml CI workflow that builds HPX with ITTNotify using ittapi as a standalone provider

## Any background context you want to provide?

Follow-up to #7250. This uses intel/ittapi as a lightweight stand-in that provides the ittnotify headers and static library without needing a full VTune install.

## Checklist

- [x] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
