### PR TITLE
tracing: add hpx::tracing::rename_region abstraction

### DIFF
--- a/libs/core/threading_base/src/thread_data.cpp
+++ b/libs/core/threading_base/src/thread_data.cpp
@@ -303,9 +303,7 @@ namespace hpx::threads {
             spinlock_pool::spinlock_for(this));
         std::swap(description_, value);
 
-#if defined(HPX_HAVE_MODULE_TRACY)
-        tracy::detail::rename_region(description_.get_description());
-#endif
+        hpx::tracing::rename_region(description_.get_description());
 
         return value;
     }

--- a/libs/core/tracing/include/hpx/tracing/tracing.hpp
+++ b/libs/core/tracing/include/hpx/tracing/tracing.hpp
@@ -97,6 +97,10 @@ namespace hpx::tracing {
     HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void set_thread_name(
         char const* name) noexcept;
 
+    ////////////////////////////////////////////////////////////////////////////
+    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT char const* rename_region(
+        char const* name) noexcept;
+
 }    // namespace hpx::tracing
 
 #elif defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0
@@ -177,6 +181,14 @@ namespace hpx::tracing {
     ////////////////////////////////////////////////////////////////////////////
     HPX_CXX_CORE_EXPORT constexpr void set_thread_name(char const*) noexcept {}
 
+    ////////////////////////////////////////////////////////////////////////////
+    // ITT has no rename_region equivalent
+    HPX_CXX_CORE_EXPORT constexpr char const* rename_region(
+        char const*) noexcept
+    {
+        return nullptr;
+    }
+
 }    // namespace hpx::tracing
 
 #else
@@ -235,6 +247,13 @@ namespace hpx::tracing {
 
     ////////////////////////////////////////////////////////////////////////////
     HPX_CXX_CORE_EXPORT constexpr void set_thread_name(char const*) noexcept {}
+
+    ////////////////////////////////////////////////////////////////////////////
+    HPX_CXX_CORE_EXPORT constexpr char const* rename_region(
+        char const*) noexcept
+    {
+        return nullptr;
+    }
 
 }    // namespace hpx::tracing
 

--- a/libs/core/tracing/src/tracing.cpp
+++ b/libs/core/tracing/src/tracing.cpp
@@ -85,6 +85,14 @@ namespace hpx::tracing {
         hpx::tracy::set_thread_name(name);
     }
 
+    ////////////////////////////////////////////////////////////////////////////
+    // rename_region
+
+    char const* rename_region(char const* name) noexcept
+    {
+        return hpx::tracy::detail::rename_region(name);
+    }
+
 }    // namespace hpx::tracing
 
 #elif defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0


### PR DESCRIPTION

## Proposed Changes
- Add `hpx::tracing::rename_region` free function to the unified tracing abstraction layer in `libs/core/tracing`
- Implement Tracy backend by delegating to `hpx::tracy::detail::rename_region`; ITT and no-op branches are inline no-ops in the header since ITTNotify has no rename equivalent
- Replace the raw `#if defined(HPX_HAVE_MODULE_TRACY)` / `tracy::detail::rename_region` / `#endif` block in `thread_data.cpp` with a clean backend-agnostic `hpx::tracing::rename_region(...)` call

## Any background context you want to provide?


## Checklist
- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.