### PR TITLE
Adapting HPX modules from level 37 and 38 to C++20 modules

### DIFF
--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -392,7 +392,6 @@ with section("parse"):
                                              'SOURCES': '+',
                                              'SOURCE_ROOT': 1,
                                              'ARGS': '+',
-                                             'EXECUTABLE': 1,
                                              'PSEUDO_DEPS_NAME': 1,
                                              'LOCALITIES': 1,
                                              'PARCELPORTS': '+',

--- a/.codacy.yml
+++ b/.codacy.yml
@@ -13,4 +13,5 @@ exclude_paths:
 tools:
   duplication:
     exclude:
+      - "tests/**"
       - "**/tests/**"

--- a/components/component_storage/src/component_module.cpp
+++ b/components/component_storage/src/component_module.cpp
@@ -9,7 +9,7 @@
 #include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/components_base.hpp>
-#include <hpx/runtime_components/component_factory.hpp>
+#include <hpx/modules/runtime_components.hpp>
 
 #include <hpx/components/component_storage/server/migrate_to_storage.hpp>
 

--- a/components/component_storage/src/component_storage.cpp
+++ b/components/component_storage/src/component_storage.cpp
@@ -7,8 +7,8 @@
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/modules/async_distributed.hpp>
+#include <hpx/modules/runtime_components.hpp>
 #include <hpx/modules/type_support.hpp>
-#include <hpx/runtime_components/new.hpp>
 
 #include <hpx/components/component_storage/component_storage.hpp>
 

--- a/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_component_impl.hpp
+++ b/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_component_impl.hpp
@@ -12,7 +12,7 @@
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/components.hpp>
 #include <hpx/modules/preprocessor.hpp>
-#include <hpx/runtime_components/component_factory.hpp>
+#include <hpx/modules/runtime_components.hpp>
 
 #include <hpx/components/containers/partitioned_vector/partitioned_vector_decl.hpp>
 

--- a/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_decl.hpp
+++ b/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_decl.hpp
@@ -18,9 +18,8 @@
 #include <hpx/modules/async_combinators.hpp>
 #include <hpx/modules/components.hpp>
 #include <hpx/modules/functional.hpp>
+#include <hpx/modules/runtime_components.hpp>
 #include <hpx/modules/type_support.hpp>
-#include <hpx/runtime_components/distributed_metadata_base.hpp>
-#include <hpx/runtime_components/new.hpp>
 #include <hpx/runtime_distributed/copy_component.hpp>
 
 #include <hpx/components/containers/partitioned_vector/export_definitions.hpp>

--- a/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_impl.hpp
+++ b/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_impl.hpp
@@ -18,8 +18,7 @@
 #include <hpx/modules/components.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/execution.hpp>
-#include <hpx/runtime_components/distributed_metadata_base.hpp>
-#include <hpx/runtime_components/new.hpp>
+#include <hpx/modules/runtime_components.hpp>
 #include <hpx/runtime_distributed/copy_component.hpp>
 
 #include <hpx/components/containers/partitioned_vector/partitioned_vector_component_impl.hpp>

--- a/components/containers/partitioned_vector/src/partitioned_vector_component.cpp
+++ b/components/containers/partitioned_vector/src/partitioned_vector_component.cpp
@@ -11,7 +11,7 @@
 /// required for proper functioning of components in the context of HPX.
 
 #include <hpx/config.hpp>
-#include <hpx/runtime_components/component_factory.hpp>
+#include <hpx/modules/runtime_components.hpp>
 
 #include <hpx/components/containers/partitioned_vector/export_definitions.hpp>
 #include <hpx/components/containers/partitioned_vector/partitioned_vector.hpp>

--- a/components/containers/unordered/include/hpx/components/containers/unordered/partition_unordered_map_component.hpp
+++ b/components/containers/unordered/include/hpx/components/containers/unordered/partition_unordered_map_component.hpp
@@ -28,8 +28,8 @@
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/preprocessor.hpp>
+#include <hpx/modules/runtime_components.hpp>
 #include <hpx/modules/type_support.hpp>
-#include <hpx/runtime_components/component_factory.hpp>
 
 #include <cstddef>
 #include <memory>

--- a/components/containers/unordered/include/hpx/components/containers/unordered/unordered_map.hpp
+++ b/components/containers/unordered/include/hpx/components/containers/unordered/unordered_map.hpp
@@ -16,10 +16,9 @@
 #include <hpx/modules/components.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/functional.hpp>
+#include <hpx/modules/runtime_components.hpp>
 #include <hpx/modules/serialization.hpp>
 #include <hpx/modules/type_support.hpp>
-#include <hpx/runtime_components/distributed_metadata_base.hpp>
-#include <hpx/runtime_components/new.hpp>
 #include <hpx/runtime_distributed/copy_component.hpp>
 
 #include <hpx/components/containers/unordered/partition_unordered_map_component.hpp>

--- a/components/containers/unordered/src/partition_unordered_map_component.cpp
+++ b/components/containers/unordered/src/partition_unordered_map_component.cpp
@@ -10,7 +10,7 @@
 /// required for proper functioning of components in the context of HPX.
 
 #include <hpx/config.hpp>
-#include <hpx/runtime_components/component_factory.hpp>
+#include <hpx/modules/runtime_components.hpp>
 
 #include <hpx/components/containers/unordered/partition_unordered_map_component.hpp>
 #include <hpx/components/containers/unordered/unordered_map.hpp>

--- a/components/iostreams/src/component_module.cpp
+++ b/components/iostreams/src/component_module.cpp
@@ -8,12 +8,13 @@
 #include <hpx/config.hpp>
 
 #include <hpx/modules/actions.hpp>
-#include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/actions_base.hpp>
+#include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/functional.hpp>
+#include <hpx/modules/runtime_components.hpp>
+#include <hpx/modules/runtime_configuration.hpp>
 #include <hpx/modules/runtime_local.hpp>
-#include <hpx/runtime_components/component_factory.hpp>
 
 #include <hpx/components/iostreams/ostream.hpp>
 #include <hpx/components/iostreams/server/output_stream.hpp>

--- a/components/performance_counters/papi/src/server/papi.cpp
+++ b/components/performance_counters/papi/src/server/papi.cpp
@@ -14,10 +14,10 @@
 #include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/errors.hpp>
+#include <hpx/modules/runtime_components.hpp>
 #include <hpx/modules/runtime_local.hpp>
 #include <hpx/modules/timing.hpp>
 #include <hpx/modules/type_support.hpp>
-#include <hpx/runtime_components/derived_component_factory.hpp>
 
 #include <cstdint>
 #include <functional>

--- a/components/process/include/hpx/components/process/process.hpp
+++ b/components/process/include/hpx/components/process/process.hpp
@@ -8,7 +8,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/modules/naming_base.hpp>
-#include <hpx/runtime_components/new.hpp>
+#include <hpx/modules/runtime_components.hpp>
 
 #include <hpx/components/process/child.hpp>
 

--- a/components/process/src/process.cpp
+++ b/components/process/src/process.cpp
@@ -5,7 +5,8 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/modules/components_base.hpp>
-#include <hpx/runtime_components/component_factory.hpp>
+#include <hpx/modules/runtime_components.hpp>
+#include <hpx/modules/runtime_configuration.hpp>
 
 #include <hpx/components/process/process.hpp>
 #include <hpx/components/process/server/child.hpp>

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/adjacent_difference.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/adjacent_difference.hpp
@@ -316,7 +316,7 @@ namespace hpx::parallel {
                               std::size_t part_size) mutable {
                     // VS2015RC bails out when op is captured by ref
                     using hpx::get;
-                    util::const_loop_n<std::decay_t<ExPolicy>>(
+                    util::loop_n<std::decay_t<ExPolicy>>(
                         part_begin, part_size, [op](auto&& it) mutable {
                             get<2>(*it) =
                                 HPX_INVOKE(op, get<0>(*it), get<1>(*it));

--- a/libs/core/algorithms/include/hpx/parallel/datapar/adjacent_difference.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/datapar/adjacent_difference.hpp
@@ -50,7 +50,7 @@ namespace hpx::parallel::detail {
 
             using hpx::get;
 
-            util::const_loop_n<std::decay_t<ExPolicy>>(
+            util::loop_n<std::decay_t<ExPolicy>>(
                 hpx::util::zip_iterator(first, prev, dest), count,
                 [op](auto&& it) mutable {
                     get<2>(*it) = HPX_INVOKE(op, get<0>(*it), get<1>(*it));

--- a/libs/core/algorithms/include/hpx/parallel/util/loop.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/loop.hpp
@@ -525,7 +525,7 @@ namespace hpx::parallel::util {
 
     HPX_CXX_CORE_EXPORT template <typename ExPolicy>
     struct const_loop_n_t final
-      : hpx::functional::detail::tag_fallback<loop_n_t<ExPolicy>>
+      : hpx::functional::detail::tag_fallback<const_loop_n_t<ExPolicy>>
     {
     private:
         template <typename Iter, typename F>

--- a/libs/core/algorithms/tests/unit/algorithms/sort_by_key.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/sort_by_key.cpp
@@ -29,21 +29,20 @@
 //
 namespace debug {
     template <typename T>
-    void output(std::string const& name, std::vector<T> const& v)
+    void output([[maybe_unused]] std::string const& name,
+        [[maybe_unused]] std::vector<T> const& v)
     {
 #ifdef EXTRA_DEBUG7
         std::cout << name.c_str() << "\t : {" << v.size() << "} : ";
         std::copy(std::begin(v), std::end(v),
             std::ostream_iterator<T>(std::cout, ", "));
         std::cout << "\n";
-#else
-        HPX_UNUSED(name);
-        HPX_UNUSED(v);
 #endif
     }
 
     template <typename Iter>
-    void output(std::string const& name, Iter begin, Iter end)
+    void output([[maybe_unused]] std::string const& name,
+        [[maybe_unused]] Iter begin, [[maybe_unused]] Iter end)
     {
 #ifdef EXTRA_DEBUG
         std::cout << name.c_str() << "\t : {" << std::distance(begin, end)
@@ -53,10 +52,6 @@ namespace debug {
                 typename std::iterator_traits<Iter>::value_type>(
                 std::cout, ", "));
         std::cout << "\n";
-#else
-        HPX_UNUSED(name);
-        HPX_UNUSED(begin);
-        HPX_UNUSED(end);
 #endif
     }
 

--- a/libs/core/executors/tests/unit/CMakeLists.txt
+++ b/libs/core/executors/tests/unit/CMakeLists.txt
@@ -61,7 +61,7 @@ if(HPX_WITH_CXX_MODULES AND (CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
   # Clang (last tested version is v22) fails compiling the following tests when
   # C++ module support is enabled.
   set(failing_clang_tests explicit_scheduler_executor parallel_scheduler
-                          thread_pool_scheduler
+                          scheduler_executor thread_pool_scheduler
   )
   foreach(test ${failing_clang_tests})
     target_compile_definitions(

--- a/libs/core/resource_partitioner/tests/unit/named_pool_executor.cpp
+++ b/libs/core/resource_partitioner/tests/unit/named_pool_executor.cpp
@@ -57,8 +57,7 @@ int hpx_main()
     }
 
     // Make sure default construction works
-    hpx::execution::parallel_executor exec_default;
-    HPX_UNUSED(exec_default);
+    [[maybe_unused]] hpx::execution::parallel_executor exec_default;
 
     // setup executors for different task priorities on the pools
     // segfaults or exceptions in any of the following will cause

--- a/libs/core/type_support/include/hpx/type_support/lazy_enable_if.hpp
+++ b/libs/core/type_support/include/hpx/type_support/lazy_enable_if.hpp
@@ -18,6 +18,6 @@ namespace hpx::util {
     template <typename T>
     struct lazy_enable_if<true, T>
     {
-        using type = typename T::type;
+        using type = T::type;
     };
 }    // namespace hpx::util

--- a/libs/full/actions_base/include/hpx/actions_base/macros.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/macros.hpp
@@ -292,7 +292,7 @@
 /// The parameter \a action is the type of the action to define the
 /// boilerplate for.
 ///
-/// The parameter \a actionname specifies an unique name of the action to be
+/// The parameter \a actionname specifies a unique name of the action to be
 /// used for serialization purposes.
 /// The second parameter has to be usable as a plain (nonqualified) C++
 /// identifier, it should not contain special characters which cannot be part
@@ -483,7 +483,11 @@
     /**/
 
 #define HPX_DEFINE_PLAIN_ACTION_1(func)                                        \
-    HPX_DEFINE_PLAIN_ACTION_2(func, HPX_PP_CAT(func, _action))                 \
+    HPX_DEFINE_PLAIN_ACTION_3(HPX_PP_EMPTY(), func, HPX_PP_CAT(func, _action)) \
+    /**/
+
+#define HPX_DEFINE_PLAIN_ACTION_2(func, name)                                  \
+    HPX_DEFINE_PLAIN_ACTION_3(HPX_PP_EMPTY(), func, name)                      \
     /**/
 
 #if defined(HPX_HAVE_CXX26_REFLECTION)
@@ -491,13 +495,13 @@
 /// When C++26 reflection is available, HPX_DEFINE_PLAIN_ACTION_2 uses
 /// reflect_action<^^func> instead of make_action_t. This eliminates the
 /// need for HPX_REGISTER_ACTION while keeping the same user-facing syntax.
-#define HPX_DEFINE_PLAIN_ACTION_2(func, name)                                  \
-    using name = hpx::actions::reflect_action<^^func>                          \
+#define HPX_DEFINE_PLAIN_ACTION_3(Prefix, func, name)                          \
+    Prefix using name = hpx::actions::reflect_action<^^func>                   \
     /**/
 // clang-format on
 #elif defined(__NVCC__) || defined(__CUDACC__)
-#define HPX_DEFINE_PLAIN_ACTION_2(func, name)                                  \
-    struct name                                                                \
+#define HPX_DEFINE_PLAIN_ACTION_3(Prefix, func, name)                          \
+    Prefix struct name                                                         \
       : hpx::actions::make_action<                                             \
             typename std::add_pointer<                                         \
                 typename std::remove_pointer<decltype(&func)>::type>::type,    \
@@ -505,18 +509,24 @@
     {                                                                          \
     } /**/
 #else
-#define HPX_DEFINE_PLAIN_ACTION_2(func, name)                                  \
-    struct name : hpx::actions::make_action_t<decltype(&func), &func, name>    \
+#define HPX_DEFINE_PLAIN_ACTION_3(Prefix, func, name)                          \
+    Prefix struct name                                                         \
+      : hpx::actions::make_action_t<decltype(&func), &func, name>              \
     {                                                                          \
     } /**/
 #endif
 
 #define HPX_DEFINE_PLAIN_DIRECT_ACTION_1(func)                                 \
-    HPX_DEFINE_PLAIN_DIRECT_ACTION_2(func, HPX_PP_CAT(func, _action))          \
+    HPX_DEFINE_PLAIN_DIRECT_ACTION_3(                                          \
+        HPX_PP_EMPTY(), func, HPX_PP_CAT(func, _action))                       \
     /**/
 
 #define HPX_DEFINE_PLAIN_DIRECT_ACTION_2(func, name)                           \
-    struct name                                                                \
+    HPX_DEFINE_PLAIN_DIRECT_ACTION_3(HPX_PP_EMPTY(), func, name)               \
+    /**/
+
+#define HPX_DEFINE_PLAIN_DIRECT_ACTION_3(Prefix, func, name)                   \
+    Prefix struct name                                                         \
       : hpx::actions::make_direct_action_t<decltype(&func), &func, name>       \
     {                                                                          \
     } /**/
@@ -597,7 +607,7 @@
 /// be encapsulated into a plain action. The parameter \p name is the name of
 /// the action type defined by this macro.
 ///
-/// The second parameter has to be usable as a plain (non-qualified) C++
+/// The second parameter has to be usable as a plain (nonqualified) C++
 /// identifier, it should not contain special characters which cannot be part of
 /// a C++ identifier, such as '<', '>', or ':'.
 ///

--- a/libs/full/agas/CMakeLists.txt
+++ b/libs/full/agas/CMakeLists.txt
@@ -29,6 +29,7 @@ include(HPX_AddModule)
 add_hpx_module(
   full agas
   GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_MODULE_GEN ON
   SOURCES ${agas_sources}
   HEADERS ${agas_headers}
   COMPAT_HEADERS ${agas_compat_headers}

--- a/libs/full/agas/include/hpx/agas/addressing_service.hpp
+++ b/libs/full/agas/include/hpx/agas/addressing_service.hpp
@@ -37,13 +37,13 @@
 
 #include <hpx/config/warnings_prefix.hpp>
 
-namespace hpx { namespace agas {
+namespace hpx::agas {
 
 #if defined(HPX_HAVE_NETWORKING)
-    HPX_EXPORT void destroy_big_boot_barrier();
+    HPX_CXX_EXPORT HPX_EXPORT void destroy_big_boot_barrier();
 #endif
 
-    struct addressing_service
+    HPX_CXX_EXPORT struct addressing_service
     {
     public:
         HPX_NON_COPYABLE(addressing_service);
@@ -115,7 +115,6 @@ namespace hpx { namespace agas {
 #if defined(HPX_HAVE_NETWORKING)
         ~addressing_service()
         {
-            // TODO: Free the future pools?
             destroy_big_boot_barrier();
         }
 #else
@@ -1217,7 +1216,6 @@ namespace hpx { namespace agas {
         // Pre-cache locality endpoints in hosted locality namespace
         void pre_cache_endpoints(std::vector<parcelset::endpoints_type> const&);
     };
-
-}}    // namespace hpx::agas
+}    // namespace hpx::agas
 
 #include <hpx/config/warnings_suffix.hpp>

--- a/libs/full/agas/include/hpx/agas/agas_fwd.hpp
+++ b/libs/full/agas/include/hpx/agas/agas_fwd.hpp
@@ -14,12 +14,13 @@ namespace hpx {
 
     namespace agas {
 
-        struct HPX_EXPORT addressing_service;
+        HPX_CXX_EXPORT struct HPX_EXPORT addressing_service;
     }    // namespace agas
 
     namespace naming {
 
-        HPX_EXPORT agas::addressing_service& get_agas_client();
-        HPX_EXPORT agas::addressing_service* get_agas_client_ptr();
+        HPX_CXX_EXPORT HPX_EXPORT agas::addressing_service& get_agas_client();
+        HPX_CXX_EXPORT HPX_EXPORT agas::addressing_service*
+        get_agas_client_ptr();
     }    // namespace naming
 }    // namespace hpx

--- a/libs/full/agas/include/hpx/agas/state.hpp
+++ b/libs/full/agas/include/hpx/agas/state.hpp
@@ -9,8 +9,8 @@
 #include <hpx/config.hpp>
 #include <hpx/modules/threading_base.hpp>
 
-namespace hpx { namespace agas {
+namespace hpx::agas {
 
     // return whether resolver client is in state described by 'mask'
-    HPX_EXPORT bool router_is(state st);
-}}    // namespace hpx::agas
+    HPX_CXX_EXPORT HPX_EXPORT bool router_is(state st);
+}    // namespace hpx::agas

--- a/libs/full/async_colocated/CMakeLists.txt
+++ b/libs/full/async_colocated/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2022 The STE||AR-Group
+# Copyright (c) 2019-2026 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -15,6 +15,7 @@ set(async_colocated_headers
     hpx/async_colocated/async_colocated_callback.hpp
     hpx/async_colocated/async_colocated_fwd.hpp
     hpx/async_colocated/async_colocated.hpp
+    hpx/async_colocated/macros.hpp
     hpx/async_colocated/post_colocated_callback_fwd.hpp
     hpx/async_colocated/post_colocated_callback.hpp
     hpx/async_colocated/post_colocated_fwd.hpp
@@ -24,6 +25,8 @@ set(async_colocated_headers
     hpx/async_colocated/register_post_colocated.hpp
     hpx/async_colocated/server/destroy_component.hpp
 )
+
+set(async_colocated_macros_headers hpx/async_colocated/macros.hpp)
 
 # cmake-format: off
 set(async_colocated_compat_headers
@@ -48,8 +51,10 @@ include(HPX_AddModule)
 add_hpx_module(
   full async_colocated
   GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_MODULE_GEN ON
   SOURCES ${async_colocated_sources}
   HEADERS ${async_colocated_headers}
+  MACRO_HEADERS ${async_colocated_macros_headers}
   COMPAT_HEADERS ${async_colocated_compat_headers}
   DEPENDENCIES hpx_core
   MODULE_DEPENDENCIES hpx_actions_base hpx_agas_base hpx_async_distributed

--- a/libs/full/async_colocated/include/hpx/async_colocated/async_colocated.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/async_colocated.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -25,8 +25,9 @@
 #include <type_traits>
 #include <utility>
 
-namespace hpx { namespace detail {
-    template <typename Action, typename Ts = typename Action::arguments_type>
+namespace hpx::detail {
+
+    template <typename Action, typename Ts = Action::arguments_type>
     struct async_colocated_bound_action;
 
     template <typename Action, typename... Ts>
@@ -39,54 +40,31 @@ namespace hpx { namespace detail {
                 hpx::id_type>,
             Ts...>;
     };
-}}    // namespace hpx::detail
 
-#define HPX_REGISTER_ASYNC_COLOCATED_DECLARATION(Action, Name)                 \
-    HPX_UTIL_REGISTER_UNIQUE_FUNCTION_DECLARATION(                             \
-        void(hpx::id_type, hpx::id_type),                                      \
-        (hpx::util::functional::detail::async_continuation_impl<               \
-            typename hpx::detail::async_colocated_bound_action<Action>::type,  \
-            hpx::util::unused_type>),                                          \
-        Name)                                                                  \
-    /**/
-
-#define HPX_REGISTER_ASYNC_COLOCATED(Action, Name)                             \
-    HPX_UTIL_REGISTER_UNIQUE_FUNCTION(void(hpx::id_type, hpx::id_type),        \
-        (hpx::util::functional::detail::async_continuation_impl<               \
-            typename hpx::detail::async_colocated_bound_action<Action>::type,  \
-            hpx::util::unused_type>),                                          \
-        Name)                                                                  \
-    /**/
-
-namespace hpx { namespace detail {
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename... Ts>
-    hpx::future<typename traits::promise_local_result<
-        typename hpx::traits::extract_action<Action>::remote_result_type>::type>
-    async_colocated(hpx::id_type const& gid,
-        Ts&&...
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
-        vs
-#endif
-    )
+    hpx::future<traits::promise_local_result_t<
+        typename hpx::traits::extract_action<Action>::remote_result_type>>
+    async_colocated(
+        [[maybe_unused]] hpx::id_type const& id, [[maybe_unused]] Ts&&... vs)
     {
         // Attach the requested action as a continuation to a resolve_async
         // call on the locality responsible for the target gid.
         hpx::id_type service_target(
-            agas::primary_namespace::get_service_instance(gid.get_gid()),
+            agas::primary_namespace::get_service_instance(id.get_gid()),
             hpx::id_type::management_type::unmanaged);
 
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
         using remote_result_type =
-            typename hpx::traits::extract_action<Action>::remote_result_type;
+            hpx::traits::extract_action<Action>::remote_result_type;
         using action_type = agas::server::primary_namespace::colocate_action;
 
         using placeholders::_2;
         return detail::async_continue_r<action_type, remote_result_type>(
             util::functional::async_continuation(hpx::bind<Action>(
-                hpx::bind(util::functional::extract_locality(), _2, gid),
+                hpx::bind(util::functional::extract_locality(), _2, id),
                 HPX_FORWARD(Ts, vs)...)),
-            service_target, gid.get_gid());
+            service_target, id.get_gid());
 #else
         HPX_ASSERT(false);
         return hpx::future<typename traits::promise_local_result<typename hpx::
@@ -96,63 +74,57 @@ namespace hpx { namespace detail {
 
     template <typename Component, typename Signature, typename Derived,
         typename... Ts>
-    hpx::future<typename traits::promise_local_result<typename hpx::traits::
-            extract_action<Derived>::remote_result_type>::type>
+    hpx::future<traits::promise_local_result_t<
+        typename hpx::traits::extract_action<Derived>::remote_result_type>>
     async_colocated(
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
-        hpx::id_type const& gid, Ts&&... vs)
+        hpx::id_type const& id, Ts&&... vs)
     {
-        return async_colocated<Derived>(gid, HPX_FORWARD(Ts, vs)...);
+        return async_colocated<Derived>(id, HPX_FORWARD(Ts, vs)...);
     }
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename Continuation, typename... Ts>
-    std::enable_if_t<traits::is_continuation_v<Continuation>,
-        hpx::future<traits::promise_local_result_t<
-            typename hpx::traits::extract_action<Action>::remote_result_type>>>
-    async_colocated(Continuation&& cont, hpx::id_type const& gid,
-        Ts&&...
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
-        vs
-#endif
-    )
+        requires(traits::is_continuation_v<Continuation>)
+    hpx::future<traits::promise_local_result_t<
+        typename hpx::traits::extract_action<Action>::remote_result_type>>
+    async_colocated([[maybe_unused]] Continuation&& cont,
+        [[maybe_unused]] hpx::id_type const& id, [[maybe_unused]] Ts&&... vs)
     {
 #if defined(HPX_COMPUTE_DEVICE_CODE)
-        HPX_UNUSED(cont);
-        HPX_UNUSED(gid);
         HPX_ASSERT(false);
 #else
         // Attach the requested action as a continuation to a resolve_async
         // call on the locality responsible for the target gid.
         hpx::id_type service_target(
-            agas::primary_namespace::get_service_instance(gid.get_gid()),
+            agas::primary_namespace::get_service_instance(id.get_gid()),
             hpx::id_type::management_type::unmanaged);
 
         using remote_result_type =
-            typename hpx::traits::extract_action<Action>::remote_result_type;
+            hpx::traits::extract_action<Action>::remote_result_type;
         using action_type = agas::server::primary_namespace::colocate_action;
 
         using placeholders::_2;
         return detail::async_continue_r<action_type, remote_result_type>(
             util::functional::async_continuation(
                 hpx::bind<Action>(
-                    hpx::bind(util::functional::extract_locality(), _2, gid),
+                    hpx::bind(util::functional::extract_locality(), _2, id),
                     HPX_FORWARD(Ts, vs)...),
                 HPX_FORWARD(Continuation, cont)),
-            service_target, gid.get_gid());
+            service_target, id.get_gid());
 #endif
     }
 
     template <typename Continuation, typename Component, typename Signature,
         typename Derived, typename... Ts>
-    std::enable_if_t<traits::is_continuation_v<Continuation>,
-        hpx::future<traits::promise_local_result_t<
-            typename hpx::traits::extract_action<Derived>::remote_result_type>>>
+        requires(traits::is_continuation_v<Continuation>)
+    hpx::future<traits::promise_local_result_t<
+        typename hpx::traits::extract_action<Derived>::remote_result_type>>
     async_colocated(Continuation&& cont,
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
-        hpx::id_type const& gid, Ts&&... vs)
+        hpx::id_type const& id, Ts&&... vs)
     {
         return async_colocated<Derived>(
-            HPX_FORWARD(Continuation, cont), gid, HPX_FORWARD(Ts, vs)...);
+            HPX_FORWARD(Continuation, cont), id, HPX_FORWARD(Ts, vs)...);
     }
-}}    // namespace hpx::detail
+}    // namespace hpx::detail

--- a/libs/full/async_colocated/include/hpx/async_colocated/async_colocated.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/async_colocated.hpp
@@ -21,13 +21,15 @@
 
 #include <hpx/async_colocated/async_colocated_fwd.hpp>
 #include <hpx/async_colocated/functional/colocated_helpers.hpp>
+#include <hpx/async_colocated/macros.hpp>
 
 #include <type_traits>
 #include <utility>
 
 namespace hpx::detail {
 
-    template <typename Action, typename Ts = Action::arguments_type>
+    HPX_CXX_EXPORT template <typename Action,
+        typename Ts = Action::arguments_type>
     struct async_colocated_bound_action;
 
     template <typename Action, typename... Ts>
@@ -42,7 +44,7 @@ namespace hpx::detail {
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Action, typename... Ts>
+    HPX_CXX_EXPORT template <typename Action, typename... Ts>
     hpx::future<traits::promise_local_result_t<
         typename hpx::traits::extract_action<Action>::remote_result_type>>
     async_colocated(
@@ -72,8 +74,8 @@ namespace hpx::detail {
 #endif
     }
 
-    template <typename Component, typename Signature, typename Derived,
-        typename... Ts>
+    HPX_CXX_EXPORT template <typename Component, typename Signature,
+        typename Derived, typename... Ts>
     hpx::future<traits::promise_local_result_t<
         typename hpx::traits::extract_action<Derived>::remote_result_type>>
     async_colocated(
@@ -84,7 +86,8 @@ namespace hpx::detail {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Action, typename Continuation, typename... Ts>
+    HPX_CXX_EXPORT template <typename Action, typename Continuation,
+        typename... Ts>
         requires(traits::is_continuation_v<Continuation>)
     hpx::future<traits::promise_local_result_t<
         typename hpx::traits::extract_action<Action>::remote_result_type>>
@@ -115,8 +118,8 @@ namespace hpx::detail {
 #endif
     }
 
-    template <typename Continuation, typename Component, typename Signature,
-        typename Derived, typename... Ts>
+    HPX_CXX_EXPORT template <typename Continuation, typename Component,
+        typename Signature, typename Derived, typename... Ts>
         requires(traits::is_continuation_v<Continuation>)
     hpx::future<traits::promise_local_result_t<
         typename hpx::traits::extract_action<Derived>::remote_result_type>>

--- a/libs/full/async_colocated/include/hpx/async_colocated/async_colocated_callback.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/async_colocated_callback.hpp
@@ -21,7 +21,7 @@
 namespace hpx::detail {
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Action, typename Callback, typename... Ts>
+    HPX_CXX_EXPORT template <typename Action, typename Callback, typename... Ts>
     hpx::future<traits::promise_local_result_t<
         typename hpx::traits::extract_action<Action>::remote_result_type>>
     async_colocated_cb([[maybe_unused]] hpx::id_type const& id,
@@ -49,8 +49,8 @@ namespace hpx::detail {
 #endif
     }
 
-    template <typename Component, typename Signature, typename Derived,
-        typename Callback, typename... Ts>
+    HPX_CXX_EXPORT template <typename Component, typename Signature,
+        typename Derived, typename Callback, typename... Ts>
     hpx::future<traits::promise_local_result_t<
         typename hpx::traits::extract_action<Derived>::remote_result_type>>
     async_colocated_cb(
@@ -62,8 +62,8 @@ namespace hpx::detail {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Action, typename Continuation, typename Callback,
-        typename... Ts>
+    HPX_CXX_EXPORT template <typename Action, typename Continuation,
+        typename Callback, typename... Ts>
     hpx::future<traits::promise_local_result_t<
         typename hpx::traits::extract_action<Action>::remote_result_type>>
     async_colocated_cb([[maybe_unused]] Continuation&& cont,
@@ -94,8 +94,8 @@ namespace hpx::detail {
 #endif
     }
 
-    template <typename Continuation, typename Component, typename Signature,
-        typename Derived, typename Callback, typename... Ts>
+    HPX_CXX_EXPORT template <typename Continuation, typename Component,
+        typename Signature, typename Derived, typename Callback, typename... Ts>
     hpx::future<traits::promise_local_result_t<
         typename hpx::traits::extract_action<Derived>::remote_result_type>>
     async_colocated_cb(Continuation&& cont,

--- a/libs/full/async_colocated/include/hpx/async_colocated/async_colocated_callback.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/async_colocated_callback.hpp
@@ -18,103 +18,91 @@
 
 #include <utility>
 
-namespace hpx { namespace detail {
+namespace hpx::detail {
+
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename Callback, typename... Ts>
-    hpx::future<typename traits::promise_local_result<
-        typename hpx::traits::extract_action<Action>::remote_result_type>::type>
-    async_colocated_cb(hpx::id_type const& gid, Callback&& cb,
-        Ts&&...
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
-        vs
-#endif
-    )
+    hpx::future<traits::promise_local_result_t<
+        typename hpx::traits::extract_action<Action>::remote_result_type>>
+    async_colocated_cb([[maybe_unused]] hpx::id_type const& id,
+        [[maybe_unused]] Callback&& cb, [[maybe_unused]] Ts&&... vs)
     {
 #if defined(HPX_COMPUTE_DEVICE_CODE)
-        HPX_UNUSED(gid);
-        HPX_UNUSED(cb);
         HPX_ASSERT(false);
 #else
         // Attach the requested action as a continuation to a resolve_async
         // call on the locality responsible for the target gid.
         hpx::id_type service_target(
-            agas::primary_namespace::get_service_instance(gid.get_gid()),
+            agas::primary_namespace::get_service_instance(id.get_gid()),
             hpx::id_type::management_type::unmanaged);
 
-        typedef typename hpx::traits::extract_action<Action>::remote_result_type
-            remote_result_type;
-        typedef agas::server::primary_namespace::colocate_action action_type;
+        using remote_result_type =
+            hpx::traits::extract_action<Action>::remote_result_type;
+        using action_type = agas::server::primary_namespace::colocate_action;
 
         using placeholders::_2;
         return detail::async_continue_r_cb<action_type, remote_result_type>(
             util::functional::async_continuation(hpx::bind<Action>(
-                hpx::bind(util::functional::extract_locality(), _2, gid),
+                hpx::bind(util::functional::extract_locality(), _2, id),
                 HPX_FORWARD(Ts, vs)...)),
-            service_target, HPX_FORWARD(Callback, cb), gid.get_gid());
+            service_target, HPX_FORWARD(Callback, cb), id.get_gid());
 #endif
     }
 
     template <typename Component, typename Signature, typename Derived,
         typename Callback, typename... Ts>
-    hpx::future<typename traits::promise_local_result<typename hpx::traits::
-            extract_action<Derived>::remote_result_type>::type>
+    hpx::future<traits::promise_local_result_t<
+        typename hpx::traits::extract_action<Derived>::remote_result_type>>
     async_colocated_cb(
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
-        hpx::id_type const& gid, Callback&& cb, Ts&&... vs)
+        hpx::id_type const& id, Callback&& cb, Ts&&... vs)
     {
         return async_colocated_cb<Derived>(
-            gid, HPX_FORWARD(Callback, cb), HPX_FORWARD(Ts, vs)...);
+            id, HPX_FORWARD(Callback, cb), HPX_FORWARD(Ts, vs)...);
     }
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename Continuation, typename Callback,
         typename... Ts>
-    hpx::future<typename traits::promise_local_result<
-        typename hpx::traits::extract_action<Action>::remote_result_type>::type>
-    async_colocated_cb(
-        Continuation&& cont, hpx::id_type const& gid, Callback&& cb,
-        Ts&&...
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
-        vs
-#endif
-    )
+    hpx::future<traits::promise_local_result_t<
+        typename hpx::traits::extract_action<Action>::remote_result_type>>
+    async_colocated_cb([[maybe_unused]] Continuation&& cont,
+        [[maybe_unused]] hpx::id_type const& id, [[maybe_unused]] Callback&& cb,
+        [[maybe_unused]] Ts&&... vs)
     {
 #if defined(HPX_COMPUTE_DEVICE_CODE)
-        HPX_UNUSED(cont);
-        HPX_UNUSED(gid);
-        HPX_UNUSED(cb);
         HPX_ASSERT(false);
 #else
         // Attach the requested action as a continuation to a resolve_async
         // call on the locality responsible for the target gid.
         hpx::id_type service_target(
-            agas::primary_namespace::get_service_instance(gid.get_gid()),
+            agas::primary_namespace::get_service_instance(id.get_gid()),
             hpx::id_type::management_type::unmanaged);
 
-        typedef typename hpx::traits::extract_action<Action>::remote_result_type
-            remote_result_type;
-        typedef agas::server::primary_namespace::colocate_action action_type;
+        using remote_result_type =
+            hpx::traits::extract_action<Action>::remote_result_type;
+        using action_type = agas::server::primary_namespace::colocate_action;
 
         using placeholders::_2;
         return detail::async_continue_r_cb<action_type, remote_result_type>(
             util::functional::async_continuation(
                 hpx::bind<Action>(
-                    hpx::bind(util::functional::extract_locality(), _2, gid),
+                    hpx::bind(util::functional::extract_locality(), _2, id),
                     HPX_FORWARD(Ts, vs)...),
                 HPX_FORWARD(Continuation, cont)),
-            service_target, HPX_FORWARD(Callback, cb), gid.get_gid());
+            service_target, HPX_FORWARD(Callback, cb), id.get_gid());
 #endif
     }
 
     template <typename Continuation, typename Component, typename Signature,
         typename Derived, typename Callback, typename... Ts>
-    hpx::future<typename traits::promise_local_result<typename hpx::traits::
-            extract_action<Derived>::remote_result_type>::type>
+    hpx::future<traits::promise_local_result_t<
+        typename hpx::traits::extract_action<Derived>::remote_result_type>>
     async_colocated_cb(Continuation&& cont,
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
-        hpx::id_type const& gid, Callback&& cb, Ts&&... vs)
+        hpx::id_type const& id, Callback&& cb, Ts&&... vs)
     {
-        return async_colocated_cb<Derived>(HPX_FORWARD(Continuation, cont), gid,
+        return async_colocated_cb<Derived>(HPX_FORWARD(Continuation, cont), id,
             HPX_FORWARD(Callback, cb), HPX_FORWARD(Ts, vs)...);
     }
-}}    // namespace hpx::detail
+}    // namespace hpx::detail

--- a/libs/full/async_colocated/include/hpx/async_colocated/async_colocated_callback_fwd.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/async_colocated_callback_fwd.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -6,38 +6,40 @@
 
 #pragma once
 
-#include <hpx/async_colocated/async_colocated_fwd.hpp>
 #include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/futures.hpp>
 
-namespace hpx { namespace detail {
+#include <hpx/async_colocated/async_colocated_fwd.hpp>
+
+namespace hpx::detail {
+
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename Callback, typename... Ts>
-    hpx::future<typename traits::promise_local_result<
-        typename hpx::traits::extract_action<Action>::remote_result_type>::type>
-    async_colocated_cb(hpx::id_type const& gid, Callback&& cb, Ts&&... vs);
+    hpx::future<traits::promise_local_result_t<
+        typename hpx::traits::extract_action<Action>::remote_result_type>>
+    async_colocated_cb(hpx::id_type const& id, Callback&& cb, Ts&&... vs);
 
     template <typename Component, typename Signature, typename Derived,
         typename Callback, typename... Ts>
-    hpx::future<typename traits::promise_local_result<typename hpx::traits::
-            extract_action<Derived>::remote_result_type>::type>
+    hpx::future<traits::promise_local_result_t<
+        typename hpx::traits::extract_action<Derived>::remote_result_type>>
     async_colocated_cb(
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
-        hpx::id_type const& gid, Callback&& cb, Ts&&... vs);
+        hpx::id_type const& id, Callback&& cb, Ts&&... vs);
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename Continuation, typename Callback,
         typename... Ts>
-    hpx::future<typename traits::promise_local_result<
-        typename hpx::traits::extract_action<Action>::remote_result_type>::type>
-    async_colocated_cb(Continuation&& cont, hpx::id_type const& gid,
-        Callback&& cb, Ts&&... vs);
+    hpx::future<traits::promise_local_result_t<
+        typename hpx::traits::extract_action<Action>::remote_result_type>>
+    async_colocated_cb(
+        Continuation&& cont, hpx::id_type const& id, Callback&& cb, Ts&&... vs);
 
     template <typename Continuation, typename Component, typename Signature,
         typename Derived, typename Callback, typename... Ts>
-    hpx::future<typename traits::promise_local_result<typename hpx::traits::
-            extract_action<Derived>::remote_result_type>::type>
+    hpx::future<traits::promise_local_result_t<
+        typename hpx::traits::extract_action<Derived>::remote_result_type>>
     async_colocated_cb(Continuation&& cont,
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
-        hpx::id_type const& gid, Callback&& cb, Ts&&... vs);
-}}    // namespace hpx::detail
+        hpx::id_type const& id, Callback&& cb, Ts&&... vs);
+}    // namespace hpx::detail

--- a/libs/full/async_colocated/include/hpx/async_colocated/async_colocated_callback_fwd.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/async_colocated_callback_fwd.hpp
@@ -14,13 +14,13 @@
 namespace hpx::detail {
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Action, typename Callback, typename... Ts>
+    HPX_CXX_EXPORT template <typename Action, typename Callback, typename... Ts>
     hpx::future<traits::promise_local_result_t<
         typename hpx::traits::extract_action<Action>::remote_result_type>>
     async_colocated_cb(hpx::id_type const& id, Callback&& cb, Ts&&... vs);
 
-    template <typename Component, typename Signature, typename Derived,
-        typename Callback, typename... Ts>
+    HPX_CXX_EXPORT template <typename Component, typename Signature,
+        typename Derived, typename Callback, typename... Ts>
     hpx::future<traits::promise_local_result_t<
         typename hpx::traits::extract_action<Derived>::remote_result_type>>
     async_colocated_cb(
@@ -28,15 +28,15 @@ namespace hpx::detail {
         hpx::id_type const& id, Callback&& cb, Ts&&... vs);
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Action, typename Continuation, typename Callback,
-        typename... Ts>
+    HPX_CXX_EXPORT template <typename Action, typename Continuation,
+        typename Callback, typename... Ts>
     hpx::future<traits::promise_local_result_t<
         typename hpx::traits::extract_action<Action>::remote_result_type>>
     async_colocated_cb(
         Continuation&& cont, hpx::id_type const& id, Callback&& cb, Ts&&... vs);
 
-    template <typename Continuation, typename Component, typename Signature,
-        typename Derived, typename Callback, typename... Ts>
+    HPX_CXX_EXPORT template <typename Continuation, typename Component,
+        typename Signature, typename Derived, typename Callback, typename... Ts>
     hpx::future<traits::promise_local_result_t<
         typename hpx::traits::extract_action<Derived>::remote_result_type>>
     async_colocated_cb(Continuation&& cont,

--- a/libs/full/async_colocated/include/hpx/async_colocated/async_colocated_fwd.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/async_colocated_fwd.hpp
@@ -17,13 +17,13 @@
 namespace hpx::detail {
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Action, typename... Ts>
+    HPX_CXX_EXPORT template <typename Action, typename... Ts>
     hpx::future<traits::promise_local_result_t<
         typename hpx::traits::extract_action<Action>::remote_result_type>>
     async_colocated(hpx::id_type const& id, Ts&&... vs);
 
-    template <typename Component, typename Signature, typename Derived,
-        typename... Ts>
+    HPX_CXX_EXPORT template <typename Component, typename Signature,
+        typename Derived, typename... Ts>
     hpx::future<traits::promise_local_result_t<
         typename hpx::traits::extract_action<Derived>::remote_result_type>>
     async_colocated(hpx::actions::basic_action<Component, Signature, Derived>,
@@ -32,14 +32,15 @@ namespace hpx::detail {
     ///////////////////////////////////////////////////////////////////////////
     // MSVC complains about ambiguities if it sees this forward declaration
 #if !defined(HPX_MSVC)
-    template <typename Action, typename Continuation, typename... Ts>
-        requires(traits::is_continuation_v < Continuation)
+    HPX_CXX_EXPORT template <typename Action, typename Continuation,
+        typename... Ts>
+        requires(traits::is_continuation_v<Continuation>)
     hpx::future<traits::promise_local_result_t<
         typename hpx::traits::extract_action<Action>::remote_result_type>>
     async_colocated(Continuation&& cont, hpx::id_type const& id, Ts&&... vs);
 
-    template <typename Continuation, typename Component, typename Signature,
-        typename Derived, typename... Ts>
+    HPX_CXX_EXPORT template <typename Continuation, typename Component,
+        typename Signature, typename Derived, typename... Ts>
         requires(traits::is_continuation_v<Continuation>)
     hpx::future<traits::promise_local_result_t<
         typename hpx::traits::extract_action<Derived>::remote_result_type>>

--- a/libs/full/async_colocated/include/hpx/async_colocated/async_colocated_fwd.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/async_colocated_fwd.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -14,7 +14,8 @@
 
 #include <type_traits>
 
-namespace hpx { namespace detail {
+namespace hpx::detail {
+
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename... Ts>
     hpx::future<traits::promise_local_result_t<
@@ -32,18 +33,18 @@ namespace hpx { namespace detail {
     // MSVC complains about ambiguities if it sees this forward declaration
 #if !defined(HPX_MSVC)
     template <typename Action, typename Continuation, typename... Ts>
-    std::enable_if_t<traits::is_continuation_v<Continuation>,
-        hpx::future<traits::promise_local_result_t<
-            typename hpx::traits::extract_action<Action>::remote_result_type>>>
+        requires(traits::is_continuation_v < Continuation)
+    hpx::future<traits::promise_local_result_t<
+        typename hpx::traits::extract_action<Action>::remote_result_type>>
     async_colocated(Continuation&& cont, hpx::id_type const& id, Ts&&... vs);
 
     template <typename Continuation, typename Component, typename Signature,
         typename Derived, typename... Ts>
-    std::enable_if_t<traits::is_continuation_v<Continuation>,
-        hpx::future<traits::promise_local_result_t<
-            typename hpx::traits::extract_action<Derived>::remote_result_type>>>
+        requires(traits::is_continuation_v<Continuation>)
+    hpx::future<traits::promise_local_result_t<
+        typename hpx::traits::extract_action<Derived>::remote_result_type>>
     async_colocated(Continuation&& cont,
         hpx::actions::basic_action<Component, Signature, Derived>,
         hpx::id_type const& id, Ts&&... vs);
 #endif
-}}    // namespace hpx::detail
+}    // namespace hpx::detail

--- a/libs/full/async_colocated/include/hpx/async_colocated/functional/colocated_helpers.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/functional/colocated_helpers.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2023 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/full/async_colocated/include/hpx/async_colocated/functional/colocated_helpers.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/functional/colocated_helpers.hpp
@@ -21,7 +21,7 @@
 namespace hpx::util::functional {
 
     ///////////////////////////////////////////////////////////////////////////
-    struct extract_locality
+    HPX_CXX_EXPORT struct extract_locality
     {
         hpx::id_type operator()(
             hpx::id_type const& locality_id, hpx::id_type const& id) const
@@ -39,7 +39,7 @@ namespace hpx::util::functional {
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
 
-        template <typename Bound, typename Continuation>
+        HPX_CXX_EXPORT template <typename Bound, typename Continuation>
         struct post_continuation_impl
         {
             using bound_type = std::decay_t<Bound>;
@@ -160,7 +160,7 @@ namespace hpx::util::functional {
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
 
-        template <typename Bound, typename Continuation>
+        HPX_CXX_EXPORT template <typename Bound, typename Continuation>
         struct async_continuation_impl
         {
             using bound_type = std::decay_t<Bound>;

--- a/libs/full/async_colocated/include/hpx/async_colocated/get_colocation_id.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/get_colocation_id.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2022 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c) 2011      Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -36,7 +36,7 @@ namespace hpx {
     ///           hpx::exception.
     ///
     /// \see    \a hpx::get_colocation_id()
-    HPX_EXPORT hpx::id_type get_colocation_id(
+    HPX_CXX_EXPORT HPX_EXPORT hpx::id_type get_colocation_id(
         launch::sync_policy, hpx::id_type const& id, error_code& ec = throws);
 
     /// \brief Asynchronously return the id of the locality where the object
@@ -45,6 +45,6 @@ namespace hpx {
     /// \param id [in] The id of the object to locate.
     ///
     /// \see    \a hpx::get_colocation_id(launch::sync_policy)
-    HPX_EXPORT hpx::future<hpx::id_type> get_colocation_id(
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future<hpx::id_type> get_colocation_id(
         hpx::id_type const& id);
 }    // namespace hpx

--- a/libs/full/async_colocated/include/hpx/async_colocated/macros.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/macros.hpp
@@ -1,0 +1,33 @@
+//  Copyright (c) 2007-2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+////////////////////////////////////////////////////////////////////////////////
+// from async_colocated.hpp
+#define HPX_REGISTER_ASYNC_COLOCATED_DECLARATION(Action, Name)                 \
+    HPX_UTIL_REGISTER_UNIQUE_FUNCTION_DECLARATION(                             \
+        void(hpx::id_type, hpx::id_type),                                      \
+        (hpx::util::functional::detail::async_continuation_impl<               \
+            typename hpx::detail::async_colocated_bound_action<Action>::type,  \
+            hpx::util::unused_type>),                                          \
+        Name)                                                                  \
+    /**/
+
+#define HPX_REGISTER_ASYNC_COLOCATED(Action, Name)                             \
+    HPX_UTIL_REGISTER_UNIQUE_FUNCTION(void(hpx::id_type, hpx::id_type),        \
+        (hpx::util::functional::detail::async_continuation_impl<               \
+            typename hpx::detail::async_colocated_bound_action<Action>::type,  \
+            hpx::util::unused_type>),                                          \
+        Name)                                                                  \
+    /**/
+
+////////////////////////////////////////////////////////////////////////////////
+// from register_post_colocated.hpp
+#define HPX_REGISTER_APPLY_COLOCATED_DECLARATION(Action, Name)
+#define HPX_REGISTER_APPLY_COLOCATED(action, name)

--- a/libs/full/async_colocated/include/hpx/async_colocated/macros.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/macros.hpp
@@ -8,6 +8,8 @@
 
 #include <hpx/config.hpp>
 
+#include <hpx/async_distributed/macros.hpp>
+
 ////////////////////////////////////////////////////////////////////////////////
 // from async_colocated.hpp
 #define HPX_REGISTER_ASYNC_COLOCATED_DECLARATION(Action, Name)                 \

--- a/libs/full/async_colocated/include/hpx/async_colocated/post_colocated.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/post_colocated.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2022 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -22,81 +22,81 @@
 #include <type_traits>
 #include <utility>
 
-namespace hpx { namespace detail {
+namespace hpx::detail {
+
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename... Ts>
-    bool post_colocated(hpx::id_type const& gid, Ts&&... vs)
+    bool post_colocated(hpx::id_type const& id, Ts&&... vs)
     {
         // shortcut co-location code if target already is a locality
-        if (naming::is_locality(gid))
+        if (naming::is_locality(id))
         {
-            return post<Action>(gid, HPX_FORWARD(Ts, vs)...);
+            return post<Action>(id, HPX_FORWARD(Ts, vs)...);
         }
 
         // Attach the requested action as a continuation to a resolve_async
         // call on the locality responsible for the target gid.
         hpx::id_type service_target(
-            agas::primary_namespace::get_service_instance(gid.get_gid()),
+            agas::primary_namespace::get_service_instance(id.get_gid()),
             hpx::id_type::management_type::unmanaged);
 
-        typedef agas::server::primary_namespace::colocate_action action_type;
+        using action_type = agas::server::primary_namespace::colocate_action;
 
         using placeholders::_2;
         return post_continue<action_type>(
             util::functional::post_continuation(hpx::bind<Action>(
-                hpx::bind(util::functional::extract_locality(), _2, gid),
+                hpx::bind(util::functional::extract_locality(), _2, id),
                 HPX_FORWARD(Ts, vs)...)),
-            service_target, gid.get_gid());
+            service_target, id.get_gid());
     }
 
     template <typename Component, typename Signature, typename Derived,
         typename... Ts>
     bool post_colocated(
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
-        hpx::id_type const& gid, Ts&&... vs)
+        hpx::id_type const& id, Ts&&... vs)
     {
-        return post_colocated<Derived>(gid, HPX_FORWARD(Ts, vs)...);
+        return post_colocated<Derived>(id, HPX_FORWARD(Ts, vs)...);
     }
 
     template <typename Action, typename Continuation, typename... Ts>
-    typename std::enable_if<traits::is_continuation<Continuation>::value,
-        bool>::type
-    post_colocated(Continuation&& cont, hpx::id_type const& gid, Ts&&... vs)
+        requires(traits::is_continuation_v<Continuation>)
+    bool post_colocated(Continuation&& cont, hpx::id_type const& id, Ts&&... vs)
     {
         // shortcut co-location code if target already is a locality
-        if (naming::is_locality(gid))
+        if (naming::is_locality(id))
         {
             return post_continue<Action>(
-                HPX_FORWARD(Continuation, cont), gid, HPX_FORWARD(Ts, vs)...);
+                HPX_FORWARD(Continuation, cont), id, HPX_FORWARD(Ts, vs)...);
         }
 
         // Attach the requested action as a continuation to a resolve_async
         // call on the locality responsible for the target gid.
         hpx::id_type service_target(
-            agas::primary_namespace::get_service_instance(gid.get_gid()),
+            agas::primary_namespace::get_service_instance(id.get_gid()),
             hpx::id_type::management_type::unmanaged);
 
-        typedef agas::server::primary_namespace::colocate_action action_type;
+        using action_type = agas::server::primary_namespace::colocate_action;
 
         using placeholders::_2;
         return post_continue<action_type>(
             util::functional::post_continuation(
                 hpx::bind<Action>(
-                    hpx::bind(util::functional::extract_locality(), _2, gid),
+                    hpx::bind(util::functional::extract_locality(), _2, id),
                     HPX_FORWARD(Ts, vs)...),
                 HPX_FORWARD(Continuation, cont)),
-            service_target, gid.get_gid());
+            service_target, id.get_gid());
     }
 
     template <typename Continuation, typename Component, typename Signature,
         typename Derived, typename... Ts>
     bool post_colocated(Continuation&& cont,
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
-        hpx::id_type const& gid, Ts&&... vs)
+        hpx::id_type const& id, Ts&&... vs)
     {
         return post_colocated<Derived>(
-            HPX_FORWARD(Continuation, cont), gid, HPX_FORWARD(Ts, vs)...);
+            HPX_FORWARD(Continuation, cont), id, HPX_FORWARD(Ts, vs)...);
     }
-}}    // namespace hpx::detail
+}    // namespace hpx::detail
 
 #endif

--- a/libs/full/async_colocated/include/hpx/async_colocated/post_colocated.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/post_colocated.hpp
@@ -25,7 +25,7 @@
 namespace hpx::detail {
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Action, typename... Ts>
+    HPX_CXX_EXPORT template <typename Action, typename... Ts>
     bool post_colocated(hpx::id_type const& id, Ts&&... vs)
     {
         // shortcut co-location code if target already is a locality
@@ -50,8 +50,8 @@ namespace hpx::detail {
             service_target, id.get_gid());
     }
 
-    template <typename Component, typename Signature, typename Derived,
-        typename... Ts>
+    HPX_CXX_EXPORT template <typename Component, typename Signature,
+        typename Derived, typename... Ts>
     bool post_colocated(
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
         hpx::id_type const& id, Ts&&... vs)
@@ -59,7 +59,8 @@ namespace hpx::detail {
         return post_colocated<Derived>(id, HPX_FORWARD(Ts, vs)...);
     }
 
-    template <typename Action, typename Continuation, typename... Ts>
+    HPX_CXX_EXPORT template <typename Action, typename Continuation,
+        typename... Ts>
         requires(traits::is_continuation_v<Continuation>)
     bool post_colocated(Continuation&& cont, hpx::id_type const& id, Ts&&... vs)
     {
@@ -88,8 +89,8 @@ namespace hpx::detail {
             service_target, id.get_gid());
     }
 
-    template <typename Continuation, typename Component, typename Signature,
-        typename Derived, typename... Ts>
+    HPX_CXX_EXPORT template <typename Continuation, typename Component,
+        typename Signature, typename Derived, typename... Ts>
     bool post_colocated(Continuation&& cont,
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
         hpx::id_type const& id, Ts&&... vs)

--- a/libs/full/async_colocated/include/hpx/async_colocated/post_colocated_callback.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/post_colocated_callback.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2022 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -25,19 +25,19 @@ namespace hpx::detail {
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename Callback, typename... Ts>
-    bool post_colocated_cb(hpx::id_type const& gid, Callback&& cb, Ts&&... vs)
+    bool post_colocated_cb(hpx::id_type const& id, Callback&& cb, Ts&&... vs)
     {
         // shortcut co-location code if target already is a locality
-        if (naming::is_locality(gid))
+        if (naming::is_locality(id))
         {
             return hpx::post_cb<Action>(
-                gid, HPX_FORWARD(Callback, cb), HPX_FORWARD(Ts, vs)...);
+                id, HPX_FORWARD(Callback, cb), HPX_FORWARD(Ts, vs)...);
         }
 
         // Attach the requested action as a continuation to a resolve_async
         // call on the locality responsible for the target gid.
         hpx::id_type service_target(
-            agas::primary_namespace::get_service_instance(gid.get_gid()),
+            agas::primary_namespace::get_service_instance(id.get_gid()),
             hpx::id_type::management_type::unmanaged);
 
         using action_type = agas::server::primary_namespace::colocate_action;
@@ -45,41 +45,41 @@ namespace hpx::detail {
         using placeholders::_2;
         return post_continue_cb<action_type>(
             util::functional::post_continuation(hpx::bind<Action>(
-                hpx::bind(util::functional::extract_locality(), _2, gid),
+                hpx::bind(util::functional::extract_locality(), _2, id),
                 HPX_FORWARD(Ts, vs)...)),
-            service_target, HPX_FORWARD(Callback, cb), gid.get_gid());
+            service_target, HPX_FORWARD(Callback, cb), id.get_gid());
     }
 
     template <typename Component, typename Signature, typename Derived,
         typename Callback, typename... Ts>
     bool post_colocated_cb(
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
-        hpx::id_type const& gid, Callback&& cb, Ts&&... vs)
+        hpx::id_type const& id, Callback&& cb, Ts&&... vs)
     {
         return post_colocated_cb<Derived>(
-            gid, HPX_FORWARD(Callback, cb), HPX_FORWARD(Ts, vs)...);
+            id, HPX_FORWARD(Callback, cb), HPX_FORWARD(Ts, vs)...);
     }
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename Continuation, typename Callback,
         typename... Ts>
     bool post_colocated_cb(
-        Continuation&& cont, hpx::id_type const& gid, Callback&& cb, Ts&&... vs)
+        Continuation&& cont, hpx::id_type const& id, Callback&& cb, Ts&&... vs)
     {
         // shortcut co-location code if target already is a locality
-        if (naming::is_locality(gid))
+        if (naming::is_locality(id))
         {
             constexpr hpx::launch::async_policy policy(
                 actions::action_priority<Action>(),
                 actions::action_stacksize<Action>());
-            return hpx::post_p_cb<Action>(HPX_FORWARD(Continuation, cont), gid,
+            return hpx::post_p_cb<Action>(HPX_FORWARD(Continuation, cont), id,
                 policy, HPX_FORWARD(Callback, cb), HPX_FORWARD(Ts, vs)...);
         }
 
         // Attach the requested action as a continuation to a resolve_async
         // call on the locality responsible for the target gid.
         hpx::id_type service_target(
-            agas::primary_namespace::get_service_instance(gid.get_gid()),
+            agas::primary_namespace::get_service_instance(id.get_gid()),
             hpx::id_type::management_type::unmanaged);
 
         using action_type = agas::server::primary_namespace::colocate_action;
@@ -88,19 +88,19 @@ namespace hpx::detail {
         return post_continue_cb<action_type>(
             util::functional::post_continuation(
                 hpx::bind<Action>(
-                    hpx::bind(util::functional::extract_locality(), _2, gid),
+                    hpx::bind(util::functional::extract_locality(), _2, id),
                     HPX_FORWARD(Ts, vs)...),
                 HPX_FORWARD(Continuation, cont)),
-            service_target, HPX_FORWARD(Callback, cb), gid.get_gid());
+            service_target, HPX_FORWARD(Callback, cb), id.get_gid());
     }
 
     template <typename Continuation, typename Component, typename Signature,
         typename Derived, typename Callback, typename... Ts>
     bool post_colocated_cb(Continuation&& cont,
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
-        hpx::id_type const& gid, Callback&& cb, Ts&&... vs)
+        hpx::id_type const& id, Callback&& cb, Ts&&... vs)
     {
-        return post_colocated_cb<Derived>(HPX_FORWARD(Continuation, cont), gid,
+        return post_colocated_cb<Derived>(HPX_FORWARD(Continuation, cont), id,
             HPX_FORWARD(Callback, cb), HPX_FORWARD(Ts, vs)...);
     }
 }    // namespace hpx::detail

--- a/libs/full/async_colocated/include/hpx/async_colocated/post_colocated_callback.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/post_colocated_callback.hpp
@@ -24,7 +24,7 @@
 namespace hpx::detail {
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Action, typename Callback, typename... Ts>
+    HPX_CXX_EXPORT template <typename Action, typename Callback, typename... Ts>
     bool post_colocated_cb(hpx::id_type const& id, Callback&& cb, Ts&&... vs)
     {
         // shortcut co-location code if target already is a locality
@@ -50,8 +50,8 @@ namespace hpx::detail {
             service_target, HPX_FORWARD(Callback, cb), id.get_gid());
     }
 
-    template <typename Component, typename Signature, typename Derived,
-        typename Callback, typename... Ts>
+    HPX_CXX_EXPORT template <typename Component, typename Signature,
+        typename Derived, typename Callback, typename... Ts>
     bool post_colocated_cb(
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
         hpx::id_type const& id, Callback&& cb, Ts&&... vs)
@@ -61,8 +61,8 @@ namespace hpx::detail {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Action, typename Continuation, typename Callback,
-        typename... Ts>
+    HPX_CXX_EXPORT template <typename Action, typename Continuation,
+        typename Callback, typename... Ts>
     bool post_colocated_cb(
         Continuation&& cont, hpx::id_type const& id, Callback&& cb, Ts&&... vs)
     {
@@ -94,8 +94,8 @@ namespace hpx::detail {
             service_target, HPX_FORWARD(Callback, cb), id.get_gid());
     }
 
-    template <typename Continuation, typename Component, typename Signature,
-        typename Derived, typename Callback, typename... Ts>
+    HPX_CXX_EXPORT template <typename Continuation, typename Component,
+        typename Signature, typename Derived, typename Callback, typename... Ts>
     bool post_colocated_cb(Continuation&& cont,
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
         hpx::id_type const& id, Callback&& cb, Ts&&... vs)

--- a/libs/full/async_colocated/include/hpx/async_colocated/post_colocated_callback_fwd.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/post_colocated_callback_fwd.hpp
@@ -13,23 +13,23 @@
 namespace hpx::detail {
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Action, typename Callback, typename... Ts>
+    HPX_CXX_EXPORT template <typename Action, typename Callback, typename... Ts>
     bool post_colocated_cb(hpx::id_type const& id, Callback&& cb, Ts&&... vs);
 
-    template <typename Component, typename Signature, typename Derived,
-        typename Callback, typename... Ts>
+    HPX_CXX_EXPORT template <typename Component, typename Signature,
+        typename Derived, typename Callback, typename... Ts>
     bool post_colocated_cb(
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
         hpx::id_type const& id, Callback&& cb, Ts&&... vs);
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Action, typename Continuation, typename Callback,
-        typename... Ts>
+    HPX_CXX_EXPORT template <typename Action, typename Continuation,
+        typename Callback, typename... Ts>
     bool post_colocated_cb(
         Continuation&& cont, hpx::id_type const& id, Callback&& cb, Ts&&... vs);
 
-    template <typename Continuation, typename Component, typename Signature,
-        typename Derived, typename Callback, typename... Ts>
+    HPX_CXX_EXPORT template <typename Continuation, typename Component,
+        typename Signature, typename Derived, typename Callback, typename... Ts>
     bool post_colocated_cb(Continuation&& cont,
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
         hpx::id_type const& id, Callback&& cb, Ts&&... vs);

--- a/libs/full/async_colocated/include/hpx/async_colocated/post_colocated_callback_fwd.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/post_colocated_callback_fwd.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2022 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -10,26 +10,27 @@
 #include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/naming_base.hpp>
 
-namespace hpx { namespace detail {
+namespace hpx::detail {
+
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename Callback, typename... Ts>
-    bool post_colocated_cb(hpx::id_type const& gid, Callback&& cb, Ts&&... vs);
+    bool post_colocated_cb(hpx::id_type const& id, Callback&& cb, Ts&&... vs);
 
     template <typename Component, typename Signature, typename Derived,
         typename Callback, typename... Ts>
     bool post_colocated_cb(
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
-        hpx::id_type const& gid, Callback&& cb, Ts&&... vs);
+        hpx::id_type const& id, Callback&& cb, Ts&&... vs);
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename Continuation, typename Callback,
         typename... Ts>
-    bool post_colocated_cb(Continuation&& cont, hpx::id_type const& gid,
-        Callback&& cb, Ts&&... vs);
+    bool post_colocated_cb(
+        Continuation&& cont, hpx::id_type const& id, Callback&& cb, Ts&&... vs);
 
     template <typename Continuation, typename Component, typename Signature,
         typename Derived, typename Callback, typename... Ts>
     bool post_colocated_cb(Continuation&& cont,
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
-        hpx::id_type const& gid, Callback&& cb, Ts&&... vs);
-}}    // namespace hpx::detail
+        hpx::id_type const& id, Callback&& cb, Ts&&... vs);
+}    // namespace hpx::detail

--- a/libs/full/async_colocated/include/hpx/async_colocated/post_colocated_fwd.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/post_colocated_fwd.hpp
@@ -15,23 +15,24 @@
 namespace hpx::detail {
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Action, typename... Ts>
+    HPX_CXX_EXPORT template <typename Action, typename... Ts>
     bool post_colocated(hpx::id_type const& id, Ts&&... vs);
 
-    template <typename Component, typename Signature, typename Derived,
-        typename... Ts>
+    HPX_CXX_EXPORT template <typename Component, typename Signature,
+        typename Derived, typename... Ts>
     bool post_colocated(
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
         hpx::id_type const& id, Ts&&... vs);
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Action, typename Continuation, typename... Ts>
+    HPX_CXX_EXPORT template <typename Action, typename Continuation,
+        typename... Ts>
         requires(traits::is_continuation_v<Continuation>)
     bool post_colocated(
         Continuation&& cont, hpx::id_type const& id, Ts&&... vs);
 
-    template <typename Continuation, typename Component, typename Signature,
-        typename Derived, typename... Ts>
+    HPX_CXX_EXPORT template <typename Continuation, typename Component,
+        typename Signature, typename Derived, typename... Ts>
     bool post_colocated(Continuation&& cont,
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
         hpx::id_type const& id, Ts&&... vs);

--- a/libs/full/async_colocated/include/hpx/async_colocated/post_colocated_fwd.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/post_colocated_fwd.hpp
@@ -12,26 +12,27 @@
 
 #include <type_traits>
 
-namespace hpx { namespace detail {
+namespace hpx::detail {
+
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename... Ts>
-    bool post_colocated(hpx::id_type const& gid, Ts&&... vs);
+    bool post_colocated(hpx::id_type const& id, Ts&&... vs);
 
     template <typename Component, typename Signature, typename Derived,
         typename... Ts>
     bool post_colocated(
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
-        hpx::id_type const& gid, Ts&&... vs);
+        hpx::id_type const& id, Ts&&... vs);
 
     ///////////////////////////////////////////////////////////////////////////
     template <typename Action, typename Continuation, typename... Ts>
-    typename std::enable_if<traits::is_continuation<Continuation>::value,
-        bool>::type
-    post_colocated(Continuation&& cont, hpx::id_type const& gid, Ts&&... vs);
+        requires(traits::is_continuation_v<Continuation>)
+    bool post_colocated(
+        Continuation&& cont, hpx::id_type const& id, Ts&&... vs);
 
     template <typename Continuation, typename Component, typename Signature,
         typename Derived, typename... Ts>
     bool post_colocated(Continuation&& cont,
         hpx::actions::basic_action<Component, Signature, Derived> /*act*/,
-        hpx::id_type const& gid, Ts&&... vs);
-}}    // namespace hpx::detail
+        hpx::id_type const& id, Ts&&... vs);
+}    // namespace hpx::detail

--- a/libs/full/async_colocated/include/hpx/async_colocated/register_post_colocated.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/register_post_colocated.hpp
@@ -7,14 +7,15 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/async_colocated/functional/colocated_helpers.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/datastructures.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/naming_base.hpp>
 #include <hpx/modules/type_support.hpp>
 
-namespace hpx { namespace detail {
+#include <hpx/async_colocated/functional/colocated_helpers.hpp>
+
+namespace hpx::detail {
 
     template <typename Action, typename Ts = typename Action::arguments_type>
     struct post_colocated_bound_action;
@@ -29,7 +30,4 @@ namespace hpx { namespace detail {
                 hpx::id_type>,
             Ts...>;
     };
-}}    // namespace hpx::detail
-
-#define HPX_REGISTER_APPLY_COLOCATED_DECLARATION(Action, Name)
-#define HPX_REGISTER_APPLY_COLOCATED(action, name)
+}    // namespace hpx::detail

--- a/libs/full/async_colocated/include/hpx/async_colocated/register_post_colocated.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/register_post_colocated.hpp
@@ -14,10 +14,12 @@
 #include <hpx/modules/type_support.hpp>
 
 #include <hpx/async_colocated/functional/colocated_helpers.hpp>
+#include <hpx/async_colocated/macros.hpp>
 
 namespace hpx::detail {
 
-    template <typename Action, typename Ts = typename Action::arguments_type>
+    HPX_CXX_EXPORT template <typename Action,
+        typename Ts = typename Action::arguments_type>
     struct post_colocated_bound_action;
 
     template <typename Action, typename... Ts>

--- a/libs/full/async_colocated/include/hpx/async_colocated/server/destroy_component.hpp
+++ b/libs/full/async_colocated/include/hpx/async_colocated/server/destroy_component.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2025 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c) 2011-2017 Thomas Heller
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -17,11 +17,11 @@
 namespace hpx::components::server {
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT void destroy_component(
+    HPX_CXX_EXPORT HPX_EXPORT void destroy_component(
         naming::gid_type const& gid, naming::address const& addr);
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Component>
+    HPX_CXX_EXPORT template <typename Component>
     void destroy(naming::gid_type const& gid, naming::address const& addr)
     {
         // make sure this component is located here
@@ -59,7 +59,7 @@ namespace hpx::components::server {
         component_heap<Component>().free(c, 1);
     }
 
-    template <typename Component>
+    HPX_CXX_EXPORT template <typename Component>
     void destroy(naming::gid_type const& gid)
     {
         naming::address addr;

--- a/libs/full/async_colocated/src/get_colocation_id.cpp
+++ b/libs/full/async_colocated/src/get_colocation_id.cpp
@@ -6,12 +6,13 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/assert.hpp>
-#include <hpx/async_colocated/get_colocation_id.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/naming_base.hpp>
+
+#include <hpx/async_colocated/get_colocation_id.hpp>
 
 namespace hpx {
 

--- a/libs/full/async_colocated/src/server/destroy_component.cpp
+++ b/libs/full/async_colocated/src/server/destroy_component.cpp
@@ -5,14 +5,15 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
-#include <hpx/async_colocated/get_colocation_id.hpp>
-#include <hpx/async_colocated/server/destroy_component.hpp>
 #include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/logging.hpp>
 #include <hpx/modules/naming_base.hpp>
 #include <hpx/modules/type_support.hpp>
+
+#include <hpx/async_colocated/get_colocation_id.hpp>
+#include <hpx/async_colocated/server/destroy_component.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/libs/full/checkpoint/include/hpx/checkpoint/checkpoint.hpp
+++ b/libs/full/checkpoint/include/hpx/checkpoint/checkpoint.hpp
@@ -22,8 +22,8 @@
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/naming.hpp>
+#include <hpx/modules/runtime_components.hpp>
 #include <hpx/modules/serialization.hpp>
-#include <hpx/runtime_components/new.hpp>
 #include <hpx/runtime_distributed/find_here.hpp>
 
 #include <cstddef>

--- a/libs/full/collectives/CMakeLists.txt
+++ b/libs/full/collectives/CMakeLists.txt
@@ -78,10 +78,12 @@ add_hpx_module(
   MODULE_DEPENDENCIES
     hpx_actions
     hpx_actions_base
+    hpx_async_colocated
     hpx_async_distributed
     hpx_components
     hpx_components_base
     hpx_naming_base
+    hpx_runtime_components
     hpx_runtime_distributed
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/full/collectives/include/hpx/collectives/broadcast_direct.hpp
+++ b/libs/full/collectives/include/hpx/collectives/broadcast_direct.hpp
@@ -129,10 +129,9 @@ namespace hpx { namespace lcos {
 #include <hpx/config.hpp>
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/assert.hpp>
-#include <hpx/async_colocated/async_colocated.hpp>
-#include <hpx/async_colocated/post_colocated.hpp>
 #include <hpx/modules/actions.hpp>
 #include <hpx/modules/actions_base.hpp>
+#include <hpx/modules/async_colocated.hpp>
 #include <hpx/modules/async_combinators.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/datastructures.hpp>

--- a/libs/full/collectives/include/hpx/collectives/exclusive_scan.hpp
+++ b/libs/full/collectives/include/hpx/collectives/exclusive_scan.hpp
@@ -281,6 +281,7 @@ namespace hpx { namespace collectives {
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/futures.hpp>
+#include <hpx/modules/tag_invoke.hpp>
 #include <hpx/modules/type_support.hpp>
 
 #include <concepts>

--- a/libs/full/collectives/include/hpx/collectives/fold.hpp
+++ b/libs/full/collectives/include/hpx/collectives/fold.hpp
@@ -159,9 +159,9 @@ namespace hpx { namespace lcos {
 
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
-#include <hpx/async_colocated/async_colocated.hpp>
 #include <hpx/modules/actions.hpp>
 #include <hpx/modules/actions_base.hpp>
+#include <hpx/modules/async_colocated.hpp>
 #include <hpx/modules/async_combinators.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/datastructures.hpp>

--- a/libs/full/collectives/include/hpx/collectives/inclusive_scan.hpp
+++ b/libs/full/collectives/include/hpx/collectives/inclusive_scan.hpp
@@ -227,6 +227,7 @@ namespace hpx { namespace collectives {
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/futures.hpp>
+#include <hpx/modules/tag_invoke.hpp>
 #include <hpx/modules/type_support.hpp>
 
 #include <cstddef>

--- a/libs/full/collectives/include/hpx/collectives/reduce_direct.hpp
+++ b/libs/full/collectives/include/hpx/collectives/reduce_direct.hpp
@@ -75,9 +75,9 @@ namespace hpx { namespace lcos {
 
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
-#include <hpx/async_colocated/async_colocated.hpp>
 #include <hpx/modules/actions.hpp>
 #include <hpx/modules/actions_base.hpp>
+#include <hpx/modules/async_colocated.hpp>
 #include <hpx/modules/async_combinators.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/datastructures.hpp>

--- a/libs/full/collectives/src/channel_communicator.cpp
+++ b/libs/full/collectives/src/channel_communicator.cpp
@@ -16,8 +16,8 @@
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/lock_registration.hpp>
+#include <hpx/modules/runtime_components.hpp>
 #include <hpx/modules/synchronization.hpp>
-#include <hpx/runtime_components/new.hpp>
 
 #include <cstddef>
 #include <memory>

--- a/libs/full/collectives/src/create_communicator.cpp
+++ b/libs/full/collectives/src/create_communicator.cpp
@@ -19,10 +19,9 @@
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/modules/lock_registration.hpp>
+#include <hpx/modules/runtime_components.hpp>
 #include <hpx/modules/synchronization.hpp>
 #include <hpx/modules/type_support.hpp>
-#include <hpx/runtime_components/component_factory.hpp>
-#include <hpx/runtime_components/new.hpp>
 #include <hpx/runtime_distributed/server/runtime_support.hpp>
 
 #include <algorithm>

--- a/libs/full/collectives/src/detail/channel_communicator_server.cpp
+++ b/libs/full/collectives/src/detail/channel_communicator_server.cpp
@@ -13,7 +13,7 @@
 #include <hpx/collectives/detail/channel_communicator.hpp>
 #include <hpx/modules/components.hpp>
 #include <hpx/modules/components_base.hpp>
-#include <hpx/runtime_components/component_factory.hpp>
+#include <hpx/modules/runtime_components.hpp>
 
 #include <cstddef>
 #include <utility>

--- a/libs/full/collectives/src/latch.cpp
+++ b/libs/full/collectives/src/latch.cpp
@@ -11,11 +11,10 @@
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/components.hpp>
 #include <hpx/modules/futures.hpp>
+#include <hpx/modules/runtime_components.hpp>
 #include <hpx/modules/runtime_local.hpp>
 #include <hpx/modules/type_support.hpp>
 #include <hpx/performance_counters/counters.hpp>
-#include <hpx/runtime_components/derived_component_factory.hpp>
-#include <hpx/runtime_components/new.hpp>
 #include <hpx/runtime_distributed/find_here.hpp>
 
 #include <cstddef>

--- a/libs/full/compute/include/hpx/compute/host/target_distribution_policy.hpp
+++ b/libs/full/compute/include/hpx/compute/host/target_distribution_policy.hpp
@@ -19,8 +19,8 @@
 #include <hpx/compute/host/distributed_target.hpp>
 #include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/futures.hpp>
+#include <hpx/modules/runtime_components.hpp>
 #include <hpx/modules/serialization.hpp>
-#include <hpx/runtime_components/create_component_helpers.hpp>
 
 #include <algorithm>
 #include <cstddef>

--- a/libs/full/distribution_policies/include/hpx/distribution_policies/binpacking_distribution_policy.hpp
+++ b/libs/full/distribution_policies/include/hpx/distribution_policies/binpacking_distribution_policy.hpp
@@ -17,9 +17,9 @@
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/naming_base.hpp>
 #include <hpx/modules/pack_traversal.hpp>
+#include <hpx/modules/runtime_components.hpp>
 #include <hpx/modules/serialization.hpp>
 #include <hpx/performance_counters/performance_counter.hpp>
-#include <hpx/runtime_components/create_component_helpers.hpp>
 
 #include <algorithm>
 #include <cstddef>

--- a/libs/full/distribution_policies/include/hpx/distribution_policies/colocating_distribution_policy.hpp
+++ b/libs/full/distribution_policies/include/hpx/distribution_policies/colocating_distribution_policy.hpp
@@ -9,12 +9,9 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/async_colocated/async_colocated.hpp>
-#include <hpx/async_colocated/async_colocated_callback.hpp>
-#include <hpx/async_colocated/post_colocated_callback_fwd.hpp>
-#include <hpx/async_colocated/post_colocated_fwd.hpp>
 #include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_base.hpp>
+#include <hpx/modules/async_colocated.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/components.hpp>
 #include <hpx/modules/components_base.hpp>

--- a/libs/full/distribution_policies/include/hpx/distribution_policies/colocating_distribution_policy.hpp
+++ b/libs/full/distribution_policies/include/hpx/distribution_policies/colocating_distribution_policy.hpp
@@ -17,8 +17,8 @@
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/naming_base.hpp>
+#include <hpx/modules/runtime_components.hpp>
 #include <hpx/modules/serialization.hpp>
-#include <hpx/runtime_components/create_component_helpers.hpp>
 
 #include <algorithm>
 #include <cstddef>

--- a/libs/full/distribution_policies/include/hpx/distribution_policies/default_distribution_policy.hpp
+++ b/libs/full/distribution_policies/include/hpx/distribution_policies/default_distribution_policy.hpp
@@ -18,8 +18,8 @@
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/naming_base.hpp>
+#include <hpx/modules/runtime_components.hpp>
 #include <hpx/modules/serialization.hpp>
-#include <hpx/runtime_components/create_component_helpers.hpp>
 
 #include <algorithm>
 #include <cstddef>

--- a/libs/full/distribution_policies/include/hpx/distribution_policies/target_distribution_policy.hpp
+++ b/libs/full/distribution_policies/include/hpx/distribution_policies/target_distribution_policy.hpp
@@ -15,8 +15,8 @@
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/naming_base.hpp>
+#include <hpx/modules/runtime_components.hpp>
 #include <hpx/modules/serialization.hpp>
-#include <hpx/runtime_components/create_component_helpers.hpp>
 
 #include <algorithm>
 #include <cstddef>

--- a/libs/full/include/include/hpx/include/applier.hpp
+++ b/libs/full/include/include/hpx/include/applier.hpp
@@ -8,7 +8,6 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/async_colocated/post_colocated.hpp>
-#include <hpx/async_colocated/post_colocated_callback.hpp>
+#include <hpx/modules/async_colocated.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/runtime_distributed/applier.hpp>

--- a/libs/full/include/include/hpx/include/async.hpp
+++ b/libs/full/include/include/hpx/include/async.hpp
@@ -9,6 +9,5 @@
 #include <hpx/config.hpp>
 #include <hpx/modules/async_local.hpp>
 
-#include <hpx/async_colocated/async_colocated.hpp>
-#include <hpx/async_colocated/async_colocated_callback.hpp>
+#include <hpx/modules/async_colocated.hpp>
 #include <hpx/modules/async_distributed.hpp>

--- a/libs/full/include/include/hpx/include/components.hpp
+++ b/libs/full/include/include/hpx/include/components.hpp
@@ -10,16 +10,11 @@
 #include <hpx/config.hpp>
 #include <hpx/include/actions.hpp>
 
-#include <hpx/runtime_components/component_factory.hpp>
-#include <hpx/runtime_components/component_registry.hpp>
-#include <hpx/runtime_components/derived_component_factory.hpp>
-#include <hpx/runtime_components/distributed_metadata_base.hpp>
-#include <hpx/runtime_components/new.hpp>
-
 #include <hpx/modules/actions.hpp>
 #include <hpx/modules/async_colocated.hpp>
 #include <hpx/modules/components.hpp>
 #include <hpx/modules/components_base.hpp>
+#include <hpx/modules/runtime_components.hpp>
 
 #include <hpx/runtime_distributed/copy_component.hpp>
 #include <hpx/runtime_distributed/migrate_component.hpp>

--- a/libs/full/include/include/hpx/include/components.hpp
+++ b/libs/full/include/include/hpx/include/components.hpp
@@ -16,9 +16,8 @@
 #include <hpx/runtime_components/distributed_metadata_base.hpp>
 #include <hpx/runtime_components/new.hpp>
 
-#include <hpx/async_colocated/server/destroy_component.hpp>
-
 #include <hpx/modules/actions.hpp>
+#include <hpx/modules/async_colocated.hpp>
 #include <hpx/modules/components.hpp>
 #include <hpx/modules/components_base.hpp>
 

--- a/libs/full/include/include/hpx/include/naming.hpp
+++ b/libs/full/include/include/hpx/include/naming.hpp
@@ -8,5 +8,5 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/agas/addressing_service.hpp>
+#include <hpx/modules/agas.hpp>
 #include <hpx/modules/naming_base.hpp>

--- a/libs/full/include/include/hpx/include/post.hpp
+++ b/libs/full/include/include/hpx/include/post.hpp
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/async_colocated/post_colocated.hpp>
-#include <hpx/async_colocated/post_colocated_callback.hpp>
+#include <hpx/modules/async_colocated.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/async_local.hpp>

--- a/libs/full/init_runtime/CMakeLists.txt
+++ b/libs/full/init_runtime/CMakeLists.txt
@@ -31,6 +31,7 @@ if(HPX_WITH_DISTRIBUTED_RUNTIME)
   set(init_runtime_sources ${init_runtime_sources} pre_main.cpp)
 
   set(init_runtime_optional_module_dependencies
+      hpx_agas
       hpx_actions_base
       hpx_async_distributed
       hpx_collectives
@@ -38,6 +39,7 @@ if(HPX_WITH_DISTRIBUTED_RUNTIME)
       hpx_naming
       hpx_parcelports
       hpx_performance_counters
+      hpx_runtime_components
       hpx_runtime_distributed
   )
 endif()

--- a/libs/full/init_runtime/src/init_logging.cpp
+++ b/libs/full/init_runtime/src/init_logging.cpp
@@ -12,8 +12,8 @@
 #include <hpx/modules/runtime_configuration.hpp>
 
 #if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
+#include <hpx/modules/runtime_components.hpp>
 #include <hpx/modules/threading_base.hpp>
-#include <hpx/runtime_components/console_logging.hpp>
 #endif
 
 #include <cstddef>

--- a/libs/full/init_runtime/src/pre_main.cpp
+++ b/libs/full/init_runtime/src/pre_main.cpp
@@ -9,12 +9,11 @@
 
 #if defined(HPX_HAVE_DISTRIBUTED_RUNTIME)
 
-#include <hpx/agas/addressing_service.hpp>
 #include <hpx/collectives/barrier.hpp>
 #include <hpx/collectives/channel_communicator.hpp>
 #include <hpx/collectives/create_communicator.hpp>
 #include <hpx/collectives/latch.hpp>
-#include <hpx/init_runtime/pre_main.hpp>
+#include <hpx/modules/agas.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/datastructures.hpp>
 #include <hpx/modules/errors.hpp>
@@ -30,6 +29,8 @@
 #include <hpx/runtime_distributed/applier.hpp>
 #include <hpx/runtime_distributed/runtime_fwd.hpp>
 #include <hpx/runtime_distributed/runtime_support.hpp>
+
+#include <hpx/init_runtime/pre_main.hpp>
 
 #include <string>
 #include <vector>

--- a/libs/full/init_runtime/src/pre_main.cpp
+++ b/libs/full/init_runtime/src/pre_main.cpp
@@ -19,12 +19,12 @@
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/logging.hpp>
 #include <hpx/modules/parcelset.hpp>
+#include <hpx/modules/runtime_components.hpp>
 #include <hpx/modules/runtime_configuration.hpp>
 #include <hpx/modules/runtime_local.hpp>
 #include <hpx/performance_counters/agas_counter_types.hpp>
 #include <hpx/performance_counters/parcelhandler_counter_types.hpp>
 #include <hpx/performance_counters/threadmanager_counter_types.hpp>
-#include <hpx/runtime_components/console_logging.hpp>
 #include <hpx/runtime_distributed.hpp>
 #include <hpx/runtime_distributed/applier.hpp>
 #include <hpx/runtime_distributed/runtime_fwd.hpp>

--- a/libs/full/lcos_distributed/CMakeLists.txt
+++ b/libs/full/lcos_distributed/CMakeLists.txt
@@ -32,6 +32,6 @@ add_hpx_module(
   COMPAT_HEADERS ${lcos_distributed_compat_headers}
   DEPENDENCIES hpx_core
   MODULE_DEPENDENCIES hpx_actions_base hpx_actions hpx_async_distributed
-                      hpx_components_base hpx_naming
+                      hpx_components_base hpx_naming hpx_runtime_components
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/full/lcos_distributed/include/hpx/lcos_distributed/channel.hpp
+++ b/libs/full/lcos_distributed/include/hpx/lcos_distributed/channel.hpp
@@ -15,7 +15,7 @@
 #include <hpx/modules/components.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/naming.hpp>
-#include <hpx/runtime_components/new.hpp>
+#include <hpx/modules/runtime_components.hpp>
 
 #include <cstddef>
 #include <type_traits>

--- a/libs/full/parcelport_gasnet/CMakeLists.txt
+++ b/libs/full/parcelport_gasnet/CMakeLists.txt
@@ -35,7 +35,7 @@ endif()
 include(HPX_AddModule)
 add_hpx_module(
   full parcelport_gasnet
-  GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_GEN OFF
   SOURCES ${parcelport_gasnet_sources}
   HEADERS ${parcelport_gasnet_headers}
   DEPENDENCIES hpx_core hpx_gasnet_base PkgConfig::GASNET

--- a/libs/full/parcelport_lci/CMakeLists.txt
+++ b/libs/full/parcelport_lci/CMakeLists.txt
@@ -57,7 +57,7 @@ hpx_setup_lci()
 include(HPX_AddModule)
 add_hpx_module(
   full parcelport_lci
-  GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_GEN OFF
   SOURCES ${parcelport_lci_sources}
   HEADERS ${parcelport_lci_headers}
   COMPAT_HEADERS ${parcelport_lci_compat_headers}

--- a/libs/full/parcelport_lcw/CMakeLists.txt
+++ b/libs/full/parcelport_lcw/CMakeLists.txt
@@ -52,7 +52,7 @@ hpx_setup_lcw()
 include(HPX_AddModule)
 add_hpx_module(
   full parcelport_lcw
-  GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_GEN OFF
   SOURCES ${parcelport_lcw_sources}
   HEADERS ${parcelport_lcw_headers}
   COMPAT_HEADERS ${parcelport_lcw_compat_headers}

--- a/libs/full/parcelport_mpi/CMakeLists.txt
+++ b/libs/full/parcelport_mpi/CMakeLists.txt
@@ -32,7 +32,7 @@ hpx_setup_mpi()
 include(HPX_AddModule)
 add_hpx_module(
   full parcelport_mpi
-  GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_GEN OFF
   SOURCES ${parcelport_mpi_sources}
   HEADERS ${parcelport_mpi_headers}
   COMPAT_HEADERS ${parcelport_mpi_compat_headers}

--- a/libs/full/parcelport_tcp/CMakeLists.txt
+++ b/libs/full/parcelport_tcp/CMakeLists.txt
@@ -26,7 +26,7 @@ set(parcelport_tcp_sources connection_handler_tcp.cpp locality.cpp
 include(HPX_AddModule)
 add_hpx_module(
   full parcelport_tcp
-  GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_GEN OFF
   SOURCES ${parcelport_tcp_sources}
   HEADERS ${parcelport_tcp_headers}
   COMPAT_HEADERS ${parcelport_tcp_compat_headers}

--- a/libs/full/performance_counters/include/hpx/performance_counters/agas_counter_types.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/agas_counter_types.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/agas/addressing_service.hpp>
+#include <hpx/modules/agas.hpp>
 
 namespace hpx { namespace performance_counters {
 

--- a/libs/full/performance_counters/src/agas_counter_types.cpp
+++ b/libs/full/performance_counters/src/agas_counter_types.cpp
@@ -6,8 +6,9 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
-#include <hpx/agas/addressing_service.hpp>
+#include <hpx/modules/agas.hpp>
 #include <hpx/modules/functional.hpp>
+
 #include <hpx/performance_counters/agas_counter_types.hpp>
 #include <hpx/performance_counters/component_namespace_counters.hpp>
 #include <hpx/performance_counters/counter_creators.hpp>

--- a/libs/full/performance_counters/src/component_namespace_counters.cpp
+++ b/libs/full/performance_counters/src/component_namespace_counters.cpp
@@ -7,14 +7,14 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
-#include <hpx/agas/addressing_service.hpp>
-#include <hpx/agas/agas_fwd.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/format.hpp>
+#include <hpx/modules/agas.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/naming.hpp>
+
 #include <hpx/performance_counters/agas_namespace_action_code.hpp>
 #include <hpx/performance_counters/component_namespace_counters.hpp>
 #include <hpx/performance_counters/counter_creators.hpp>

--- a/libs/full/performance_counters/src/counter_creators.cpp
+++ b/libs/full/performance_counters/src/counter_creators.cpp
@@ -5,16 +5,17 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
-#include <hpx/agas/agas_fwd.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/modules/actions.hpp>
 #include <hpx/modules/actions_base.hpp>
+#include <hpx/modules/agas.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/naming_base.hpp>
 #include <hpx/modules/type_support.hpp>
+
 #include <hpx/performance_counters/agas_namespace_action_code.hpp>
 #include <hpx/performance_counters/counter_creators.hpp>
 #include <hpx/performance_counters/counters.hpp>

--- a/libs/full/performance_counters/src/locality_namespace_counters.cpp
+++ b/libs/full/performance_counters/src/locality_namespace_counters.cpp
@@ -7,14 +7,14 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
-#include <hpx/agas/addressing_service.hpp>
-#include <hpx/agas/agas_fwd.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/format.hpp>
+#include <hpx/modules/agas.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/naming.hpp>
+
 #include <hpx/performance_counters/agas_namespace_action_code.hpp>
 #include <hpx/performance_counters/counter_creators.hpp>
 #include <hpx/performance_counters/counters.hpp>

--- a/libs/full/performance_counters/src/primary_namespace_counters.cpp
+++ b/libs/full/performance_counters/src/primary_namespace_counters.cpp
@@ -7,14 +7,14 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
-#include <hpx/agas/addressing_service.hpp>
-#include <hpx/agas/agas_fwd.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/format.hpp>
+#include <hpx/modules/agas.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/naming.hpp>
+
 #include <hpx/performance_counters/agas_namespace_action_code.hpp>
 #include <hpx/performance_counters/counter_creators.hpp>
 #include <hpx/performance_counters/counters.hpp>

--- a/libs/full/performance_counters/src/server/arithmetics_counter.cpp
+++ b/libs/full/performance_counters/src/server/arithmetics_counter.cpp
@@ -9,13 +9,13 @@
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/errors.hpp>
+#include <hpx/modules/runtime_components.hpp>
 #include <hpx/modules/runtime_local.hpp>
 #include <hpx/modules/string_util.hpp>
 #include <hpx/performance_counters/counter_creators.hpp>
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/performance_counters/performance_counter.hpp>
 #include <hpx/performance_counters/server/arithmetics_counter.hpp>
-#include <hpx/runtime_components/derived_component_factory.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/libs/full/performance_counters/src/server/arithmetics_counter_extended.cpp
+++ b/libs/full/performance_counters/src/server/arithmetics_counter_extended.cpp
@@ -7,13 +7,13 @@
 #include <hpx/config.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/errors.hpp>
+#include <hpx/modules/runtime_components.hpp>
 #include <hpx/modules/runtime_local.hpp>
 #include <hpx/modules/string_util.hpp>
 #include <hpx/performance_counters/counter_creators.hpp>
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/performance_counters/performance_counter.hpp>
 #include <hpx/performance_counters/server/arithmetics_counter_extended.hpp>
-#include <hpx/runtime_components/derived_component_factory.hpp>
 
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/count.hpp>

--- a/libs/full/performance_counters/src/server/elapsed_time_counter.cpp
+++ b/libs/full/performance_counters/src/server/elapsed_time_counter.cpp
@@ -7,11 +7,11 @@
 #include <hpx/config.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/errors.hpp>
+#include <hpx/modules/runtime_components.hpp>
 #include <hpx/modules/runtime_local.hpp>
 #include <hpx/performance_counters/counter_creators.hpp>
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/performance_counters/server/elapsed_time_counter.hpp>
-#include <hpx/runtime_components/derived_component_factory.hpp>
 
 #include <cstdint>
 

--- a/libs/full/performance_counters/src/server/raw_counter.cpp
+++ b/libs/full/performance_counters/src/server/raw_counter.cpp
@@ -8,10 +8,10 @@
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/functional.hpp>
+#include <hpx/modules/runtime_components.hpp>
 #include <hpx/modules/runtime_local.hpp>
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/performance_counters/server/raw_counter.hpp>
-#include <hpx/runtime_components/derived_component_factory.hpp>
 
 #include <cstdint>
 #include <utility>

--- a/libs/full/performance_counters/src/server/raw_values_counter.cpp
+++ b/libs/full/performance_counters/src/server/raw_values_counter.cpp
@@ -8,10 +8,10 @@
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/functional.hpp>
+#include <hpx/modules/runtime_components.hpp>
 #include <hpx/modules/runtime_local.hpp>
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/performance_counters/server/raw_values_counter.hpp>
-#include <hpx/runtime_components/derived_component_factory.hpp>
 
 #include <cstdint>
 #include <utility>

--- a/libs/full/performance_counters/src/server/statistics_counter.cpp
+++ b/libs/full/performance_counters/src/server/statistics_counter.cpp
@@ -10,13 +10,13 @@
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/functional.hpp>
+#include <hpx/modules/runtime_components.hpp>
 #include <hpx/modules/runtime_local.hpp>
 #include <hpx/modules/thread_support.hpp>
 #include <hpx/performance_counters/counter_creators.hpp>
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/performance_counters/performance_counter.hpp>
 #include <hpx/performance_counters/server/statistics_counter.hpp>
-#include <hpx/runtime_components/derived_component_factory.hpp>
 
 #include <boost/accumulators/accumulators.hpp>
 #include <boost/accumulators/statistics/max.hpp>

--- a/libs/full/performance_counters/src/symbol_namespace_counters.cpp
+++ b/libs/full/performance_counters/src/symbol_namespace_counters.cpp
@@ -7,13 +7,13 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
-#include <hpx/agas/addressing_service.hpp>
-#include <hpx/agas/agas_fwd.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/format.hpp>
+#include <hpx/modules/agas.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/functional.hpp>
+
 #include <hpx/performance_counters/agas_namespace_action_code.hpp>
 #include <hpx/performance_counters/counter_creators.hpp>
 #include <hpx/performance_counters/counters.hpp>

--- a/libs/full/runtime_components/CMakeLists.txt
+++ b/libs/full/runtime_components/CMakeLists.txt
@@ -19,11 +19,14 @@ set(runtime_components_headers
     hpx/runtime_components/create_component_helpers.hpp
     hpx/runtime_components/derived_component_factory.hpp
     hpx/runtime_components/distributed_metadata_base.hpp
+    hpx/runtime_components/macros.hpp
     hpx/runtime_components/new.hpp
     hpx/runtime_components/server/console_error_sink.hpp
     hpx/runtime_components/server/console_error_sink_singleton.hpp
     hpx/runtime_components/server/console_logging.hpp
 )
+
+set(runtime_components_macro_headers hpx/runtime_components/macros.hpp)
 
 # cmake-format: off
 set(runtime_components_compat_headers
@@ -56,7 +59,9 @@ include(HPX_AddModule)
 add_hpx_module(
   full runtime_components
   GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_MODULE_GEN ON
   HEADERS ${runtime_components_headers}
+  MACRO_HEADERS ${runtime_components_macro_headers}
   SOURCES ${runtime_components_sources}
   COMPAT_HEADERS ${runtime_components_compat_headers}
   DEPENDENCIES hpx_core

--- a/libs/full/runtime_components/include/hpx/runtime_components/component_factory.hpp
+++ b/libs/full/runtime_components/include/hpx/runtime_components/component_factory.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2024 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c) 2011      Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -41,123 +41,9 @@
 #else
 
 #include <hpx/config.hpp>
-#include <hpx/modules/preprocessor.hpp>
 #include <hpx/modules/runtime_configuration.hpp>
+
 #include <hpx/runtime_components/component_registry.hpp>
+#include <hpx/runtime_components/macros.hpp>
 
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
-
-///////////////////////////////////////////////////////////////////////////////
-// This macro is used create and to register a minimal component factory with
-// Hpx.Plugin.
-#define HPX_REGISTER_MINIMAL_COMPONENT_FACTORY(...)                            \
-    HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_(__VA_ARGS__)                       \
-    /**/
-
-#define HPX_REGISTER_COMPONENT(...)                                            \
-    HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_(__VA_ARGS__)                       \
-    /**/
-
-#define HPX_REGISTER_ENABLED_COMPONENT_FACTORY(ComponentType, componentname)   \
-    HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_3(ComponentType, componentname,     \
-        ::hpx::components::factory_state::enabled)                             \
-    HPX_DEFINE_GET_COMPONENT_TYPE(ComponentType::wrapped_type)                 \
-    /**/
-
-#define HPX_REGISTER_DISABLED_COMPONENT_FACTORY(ComponentType, componentname)  \
-    HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_3(ComponentType, componentname,     \
-        ::hpx::components::factory_state::disabled)                            \
-    HPX_DEFINE_GET_COMPONENT_TYPE(ComponentType::wrapped_type)                 \
-/**/
-
-///////////////////////////////////////////////////////////////////////////////
-#define HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_(...)                           \
-    HPX_PP_EXPAND(HPX_PP_CAT(HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_,          \
-        HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))                               \
-/**/
-#define HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_1(ComponentType)                \
-    HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_3(                                  \
-        ComponentType, ComponentType, ::hpx::components::factory_state::check) \
-    HPX_DEFINE_GET_COMPONENT_TYPE(ComponentType::wrapped_type)                 \
-/**/
-#define HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_2(ComponentType, componentname) \
-    HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_3(                                  \
-        ComponentType, componentname, ::hpx::components::factory_state::check) \
-    HPX_DEFINE_GET_COMPONENT_TYPE(ComponentType::wrapped_type)                 \
-/**/
-#define HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_3(                              \
-    ComponentType, componentname, state)                                       \
-    HPX_REGISTER_COMPONENT_HEAP(ComponentType)                                 \
-    HPX_REGISTER_COMPONENT_FACTORY(componentname)                              \
-    HPX_DEFINE_COMPONENT_NAME(ComponentType::type_holder, componentname)       \
-    HPX_REGISTER_MINIMAL_COMPONENT_REGISTRY_3(                                 \
-        ComponentType, componentname, state)                                   \
-/**/
-
-///////////////////////////////////////////////////////////////////////////////
-#define HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_DYNAMIC(...)                    \
-    HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_DYNAMIC_(__VA_ARGS__)               \
-/**/
-
-// same as above, just a better name
-
-/// This macro is used create and to register a minimal component factory for
-/// a component type which allows it to be remotely created using the
-/// hpx::new_<> function.
-/// This macro can be invoked with one, two or three arguments
-#define HPX_REGISTER_COMPONENT_DYNAMIC(...)                                    \
-    HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_DYNAMIC_(__VA_ARGS__)               \
-    /**/
-
-#define HPX_REGISTER_ENABLED_COMPONENT_FACTORY_DYNAMIC(                        \
-    ComponentType, componentname)                                              \
-    HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_DYNAMIC_3(ComponentType,            \
-        componentname, ::hpx::components::factory_state::enabled)              \
-    HPX_DEFINE_GET_COMPONENT_TYPE(ComponentType::wrapped_type)                 \
-    /**/
-
-#define HPX_REGISTER_DISABLED_COMPONENT_FACTORY_DYNAMIC(                       \
-    ComponentType, componentname)                                              \
-    HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_DYNAMIC_3(ComponentType,            \
-        componentname, ::hpx::components::factory_state::disabled)             \
-    HPX_DEFINE_GET_COMPONENT_TYPE(ComponentType::wrapped_type)                 \
-    /**/
-
-#define HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_DYNAMIC_(...)                   \
-    HPX_PP_EXPAND(HPX_PP_CAT(HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_DYNAMIC_,  \
-        HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))                               \
-/**/
-#define HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_DYNAMIC_1(ComponentType)        \
-    HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_DYNAMIC_3(                          \
-        ComponentType, ComponentType, ::hpx::components::factory_state::check) \
-    HPX_DEFINE_GET_COMPONENT_TYPE(ComponentType::wrapped_type)                 \
-/**/
-#define HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_DYNAMIC_2(                      \
-    ComponentType, componentname)                                              \
-    HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_DYNAMIC_3(                          \
-        ComponentType, componentname, ::hpx::components::factory_state::check) \
-    HPX_DEFINE_GET_COMPONENT_TYPE(ComponentType::wrapped_type)                 \
-/**/
-#define HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_DYNAMIC_3(                      \
-    ComponentType, componentname, state)                                       \
-    HPX_REGISTER_COMPONENT_HEAP(ComponentType)                                 \
-    HPX_DEFINE_COMPONENT_NAME(ComponentType::type_holder, componentname)       \
-    HPX_REGISTER_MINIMAL_COMPONENT_REGISTRY_DYNAMIC_3(                         \
-        ComponentType, componentname, state)                                   \
-    /**/
-
-#else    // COMPUTE DEVICE CODE
-
-#define HPX_REGISTER_COMPONENT(...)
-#define HPX_REGISTER_ENABLED_COMPONENT_FACTORY(ComponentType, componentname)
-#define HPX_REGISTER_DISABLED_COMPONENT_FACTORY(ComponentType, componentname)
-#define HPX_REGISTER_MINIMAL_COMPONENT_FACTORY(...)
-#define HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_DYNAMIC(...)
-#define HPX_REGISTER_COMPONENT_DYNAMIC(...)
-#define HPX_REGISTER_ENABLED_COMPONENT_FACTORY_DYNAMIC(                        \
-    ComponentType, componentname)
-#define HPX_REGISTER_DISABLED_COMPONENT_FACTORY_DYNAMIC(                       \
-    ComponentType, componentname)
-
-#endif
 #endif

--- a/libs/full/runtime_components/include/hpx/runtime_components/component_registry.hpp
+++ b/libs/full/runtime_components/include/hpx/runtime_components/component_registry.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2024 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c) 2017      Thomas Heller
 //  Copyright (c) 2011      Bryce Lelbach
 //
@@ -11,8 +11,9 @@
 #include <hpx/config.hpp>
 #include <hpx/modules/async_colocated.hpp>
 #include <hpx/modules/components_base.hpp>
-#include <hpx/modules/preprocessor.hpp>
 #include <hpx/modules/runtime_configuration.hpp>
+
+#include <hpx/runtime_components/macros.hpp>
 
 #include <string>
 #include <vector>
@@ -38,7 +39,7 @@ namespace hpx::components {
     ///
     /// \tparam Component   The component type this registry should be
     ///                     responsible for.
-    template <typename Component, factory_state state>
+    HPX_CXX_EXPORT template <typename Component, factory_state state>
     struct component_registry : component_registry_base
     {
         /// \brief Return the ini-information for all contained components
@@ -90,54 +91,3 @@ namespace hpx::components {
         }
     };
 }    // namespace hpx::components
-
-///////////////////////////////////////////////////////////////////////////////
-/// This macro is used create and to register a minimal component registry with
-/// Hpx.Plugin.
-
-#define HPX_REGISTER_MINIMAL_COMPONENT_REGISTRY(...)                           \
-    HPX_REGISTER_MINIMAL_COMPONENT_REGISTRY_(__VA_ARGS__)                      \
-    /**/
-
-#define HPX_REGISTER_MINIMAL_COMPONENT_REGISTRY_(...)                          \
-    HPX_PP_EXPAND(HPX_PP_CAT(HPX_REGISTER_MINIMAL_COMPONENT_REGISTRY_,         \
-        HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))                               \
-    /**/
-
-#define HPX_REGISTER_MINIMAL_COMPONENT_REGISTRY_2(                             \
-    ComponentType, componentname)                                              \
-    HPX_REGISTER_MINIMAL_COMPONENT_REGISTRY_3(                                 \
-        ComponentType, componentname, ::hpx::components::factory_state::check) \
-/**/
-#define HPX_REGISTER_MINIMAL_COMPONENT_REGISTRY_3(                             \
-    ComponentType, componentname, state)                                       \
-    using componentname##_component_registry_type =                            \
-        hpx::components::component_registry<ComponentType, state>;             \
-    HPX_REGISTER_COMPONENT_REGISTRY(                                           \
-        componentname##_component_registry_type, componentname)                \
-    template struct hpx::components::component_registry<ComponentType, state>; \
-/**/
-
-///////////////////////////////////////////////////////////////////////////////
-#define HPX_REGISTER_MINIMAL_COMPONENT_REGISTRY_DYNAMIC(...)                   \
-    HPX_REGISTER_MINIMAL_COMPONENT_REGISTRY_DYNAMIC_(__VA_ARGS__)              \
-    /**/
-
-#define HPX_REGISTER_MINIMAL_COMPONENT_REGISTRY_DYNAMIC_(...)                  \
-    HPX_PP_EXPAND(HPX_PP_CAT(HPX_REGISTER_MINIMAL_COMPONENT_REGISTRY_DYNAMIC_, \
-        HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))                               \
-    /**/
-
-#define HPX_REGISTER_MINIMAL_COMPONENT_REGISTRY_DYNAMIC_2(                     \
-    ComponentType, componentname)                                              \
-    HPX_REGISTER_MINIMAL_COMPONENT_REGISTRY_DYNAMIC_3(                         \
-        ComponentType, componentname, ::hpx::components::factory_state::check) \
-/**/
-#define HPX_REGISTER_MINIMAL_COMPONENT_REGISTRY_DYNAMIC_3(                     \
-    ComponentType, componentname, state)                                       \
-    using componentname##_component_registry_type =                            \
-        hpx::components::component_registry<ComponentType, state>;             \
-    HPX_REGISTER_COMPONENT_REGISTRY_DYNAMIC(                                   \
-        componentname##_component_registry_type, componentname)                \
-    template struct hpx::components::component_registry<ComponentType, state>; \
-/**/

--- a/libs/full/runtime_components/include/hpx/runtime_components/component_registry.hpp
+++ b/libs/full/runtime_components/include/hpx/runtime_components/component_registry.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/async_colocated/server/destroy_component.hpp>
+#include <hpx/modules/async_colocated.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/preprocessor.hpp>
 #include <hpx/modules/runtime_configuration.hpp>
@@ -56,7 +56,7 @@ namespace hpx::components {
         bool get_component_info(std::vector<std::string>& fillini,
             std::string const& filepath, bool is_static = false) override
         {
-            using type_holder = typename Component::type_holder;
+            using type_holder = Component::type_holder;
 
             char const* name = get_component_name<type_holder>();
             char const* more = traits::component_config_data<Component>::call();
@@ -86,7 +86,7 @@ namespace hpx::components {
                 components::set_component_type<type_holder>(type);
             }
             components::enabled(type) = enabled;
-            components::deleter(type) = &server::destroy<Component>;
+            components::deleter(type) = &server::template destroy<Component>;
         }
     };
 }    // namespace hpx::components

--- a/libs/full/runtime_components/include/hpx/runtime_components/components_fwd.hpp
+++ b/libs/full/runtime_components/include/hpx/runtime_components/components_fwd.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2014 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c) 2011      Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -8,11 +8,6 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/components.hpp>
-#include <hpx/modules/runtime_configuration.hpp>
-
-#include <cstddef>
-#include <string>
 
 namespace hpx {
 
@@ -20,22 +15,23 @@ namespace hpx {
     namespace components {
 
         ///////////////////////////////////////////////////////////////////////
-        template <typename Component>
+        HPX_CXX_EXPORT template <typename Component>
         struct component_factory;
 
-        class runtime_support;
+        HPX_CXX_EXPORT class runtime_support;
 
         namespace stubs {
 
-            struct runtime_support;
+            HPX_CXX_EXPORT struct runtime_support;
         }    // namespace stubs
 
         namespace server {
 
-            class HPX_EXPORT runtime_support;
+            HPX_CXX_EXPORT class HPX_EXPORT runtime_support;
         }    // namespace server
 
     }    // namespace components
 
-    HPX_EXPORT components::server::runtime_support* get_runtime_support_ptr();
+    HPX_CXX_EXPORT HPX_EXPORT components::server::runtime_support*
+    get_runtime_support_ptr();
 }    // namespace hpx

--- a/libs/full/runtime_components/include/hpx/runtime_components/console_error_sink.hpp
+++ b/libs/full/runtime_components/include/hpx/runtime_components/console_error_sink.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c) 2011      Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -14,12 +14,13 @@
 #include <exception>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace components {
+namespace hpx::components {
 
     // Stub function which applies the console_error_sink action.
-    HPX_EXPORT void console_error_sink(
+    HPX_CXX_EXPORT HPX_EXPORT void console_error_sink(
         hpx::id_type const& dst, std::exception_ptr const& e);
 
     // Stub function which applies the console_error_sink action.
-    HPX_EXPORT void console_error_sink(std::exception_ptr const& e);
-}}    // namespace hpx::components
+    HPX_CXX_EXPORT HPX_EXPORT void console_error_sink(
+        std::exception_ptr const& e);
+}    // namespace hpx::components

--- a/libs/full/runtime_components/include/hpx/runtime_components/console_logging.hpp
+++ b/libs/full/runtime_components/include/hpx/runtime_components/console_logging.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -14,10 +14,10 @@
 #include <string>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace components {
+namespace hpx::components {
 
-    HPX_EXPORT void console_logging(
+    HPX_CXX_EXPORT HPX_EXPORT void console_logging(
         logging_destination dest, std::size_t level, std::string const& msg);
-    HPX_EXPORT void cleanup_logging();
-    HPX_EXPORT void activate_logging();
-}}    // namespace hpx::components
+    HPX_CXX_EXPORT HPX_EXPORT void cleanup_logging();
+    HPX_CXX_EXPORT HPX_EXPORT void activate_logging();
+}    // namespace hpx::components

--- a/libs/full/runtime_components/include/hpx/runtime_components/create_component_helpers.hpp
+++ b/libs/full/runtime_components/include/hpx/runtime_components/create_component_helpers.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/async_colocated/async_colocated_fwd.hpp>
+#include <hpx/modules/async_colocated.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/async_local.hpp>
 #include <hpx/modules/errors.hpp>

--- a/libs/full/runtime_components/include/hpx/runtime_components/create_component_helpers.hpp
+++ b/libs/full/runtime_components/include/hpx/runtime_components/create_component_helpers.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2020-2024 Hartmut Kaiser
+//  Copyright (c) 2020-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -33,10 +33,10 @@ namespace hpx::components {
 
     ///////////////////////////////////////////////////////////////////////////
     /// Asynchronously create a new instance of a component
-    template <typename Component, typename... Ts>
-    future<hpx::id_type> create_async(hpx::id_type const& gid, Ts&&... vs)
+    HPX_CXX_EXPORT template <typename Component, typename... Ts>
+    future<hpx::id_type> create_async(hpx::id_type const& id, Ts&&... vs)
     {
-        if (!naming::is_locality(gid))
+        if (!naming::is_locality(id))
         {
             HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "stubs::runtime_support::create_component_async",
@@ -47,14 +47,14 @@ namespace hpx::components {
         using action_type =
             server::create_component_action<Component, std::decay_t<Ts>...>;
 
-        return hpx::async<action_type>(gid, HPX_FORWARD(Ts, vs)...);
+        return hpx::async<action_type>(id, HPX_FORWARD(Ts, vs)...);
     }
 
-    template <bool WithCount, typename Component, typename... Ts>
+    HPX_CXX_EXPORT template <bool WithCount, typename Component, typename... Ts>
     future<std::vector<hpx::id_type>> bulk_create_async(
-        hpx::id_type const& gid, std::size_t count, Ts&&... vs)
+        hpx::id_type const& id, std::size_t count, Ts&&... vs)
     {
-        if (!naming::is_locality(gid))
+        if (!naming::is_locality(id))
         {
             HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                 "stubs::runtime_support::bulk_create_component_async",
@@ -65,53 +65,53 @@ namespace hpx::components {
         using action_type = server::bulk_create_component_action<WithCount,
             Component, std::decay_t<Ts>...>;
 
-        return hpx::async<action_type>(gid, count, HPX_FORWARD(Ts, vs)...);
+        return hpx::async<action_type>(id, count, HPX_FORWARD(Ts, vs)...);
     }
 
-    template <typename Component, typename... Ts>
-    hpx::id_type create(hpx::id_type const& gid, Ts&&... vs)
+    HPX_CXX_EXPORT template <typename Component, typename... Ts>
+    hpx::id_type create(hpx::id_type const& id, Ts&&... vs)
     {
-        return create_async<Component>(gid, HPX_FORWARD(Ts, vs)...).get();
+        return create_async<Component>(id, HPX_FORWARD(Ts, vs)...).get();
     }
 
-    template <bool WithCount, typename Component, typename... Ts>
+    HPX_CXX_EXPORT template <bool WithCount, typename Component, typename... Ts>
     std::vector<hpx::id_type> bulk_create(
-        hpx::id_type const& gid, std::size_t count, Ts&&... vs)
+        hpx::id_type const& id, std::size_t count, Ts&&... vs)
     {
         return bulk_create_async<WithCount, Component>(
-            gid, count, HPX_FORWARD(Ts, vs)...)
+            id, count, HPX_FORWARD(Ts, vs)...)
             .get();
     }
 
-    template <typename Component, typename... Ts>
+    HPX_CXX_EXPORT template <typename Component, typename... Ts>
     future<hpx::id_type> create_colocated_async(
-        hpx::id_type const& gid, Ts&&... vs)
+        hpx::id_type const& id, Ts&&... vs)
     {
         using action_type =
             server::create_component_action<Component, std::decay_t<Ts>...>;
 
         return hpx::detail::async_colocated<action_type>(
-            gid, HPX_FORWARD(Ts, vs)...);
+            id, HPX_FORWARD(Ts, vs)...);
     }
 
-    template <typename Component, typename... Ts>
-    static hpx::id_type create_colocated(hpx::id_type const& gid, Ts&&... vs)
+    HPX_CXX_EXPORT template <typename Component, typename... Ts>
+    hpx::id_type create_colocated(hpx::id_type const& id, Ts&&... vs)
     {
-        return create_colocated_async(gid, HPX_FORWARD(Ts, vs)...).get();
+        return create_colocated_async(id, HPX_FORWARD(Ts, vs)...).get();
     }
 
-    template <bool WithCount, typename Component, typename... Ts>
-    static future<std::vector<hpx::id_type>> bulk_create_colocated_async(
-        hpx::id_type const& gid, std::size_t count, Ts&&... vs)
+    HPX_CXX_EXPORT template <bool WithCount, typename Component, typename... Ts>
+    future<std::vector<hpx::id_type>> bulk_create_colocated_async(
+        hpx::id_type const& id, std::size_t count, Ts&&... vs)
     {
         using action_type = server::bulk_create_component_action<WithCount,
             Component, std::decay_t<Ts>...>;
 
         return hpx::detail::async_colocated<action_type>(
-            gid, count, HPX_FORWARD(Ts, vs)...);
+            id, count, HPX_FORWARD(Ts, vs)...);
     }
 
-    template <bool WithCount, typename Component, typename... Ts>
+    HPX_CXX_EXPORT template <bool WithCount, typename Component, typename... Ts>
     std::vector<hpx::id_type> bulk_create_colocated(
         hpx::id_type const& id, std::size_t count, Ts&&... vs)
     {

--- a/libs/full/runtime_components/include/hpx/runtime_components/derived_component_factory.hpp
+++ b/libs/full/runtime_components/include/hpx/runtime_components/derived_component_factory.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2024 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c) 2017      Thomas Heller
 //  Copyright (c) 2011      Bryce Lelbach
 //
@@ -10,82 +10,5 @@
 
 #include <hpx/config.hpp>
 
-#if !defined(HPX_COMPUTE_DEVICE_CODE)
-#include <hpx/modules/preprocessor.hpp>
 #include <hpx/runtime_components/component_factory.hpp>
-
-///////////////////////////////////////////////////////////////////////////////
-/// This macro is used create and to register a minimal component factory with
-/// Hpx.Plugin. This macro may be used if the registered component factory is
-/// the only factory to be exposed from a particular module. If more than one
-/// factory needs to be exposed the \a HPX_REGISTER_COMPONENT_FACTORY and
-/// \a HPX_REGISTER_COMPONENT_MODULE macros should be used instead.
-#define HPX_REGISTER_DERIVED_COMPONENT_FACTORY(...)                            \
-    HPX_REGISTER_DERIVED_COMPONENT_FACTORY_(__VA_ARGS__)                       \
-    /**/
-
-#define HPX_REGISTER_DERIVED_COMPONENT_FACTORY_(...)                           \
-    HPX_PP_EXPAND(HPX_PP_CAT(HPX_REGISTER_DERIVED_COMPONENT_FACTORY_,          \
-        HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))                               \
-    /**/
-
-#define HPX_REGISTER_DERIVED_COMPONENT_FACTORY_3(                              \
-    ComponentType, componentname, basecomponentname)                           \
-    HPX_REGISTER_DERIVED_COMPONENT_FACTORY_4(ComponentType, componentname,     \
-        basecomponentname, ::hpx::components::factory_state::check)            \
-    HPX_DEFINE_GET_COMPONENT_TYPE(ComponentType::wrapped_type)                 \
-    /**/
-
-#define HPX_REGISTER_DERIVED_COMPONENT_FACTORY_4(                              \
-    ComponentType, componentname, basecomponentname, state)                    \
-    HPX_REGISTER_COMPONENT_HEAP(ComponentType)                                 \
-    HPX_REGISTER_COMPONENT_FACTORY(componentname)                              \
-    HPX_DEFINE_COMPONENT_NAME(                                                 \
-        ComponentType::type_holder, componentname, basecomponentname)          \
-    HPX_REGISTER_MINIMAL_COMPONENT_REGISTRY_3(                                 \
-        ComponentType, componentname, state)                                   \
-    /**/
-
-///////////////////////////////////////////////////////////////////////////////
-#define HPX_REGISTER_DERIVED_COMPONENT_FACTORY_DYNAMIC(...)                    \
-    HPX_REGISTER_DERIVED_COMPONENT_FACTORY_DYNAMIC_(__VA_ARGS__)               \
-    /**/
-
-#define HPX_REGISTER_DERIVED_COMPONENT_FACTORY_DYNAMIC_(...)                   \
-    HPX_PP_EXPAND(HPX_PP_CAT(HPX_REGISTER_DERIVED_COMPONENT_FACTORY_DYNAMIC_,  \
-        HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))                               \
-    /**/
-
-#define HPX_REGISTER_DERIVED_COMPONENT_FACTORY_DYNAMIC_3(                      \
-    ComponentType, componentname, basecomponentname)                           \
-    HPX_REGISTER_DERIVED_COMPONENT_FACTORY_DYNAMIC_4(ComponentType,            \
-        componentname, basecomponentname,                                      \
-        ::hpx::components::factory_state::check)                               \
-    HPX_DEFINE_GET_COMPONENT_TYPE(ComponentType::wrapped_type)                 \
-    /**/
-
-#define HPX_REGISTER_DERIVED_COMPONENT_FACTORY_DYNAMIC_4(                      \
-    ComponentType, componentname, basecomponentname, state)                    \
-    HPX_REGISTER_COMPONENT_HEAP(ComponentType)                                 \
-    HPX_DEFINE_COMPONENT_NAME(                                                 \
-        ComponentType::type_holder, componentname, basecomponentname)          \
-    HPX_REGISTER_MINIMAL_COMPONENT_REGISTRY_DYNAMIC_3(                         \
-        ComponentType, componentname, state)                                   \
-    /**/
-
-#else    // COMPUTE DEVICE CODE
-
-#define HPX_REGISTER_DERIVED_COMPONENT_FACTORY(...)
-#define HPX_REGISTER_DERIVED_COMPONENT_FACTORY_(...)
-#define HPX_REGISTER_DERIVED_COMPONENT_FACTORY_3(                              \
-    ComponentType, componentname, basecomponentname)
-#define HPX_REGISTER_DERIVED_COMPONENT_FACTORY_4(                              \
-    ComponentType, componentname, basecomponentname, state)
-#define HPX_REGISTER_DERIVED_COMPONENT_FACTORY_DYNAMIC(...)
-#define HPX_REGISTER_DERIVED_COMPONENT_FACTORY_DYNAMIC_(...)
-#define HPX_REGISTER_DERIVED_COMPONENT_FACTORY_DYNAMIC_3(                      \
-    ComponentType, componentname, basecomponentname)
-#define HPX_REGISTER_DERIVED_COMPONENT_FACTORY_DYNAMIC_4(                      \
-    ComponentType, componentname, basecomponentname, state)
-
-#endif
+#include <hpx/runtime_components/macros.hpp>

--- a/libs/full/runtime_components/include/hpx/runtime_components/distributed_metadata_base.hpp
+++ b/libs/full/runtime_components/include/hpx/runtime_components/distributed_metadata_base.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2024 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -12,14 +12,15 @@
 #include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/components_base.hpp>
-#include <hpx/modules/preprocessor.hpp>
+
+#include <hpx/runtime_components/macros.hpp>
 
 #include <type_traits>
 
 namespace hpx::components::server {
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename ConfigData, typename Derived = void>
+    HPX_CXX_EXPORT template <typename ConfigData, typename Derived = void>
     class distributed_metadata_base
       : public hpx::components::component_base<
             std::conditional_t<std::is_void_v<Derived>,
@@ -36,7 +37,7 @@ namespace hpx::components::server {
         {
         }
 
-        /// Retrieve the configuration data.
+        // Retrieve the configuration data.
         ConfigData get() const
         {
             return data_;
@@ -48,48 +49,3 @@ namespace hpx::components::server {
         ConfigData data_;
     };
 }    // namespace hpx::components::server
-
-#define HPX_DISTRIBUTED_METADATA_DECLARATION(...)                              \
-    HPX_DISTRIBUTED_METADATA_DECLARATION_(__VA_ARGS__)                         \
-    /**/
-#define HPX_DISTRIBUTED_METADATA_DECLARATION_(...)                             \
-    HPX_PP_EXPAND(HPX_PP_CAT(HPX_DISTRIBUTED_METADATA_DECLARATION_,            \
-        HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))                               \
-    /**/
-
-#define HPX_DISTRIBUTED_METADATA_DECLARATION_1(config)                         \
-    HPX_DISTRIBUTED_METADATA_DECLARATION_2(config, config)                     \
-    /**/
-#define HPX_DISTRIBUTED_METADATA_DECLARATION_2(config, name)                   \
-    HPX_REGISTER_ACTION_DECLARATION(                                           \
-        ::hpx::components::server::distributed_metadata_base<                  \
-            config>::get_action,                                               \
-        HPX_PP_CAT(__distributed_metadata_get_action_, name))                  \
-    HPX_REGISTER_ACTION_DECLARATION(                                           \
-        ::hpx::lcos::base_lco_with_value<config>::set_value_action,            \
-        HPX_PP_CAT(__set_value_distributed_metadata_config_data_, name))       \
-    /**/
-
-#define HPX_DISTRIBUTED_METADATA(...)                                          \
-    HPX_DISTRIBUTED_METADATA_(__VA_ARGS__)                                     \
-    /**/
-#define HPX_DISTRIBUTED_METADATA_(...)                                         \
-    HPX_PP_EXPAND(HPX_PP_CAT(                                                  \
-        HPX_DISTRIBUTED_METADATA_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))    \
-    /**/
-
-#define HPX_DISTRIBUTED_METADATA_1(config)                                     \
-    HPX_DISTRIBUTED_METADATA_2(config, config)                                 \
-    /**/
-#define HPX_DISTRIBUTED_METADATA_2(config, name)                               \
-    HPX_REGISTER_ACTION(::hpx::components::server::distributed_metadata_base<  \
-                            config>::get_action,                               \
-        HPX_PP_CAT(__distributed_metadata_get_action_, name))                  \
-    HPX_REGISTER_ACTION(                                                       \
-        ::hpx::lcos::base_lco_with_value<config>::set_value_action,            \
-        HPX_PP_CAT(__set_value_distributed_metadata_config_data_, name))       \
-    typedef ::hpx::components::component<                                      \
-        ::hpx::components::server::distributed_metadata_base<config>>          \
-        HPX_PP_CAT(__distributed_metadata_, name);                             \
-    HPX_REGISTER_COMPONENT(HPX_PP_CAT(__distributed_metadata_, name))          \
-    /**/

--- a/libs/full/runtime_components/include/hpx/runtime_components/macros.hpp
+++ b/libs/full/runtime_components/include/hpx/runtime_components/macros.hpp
@@ -1,0 +1,310 @@
+//  Copyright (c) 2007-2026 Hartmut Kaiser
+//  Copyright (c) 2011      Bryce Lelbach
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/modules/preprocessor.hpp>
+
+#include <hpx/components_base/macros.hpp>
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+
+///////////////////////////////////////////////////////////////////////////////
+// from component_factory.hpp
+
+// This macro is used create and to register a minimal component factory with
+// Hpx.Plugin.
+#define HPX_REGISTER_MINIMAL_COMPONENT_FACTORY(...)                            \
+    HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_(__VA_ARGS__)                       \
+    /**/
+
+#define HPX_REGISTER_COMPONENT(...)                                            \
+    HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_(__VA_ARGS__)                       \
+    /**/
+
+#define HPX_REGISTER_ENABLED_COMPONENT_FACTORY(ComponentType, componentname)   \
+    HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_3(ComponentType, componentname,     \
+        ::hpx::components::factory_state::enabled)                             \
+    HPX_DEFINE_GET_COMPONENT_TYPE(ComponentType::wrapped_type)                 \
+    /**/
+
+#define HPX_REGISTER_DISABLED_COMPONENT_FACTORY(ComponentType, componentname)  \
+    HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_3(ComponentType, componentname,     \
+        ::hpx::components::factory_state::disabled)                            \
+    HPX_DEFINE_GET_COMPONENT_TYPE(ComponentType::wrapped_type)                 \
+/**/
+
+///////////////////////////////////////////////////////////////////////////////
+#define HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_(...)                           \
+    HPX_PP_EXPAND(HPX_PP_CAT(HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_,          \
+        HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))                               \
+/**/
+#define HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_1(ComponentType)                \
+    HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_3(                                  \
+        ComponentType, ComponentType, ::hpx::components::factory_state::check) \
+    HPX_DEFINE_GET_COMPONENT_TYPE(ComponentType::wrapped_type)                 \
+/**/
+#define HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_2(ComponentType, componentname) \
+    HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_3(                                  \
+        ComponentType, componentname, ::hpx::components::factory_state::check) \
+    HPX_DEFINE_GET_COMPONENT_TYPE(ComponentType::wrapped_type)                 \
+/**/
+#define HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_3(                              \
+    ComponentType, componentname, state)                                       \
+    HPX_REGISTER_COMPONENT_HEAP(ComponentType)                                 \
+    HPX_REGISTER_COMPONENT_FACTORY(componentname)                              \
+    HPX_DEFINE_COMPONENT_NAME(ComponentType::type_holder, componentname)       \
+    HPX_REGISTER_MINIMAL_COMPONENT_REGISTRY_3(                                 \
+        ComponentType, componentname, state)                                   \
+/**/
+
+///////////////////////////////////////////////////////////////////////////////
+#define HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_DYNAMIC(...)                    \
+    HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_DYNAMIC_(__VA_ARGS__)               \
+/**/
+
+// same as above, just a better name
+
+/// This macro is used create and to register a minimal component factory for
+/// a component type which allows it to be remotely created using the
+/// hpx::new_<> function.
+/// This macro can be invoked with one, two or three arguments
+#define HPX_REGISTER_COMPONENT_DYNAMIC(...)                                    \
+    HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_DYNAMIC_(__VA_ARGS__)               \
+    /**/
+
+#define HPX_REGISTER_ENABLED_COMPONENT_FACTORY_DYNAMIC(                        \
+    ComponentType, componentname)                                              \
+    HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_DYNAMIC_3(ComponentType,            \
+        componentname, ::hpx::components::factory_state::enabled)              \
+    HPX_DEFINE_GET_COMPONENT_TYPE(ComponentType::wrapped_type)                 \
+    /**/
+
+#define HPX_REGISTER_DISABLED_COMPONENT_FACTORY_DYNAMIC(                       \
+    ComponentType, componentname)                                              \
+    HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_DYNAMIC_3(ComponentType,            \
+        componentname, ::hpx::components::factory_state::disabled)             \
+    HPX_DEFINE_GET_COMPONENT_TYPE(ComponentType::wrapped_type)                 \
+    /**/
+
+#define HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_DYNAMIC_(...)                   \
+    HPX_PP_EXPAND(HPX_PP_CAT(HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_DYNAMIC_,  \
+        HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))                               \
+/**/
+#define HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_DYNAMIC_1(ComponentType)        \
+    HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_DYNAMIC_3(                          \
+        ComponentType, ComponentType, ::hpx::components::factory_state::check) \
+    HPX_DEFINE_GET_COMPONENT_TYPE(ComponentType::wrapped_type)                 \
+/**/
+#define HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_DYNAMIC_2(                      \
+    ComponentType, componentname)                                              \
+    HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_DYNAMIC_3(                          \
+        ComponentType, componentname, ::hpx::components::factory_state::check) \
+    HPX_DEFINE_GET_COMPONENT_TYPE(ComponentType::wrapped_type)                 \
+/**/
+#define HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_DYNAMIC_3(                      \
+    ComponentType, componentname, state)                                       \
+    HPX_REGISTER_COMPONENT_HEAP(ComponentType)                                 \
+    HPX_DEFINE_COMPONENT_NAME(ComponentType::type_holder, componentname)       \
+    HPX_REGISTER_MINIMAL_COMPONENT_REGISTRY_DYNAMIC_3(                         \
+        ComponentType, componentname, state)                                   \
+    /**/
+
+#else    // COMPUTE DEVICE CODE
+
+#define HPX_REGISTER_COMPONENT(...)
+#define HPX_REGISTER_ENABLED_COMPONENT_FACTORY(ComponentType, componentname)
+#define HPX_REGISTER_DISABLED_COMPONENT_FACTORY(ComponentType, componentname)
+#define HPX_REGISTER_MINIMAL_COMPONENT_FACTORY(...)
+#define HPX_REGISTER_MINIMAL_COMPONENT_FACTORY_DYNAMIC(...)
+#define HPX_REGISTER_COMPONENT_DYNAMIC(...)
+#define HPX_REGISTER_ENABLED_COMPONENT_FACTORY_DYNAMIC(                        \
+    ComponentType, componentname)
+#define HPX_REGISTER_DISABLED_COMPONENT_FACTORY_DYNAMIC(                       \
+    ComponentType, componentname)
+
+#endif
+
+///////////////////////////////////////////////////////////////////////////////
+// from component_registry.hpp
+
+/// This macro is used create and to register a minimal component registry with
+/// Hpx.Plugin.
+
+#define HPX_REGISTER_MINIMAL_COMPONENT_REGISTRY(...)                           \
+    HPX_REGISTER_MINIMAL_COMPONENT_REGISTRY_(__VA_ARGS__)                      \
+    /**/
+
+#define HPX_REGISTER_MINIMAL_COMPONENT_REGISTRY_(...)                          \
+    HPX_PP_EXPAND(HPX_PP_CAT(HPX_REGISTER_MINIMAL_COMPONENT_REGISTRY_,         \
+        HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))                               \
+    /**/
+
+#define HPX_REGISTER_MINIMAL_COMPONENT_REGISTRY_2(                             \
+    ComponentType, componentname)                                              \
+    HPX_REGISTER_MINIMAL_COMPONENT_REGISTRY_3(                                 \
+        ComponentType, componentname, ::hpx::components::factory_state::check) \
+/**/
+#define HPX_REGISTER_MINIMAL_COMPONENT_REGISTRY_3(                             \
+    ComponentType, componentname, state)                                       \
+    using componentname##_component_registry_type =                            \
+        hpx::components::component_registry<ComponentType, state>;             \
+    HPX_REGISTER_COMPONENT_REGISTRY(                                           \
+        componentname##_component_registry_type, componentname)                \
+    template struct hpx::components::component_registry<ComponentType, state>; \
+/**/
+
+///////////////////////////////////////////////////////////////////////////////
+#define HPX_REGISTER_MINIMAL_COMPONENT_REGISTRY_DYNAMIC(...)                   \
+    HPX_REGISTER_MINIMAL_COMPONENT_REGISTRY_DYNAMIC_(__VA_ARGS__)              \
+    /**/
+
+#define HPX_REGISTER_MINIMAL_COMPONENT_REGISTRY_DYNAMIC_(...)                  \
+    HPX_PP_EXPAND(HPX_PP_CAT(HPX_REGISTER_MINIMAL_COMPONENT_REGISTRY_DYNAMIC_, \
+        HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))                               \
+    /**/
+
+#define HPX_REGISTER_MINIMAL_COMPONENT_REGISTRY_DYNAMIC_2(                     \
+    ComponentType, componentname)                                              \
+    HPX_REGISTER_MINIMAL_COMPONENT_REGISTRY_DYNAMIC_3(                         \
+        ComponentType, componentname, ::hpx::components::factory_state::check) \
+/**/
+#define HPX_REGISTER_MINIMAL_COMPONENT_REGISTRY_DYNAMIC_3(                     \
+    ComponentType, componentname, state)                                       \
+    using componentname##_component_registry_type =                            \
+        hpx::components::component_registry<ComponentType, state>;             \
+    HPX_REGISTER_COMPONENT_REGISTRY_DYNAMIC(                                   \
+        componentname##_component_registry_type, componentname)                \
+    template struct hpx::components::component_registry<ComponentType, state>; \
+    /**/
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+///////////////////////////////////////////////////////////////////////////////
+// from derived_component_factory.hpp
+
+/// This macro is used create and to register a minimal component factory with
+/// Hpx.Plugin. This macro may be used if the registered component factory is
+/// the only factory to be exposed from a particular module. If more than one
+/// factory needs to be exposed the \a HPX_REGISTER_COMPONENT_FACTORY and
+/// \a HPX_REGISTER_COMPONENT_MODULE macros should be used instead.
+#define HPX_REGISTER_DERIVED_COMPONENT_FACTORY(...)                            \
+    HPX_REGISTER_DERIVED_COMPONENT_FACTORY_(__VA_ARGS__)                       \
+    /**/
+
+#define HPX_REGISTER_DERIVED_COMPONENT_FACTORY_(...)                           \
+    HPX_PP_EXPAND(HPX_PP_CAT(HPX_REGISTER_DERIVED_COMPONENT_FACTORY_,          \
+        HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))                               \
+    /**/
+
+#define HPX_REGISTER_DERIVED_COMPONENT_FACTORY_3(                              \
+    ComponentType, componentname, basecomponentname)                           \
+    HPX_REGISTER_DERIVED_COMPONENT_FACTORY_4(ComponentType, componentname,     \
+        basecomponentname, ::hpx::components::factory_state::check)            \
+    HPX_DEFINE_GET_COMPONENT_TYPE(ComponentType::wrapped_type)                 \
+    /**/
+
+#define HPX_REGISTER_DERIVED_COMPONENT_FACTORY_4(                              \
+    ComponentType, componentname, basecomponentname, state)                    \
+    HPX_REGISTER_COMPONENT_HEAP(ComponentType)                                 \
+    HPX_REGISTER_COMPONENT_FACTORY(componentname)                              \
+    HPX_DEFINE_COMPONENT_NAME(                                                 \
+        ComponentType::type_holder, componentname, basecomponentname)          \
+    HPX_REGISTER_MINIMAL_COMPONENT_REGISTRY_3(                                 \
+        ComponentType, componentname, state)                                   \
+    /**/
+
+///////////////////////////////////////////////////////////////////////////////
+#define HPX_REGISTER_DERIVED_COMPONENT_FACTORY_DYNAMIC(...)                    \
+    HPX_REGISTER_DERIVED_COMPONENT_FACTORY_DYNAMIC_(__VA_ARGS__)               \
+    /**/
+
+#define HPX_REGISTER_DERIVED_COMPONENT_FACTORY_DYNAMIC_(...)                   \
+    HPX_PP_EXPAND(HPX_PP_CAT(HPX_REGISTER_DERIVED_COMPONENT_FACTORY_DYNAMIC_,  \
+        HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))                               \
+    /**/
+
+#define HPX_REGISTER_DERIVED_COMPONENT_FACTORY_DYNAMIC_3(                      \
+    ComponentType, componentname, basecomponentname)                           \
+    HPX_REGISTER_DERIVED_COMPONENT_FACTORY_DYNAMIC_4(ComponentType,            \
+        componentname, basecomponentname,                                      \
+        ::hpx::components::factory_state::check)                               \
+    HPX_DEFINE_GET_COMPONENT_TYPE(ComponentType::wrapped_type)                 \
+    /**/
+
+#define HPX_REGISTER_DERIVED_COMPONENT_FACTORY_DYNAMIC_4(                      \
+    ComponentType, componentname, basecomponentname, state)                    \
+    HPX_REGISTER_COMPONENT_HEAP(ComponentType)                                 \
+    HPX_DEFINE_COMPONENT_NAME(                                                 \
+        ComponentType::type_holder, componentname, basecomponentname)          \
+    HPX_REGISTER_MINIMAL_COMPONENT_REGISTRY_DYNAMIC_3(                         \
+        ComponentType, componentname, state)                                   \
+    /**/
+
+#else    // COMPUTE DEVICE CODE
+
+#define HPX_REGISTER_DERIVED_COMPONENT_FACTORY(...)
+#define HPX_REGISTER_DERIVED_COMPONENT_FACTORY_(...)
+#define HPX_REGISTER_DERIVED_COMPONENT_FACTORY_3(                              \
+    ComponentType, componentname, basecomponentname)
+#define HPX_REGISTER_DERIVED_COMPONENT_FACTORY_4(                              \
+    ComponentType, componentname, basecomponentname, state)
+#define HPX_REGISTER_DERIVED_COMPONENT_FACTORY_DYNAMIC(...)
+#define HPX_REGISTER_DERIVED_COMPONENT_FACTORY_DYNAMIC_(...)
+#define HPX_REGISTER_DERIVED_COMPONENT_FACTORY_DYNAMIC_3(                      \
+    ComponentType, componentname, basecomponentname)
+#define HPX_REGISTER_DERIVED_COMPONENT_FACTORY_DYNAMIC_4(                      \
+    ComponentType, componentname, basecomponentname, state)
+
+#endif
+
+////////////////////////////////////////////////////////////////////////////////
+// from distributed_metadata_base.hpp
+#define HPX_DISTRIBUTED_METADATA_DECLARATION(...)                              \
+    HPX_DISTRIBUTED_METADATA_DECLARATION_(__VA_ARGS__)                         \
+    /**/
+#define HPX_DISTRIBUTED_METADATA_DECLARATION_(...)                             \
+    HPX_PP_EXPAND(HPX_PP_CAT(HPX_DISTRIBUTED_METADATA_DECLARATION_,            \
+        HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))                               \
+    /**/
+
+#define HPX_DISTRIBUTED_METADATA_DECLARATION_1(config)                         \
+    HPX_DISTRIBUTED_METADATA_DECLARATION_2(config, config)                     \
+    /**/
+#define HPX_DISTRIBUTED_METADATA_DECLARATION_2(config, name)                   \
+    HPX_REGISTER_ACTION_DECLARATION(                                           \
+        ::hpx::components::server::distributed_metadata_base<                  \
+            config>::get_action,                                               \
+        HPX_PP_CAT(__distributed_metadata_get_action_, name))                  \
+    HPX_REGISTER_ACTION_DECLARATION(                                           \
+        ::hpx::lcos::base_lco_with_value<config>::set_value_action,            \
+        HPX_PP_CAT(__set_value_distributed_metadata_config_data_, name))       \
+    /**/
+
+#define HPX_DISTRIBUTED_METADATA(...)                                          \
+    HPX_DISTRIBUTED_METADATA_(__VA_ARGS__)                                     \
+    /**/
+#define HPX_DISTRIBUTED_METADATA_(...)                                         \
+    HPX_PP_EXPAND(HPX_PP_CAT(                                                  \
+        HPX_DISTRIBUTED_METADATA_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))    \
+    /**/
+
+#define HPX_DISTRIBUTED_METADATA_1(config)                                     \
+    HPX_DISTRIBUTED_METADATA_2(config, config)                                 \
+    /**/
+#define HPX_DISTRIBUTED_METADATA_2(config, name)                               \
+    HPX_REGISTER_ACTION(::hpx::components::server::distributed_metadata_base<  \
+                            config>::get_action,                               \
+        HPX_PP_CAT(__distributed_metadata_get_action_, name))                  \
+    HPX_REGISTER_ACTION(                                                       \
+        ::hpx::lcos::base_lco_with_value<config>::set_value_action,            \
+        HPX_PP_CAT(__set_value_distributed_metadata_config_data_, name))       \
+    typedef ::hpx::components::component<                                      \
+        ::hpx::components::server::distributed_metadata_base<config>>          \
+        HPX_PP_CAT(__distributed_metadata_, name);                             \
+    HPX_REGISTER_COMPONENT(HPX_PP_CAT(__distributed_metadata_, name))          \
+    /**/

--- a/libs/full/runtime_components/include/hpx/runtime_components/new.hpp
+++ b/libs/full/runtime_components/include/hpx/runtime_components/new.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -18,6 +18,7 @@
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/naming_base.hpp>
 #include <hpx/modules/type_support.hpp>
+
 #include <hpx/runtime_components/create_component_helpers.hpp>
 
 #include <algorithm>
@@ -319,7 +320,7 @@ namespace hpx::components {
             template <typename... Ts>
             static type call(Ts&&... ts)
             {
-                using component_type = typename Component::wrapping_type;
+                using component_type = Component::wrapping_type;
 
                 hpx::id_type id(components::server::create<component_type>(
                                     HPX_FORWARD(Ts, ts)...),
@@ -336,7 +337,7 @@ namespace hpx::components {
             template <typename... Ts>
             static type call(std::size_t count, Ts&&... ts)
             {
-                using component_type = typename Component::wrapping_type;
+                using component_type = Component::wrapping_type;
 
                 std::vector<hpx::id_type> result;
                 result.reserve(count);
@@ -352,6 +353,7 @@ namespace hpx::components {
             }
         };
 
+        ///////////////////////////////////////////////////////////////////////
         // same as above, just fully synchronous
         template <typename Component>
         struct local_new_component_sync
@@ -361,7 +363,7 @@ namespace hpx::components {
             template <typename... Ts>
             static type call(Ts&&... ts)
             {
-                using component_type = typename Component::wrapping_type;
+                using component_type = Component::wrapping_type;
 
                 hpx::id_type id(components::server::create<component_type>(
                                     HPX_FORWARD(Ts, ts)...),
@@ -379,7 +381,7 @@ namespace hpx::components {
             template <typename... Ts>
             static type call(std::size_t count, Ts&&... ts)
             {
-                using component_type = typename Component::wrapping_type;
+                using component_type = Component::wrapping_type;
 
                 std::vector<hpx::id_type> result;
                 result.reserve(count);
@@ -397,11 +399,9 @@ namespace hpx::components {
     }    // namespace detail
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Component, typename... Ts>
-    inline typename util::lazy_enable_if<
-        traits::is_component_or_component_array<Component>::value,
-        detail::new_component<Component>>::type
-    new_(id_type const& locality, Ts&&... vs)
+    HPX_CXX_EXPORT template <typename Component, typename... Ts>
+        requires(traits::is_component_or_component_array_v<Component>)
+    decltype(auto) new_(id_type const& locality, Ts&&... vs)
     {
         if (naming::get_locality_id_from_id(locality) ==
             agas::get_locality_id())
@@ -414,12 +414,11 @@ namespace hpx::components {
             locality, HPX_FORWARD(Ts, vs)...);
     }
 
-    template <typename Component, typename DistPolicy, typename... Ts>
-    inline typename util::lazy_enable_if<
-        traits::is_component_or_component_array<Component>::value &&
-            traits::is_distribution_policy<DistPolicy>::value,
-        detail::new_component<Component>>::type
-    new_(DistPolicy const& policy, Ts&&... vs)
+    HPX_CXX_EXPORT template <typename Component, typename DistPolicy,
+        typename... Ts>
+        requires(traits::is_component_or_component_array_v<Component> &&
+            traits::is_distribution_policy_v<DistPolicy>)
+    decltype(auto) new_(DistPolicy const& policy, Ts&&... vs)
     {
         return detail::new_component<Component>::call(
             policy, HPX_FORWARD(Ts, vs)...);
@@ -433,7 +432,7 @@ namespace hpx::components {
         struct new_client
         {
             using type = Client;
-            using component_type = typename Client::server_component_type;
+            using component_type = Client::server_component_type;
 
             template <typename... Ts>
             static type call(hpx::id_type const& locality, Ts&&... vs)
@@ -457,7 +456,7 @@ namespace hpx::components {
         struct new_client<Client[]>
         {
             using type = hpx::future<std::vector<Client>>;
-            using component_type = typename Client::server_component_type;
+            using component_type = Client::server_component_type;
 
             template <typename... Ts>
             static type call(Ts&&... vs)
@@ -477,8 +476,7 @@ namespace hpx::components {
         struct local_new_client
         {
             using type = Client;
-            using component_type =
-                typename Client::server_component_type::wrapping_type;
+            using component_type = Client::server_component_type::wrapping_type;
 
             template <typename... Ts>
             static type call(Ts&&... ts)
@@ -494,8 +492,7 @@ namespace hpx::components {
         struct local_new_client<Client[]>
         {
             using type = hpx::future<std::vector<Client>>;
-            using component_type =
-                typename Client::server_component_type::wrapping_type;
+            using component_type = Client::server_component_type::wrapping_type;
 
             template <typename... Ts>
             static type call(Ts&&... ts)
@@ -512,10 +509,9 @@ namespace hpx::components {
     }    // namespace detail
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Client, typename... Ts>
-    typename util::lazy_enable_if<traits::is_client_or_client_array_v<Client>,
-        detail::new_client<Client>>::type
-    new_(id_type const& locality, Ts&&... vs)
+    HPX_CXX_EXPORT template <typename Client, typename... Ts>
+        requires(traits::is_client_or_client_array_v<Client>)
+    decltype(auto) new_(id_type const& locality, Ts&&... vs)
     {
         if (naming::get_locality_id_from_id(locality) ==
             agas::get_locality_id())
@@ -528,11 +524,11 @@ namespace hpx::components {
             locality, HPX_FORWARD(Ts, vs)...);
     }
 
-    template <typename Client, typename DistPolicy, typename... Ts>
-    typename util::lazy_enable_if<traits::is_client_or_client_array_v<Client> &&
-            traits::is_distribution_policy_v<DistPolicy>,
-        detail::new_client<Client>>::type
-    new_(DistPolicy const& policy, Ts&&... vs)
+    HPX_CXX_EXPORT template <typename Client, typename DistPolicy,
+        typename... Ts>
+        requires(traits::is_client_or_client_array_v<Client> &&
+            traits::is_distribution_policy_v<DistPolicy>)
+    decltype(auto) new_(DistPolicy const& policy, Ts&&... vs)
     {
         return detail::new_client<Client>::call(policy, HPX_FORWARD(Ts, vs)...);
     }
@@ -541,41 +537,34 @@ namespace hpx::components {
     // Same as above, but just on this locality. This does not go through an
     // action, that means that the constructor arguments can be non-copyable and
     // non-movable.
-    template <typename Component>
-    typename util::lazy_enable_if<
-        traits::is_component_or_component_array_v<Component>,
-        detail::local_new_component<Component>>::type
-    local_new()
+    HPX_CXX_EXPORT template <typename Component>
+        requires(traits::is_component_or_component_array_v<Component>)
+    decltype(auto) local_new()
     {
         return detail::local_new_component<Component>::call();
     }
 
-    template <typename Component, typename T1, typename... Ts>
-    typename util::lazy_enable_if<
-        traits::is_component_or_component_array_v<Component> &&
-            !std::is_same_v<std::decay_t<T1>, launch::sync_policy>,
-        detail::local_new_component<Component>>::type
-    local_new(T1&& t1, Ts&&... ts)
+    HPX_CXX_EXPORT template <typename Component, typename T1, typename... Ts>
+        requires(traits::is_component_or_component_array_v<Component> &&
+            !std::is_same_v<std::decay_t<T1>, launch::sync_policy>)
+    decltype(auto) local_new(T1&& t1, Ts&&... ts)
     {
         return detail::local_new_component<Component>::call(
             HPX_FORWARD(T1, t1), HPX_FORWARD(Ts, ts)...);
     }
 
-    template <typename Component, typename... Ts>
-    typename util::lazy_enable_if<
-        traits::is_component_or_component_array_v<Component>,
-        detail::local_new_component_sync<Component>>::type
-    local_new(launch::sync_policy, Ts&&... ts)
+    HPX_CXX_EXPORT template <typename Component, typename... Ts>
+        requires(traits::is_component_or_component_array_v<Component>)
+    decltype(auto) local_new(launch::sync_policy, Ts&&... ts)
     {
         return detail::local_new_component_sync<Component>::call(
             HPX_FORWARD(Ts, ts)...);
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename Client, typename... Ts>
-    typename util::lazy_enable_if<traits::is_client_or_client_array_v<Client>,
-        detail::local_new_client<Client>>::type
-    local_new(Ts&&... ts)
+    HPX_CXX_EXPORT template <typename Client, typename... Ts>
+        requires(traits::is_client_or_client_array_v<Client>)
+    decltype(auto) local_new(Ts&&... ts)
     {
         return detail::local_new_client<Client>::call(HPX_FORWARD(Ts, ts)...);
     }
@@ -583,8 +572,8 @@ namespace hpx::components {
 
 namespace hpx {
 
-    using hpx::components::local_new;
-    using hpx::components::new_;
+    HPX_CXX_EXPORT using hpx::components::local_new;
+    HPX_CXX_EXPORT using hpx::components::new_;
 }    // namespace hpx
 
 #endif

--- a/libs/full/runtime_components/include/hpx/runtime_components/server/console_error_sink.hpp
+++ b/libs/full/runtime_components/include/hpx/runtime_components/server/console_error_sink.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -16,14 +16,15 @@
 #include <string>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace components { namespace server {
+namespace hpx::components::server {
 
     ///////////////////////////////////////////////////////////////////////////
     // console logging happens here
-    void console_error_sink(std::exception_ptr const&);
+    HPX_CXX_EXPORT void console_error_sink(std::exception_ptr const&);
 
-    HPX_DEFINE_PLAIN_ACTION(console_error_sink, console_error_sink_action);
-}}}    // namespace hpx::components::server
+    HPX_DEFINE_PLAIN_ACTION(
+        HPX_CXX_EXPORT, console_error_sink, console_error_sink_action);
+}    // namespace hpx::components::server
 
 HPX_ACTION_HAS_CRITICAL_PRIORITY(
     hpx::components::server::console_error_sink_action)

--- a/libs/full/runtime_components/include/hpx/runtime_components/server/console_error_sink_singleton.hpp
+++ b/libs/full/runtime_components/include/hpx/runtime_components/server/console_error_sink_singleton.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -16,22 +16,25 @@
 #include <utility>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace components { namespace server {
+namespace hpx::components::server {
 
     ///////////////////////////////////////////////////////////////////////////
-    class console_error_dispatcher
+    HPX_CXX_EXPORT class console_error_dispatcher
     {
     public:
-        HPX_NON_COPYABLE(console_error_dispatcher);
+        console_error_dispatcher(console_error_dispatcher const&) = delete;
+        console_error_dispatcher(console_error_dispatcher&&) = delete;
+        console_error_dispatcher& operator=(
+            console_error_dispatcher const&) = delete;
+        console_error_dispatcher& operator=(
+            console_error_dispatcher&&) = delete;
 
     public:
-        typedef util::spinlock mutex_type;
-        typedef hpx::function<void(std::string const&)> sink_type;
+        using mutex_type = util::spinlock;
+        using sink_type = hpx::function<void(std::string const&)>;
 
-        console_error_dispatcher()
-          : mtx_()
-        {
-        }
+        console_error_dispatcher() = default;
+        ~console_error_dispatcher() = default;
 
         template <typename F>
         sink_type set_error_sink(F&& sink)
@@ -55,5 +58,5 @@ namespace hpx { namespace components { namespace server {
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_EXPORT console_error_dispatcher& get_error_dispatcher();
-}}}    // namespace hpx::components::server
+    HPX_CXX_EXPORT HPX_EXPORT console_error_dispatcher& get_error_dispatcher();
+}    // namespace hpx::components::server

--- a/libs/full/runtime_components/include/hpx/runtime_components/server/console_logging.hpp
+++ b/libs/full/runtime_components/include/hpx/runtime_components/server/console_logging.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2025 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -15,6 +15,7 @@
 #include <hpx/modules/datastructures.hpp>
 #include <hpx/modules/logging.hpp>
 #include <hpx/modules/serialization.hpp>
+
 #include <hpx/runtime_components/console_logging.hpp>
 
 #include <cstddef>
@@ -25,10 +26,10 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx::components {
 
-    using message_type =
+    HPX_CXX_EXPORT using message_type =
         hpx::tuple<logging_destination, std::size_t, std::string>;
 
-    using messages_type = std::vector<message_type>;
+    HPX_CXX_EXPORT using messages_type = std::vector<message_type>;
 }    // namespace hpx::components
 
 //////////////////////////////////////////////////////////////////////////////
@@ -36,12 +37,12 @@ namespace hpx::components::server {
 
     ///////////////////////////////////////////////////////////////////////////
     // console logging happens here
-    void console_logging(messages_type const&);
+    HPX_CXX_EXPORT void console_logging(messages_type const&);
 
     ///////////////////////////////////////////////////////////////////////////
     // this type is a dummy template to avoid premature instantiation of the
     // serialization support instances
-    template <typename Dummy = void>
+    HPX_CXX_EXPORT template <typename Dummy = void>
     class console_logging_action
       : public actions::direct_action<void (*)(messages_type const&),
             console_logging, console_logging_action<Dummy>>
@@ -91,13 +92,16 @@ HPX_REGISTER_ACTION_DECLARATION(
 #if !defined(HPX_COMPUTE_DEVICE_CODE) && defined(HPX_HAVE_NETWORKING)
 ///////////////////////////////////////////////////////////////////////////
 // Logging does not make this locality black
-template <>
-struct hpx::traits::action_does_termination_detection<
-    hpx::components::server::console_logging_action<>>
-{
-    static constexpr bool call() noexcept
+namespace hpx::traits {
+
+    template <>
+    struct action_does_termination_detection<
+        hpx::components::server::console_logging_action<>>
     {
-        return true;
-    }
-};    // namespace hpx::traits
+        static constexpr bool call() noexcept
+        {
+            return true;
+        }
+    };    // namespace hpx::traits
+}    // namespace hpx::traits
 #endif

--- a/libs/full/runtime_components/src/component_registry.cpp
+++ b/libs/full/runtime_components/src/component_registry.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2024 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c) 2017      Thomas Heller
 //  Copyright (c) 2011      Bryce Lelbach
 //
@@ -12,6 +12,7 @@
 #include <hpx/modules/runtime_configuration.hpp>
 #include <hpx/modules/runtime_local.hpp>
 #include <hpx/modules/string_util.hpp>
+
 #include <hpx/runtime_components/component_registry.hpp>
 
 #include <algorithm>

--- a/libs/full/runtime_components/src/console_error_sink.cpp
+++ b/libs/full/runtime_components/src/console_error_sink.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c) 2011      Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -17,7 +17,7 @@
 #include <exception>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace components {
+namespace hpx::components {
 
     // Stub function which applies the console_error_sink action.
     void console_error_sink(
@@ -62,4 +62,4 @@ namespace hpx { namespace components {
             hpx::async<server::console_error_sink_action>(dst, e).get();
         }
     }
-}}    // namespace hpx::components
+}    // namespace hpx::components

--- a/libs/full/runtime_components/src/console_error_sink.cpp
+++ b/libs/full/runtime_components/src/console_error_sink.cpp
@@ -6,10 +6,11 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
-#include <hpx/agas/addressing_service.hpp>
+#include <hpx/modules/agas.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/runtime_local.hpp>
+
 #include <hpx/runtime_components/console_error_sink.hpp>
 #include <hpx/runtime_components/server/console_error_sink.hpp>
 

--- a/libs/full/runtime_components/src/console_logging.cpp
+++ b/libs/full/runtime_components/src/console_logging.cpp
@@ -33,7 +33,7 @@
 #include <hpx/config/warnings_prefix.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace components {
+namespace hpx::components {
 
     void fallback_console_logging_locked(
         messages_type const& msgs, std::string fail_msg = "")
@@ -346,4 +346,4 @@ namespace hpx { namespace components {
     {
         detail::logger().activate();
     }
-}}    // namespace hpx::components
+}    // namespace hpx::components

--- a/libs/full/runtime_components/src/console_logging.cpp
+++ b/libs/full/runtime_components/src/console_logging.cpp
@@ -6,8 +6,8 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
-#include <hpx/agas/addressing_service.hpp>
 #include <hpx/assert.hpp>
+#include <hpx/modules/agas.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/concurrency.hpp>
@@ -21,6 +21,7 @@
 #include <hpx/modules/thread_support.hpp>
 #include <hpx/modules/threadmanager.hpp>
 #include <hpx/modules/type_support.hpp>
+
 #include <hpx/runtime_components/console_logging.hpp>
 #include <hpx/runtime_components/server/console_logging.hpp>
 

--- a/libs/full/runtime_components/src/server/console_error_sink_server.cpp
+++ b/libs/full/runtime_components/src/server/console_error_sink_server.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -12,13 +12,14 @@
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/ini.hpp>
 #include <hpx/modules/runtime_local.hpp>
+
 #include <hpx/runtime_components/server/console_error_sink.hpp>
 #include <hpx/runtime_components/server/console_error_sink_singleton.hpp>
 
 #include <exception>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace components { namespace server {
+namespace hpx::components::server {
 
     ///////////////////////////////////////////////////////////////////////////
     // implementation of this console error sink
@@ -27,7 +28,7 @@ namespace hpx { namespace components { namespace server {
         // dispatch this error to registered functions
         get_error_dispatcher()(hpx::diagnostic_information(e));
     }
-}}}    // namespace hpx::components::server
+}    // namespace hpx::components::server
 
 ///////////////////////////////////////////////////////////////////////////////
 // This must be in global namespace

--- a/libs/full/runtime_components/src/server/console_error_sink_singleton.cpp
+++ b/libs/full/runtime_components/src/server/console_error_sink_singleton.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2025 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -6,6 +6,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/modules/static_reinit.hpp>
+
 #include <hpx/runtime_components/server/console_error_sink_singleton.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/full/runtime_components/src/server/console_logging_server.cpp
+++ b/libs/full/runtime_components/src/server/console_logging_server.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -13,6 +13,7 @@
 #include <hpx/modules/ini.hpp>
 #include <hpx/modules/logging.hpp>
 #include <hpx/modules/type_support.hpp>
+
 #include <hpx/runtime_components/console_logging.hpp>
 #include <hpx/runtime_components/server/console_logging.hpp>
 
@@ -23,7 +24,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 // definitions related to console logging
 
-namespace hpx { namespace util { namespace detail {
+namespace hpx::util::detail {
 
     struct log_lock_tag
     {
@@ -34,7 +35,7 @@ namespace hpx { namespace util { namespace detail {
         hpx::util::static_<hpx::util::spinlock, log_lock_tag> lock;
         return lock.get();
     }
-}}}    // namespace hpx::util::detail
+}    // namespace hpx::util::detail
 
 ///////////////////////////////////////////////////////////////////////////////
 // This must be in global namespace

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/agas/addressing_service.hpp>
+#include <hpx/modules/agas.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/io_service.hpp>
 #include <hpx/modules/parcelset.hpp>
@@ -18,6 +18,7 @@
 #include <hpx/performance_counters/query_counters.hpp>
 #include <hpx/performance_counters/registry.hpp>
 #include <hpx/runtime_components/server/console_error_sink_singleton.hpp>
+
 #include <hpx/runtime_distributed/applier.hpp>
 #include <hpx/runtime_distributed/find_localities.hpp>
 #include <hpx/runtime_distributed/runtime_fwd.hpp>

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed.hpp
@@ -13,11 +13,11 @@
 #include <hpx/modules/io_service.hpp>
 #include <hpx/modules/parcelset.hpp>
 #include <hpx/modules/parcelset_base.hpp>
+#include <hpx/modules/runtime_components.hpp>
 #include <hpx/modules/runtime_local.hpp>
 #include <hpx/modules/threading_base.hpp>
 #include <hpx/performance_counters/query_counters.hpp>
 #include <hpx/performance_counters/registry.hpp>
-#include <hpx/runtime_components/server/console_error_sink_singleton.hpp>
 
 #include <hpx/runtime_distributed/applier.hpp>
 #include <hpx/runtime_distributed/find_localities.hpp>

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/copy_component.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/copy_component.hpp
@@ -9,12 +9,13 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/async_colocated/async_colocated.hpp>
 #include <hpx/modules/actions_base.hpp>
+#include <hpx/modules/async_colocated.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/naming_base.hpp>
+
 #include <hpx/runtime_distributed/server/copy_component.hpp>
 
 #include <type_traits>

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/migrate_component.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/migrate_component.hpp
@@ -10,14 +10,15 @@
 
 #include <hpx/config.hpp>
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
-#include <hpx/async_colocated/async_colocated.hpp>
 #include <hpx/distribution_policies/target_distribution_policy.hpp>
 #include <hpx/modules/actions_base.hpp>
+#include <hpx/modules/async_colocated.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/components.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/naming_base.hpp>
+
 #include <hpx/runtime_distributed/server/migrate_component.hpp>
 
 #include <type_traits>

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/server/copy_component.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/server/copy_component.hpp
@@ -11,7 +11,7 @@
 #include <hpx/modules/components.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/naming_base.hpp>
-#include <hpx/runtime_components/components_fwd.hpp>
+#include <hpx/modules/runtime_components.hpp>
 #include <hpx/runtime_distributed/stubs/runtime_support.hpp>
 
 #include <memory>

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/server/runtime_support.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/server/runtime_support.hpp
@@ -9,10 +9,10 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/agas/agas_fwd.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/modules/actions.hpp>
 #include <hpx/modules/actions_base.hpp>
+#include <hpx/modules/agas.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/errors.hpp>
@@ -25,6 +25,7 @@
 #include <hpx/modules/synchronization.hpp>
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/runtime_components/components_fwd.hpp>
+
 #include <hpx/runtime_distributed/find_here.hpp>
 
 #include <atomic>

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/server/runtime_support.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/server/runtime_support.hpp
@@ -21,10 +21,10 @@
 #include <hpx/modules/plugin.hpp>
 #include <hpx/modules/plugin_factories.hpp>
 #include <hpx/modules/program_options.hpp>
+#include <hpx/modules/runtime_components.hpp>
 #include <hpx/modules/runtime_configuration.hpp>
 #include <hpx/modules/synchronization.hpp>
 #include <hpx/performance_counters/counters.hpp>
-#include <hpx/runtime_components/components_fwd.hpp>
 
 #include <hpx/runtime_distributed/find_here.hpp>
 

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/stubs/runtime_support.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/stubs/runtime_support.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/async_colocated/async_colocated_fwd.hpp>
+#include <hpx/modules/async_colocated.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/futures.hpp>
@@ -16,6 +16,7 @@
 #include <hpx/modules/naming_base.hpp>
 #include <hpx/modules/serialization.hpp>
 #include <hpx/modules/type_support.hpp>
+
 #include <hpx/runtime_distributed/server/runtime_support.hpp>
 
 #include <cstddef>

--- a/libs/full/runtime_distributed/src/applier.cpp
+++ b/libs/full/runtime_distributed/src/applier.cpp
@@ -8,9 +8,8 @@
 
 #include <hpx/config.hpp>
 
-#include <hpx/agas/addressing_service.hpp>
-#include <hpx/agas/agas_fwd.hpp>
 #include <hpx/assert.hpp>
+#include <hpx/modules/agas.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/errors.hpp>
@@ -20,6 +19,7 @@
 #include <hpx/modules/threading_base.hpp>
 #include <hpx/modules/threadmanager.hpp>
 #include <hpx/modules/type_support.hpp>
+
 #include <hpx/runtime_distributed.hpp>
 #include <hpx/runtime_distributed/applier.hpp>
 #include <hpx/runtime_distributed/runtime_fwd.hpp>

--- a/libs/full/runtime_distributed/src/big_boot_barrier.cpp
+++ b/libs/full/runtime_distributed/src/big_boot_barrier.cpp
@@ -9,9 +9,9 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_NETWORKING)
-#include <hpx/agas/addressing_service.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/modules/actions_base.hpp>
+#include <hpx/modules/agas.hpp>
 #include <hpx/modules/agas_base.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/async_distributed.hpp>
@@ -27,6 +27,7 @@
 #include <hpx/modules/static_reinit.hpp>
 #include <hpx/modules/timing.hpp>
 #include <hpx/modules/topology.hpp>
+
 #include <hpx/runtime_distributed.hpp>
 #include <hpx/runtime_distributed/big_boot_barrier.hpp>
 #include <hpx/runtime_distributed/runtime_fwd.hpp>

--- a/libs/full/runtime_distributed/src/runtime_distributed.cpp
+++ b/libs/full/runtime_distributed/src/runtime_distributed.cpp
@@ -6,9 +6,8 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
-
-#include <hpx/agas/addressing_service.hpp>
 #include <hpx/assert.hpp>
+#include <hpx/modules/agas.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/components_base.hpp>
@@ -41,6 +40,8 @@
 #include <hpx/runtime_components/console_error_sink.hpp>
 #include <hpx/runtime_components/console_logging.hpp>
 #include <hpx/runtime_components/server/console_error_sink.hpp>
+#include <hpx/version.hpp>
+
 #include <hpx/runtime_distributed.hpp>
 #include <hpx/runtime_distributed/applier.hpp>
 #include <hpx/runtime_distributed/big_boot_barrier.hpp>
@@ -49,7 +50,6 @@
 #include <hpx/runtime_distributed/runtime_fwd.hpp>
 #include <hpx/runtime_distributed/runtime_support.hpp>
 #include <hpx/runtime_distributed/server/runtime_support.hpp>
-#include <hpx/version.hpp>
 
 #include <atomic>
 #include <condition_variable>

--- a/libs/full/runtime_distributed/src/runtime_distributed.cpp
+++ b/libs/full/runtime_distributed/src/runtime_distributed.cpp
@@ -21,6 +21,7 @@
 #include <hpx/modules/logging.hpp>
 #include <hpx/modules/naming_base.hpp>
 #include <hpx/modules/parcelset.hpp>
+#include <hpx/modules/runtime_components.hpp>
 #include <hpx/modules/runtime_configuration.hpp>
 #include <hpx/modules/runtime_local.hpp>
 #include <hpx/modules/static_reinit.hpp>
@@ -36,10 +37,6 @@
 #include <hpx/performance_counters/manage_counter_type.hpp>
 #include <hpx/performance_counters/query_counters.hpp>
 #include <hpx/performance_counters/registry.hpp>
-#include <hpx/runtime_components/components_fwd.hpp>
-#include <hpx/runtime_components/console_error_sink.hpp>
-#include <hpx/runtime_components/console_logging.hpp>
-#include <hpx/runtime_components/server/console_error_sink.hpp>
 #include <hpx/version.hpp>
 
 #include <hpx/runtime_distributed.hpp>

--- a/libs/full/runtime_distributed/src/runtime_support.cpp
+++ b/libs/full/runtime_distributed/src/runtime_support.cpp
@@ -6,8 +6,8 @@
 
 #include <hpx/config.hpp>
 #include <hpx/modules/components_base.hpp>
+#include <hpx/modules/runtime_components.hpp>
 #include <hpx/performance_counters/detail/counter_interface_functions.hpp>
-#include <hpx/runtime_components/component_registry.hpp>
 #include <hpx/runtime_distributed/runtime_support.hpp>
 
 #include <mutex>

--- a/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
+++ b/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
@@ -6,10 +6,9 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
-
-#include <hpx/agas/addressing_service.hpp>
 #include <hpx/assert.hpp>
 #include <hpx/modules/actions_base.hpp>
+#include <hpx/modules/agas.hpp>
 #include <hpx/modules/async_combinators.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/command_line_handling.hpp>
@@ -34,6 +33,7 @@
 #include <hpx/modules/type_support.hpp>
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/runtime_components/console_logging.hpp>
+
 #include <hpx/runtime_distributed.hpp>
 #include <hpx/runtime_distributed/find_localities.hpp>
 #include <hpx/runtime_distributed/runtime_fwd.hpp>

--- a/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
+++ b/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
@@ -22,6 +22,7 @@
 #include <hpx/modules/logging.hpp>
 #include <hpx/modules/plugin_factories.hpp>
 #include <hpx/modules/prefix.hpp>
+#include <hpx/modules/runtime_components.hpp>
 #include <hpx/modules/runtime_configuration.hpp>
 #include <hpx/modules/runtime_local.hpp>
 #include <hpx/modules/serialization.hpp>
@@ -32,7 +33,6 @@
 #include <hpx/modules/timing.hpp>
 #include <hpx/modules/type_support.hpp>
 #include <hpx/performance_counters/counters.hpp>
-#include <hpx/runtime_components/console_logging.hpp>
 
 #include <hpx/runtime_distributed.hpp>
 #include <hpx/runtime_distributed/find_localities.hpp>

--- a/libs/full/runtime_distributed/src/stubs/runtime_support_stubs.cpp
+++ b/libs/full/runtime_distributed/src/stubs/runtime_support_stubs.cpp
@@ -7,9 +7,9 @@
 
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
-#include <hpx/async_colocated/post_colocated.hpp>
 #include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_base.hpp>
+#include <hpx/modules/async_colocated.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/errors.hpp>

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/adjacent_difference.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/adjacent_difference.hpp
@@ -12,6 +12,8 @@
 #include <hpx/modules/algorithms.hpp>
 #include <hpx/modules/executors.hpp>
 #include <hpx/modules/functional.hpp>
+#include <hpx/modules/tag_invoke.hpp>
+
 #include <hpx/parallel/segmented_algorithms/detail/dispatch.hpp>
 
 #include <algorithm>

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/adjacent_find.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/adjacent_find.hpp
@@ -11,7 +11,9 @@
 #include <hpx/modules/algorithms.hpp>
 #include <hpx/modules/executors.hpp>
 #include <hpx/modules/functional.hpp>
+#include <hpx/modules/tag_invoke.hpp>
 #include <hpx/modules/type_support.hpp>
+
 #include <hpx/parallel/segmented_algorithms/detail/dispatch.hpp>
 
 #include <algorithm>

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/is_partitioned.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/is_partitioned.hpp
@@ -9,6 +9,7 @@
 #include <hpx/config.hpp>
 #include <hpx/modules/algorithms.hpp>
 #include <hpx/modules/executors.hpp>
+#include <hpx/modules/tag_invoke.hpp>
 
 #include <iterator>
 #include <type_traits>

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/scan.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/scan.hpp
@@ -19,7 +19,9 @@
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/iterator_support.hpp>
 #include <hpx/modules/pack_traversal.hpp>
+#include <hpx/modules/tag_invoke.hpp>
 #include <hpx/modules/type_support.hpp>
+
 #include <hpx/parallel/segmented_algorithms/detail/dispatch.hpp>
 
 #include <algorithm>

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/is_partitioned.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/is_partitioned.hpp
@@ -11,6 +11,7 @@
 #include <hpx/modules/executors.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/type_support.hpp>
+
 #include <hpx/parallel/segmented_algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/segmented_algorithms/detail/is_partitioned.hpp>
 

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/is_sorted.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/is_sorted.hpp
@@ -10,7 +10,9 @@
 #include <hpx/modules/algorithms.hpp>
 #include <hpx/modules/executors.hpp>
 #include <hpx/modules/functional.hpp>
+#include <hpx/modules/tag_invoke.hpp>
 #include <hpx/modules/type_support.hpp>
+
 #include <hpx/parallel/segmented_algorithms/detail/dispatch.hpp>
 
 #include <algorithm>

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/reduce.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/reduce.hpp
@@ -11,6 +11,8 @@
 #include <hpx/modules/algorithms.hpp>
 #include <hpx/modules/executors.hpp>
 #include <hpx/modules/functional.hpp>
+#include <hpx/modules/tag_invoke.hpp>
+
 #include <hpx/parallel/segmented_algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/segmented_algorithms/detail/reduce.hpp>
 

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/replace.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/replace.hpp
@@ -10,6 +10,8 @@
 #include <hpx/modules/algorithms.hpp>
 #include <hpx/modules/executors.hpp>
 #include <hpx/modules/functional.hpp>
+#include <hpx/modules/tag_invoke.hpp>
+
 #include <hpx/parallel/segmented_algorithms/for_each.hpp>
 
 #include <algorithm>


### PR DESCRIPTION
This includes the following HPX Modules:

- agas
- async_colocated
- runtime_components