### PR TITLE
Avoid forcing inline on debug builds

### DIFF
--- a/libs/core/config/include/hpx/config/forceinline.hpp
+++ b/libs/core/config/include/hpx/config/forceinline.hpp
@@ -15,7 +15,9 @@
 
 // clang-format off
 #if !defined(HPX_FORCEINLINE)
-#   if defined(__NVCC__) || defined(__CUDACC__)
+#   if defined(HPX_DEBUG)
+#       define HPX_FORCEINLINE inline
+#   elif defined(__NVCC__) || defined(__CUDACC__)
 #       define HPX_FORCEINLINE inline
 #   elif defined(HPX_MSVC)
 #       define HPX_FORCEINLINE __forceinline


### PR DESCRIPTION
GCC and Clang apply forced inlining of functions even in Debug builds (-O0 -g). Avoiding this improves the debugging experience.