### PR TITLE
ci: fix ittnotify ref-collector build in CI

### DIFF
--- a/.github/workflows/linux_debug_ittnotify.yml
+++ b/.github/workflows/linux_debug_ittnotify.yml
@@ -26,13 +26,9 @@ jobs:
           git clone https://github.com/intel/ittapi.git
           cmake -S ittapi -B ittapi/build -GNinja \
               -DCMAKE_BUILD_TYPE=Release \
-              -DCMAKE_INSTALL_PREFIX=$PWD/ittapi/install
+              -DCMAKE_INSTALL_PREFIX=$PWD/ittapi/install \
+              -DITT_API_REFERENCE_COLLECTOR=ON
           cmake --build ittapi/build --target install
-    - name: Build ref-collector
-      shell: bash
-      run: |
-          cd ittapi/src/ittnotify_refcol
-          make CC=gcc
     - name: Configure
       shell: bash
       env:
@@ -61,7 +57,7 @@ jobs:
     - name: Test
       shell: bash
       run: |
-          export INTEL_LIBITTNOTIFY64="${GITHUB_WORKSPACE}/ittapi/src/ittnotify_refcol/libittnotify_refcol.so"
+          export INTEL_LIBITTNOTIFY64="${GITHUB_WORKSPACE}/ittapi/build/bin/libittnotify_refcol.so"
           export INTEL_LIBITTNOTIFY_LOG_DIR="${GITHUB_WORKSPACE}/itt_logs"
           # Enable ITT bindings at runtime so the ref-collector is loaded
           export HPX_HAVE_ITTNOTIFY=1


### PR DESCRIPTION
## Proposed Changes

- **Build ref-collector via CMake**: Enabled `-DITT_API_REFERENCE_COLLECTOR=ON` flag during `ittapi` installation configure step.
- **Removed Makefile Build**: Deleted the legacy `make` build step since `ittapi` has completely moved the reference collector to CMake.
- **Updated Shared Library Path**: Pointed the `INTEL_LIBITTNOTIFY64` environment variable to the new library output location at `ittapi/build/bin/libittnotify_refcol.so`.

## Any background context you want to provide?

The `intel/ittapi` upstream project recently removed the legacy `Makefile` in `src/ittnotify_refcol` and ported it to CMake. Because our workflow was cloning the latest master of `ittapi` and attempting to run `make` directly in that directory, the build step failed with `make: *** No targets specified and no makefile found. Stop.`. This PR synchronizes the CI configuration to build the collector library natively via the top-level `ittapi` CMake project.

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.