### PR TITLE
actions_base: integrate reflect_action with basic_action

### DIFF
--- a/libs/full/actions_base/include/hpx/actions_base/reflect_action.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/reflect_action.hpp
@@ -6,43 +6,52 @@
 
 /// \file reflect_action.hpp
 /// \brief Reflection-based action definition for HPX remote operations.
-///
-/// This header provides reflect_action<F>, a C++26 reflection-based
-/// replacement for the HPX_PLAIN_ACTION and HPX_REGISTER_ACTION macros.
-/// Instead of verbose boilerplate, users write a single line:
-///
-///   using compute_action = HPX_ACTION(app::compute);
-///
-/// The action name, function pointer type, arity, and registration are
-/// all derived automatically at compile time using C++26 static reflection.
-
 #pragma once
 
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_CXX26_REFLECTION)
 
+#include <hpx/actions_base/basic_action.hpp>
+#include <hpx/actions_base/plain_action.hpp>
 #include <hpx/serialization/detail/refl_qualified_name_of.hpp>
 
 #include <cstddef>
 #include <meta>
+#include <string>
 #include <type_traits>
 
 namespace hpx::actions {
 
+    /// \cond NOINTERNAL
+    namespace detail {
+
+        /// Helper to extract function type from reflection for use
+        /// as basic_action template argument (two-step workaround for
+        /// GCC/Clang restriction on splice expressions as template args).
+        template <std::meta::info F>
+        struct reflect_action_base
+        {
+            using func_type = [:std::meta::type_of(F):];
+            using type = basic_action<hpx::actions::detail::plain_function,
+                func_type, reflect_action_base<F>>;
+        };
+
+    }    // namespace detail
+    /// \endcond
+
     /// \brief Reflection-based action template.
     ///
-    /// reflect_action<F> provides the same interface as HPX_PLAIN_ACTION
-    /// but derives all properties automatically from the reflected function F:
-    ///   - Qualified name via scope_builder<F>
-    ///   - Function pointer type via std::meta::type_of(F)
-    ///   - Function pointer via splicing [:F:]
-    ///   - Arity via std::meta::parameters_of(F).size()
+    /// reflect_action<F> integrates with HPX's action system by inheriting
+    /// from basic_action<detail::plain_function, R(Ps...), reflect_action<F>>.
+    /// All properties are derived automatically from the reflected function F.
     ///
     /// \tparam F  A std::meta::info reflection of a free function.
-    ///            Obtain via the reflection operator: ^^app::my_function
     template <std::meta::info F>
     struct reflect_action
+      : basic_action<hpx::actions::detail::plain_function,
+            typename detail::reflect_action_base<F>::func_type,
+            reflect_action<F>>
     {
         /// The function type (e.g. int(double, double))
         using func_type = [:std::meta::type_of(F):];
@@ -57,16 +66,23 @@ namespace hpx::actions {
         static constexpr auto name_storage =
             hpx::serialization::detail::scope_builder<F>::value;
 
-        /// Number of parameters the function takes
-        static constexpr std::size_t arity = std::meta::parameters_of(F).size();
-
-        /// Returns the fully qualified name of the action.
-        /// Called by hpx::actions::detail::register_action during
-        /// static initialization to register this action with the
-        /// HPX action registry.
-        static consteval char const* get_action_name() noexcept
+        /// Returns the action name in HPX format: "plain action(app::compute)"
+        static std::string get_action_name(
+            naming::address::address_type /*lva*/)
         {
-            return name_storage.data;
+            return hpx::actions::detail::make_plain_action_name(
+                std::string_view(name_storage.data, name_storage.size));
+        }
+
+        /// Invokes the reflected function with the given arguments.
+        template <typename... Ts>
+        static auto invoke(naming::address::address_type /*lva*/,
+            naming::address::component_type /*comptype*/, Ts&&... vs)
+        {
+            using base_t = basic_action<hpx::actions::detail::plain_function,
+                func_type, reflect_action<F>>;
+            base_t::increment_invocation_count();
+            return func_ptr(HPX_FORWARD(Ts, vs)...);
         }
     };
 

--- a/libs/full/actions_base/include/hpx/actions_base/reflect_action.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/reflect_action.hpp
@@ -14,7 +14,7 @@
 
 #include <hpx/actions_base/basic_action.hpp>
 #include <hpx/actions_base/plain_action.hpp>
-#include <hpx/serialization/detail/refl_qualified_name_of.hpp>
+#include <hpx/modules/serialization.hpp>
 
 #include <cstddef>
 #include <meta>

--- a/libs/full/actions_base/tests/unit/reflect_action_test.cpp
+++ b/libs/full/actions_base/tests/unit/reflect_action_test.cpp
@@ -47,29 +47,29 @@ int main()
     // Test: action name extraction for simple namespace function
     {
         HPX_ACTION(app::compute, compute_action);
-        HPX_TEST_EQ(std::string(compute_action::get_action_name()),
-            std::string("app::compute"));
+        HPX_TEST_EQ(std::string(compute_action::get_action_name(nullptr)),
+            std::string("plain action(app::compute)"));
     }
 
     // Test: action name extraction for void noexcept function
     {
         HPX_ACTION(app::broadcast, broadcast_action);
-        HPX_TEST_EQ(std::string(broadcast_action::get_action_name()),
-            std::string("app::broadcast"));
+        HPX_TEST_EQ(std::string(broadcast_action::get_action_name(nullptr)),
+            std::string("plain action(app::broadcast)"));
     }
 
     // Test: action name extraction for multiple parameters
     {
         HPX_ACTION(app::transform, transform_action);
-        HPX_TEST_EQ(std::string(transform_action::get_action_name()),
-            std::string("app::transform"));
+        HPX_TEST_EQ(std::string(transform_action::get_action_name(nullptr)),
+            std::string("plain action(app::transform)"));
     }
 
     // Test: action name extraction for nested namespace
     {
         HPX_ACTION(app::nested::deep_compute, deep_action);
-        HPX_TEST_EQ(std::string(deep_action::get_action_name()),
-            std::string("app::nested::deep_compute"));
+        HPX_TEST_EQ(std::string(deep_action::get_action_name(nullptr)),
+            std::string("plain action(app::nested::deep_compute)"));
     }
 
     // Test: arity extraction


### PR DESCRIPTION
## Summary

This PR makes `reflect_action<F>` a proper HPX action by inheriting from
`basic_action<detail::plain_function, R(Ps...), reflect_action<F>>`.

## Problem

PR #7280 showed that `reflect_action` was missing required typedefs
(`component_type`, `result_type`, `arguments_type`, etc.) that
`transfer_action` depends on. These come from `basic_action`.

## Solution

Two-step workaround for compiler restriction on splice expressions
as template arguments:

```cpp
// Step 1: helper extracts func_type
template <std::meta::info F>
struct reflect_action_base {
    using func_type = [:std::meta::type_of(F):];
};

// Step 2: use alias in inheritance
template <std::meta::info F>
struct reflect_action
  : basic_action<detail::plain_function,
        typename reflect_action_base<F>::func_type,
        reflect_action<F>>
```

## What this enables

`reflect_action` now provides all typedefs `transfer_action` requires,
making it usable in HPX's full distributed invocation chain.

## Depends on

PR #7266 (merged) — `reflect_action` base template

## Checklist
- [x] I have added a new feature and have added tests to go along with it.