### PR TITLE
tracing: suppress MSVC C4251 warning, remove stale comment

### DIFF
--- a/libs/core/thread_pools/include/hpx/thread_pools/scheduling_loop.hpp
+++ b/libs/core/thread_pools/include/hpx/thread_pools/scheduling_loop.hpp
@@ -207,22 +207,6 @@ namespace hpx::threads::detail {
                                     threads::get_region_init_data(thrdptr),
                                     num_thread);
 
-                                // Dual-view Tracy instrumentation:
-                                //
-                                // rctx declared FIRST -> constructed first ->
-                                //   ZoneBegin fires with NO active fiber,
-                                //   so Tracy attributes it to the OS worker
-                                //   thread row (utilization view).
-                                //
-                                // fctx declared SECOND -> constructed second ->
-                                //   TracyFiberEnter fires INSIDE the open zone,
-                                //   so Tracy also shows this slice on the fiber
-                                //   track (M:N migration view).
-                                //
-                                // Destruction is C++ reverse order:
-                                //   ~fctx first -> TracyFiberLeave
-                                //   ~rctx last  -> ZoneEnd
-                                // Zone outlives the fiber context - correct.
                                 hpx::tracing::fiber_region fctx(
                                     threads::get_fiber_region_init_data(
                                         thrdptr),

--- a/libs/core/tracing/include/hpx/tracing/tracing.hpp
+++ b/libs/core/tracing/include/hpx/tracing/tracing.hpp
@@ -14,6 +14,8 @@
 #if defined(HPX_HAVE_TRACY)
 #include <hpx/modules/tracy.hpp>
 
+#include <hpx/config/warnings_prefix.hpp>
+
 namespace hpx::tracing {
 
     ////////////////////////////////////////////////////////////////////////////
@@ -122,6 +124,8 @@ namespace hpx::tracing {
         char const* name) noexcept;
 
 }    // namespace hpx::tracing
+
+#include <hpx/config/warnings_suffix.hpp>
 
 #elif defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0
 #include <hpx/modules/itt_notify.hpp>


### PR DESCRIPTION


## Proposed Changes

- **Suppress MSVC C4251 warning**: Added standard pragmas to disable C4251 warnings in `tracing.hpp`.
- **Remove stale comment**: Deleted the verbose Tracy dual-view comment from `scheduling_loop.hpp`.

## Any background context you want to provide?

These two minor cleanups were suggested by Panos during review:
1. Fix the MSVC DLL-interface warning (C4251) on the exported tracing region.
2. Clean up implementation comments from the worker scheduling loop.

## Checklist
- [ ] I have added a new feature and have added tests to go along with it. 
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.