### PR TITLE
actions_base: reimplement HPX_DEFINE_PLAIN_ACTION_2 using C++26 reflection

### DIFF
--- a/libs/full/actions_base/include/hpx/actions_base/macros.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/macros.hpp
@@ -486,7 +486,16 @@
     HPX_DEFINE_PLAIN_ACTION_2(func, HPX_PP_CAT(func, _action))                 \
     /**/
 
-#if defined(__NVCC__) || defined(__CUDACC__)
+#if defined(HPX_HAVE_CXX26_REFLECTION)
+// clang-format off
+/// When C++26 reflection is available, HPX_DEFINE_PLAIN_ACTION_2 uses
+/// reflect_action<^^func> instead of make_action_t. This eliminates the
+/// need for HPX_REGISTER_ACTION while keeping the same user-facing syntax.
+#define HPX_DEFINE_PLAIN_ACTION_2(func, name)                                  \
+    using name = hpx::actions::reflect_action<^^func>                          \
+    /**/
+// clang-format on
+#elif defined(__NVCC__) || defined(__CUDACC__)
 #define HPX_DEFINE_PLAIN_ACTION_2(func, name)                                  \
     struct name                                                                \
       : hpx::actions::make_action<                                             \


### PR DESCRIPTION
## Summary

When `HPX_HAVE_CXX26_REFLECTION` is defined, `HPX_DEFINE_PLAIN_ACTION_2`
now expands to:

```cpp
using name = hpx::actions::reflect_action<^^func>;
```

instead of the verbose `make_action_t` struct definition.

## Key insight

The first macro argument `func` is a named entity at the call site —
not a template parameter — so `^^func` works correctly on both
GCC trunk and Clang P2996.

## User impact

Zero — same macro syntax, reflection used internally:

```cpp
HPX_PLAIN_ACTION(app::compute, compute_action)  // unchanged
```

## Depends on

PR #7281 (merged) — `reflect_action` now inherits from `basic_action`
and provides all typedefs `transfer_action` requires.

## Backwards compatibility

Non-reflection paths (NVCC/CUDACC and standard C++) preserved unchanged.

## Checklist
- [x] I have added a new feature and have added tests to go along with it.