### PR TITLE
make_future: drop static_assert from detail::make_future

### DIFF
--- a/libs/core/execution/include/hpx/execution/algorithms/make_future.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/make_future.hpp
@@ -7,6 +7,7 @@
 
 #pragma once
 
+#include <hpx/assert.hpp>
 #include <hpx/execution/algorithms/detail/inject_scheduler.hpp>
 #include <hpx/execution/algorithms/detail/partial_algorithm.hpp>
 #include <hpx/execution/algorithms/detail/single_result.hpp>
@@ -218,11 +219,10 @@ namespace hpx::execution::experimental {
         };
 
         // Detects whether a sender's set_value completion scheduler is
-        // run_loop_scheduler. Used by detail::make_future to reject -- at
-        // compile time -- the 1-argument form make_future(sender) when the
-        // sender's completion path runs on a run_loop scheduler. That call
-        // would silently hang at runtime because the 1-argument overload
-        // constructs a future_data that never drives loop.run().
+        // run_loop_scheduler. Used by detail::make_future as a runtime
+        // guard (see HPX_ASSERT_MSG below). The trait itself is SFINAE-
+        // friendly so it can be safely instantiated during overload
+        // resolution.
         template <typename Sender, typename = void>
         struct sender_completion_is_run_loop_scheduler : std::false_type
         {
@@ -247,13 +247,25 @@ namespace hpx::execution::experimental {
         HPX_CXX_CORE_EXPORT template <typename Sender, typename Allocator>
         auto make_future(Sender&& sender, Allocator const& allocator)
         {
-            // The 1-argument make_future(sender) overload constructs a
-            // future_data that never calls loop.run(), so passing a sender
-            // whose set_value completion scheduler is a run_loop_scheduler
-            // produces a future that silently hangs. Reject at compile time
-            // and direct the user to make_future(sched, sender).
-            static_assert(!sender_completion_is_run_loop_scheduler<
-                              std::decay_t<Sender>>::value,
+            // Debug-only runtime guard against the silent-hang case:
+            // this 1-argument fallback constructs a future_data that
+            // never drives loop.run(), so a sender whose set_value
+            // completion scheduler is a run_loop_scheduler produces a
+            // future that hangs in get(). The public make_future CPO
+            // routes such senders to the scheduler-form overload via
+            // tag_override_invoke, so reaching this body with a run-loop
+            // completion scheduler indicates a direct call to
+            // detail::make_future rather than the public API. HPX_ASSERT_MSG
+            // is a no-op in release builds (HPX_DEBUG off), so this only
+            // catches the misuse in debug; an unconditional throw would
+            // also alter the release-mode failure shape and is left out
+            // intentionally -- the assert exists to flag bypassing the
+            // public CPO during development, not to harden release-mode
+            // misuse. static_assert is avoided here because tag_priority's
+            // SFINAE probing during overload resolution may instantiate
+            // this body before the scheduler-form overload is selected.
+            HPX_ASSERT_MSG(!sender_completion_is_run_loop_scheduler<
+                               std::decay_t<Sender>>::value,
                 "make_future(sender) cannot drive the parent run_loop when "
                 "the sender's completion scheduler is a run_loop_scheduler. "
                 "Use make_future(loop.get_scheduler(), sender) so the "


### PR DESCRIPTION

## Proposed Changes

- Replace the `static_assert` inside `detail::make_future(Sender, Allocator)` (introduced by #7248) with `HPX_ASSERT_MSG` and keep the `sender_completion_is_run_loop_scheduler` trait that backs it. The `static_assert` was a hard error during template substitution and broke `tag_priority`'s overload-resolution probing on GCC 12 debug, surfacing in [rostam CDash build 53308](https://cdash.rostam.cct.lsu.edu/viewBuildError.php?buildid=53308) on the `algorithm_run_loop.cpp` test cases that use `make_future(just(3) | continues_on(sched))`. `HPX_ASSERT_MSG` is a no-op in release builds and a runtime check in debug, so it does not interfere with substitution, while still flagging the silent-hang misuse during development.
- Add `#include <hpx/assert.hpp>` to `make_future.hpp` for `HPX_ASSERT_MSG`.
- Document the rationale inline: the public `make_future` CPO's `tag_override_invoke` overload already routes `make_future(run_loop_sender)` to the scheduler-form `tag_invoke` (which builds `future_data_with_run_loop` and drives `loop.run()` in `execute_deferred`), so reaching this 1-arg fallback with a run-loop completion scheduler indicates a direct call to `detail::make_future` rather than going through the public API; the runtime assert exists to flag that bypass in debug, not to harden release-mode misuse.

## Any background context you want to provide?

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
