### PR TITLE
Adapting modules of level 39/40 to C++20 modules

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -13,5 +13,6 @@ exclude_paths:
 tools:
   duplication:
     exclude:
+      - "examples/**"
       - "tests/**"
       - "**/tests/**"

--- a/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_decl.hpp
+++ b/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_decl.hpp
@@ -11,12 +11,11 @@
 
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
-#include <hpx/distribution_policies/container_distribution_policy.hpp>
-#include <hpx/distribution_policies/explicit_container_distribution_policy.hpp>
 #include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/async_combinators.hpp>
 #include <hpx/modules/components.hpp>
+#include <hpx/modules/distribution_policies.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/runtime_components.hpp>
 #include <hpx/modules/type_support.hpp>

--- a/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_impl.hpp
+++ b/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_impl.hpp
@@ -9,13 +9,12 @@
 
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
-#include <hpx/distribution_policies/container_distribution_policy.hpp>
-#include <hpx/distribution_policies/explicit_container_distribution_policy.hpp>
 #include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/async_combinators.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/components.hpp>
+#include <hpx/modules/distribution_policies.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/runtime_components.hpp>

--- a/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_predef.hpp
+++ b/components/containers/partitioned_vector/include/hpx/components/containers/partitioned_vector/partitioned_vector_predef.hpp
@@ -7,8 +7,7 @@
 
 #pragma once
 
-#include <hpx/distribution_policies/container_distribution_policy.hpp>
-#include <hpx/distribution_policies/explicit_container_distribution_policy.hpp>
+#include <hpx/modules/distribution_policies.hpp>
 
 #include <hpx/components/containers/partitioned_vector/export_definitions.hpp>
 #include <hpx/components/containers/partitioned_vector/partitioned_vector_component_decl.hpp>

--- a/components/containers/partitioned_vector/src/partitioned_vector_component_double.cpp
+++ b/components/containers/partitioned_vector/src/partitioned_vector_component_double.cpp
@@ -7,8 +7,7 @@
 #include <hpx/config.hpp>
 
 #if !defined(HPX_HAVE_STATIC_LINKING)
-#include <hpx/distribution_policies/container_distribution_policy.hpp>
-#include <hpx/distribution_policies/explicit_container_distribution_policy.hpp>
+#include <hpx/modules/distribution_policies.hpp>
 
 #include <hpx/components/containers/partitioned_vector/export_definitions.hpp>
 #include <hpx/components/containers/partitioned_vector/partitioned_vector.hpp>

--- a/components/containers/partitioned_vector/src/partitioned_vector_component_int.cpp
+++ b/components/containers/partitioned_vector/src/partitioned_vector_component_int.cpp
@@ -7,8 +7,7 @@
 #include <hpx/config.hpp>
 
 #if !defined(HPX_HAVE_STATIC_LINKING)
-#include <hpx/distribution_policies/container_distribution_policy.hpp>
-#include <hpx/distribution_policies/explicit_container_distribution_policy.hpp>
+#include <hpx/modules/distribution_policies.hpp>
 
 #include <hpx/components/containers/partitioned_vector/export_definitions.hpp>
 #include <hpx/components/containers/partitioned_vector/partitioned_vector.hpp>

--- a/components/containers/partitioned_vector/src/partitioned_vector_component_std_string.cpp
+++ b/components/containers/partitioned_vector/src/partitioned_vector_component_std_string.cpp
@@ -7,8 +7,7 @@
 #include <hpx/config.hpp>
 
 #if !defined(HPX_HAVE_STATIC_LINKING)
-#include <hpx/distribution_policies/container_distribution_policy.hpp>
-#include <hpx/distribution_policies/explicit_container_distribution_policy.hpp>
+#include <hpx/modules/distribution_policies.hpp>
 
 #include <hpx/components/containers/partitioned_vector/export_definitions.hpp>
 #include <hpx/components/containers/partitioned_vector/partitioned_vector.hpp>

--- a/components/containers/unordered/include/hpx/components/containers/unordered/unordered_map.hpp
+++ b/components/containers/unordered/include/hpx/components/containers/unordered/unordered_map.hpp
@@ -10,11 +10,11 @@
 
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
-#include <hpx/distribution_policies/container_distribution_policy.hpp>
 #include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_combinators.hpp>
 #include <hpx/modules/components.hpp>
 #include <hpx/modules/components_base.hpp>
+#include <hpx/modules/distribution_policies.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/runtime_components.hpp>
 #include <hpx/modules/serialization.hpp>

--- a/components/parcel_plugins/coalescing/include/hpx/parcel_coalescing/counter_registry.hpp
+++ b/components/parcel_plugins/coalescing/include/hpx/parcel_coalescing/counter_registry.hpp
@@ -11,10 +11,9 @@
 #if defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCEL_COALESCING)
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/hashing.hpp>
+#include <hpx/modules/performance_counters.hpp>
 #include <hpx/modules/synchronization.hpp>
 #include <hpx/modules/type_support.hpp>
-
-#include <hpx/performance_counters/counters_fwd.hpp>
 
 #include <cstdint>
 #include <string>

--- a/components/parcel_plugins/coalescing/src/coalescing_counter_registry.cpp
+++ b/components/parcel_plugins/coalescing/src/coalescing_counter_registry.cpp
@@ -9,9 +9,9 @@
 #if defined(HPX_HAVE_NETWORKING) && defined(HPX_HAVE_PARCEL_COALESCING)
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/util.hpp>
+#include <hpx/modules/performance_counters.hpp>
 
 #include <hpx/parcel_coalescing/counter_registry.hpp>
-#include <hpx/performance_counters/registry.hpp>
 
 #include <cstdint>
 #include <mutex>

--- a/components/parcel_plugins/coalescing/src/performance_counters.cpp
+++ b/components/parcel_plugins/coalescing/src/performance_counters.cpp
@@ -16,10 +16,9 @@
 #include <hpx/modules/string_util.hpp>
 
 #include <hpx/modules/components_base.hpp>
+#include <hpx/modules/performance_counters.hpp>
+
 #include <hpx/parcel_coalescing/counter_registry.hpp>
-#include <hpx/performance_counters/counter_creators.hpp>
-#include <hpx/performance_counters/counters.hpp>
-#include <hpx/performance_counters/manage_counter_type.hpp>
 
 #include <cstdint>
 #include <exception>

--- a/components/performance_counters/io/src/io_counters.cpp
+++ b/components/performance_counters/io/src/io_counters.cpp
@@ -7,15 +7,15 @@
 
 #include <hpx/config.hpp>
 #include <hpx/modules/components_base.hpp>
+#include <hpx/modules/errors.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/modules/functional.hpp>
+#include <hpx/modules/performance_counters.hpp>
 #include <hpx/modules/runtime_configuration.hpp>
 #include <hpx/modules/runtime_local.hpp>
-#include <hpx/performance_counters/manage_counter_type.hpp>
 
 #include <hpx/components/performance_counters/io/io_counters.hpp>
 
-#include <hpx/modules/errors.hpp>
 #include <boost/fusion/include/define_struct.hpp>
 #include <boost/fusion/include/io.hpp>
 #include <boost/phoenix/core.hpp>

--- a/components/performance_counters/memory_counters/src/memory.cpp
+++ b/components/performance_counters/memory_counters/src/memory.cpp
@@ -8,9 +8,9 @@
 #include <hpx/config.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/functional.hpp>
+#include <hpx/modules/performance_counters.hpp>
 #include <hpx/modules/runtime_configuration.hpp>
 #include <hpx/modules/runtime_local.hpp>
-#include <hpx/performance_counters/manage_counter_type.hpp>
 
 #include <hpx/components/performance_counters/memory_counters/mem_counter.hpp>
 

--- a/components/performance_counters/papi/include/hpx/components/performance_counters/papi/server/papi.hpp
+++ b/components/performance_counters/papi/include/hpx/components/performance_counters/papi/server/papi.hpp
@@ -12,8 +12,8 @@
 #if defined(HPX_HAVE_PAPI)
 
 #include <hpx/modules/components_base.hpp>
+#include <hpx/modules/performance_counters.hpp>
 #include <hpx/modules/runtime_local.hpp>
-#include <hpx/performance_counters/server/base_performance_counter.hpp>
 
 #include <cstdint>
 #include <map>

--- a/components/performance_counters/papi/include/hpx/components/performance_counters/papi/util/papi.hpp
+++ b/components/performance_counters/papi/include/hpx/components/performance_counters/papi/util/papi.hpp
@@ -13,8 +13,8 @@
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/modules/iterator_support.hpp>
+#include <hpx/modules/performance_counters.hpp>
 #include <hpx/modules/program_options.hpp>
-#include <hpx/performance_counters/counters.hpp>
 
 #include <cstdint>
 #include <cstring>

--- a/components/performance_counters/papi/src/papi_startup.cpp
+++ b/components/performance_counters/papi/src/papi_startup.cpp
@@ -8,18 +8,17 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_PAPI)
-
-#include <hpx/components/performance_counters/papi/server/papi.hpp>
-#include <hpx/components/performance_counters/papi/util/papi.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/iterator_support.hpp>
+#include <hpx/modules/performance_counters.hpp>
 #include <hpx/modules/program_options.hpp>
 #include <hpx/modules/runtime_configuration.hpp>
 #include <hpx/modules/runtime_local.hpp>
-#include <hpx/performance_counters/counter_creators.hpp>
-#include <hpx/performance_counters/manage_counter_type.hpp>
+
+#include <hpx/components/performance_counters/papi/server/papi.hpp>
+#include <hpx/components/performance_counters/papi/util/papi.hpp>
 
 #include <cctype>
 #include <cstdint>
@@ -289,11 +288,11 @@ namespace hpx { namespace performance_counters { namespace papi {
         using namespace hpx::performance_counters;
 
         // define & install generic PAPI counter type
-        generic_counter_type_data const papi_cnt_type = {"/papi",
+        constexpr generic_counter_type_data papi_cnt_type = {"/papi",
             counter_type::raw,
             "the current count of occurrences of a specific PAPI event",
-            HPX_PERFORMANCE_COUNTER_V1, &create_papi_counter,
-            &discover_papi_counters, ""};
+            performance_counters::HPX_PERFORMANCE_COUNTER_V1,
+            &create_papi_counter, &discover_papi_counters, ""};
         install_counter_types(&papi_cnt_type, 1);
 
         // deferred options

--- a/components/performance_counters/papi/src/papi_startup.cpp
+++ b/components/performance_counters/papi/src/papi_startup.cpp
@@ -288,7 +288,7 @@ namespace hpx { namespace performance_counters { namespace papi {
         using namespace hpx::performance_counters;
 
         // define & install generic PAPI counter type
-        constexpr generic_counter_type_data papi_cnt_type = {"/papi",
+        generic_counter_type_data const papi_cnt_type = {"/papi",
             counter_type::raw,
             "the current count of occurrences of a specific PAPI event",
             performance_counters::HPX_PERFORMANCE_COUNTER_V1,

--- a/components/performance_counters/power/src/power.cpp
+++ b/components/performance_counters/power/src/power.cpp
@@ -7,9 +7,9 @@
 #include <hpx/config.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/functional.hpp>
+#include <hpx/modules/performance_counters.hpp>
 #include <hpx/modules/runtime_configuration.hpp>
 #include <hpx/modules/runtime_local.hpp>
-#include <hpx/performance_counters/manage_counter_type.hpp>
 
 #include <hpx/components/performance_counters/power/power_counter.hpp>
 

--- a/examples/performance_counters/sine/sine.cpp
+++ b/examples/performance_counters/sine/sine.cpp
@@ -212,7 +212,7 @@ namespace performance_counters { namespace sine {
         using hpx::placeholders::_2;
 
         // define the counter types
-        generic_counter_type_data const counter_types[] = {
+        constexpr generic_counter_type_data counter_types[] = {
             // We assume that valid counter names have the following scheme:
             //
             //  /sine(locality#<locality_id>/instance#<instance_id>)/immediate/explicit
@@ -224,7 +224,8 @@ namespace performance_counters { namespace sine {
             {"/sine/immediate/explicit", counter_type::raw,
                 "returns the current value of a sine wave calculated over "
                 "an arbitrary time line (explicit, hand-rolled version)",
-                HPX_PERFORMANCE_COUNTER_V1, &explicit_sine_counter_creator,
+                hpx::performance_counters::HPX_PERFORMANCE_COUNTER_V1,
+                &explicit_sine_counter_creator,
                 &explicit_sine_counter_discoverer, ""},
             // We assume that valid counter names have the following scheme:
             //
@@ -237,7 +238,7 @@ namespace performance_counters { namespace sine {
                 "returns the current value of a sine wave calculated over "
                 "an arbitrary time line (implicit version, using HPX "
                 "facilities)",
-                HPX_PERFORMANCE_COUNTER_V1,
+                hpx::performance_counters::HPX_PERFORMANCE_COUNTER_V1,
                 hpx::bind(
                     &hpx::performance_counters::locality_raw_counter_creator,
                     _1, &immediate_sine, _2),

--- a/examples/performance_counters/sine/sine.cpp
+++ b/examples/performance_counters/sine/sine.cpp
@@ -212,7 +212,7 @@ namespace performance_counters { namespace sine {
         using hpx::placeholders::_2;
 
         // define the counter types
-        constexpr generic_counter_type_data counter_types[] = {
+        generic_counter_type_data const counter_types[] = {
             // We assume that valid counter names have the following scheme:
             //
             //  /sine(locality#<locality_id>/instance#<instance_id>)/immediate/explicit

--- a/libs/full/actions/include/hpx/actions/macros.hpp
+++ b/libs/full/actions/include/hpx/actions/macros.hpp
@@ -7,8 +7,9 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/actions_base/macros.hpp>
 #include <hpx/modules/preprocessor.hpp>
+
+#include <hpx/actions_base/macros.hpp>
 
 #include <type_traits>
 

--- a/libs/full/collectives/CMakeLists.txt
+++ b/libs/full/collectives/CMakeLists.txt
@@ -83,6 +83,7 @@ add_hpx_module(
     hpx_components
     hpx_components_base
     hpx_naming_base
+    hpx_performance_counters
     hpx_runtime_components
     hpx_runtime_distributed
   CMAKE_SUBDIRS examples tests

--- a/libs/full/collectives/src/latch.cpp
+++ b/libs/full/collectives/src/latch.cpp
@@ -5,17 +5,18 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/assert.hpp>
-#include <hpx/collectives/latch.hpp>
 #include <hpx/modules/actions.hpp>
 #include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/components.hpp>
 #include <hpx/modules/futures.hpp>
+#include <hpx/modules/performance_counters.hpp>
 #include <hpx/modules/runtime_components.hpp>
 #include <hpx/modules/runtime_local.hpp>
 #include <hpx/modules/type_support.hpp>
-#include <hpx/performance_counters/counters.hpp>
 #include <hpx/runtime_distributed/find_here.hpp>
+
+#include <hpx/collectives/latch.hpp>
 
 #include <cstddef>
 #include <exception>

--- a/libs/full/distribution_policies/CMakeLists.txt
+++ b/libs/full/distribution_policies/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2021 The STE||AR-Group
+# Copyright (c) 2019-2026 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -31,12 +31,15 @@ set(distribution_policies_compat_headers
 )
 # cmake-format: on
 
-set(distribution_policies_sources binpacking_distribution_policy.cpp)
+set(distribution_policies_sources binpacking_distribution_policy.cpp
+                                  distribution_policies.cpp
+)
 
 include(HPX_AddModule)
 add_hpx_module(
   full distribution_policies
   GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_MODULE_GEN ON
   SOURCES ${distribution_policies_sources}
   HEADERS ${distribution_policies_headers}
   COMPAT_HEADERS ${distribution_policies_compat_headers}

--- a/libs/full/distribution_policies/include/hpx/distribution_policies/binpacking_distribution_policy.hpp
+++ b/libs/full/distribution_policies/include/hpx/distribution_policies/binpacking_distribution_policy.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2023 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -32,8 +32,9 @@
 
 namespace hpx::components {
 
-    inline constexpr char const* const default_binpacking_counter_name =
-        "/runtime{locality/total}/count/component@";
+    HPX_CXX_EXPORT inline constexpr char const* const
+        default_binpacking_counter_name =
+            "/runtime{locality/total}/count/component@";
 
     namespace detail {
 
@@ -150,7 +151,7 @@ namespace hpx::components {
     /// each of the localities will equalize the number of overall objects of
     /// this type based on a given criteria (by default this criteria is the
     /// overall number of objects of this type).
-    struct binpacking_distribution_policy
+    HPX_CXX_EXPORT struct binpacking_distribution_policy
     {
     public:
         /// Default-construct a new instance of a \a binpacking_distribution_policy.
@@ -372,14 +373,15 @@ namespace hpx::components {
 
     /// A predefined instance of the binpacking \a distribution_policy. It will
     /// represent the local locality and will place all items to create here.
-    static binpacking_distribution_policy const binpacked{};
+    HPX_CXX_EXPORT HPX_EXPORT extern binpacking_distribution_policy const
+        binpacked;
 }    // namespace hpx::components
 
 /// \cond NOINTERNAL
 namespace hpx {
 
-    using hpx::components::binpacked;
-    using hpx::components::binpacking_distribution_policy;
+    HPX_CXX_EXPORT using hpx::components::binpacked;
+    HPX_CXX_EXPORT using hpx::components::binpacking_distribution_policy;
 
     template <>
     struct traits::is_distribution_policy<

--- a/libs/full/distribution_policies/include/hpx/distribution_policies/binpacking_distribution_policy.hpp
+++ b/libs/full/distribution_policies/include/hpx/distribution_policies/binpacking_distribution_policy.hpp
@@ -17,9 +17,9 @@
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/naming_base.hpp>
 #include <hpx/modules/pack_traversal.hpp>
+#include <hpx/modules/performance_counters.hpp>
 #include <hpx/modules/runtime_components.hpp>
 #include <hpx/modules/serialization.hpp>
-#include <hpx/performance_counters/performance_counter.hpp>
 
 #include <algorithm>
 #include <cstddef>

--- a/libs/full/distribution_policies/include/hpx/distribution_policies/colocating_distribution_policy.hpp
+++ b/libs/full/distribution_policies/include/hpx/distribution_policies/colocating_distribution_policy.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2014-2024 Hartmut Kaiser
+//  Copyright (c) 2014-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -31,7 +31,7 @@ namespace hpx::components {
     /// This class specifies the parameters for a distribution policy to use
     /// for creating a given number of items on the locality where a given
     /// object is currently placed.
-    struct colocating_distribution_policy
+    HPX_CXX_EXPORT struct colocating_distribution_policy
     {
         /// Default-construct a new instance of a \a colocating_distribution_policy.
         /// This policy will represent the local locality.
@@ -364,14 +364,15 @@ namespace hpx::components {
     /// A predefined instance of the co-locating \a distribution_policy. It
     /// will represent the local locality and will place all items to create
     /// here.
-    static colocating_distribution_policy const colocated{};
+    HPX_CXX_EXPORT HPX_EXPORT extern colocating_distribution_policy const
+        colocated;
 }    // namespace hpx::components
 
 /// \cond NOINTERNAL
 namespace hpx {
 
-    using hpx::components::colocated;
-    using hpx::components::colocating_distribution_policy;
+    HPX_CXX_EXPORT using hpx::components::colocated;
+    HPX_CXX_EXPORT using hpx::components::colocating_distribution_policy;
 
     template <>
     struct traits::is_distribution_policy<

--- a/libs/full/distribution_policies/include/hpx/distribution_policies/container_distribution_policy.hpp
+++ b/libs/full/distribution_policies/include/hpx/distribution_policies/container_distribution_policy.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2014 Bibek Ghimire
-//  Copyright (c) 2014-2024 Hartmut Kaiser
+//  Copyright (c) 2014-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -9,10 +9,11 @@
 
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
-#include <hpx/distribution_policies/default_distribution_policy.hpp>
 #include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/serialization.hpp>
+
+#include <hpx/distribution_policies/default_distribution_policy.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -26,7 +27,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // This class specifies the block chunking policy parameters to use for the
     // partitioning of the data in a hpx::partitioned_vector
-    struct container_distribution_policy
+    HPX_CXX_EXPORT struct container_distribution_policy
       : components::default_distribution_policy
     {
         container_distribution_policy() = default;
@@ -136,7 +137,8 @@ namespace hpx {
         std::size_t num_partitions_ = static_cast<std::size_t>(-1);
     };
 
-    static container_distribution_policy const container_layout{};
+    HPX_CXX_EXPORT HPX_EXPORT extern container_distribution_policy const
+        container_layout;
 
     ///////////////////////////////////////////////////////////////////////////
     namespace traits {

--- a/libs/full/distribution_policies/include/hpx/distribution_policies/default_distribution_policy.hpp
+++ b/libs/full/distribution_policies/include/hpx/distribution_policies/default_distribution_policy.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2014-2025 Hartmut Kaiser
+//  Copyright (c) 2014-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -33,7 +33,7 @@ namespace hpx::components {
     /// This class specifies the parameters for a simple distribution policy
     /// to use for creating (and evenly distributing) a given number of items
     /// on a given set of localities.
-    struct default_distribution_policy
+    HPX_CXX_EXPORT struct default_distribution_policy
     {
     public:
         /// Default-construct a new instance of a \a default_distribution_policy.
@@ -347,14 +347,15 @@ namespace hpx::components {
 
     /// A predefined instance of the default \a distribution_policy. It will
     /// represent the local locality and will place all items to create here.
-    static default_distribution_policy const default_layout{};
+    HPX_CXX_EXPORT HPX_EXPORT extern default_distribution_policy const
+        default_layout;
 }    // namespace hpx::components
 
 /// \cond NOINTERNAL
 namespace hpx {
 
-    using hpx::components::default_distribution_policy;
-    using hpx::components::default_layout;
+    HPX_CXX_EXPORT using hpx::components::default_distribution_policy;
+    HPX_CXX_EXPORT using hpx::components::default_layout;
 
     template <>
     struct traits::is_distribution_policy<

--- a/libs/full/distribution_policies/include/hpx/distribution_policies/explicit_container_distribution_policy.hpp
+++ b/libs/full/distribution_policies/include/hpx/distribution_policies/explicit_container_distribution_policy.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2014-2024 Hartmut Kaiser
+//  Copyright (c) 2014-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -8,10 +8,11 @@
 
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
-#include <hpx/distribution_policies/default_distribution_policy.hpp>
 #include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/serialization.hpp>
+
+#include <hpx/distribution_policies/default_distribution_policy.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -25,7 +26,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // This class specifies the block chunking policy parameters to use for the
     // partitioning of the data in a hpx::partitioned_vector
-    struct explicit_container_distribution_policy
+    HPX_CXX_EXPORT struct explicit_container_distribution_policy
       : components::default_distribution_policy
     {
         explicit_container_distribution_policy() = default;
@@ -102,8 +103,9 @@ namespace hpx {
         std::vector<std::size_t> sizes_;
     };
 
-    static explicit_container_distribution_policy const
-        explicit_container_layout{};
+    HPX_CXX_EXPORT
+    HPX_EXPORT extern explicit_container_distribution_policy const
+        explicit_container_layout;
 
     ///////////////////////////////////////////////////////////////////////////
     namespace traits {

--- a/libs/full/distribution_policies/include/hpx/distribution_policies/target_distribution_policy.hpp
+++ b/libs/full/distribution_policies/include/hpx/distribution_policies/target_distribution_policy.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2014-2023 Hartmut Kaiser
+//  Copyright (c) 2014-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -224,14 +224,14 @@ namespace hpx::components {
 
     /// A predefined instance of the \a target_distribution_policy. It will
     /// represent the local locality and will place all items to create here.
-    static target_distribution_policy const target{};
+    HPX_CXX_EXPORT HPX_EXPORT extern target_distribution_policy const target;
 }    // namespace hpx::components
 
 /// \cond NOINTERNAL
 namespace hpx {
 
-    using hpx::components::target;
-    using hpx::components::target_distribution_policy;
+    HPX_CXX_EXPORT using hpx::components::target;
+    HPX_CXX_EXPORT using hpx::components::target_distribution_policy;
 
     template <>
     struct traits::is_distribution_policy<

--- a/libs/full/distribution_policies/include/hpx/distribution_policies/unwrapping_result_policy.hpp
+++ b/libs/full/distribution_policies/include/hpx/distribution_policies/unwrapping_result_policy.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2014-2023 Hartmut Kaiser
+//  Copyright (c) 2014-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -21,10 +21,10 @@
 
 namespace hpx::components {
 
-    /// This class is a distribution policy that can be using with actions that
+    /// This class is a distribution policy that can be used with actions that
     /// return futures. For those actions it is possible to apply certain
     /// optimizations if the action is invoked synchronously.
-    struct unwrapping_result_policy
+    HPX_CXX_EXPORT struct unwrapping_result_policy
     {
     public:
         explicit unwrapping_result_policy(id_type const& id)
@@ -122,7 +122,8 @@ namespace hpx::components {
 /// \cond NOINTERNAL
 namespace hpx {
 
-    using unwrap_result = hpx::components::unwrapping_result_policy;
+    HPX_CXX_EXPORT using unwrap_result =
+        hpx::components::unwrapping_result_policy;
 
     template <>
     struct traits::is_distribution_policy<components::unwrapping_result_policy>

--- a/libs/full/distribution_policies/src/binpacking_distribution_policy.cpp
+++ b/libs/full/distribution_policies/src/binpacking_distribution_policy.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -16,7 +16,12 @@
 
 #include <hpx/config/warnings_prefix.hpp>
 
-namespace hpx { namespace components { namespace detail {
+namespace hpx::components {
+
+    binpacking_distribution_policy const binpacked{};
+}
+
+namespace hpx::components::detail {
 
     std::vector<std::size_t> get_items_count(
         std::size_t count, std::vector<std::uint64_t> const& values)
@@ -129,4 +134,4 @@ namespace hpx { namespace components { namespace detail {
 
         return localities[best_locality];
     }
-}}}    // namespace hpx::components::detail
+}    // namespace hpx::components::detail

--- a/libs/full/distribution_policies/src/binpacking_distribution_policy.cpp
+++ b/libs/full/distribution_policies/src/binpacking_distribution_policy.cpp
@@ -4,8 +4,9 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/modules/performance_counters.hpp>
+
 #include <hpx/distribution_policies/binpacking_distribution_policy.hpp>
-#include <hpx/performance_counters/counters.hpp>
 
 #include <cstddef>
 #include <cstdint>

--- a/libs/full/distribution_policies/src/distribution_policies.cpp
+++ b/libs/full/distribution_policies/src/distribution_policies.cpp
@@ -1,0 +1,28 @@
+//  Copyright (c) 2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/distribution_policies/colocating_distribution_policy.hpp>
+#include <hpx/distribution_policies/container_distribution_policy.hpp>
+#include <hpx/distribution_policies/default_distribution_policy.hpp>
+#include <hpx/distribution_policies/explicit_container_distribution_policy.hpp>
+#include <hpx/distribution_policies/target_distribution_policy.hpp>
+
+#include <hpx/config/warnings_prefix.hpp>
+
+namespace hpx {
+
+    container_distribution_policy const container_layout{};
+    explicit_container_distribution_policy const explicit_container_layout{};
+
+    namespace components {
+
+        colocating_distribution_policy const colocated{};
+        default_distribution_policy const default_layout{};
+        target_distribution_policy const target{};
+    }    // namespace components
+}    // namespace hpx
+
+#include <hpx/config/warnings_suffix.hpp>

--- a/libs/full/include/CMakeLists.txt
+++ b/libs/full/include/CMakeLists.txt
@@ -112,6 +112,7 @@ if(HPX_WITH_DISTRIBUTED_RUNTIME)
       hpx_async_colocated
       hpx_async_distributed
       hpx_components_base
+      hpx_distribution_policies
       hpx_runtime_components
       hpx_runtime_distributed
       hpx_lcos_distributed

--- a/libs/full/include/include/hpx/channel.hpp
+++ b/libs/full/include/include/hpx/channel.hpp
@@ -6,5 +6,5 @@
 
 #pragma once
 
-#include <hpx/lcos_distributed/channel.hpp>
+#include <hpx/modules/lcos_distributed.hpp>
 #include <hpx/modules/lcos_local.hpp>

--- a/libs/full/include/include/hpx/include/components.hpp
+++ b/libs/full/include/include/hpx/include/components.hpp
@@ -14,15 +14,10 @@
 #include <hpx/modules/async_colocated.hpp>
 #include <hpx/modules/components.hpp>
 #include <hpx/modules/components_base.hpp>
+#include <hpx/modules/distribution_policies.hpp>
 #include <hpx/modules/runtime_components.hpp>
 
 #include <hpx/runtime_distributed/copy_component.hpp>
 #include <hpx/runtime_distributed/migrate_component.hpp>
 #include <hpx/runtime_distributed/runtime_support.hpp>
 #include <hpx/runtime_distributed/stubs/runtime_support.hpp>
-
-#include <hpx/distribution_policies/binpacking_distribution_policy.hpp>
-#include <hpx/distribution_policies/colocating_distribution_policy.hpp>
-#include <hpx/distribution_policies/default_distribution_policy.hpp>
-#include <hpx/distribution_policies/target_distribution_policy.hpp>
-#include <hpx/distribution_policies/unwrapping_result_policy.hpp>

--- a/libs/full/include/include/hpx/include/lcos.hpp
+++ b/libs/full/include/include/hpx/include/lcos.hpp
@@ -18,5 +18,5 @@
 #include <hpx/collectives/latch.hpp>
 #include <hpx/collectives/reduce.hpp>
 #include <hpx/include/actions.hpp>
-#include <hpx/lcos_distributed/channel.hpp>
 #include <hpx/modules/async_distributed.hpp>
+#include <hpx/modules/lcos_distributed.hpp>

--- a/libs/full/include/include/hpx/include/performance_counters.hpp
+++ b/libs/full/include/include/hpx/include/performance_counters.hpp
@@ -8,12 +8,5 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/modules/performance_counters.hpp>
 #include <hpx/modules/util.hpp>
-
-#include <hpx/performance_counters/base_performance_counter.hpp>
-#include <hpx/performance_counters/counter_creators.hpp>
-#include <hpx/performance_counters/counters.hpp>
-#include <hpx/performance_counters/manage_counter.hpp>
-#include <hpx/performance_counters/manage_counter_type.hpp>
-#include <hpx/performance_counters/performance_counter.hpp>
-#include <hpx/performance_counters/performance_counter_set.hpp>

--- a/libs/full/init_runtime/src/hpx_init.cpp
+++ b/libs/full/init_runtime/src/hpx_init.cpp
@@ -54,8 +54,7 @@
 #include <hpx/modules/parcelset_base.hpp>
 #include <hpx/parcelports/init_all_parcelports.hpp>
 #endif
-#include <hpx/performance_counters/counters.hpp>
-#include <hpx/performance_counters/query_counters.hpp>
+#include <hpx/modules/performance_counters.hpp>
 #include <hpx/runtime_distributed.hpp>
 #include <hpx/runtime_distributed/runtime_fwd.hpp>
 #include <hpx/runtime_distributed/runtime_support.hpp>

--- a/libs/full/init_runtime/src/pre_main.cpp
+++ b/libs/full/init_runtime/src/pre_main.cpp
@@ -19,12 +19,10 @@
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/logging.hpp>
 #include <hpx/modules/parcelset.hpp>
+#include <hpx/modules/performance_counters.hpp>
 #include <hpx/modules/runtime_components.hpp>
 #include <hpx/modules/runtime_configuration.hpp>
 #include <hpx/modules/runtime_local.hpp>
-#include <hpx/performance_counters/agas_counter_types.hpp>
-#include <hpx/performance_counters/parcelhandler_counter_types.hpp>
-#include <hpx/performance_counters/threadmanager_counter_types.hpp>
 #include <hpx/runtime_distributed.hpp>
 #include <hpx/runtime_distributed/applier.hpp>
 #include <hpx/runtime_distributed/runtime_fwd.hpp>

--- a/libs/full/lcos_distributed/CMakeLists.txt
+++ b/libs/full/lcos_distributed/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2022 The STE||AR-Group
+# Copyright (c) 2019-2026 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -10,9 +10,12 @@ endif()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
-set(lcos_distributed_headers hpx/lcos_distributed/channel.hpp
-                             hpx/lcos_distributed/server/channel.hpp
+set(lcos_distributed_headers
+    hpx/lcos_distributed/channel.hpp hpx/lcos_distributed/macros.hpp
+    hpx/lcos_distributed/server/channel.hpp
 )
+
+set(lcos_distributed_macro_headers hpx/lcos_distributed/macros.hpp)
 
 # cmake-format: off
 set(lcos_distributed_compat_headers
@@ -27,8 +30,10 @@ include(HPX_AddModule)
 add_hpx_module(
   full lcos_distributed
   GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_MODULE_GEN ON
   SOURCES ${lcos_distributed_sources}
   HEADERS ${lcos_distributed_headers}
+  MACRO_HEADERS ${lcos_distributed_macro_headers}
   COMPAT_HEADERS ${lcos_distributed_compat_headers}
   DEPENDENCIES hpx_core
   MODULE_DEPENDENCIES hpx_actions_base hpx_actions hpx_async_distributed

--- a/libs/full/lcos_distributed/include/hpx/lcos_distributed/channel.hpp
+++ b/libs/full/lcos_distributed/include/hpx/lcos_distributed/channel.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2016-2021 Hartmut Kaiser
+//  Copyright (c) 2016-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -7,15 +7,17 @@
 #pragma once
 
 #include <hpx/config.hpp>
+
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/assert.hpp>
-#include <hpx/lcos_distributed/server/channel.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/components.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/naming.hpp>
 #include <hpx/modules/runtime_components.hpp>
+
+#include <hpx/lcos_distributed/server/channel.hpp>
 
 #include <cstddef>
 #include <type_traits>
@@ -24,15 +26,15 @@
 namespace hpx::lcos {
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename T = void>
+    HPX_CXX_EXPORT template <typename T = void>
     class channel;
-    template <typename T = void>
+    HPX_CXX_EXPORT template <typename T = void>
     class receive_channel;
-    template <typename T = void>
+    HPX_CXX_EXPORT template <typename T = void>
     class send_channel;
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename T, typename Channel>
+    HPX_CXX_EXPORT template <typename T, typename Channel>
     class channel_iterator
       : public hpx::util::iterator_facade<channel_iterator<T, Channel>, T const,
             std::input_iterator_tag>
@@ -158,7 +160,7 @@ namespace hpx::lcos {
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename T>
+    HPX_CXX_EXPORT template <typename T>
     class channel
       : public components::client_base<channel<T>, lcos::server::channel<T>>
     {
@@ -338,7 +340,7 @@ namespace hpx::lcos {
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename T>
+    HPX_CXX_EXPORT template <typename T>
     class receive_channel
       : public components::client_base<receive_channel<T>,
             lcos::server::channel<T>>
@@ -421,7 +423,7 @@ namespace hpx::lcos {
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename T>
+    HPX_CXX_EXPORT template <typename T>
     class send_channel
       : public components::client_base<send_channel<T>,
             lcos::server::channel<T>>
@@ -561,7 +563,7 @@ namespace hpx::lcos {
 
 namespace hpx::distributed {
 
-    using hpx::lcos::channel;
+    HPX_CXX_EXPORT using hpx::lcos::channel;
 }    // namespace hpx::distributed
 
 #endif

--- a/libs/full/lcos_distributed/include/hpx/lcos_distributed/macros.hpp
+++ b/libs/full/lcos_distributed/include/hpx/lcos_distributed/macros.hpp
@@ -1,0 +1,72 @@
+//  Copyright (c) 2016-2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#include <hpx/actions/macros.hpp>
+#include <hpx/actions_base/macros.hpp>
+#include <hpx/async_distributed/macros.hpp>
+#include <hpx/components_base/macros.hpp>
+
+////////////////////////////////////////////////////////////////////////////////
+// from server/channel.hpp
+#define HPX_REGISTER_CHANNEL_DECLARATION(...)                                  \
+    HPX_REGISTER_CHANNEL_DECLARATION_(__VA_ARGS__)                             \
+/**/
+#define HPX_REGISTER_CHANNEL_DECLARATION_(...)                                 \
+    HPX_PP_EXPAND(HPX_PP_CAT(HPX_REGISTER_CHANNEL_DECLARATION_,                \
+        HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))                               \
+    /**/
+
+#define HPX_REGISTER_CHANNEL_DECLARATION_1(type)                               \
+    HPX_REGISTER_CHANNEL_DECLARATION_2(type, type)                             \
+/**/
+#define HPX_REGISTER_CHANNEL_DECLARATION_2(type, name)                         \
+    using HPX_PP_CAT(__channel_, HPX_PP_CAT(type, name)) =                     \
+        ::hpx::lcos::server::channel<type>;                                    \
+    HPX_REGISTER_ACTION_DECLARATION(                                           \
+        hpx::lcos::server::channel<type>::get_generation_action,               \
+        HPX_PP_CAT(__channel_get_generation_action, HPX_PP_CAT(type, name)))   \
+    HPX_REGISTER_ACTION_DECLARATION(                                           \
+        hpx::lcos::server::channel<type>::set_generation_action,               \
+        HPX_PP_CAT(__channel_set_generation_action, HPX_PP_CAT(type, name)))   \
+    HPX_REGISTER_ACTION_DECLARATION(                                           \
+        hpx::lcos::server::channel<type>::close_action,                        \
+        HPX_PP_CAT(__channel_close_action, HPX_PP_CAT(type, name)))            \
+    /**/
+
+#define HPX_REGISTER_CHANNEL(...)                                              \
+    HPX_REGISTER_CHANNEL_(__VA_ARGS__)                                         \
+/**/
+#define HPX_REGISTER_CHANNEL_(...)                                             \
+    HPX_PP_EXPAND(HPX_PP_CAT(                                                  \
+        HPX_REGISTER_CHANNEL_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))        \
+    /**/
+
+#define HPX_REGISTER_CHANNEL_1(type)                                           \
+    HPX_REGISTER_CHANNEL_2(type, type)                                         \
+/**/
+#define HPX_REGISTER_CHANNEL_2(type, name)                                     \
+    using HPX_PP_CAT(__channel_, HPX_PP_CAT(type, name)) =                     \
+        ::hpx::lcos::server::channel<type>;                                    \
+    using HPX_PP_CAT(__channel_component_, name) =                             \
+        ::hpx::components::component<HPX_PP_CAT(                               \
+            __channel_, HPX_PP_CAT(type, name))>;                              \
+    HPX_REGISTER_DERIVED_COMPONENT_FACTORY(                                    \
+        HPX_PP_CAT(__channel_component_, name),                                \
+        HPX_PP_CAT(__channel_component_, name),                                \
+        HPX_PP_STRINGIZE(HPX_PP_CAT(__base_lco_with_value_channel_, name)))    \
+    HPX_REGISTER_ACTION(                                                       \
+        hpx::lcos::server::channel<type>::get_generation_action,               \
+        HPX_PP_CAT(__channel_get_generation_action, HPX_PP_CAT(type, name)))   \
+    HPX_REGISTER_ACTION(                                                       \
+        hpx::lcos::server::channel<type>::set_generation_action,               \
+        HPX_PP_CAT(__channel_set_generation_action, HPX_PP_CAT(type, name)))   \
+    HPX_REGISTER_ACTION(hpx::lcos::server::channel<type>::close_action,        \
+        HPX_PP_CAT(__channel_close_action, HPX_PP_CAT(type, name)))            \
+    /**/

--- a/libs/full/lcos_distributed/include/hpx/lcos_distributed/macros.hpp
+++ b/libs/full/lcos_distributed/include/hpx/lcos_distributed/macros.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/modules/preprocessor.hpp>
 
 #include <hpx/actions/macros.hpp>
 #include <hpx/actions_base/macros.hpp>

--- a/libs/full/lcos_distributed/include/hpx/lcos_distributed/server/channel.hpp
+++ b/libs/full/lcos_distributed/include/hpx/lcos_distributed/server/channel.hpp
@@ -117,4 +117,3 @@ namespace hpx::lcos::server {
         lcos::local::channel<result_type> channel_;
     };
 }    // namespace hpx::lcos::server
-

--- a/libs/full/lcos_distributed/include/hpx/lcos_distributed/server/channel.hpp
+++ b/libs/full/lcos_distributed/include/hpx/lcos_distributed/server/channel.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2016-2021 Hartmut Kaiser
+//  Copyright (c) 2016-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -15,21 +15,23 @@
 #include <hpx/modules/lcos_local.hpp>
 #include <hpx/modules/preprocessor.hpp>
 
+#include <hpx/lcos_distributed/macros.hpp>
+
 #include <cstddef>
 #include <exception>
 #include <type_traits>
 #include <utility>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace lcos { namespace server {
+namespace hpx::lcos::server {
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename T,
+    HPX_CXX_EXPORT template <typename T,
         typename RemoteType = traits::promise_remote_result_t<T>>
     class channel;
 
     ///////////////////////////////////////////////////////////////////////////
-    template <typename T, typename RemoteType>
+    HPX_CXX_EXPORT template <typename T, typename RemoteType>
     class channel
       : public lcos::base_lco_with_value<T, RemoteType,
             traits::detail::component_tag>
@@ -114,60 +116,5 @@ namespace hpx { namespace lcos { namespace server {
     private:
         lcos::local::channel<result_type> channel_;
     };
-}}}    // namespace hpx::lcos::server
+}    // namespace hpx::lcos::server
 
-#define HPX_REGISTER_CHANNEL_DECLARATION(...)                                  \
-    HPX_REGISTER_CHANNEL_DECLARATION_(__VA_ARGS__)                             \
-/**/
-#define HPX_REGISTER_CHANNEL_DECLARATION_(...)                                 \
-    HPX_PP_EXPAND(HPX_PP_CAT(HPX_REGISTER_CHANNEL_DECLARATION_,                \
-        HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))                               \
-    /**/
-
-#define HPX_REGISTER_CHANNEL_DECLARATION_1(type)                               \
-    HPX_REGISTER_CHANNEL_DECLARATION_2(type, type)                             \
-/**/
-#define HPX_REGISTER_CHANNEL_DECLARATION_2(type, name)                         \
-    using HPX_PP_CAT(__channel_, HPX_PP_CAT(type, name)) =                     \
-        ::hpx::lcos::server::channel<type>;                                    \
-    HPX_REGISTER_ACTION_DECLARATION(                                           \
-        hpx::lcos::server::channel<type>::get_generation_action,               \
-        HPX_PP_CAT(__channel_get_generation_action, HPX_PP_CAT(type, name)))   \
-    HPX_REGISTER_ACTION_DECLARATION(                                           \
-        hpx::lcos::server::channel<type>::set_generation_action,               \
-        HPX_PP_CAT(__channel_set_generation_action, HPX_PP_CAT(type, name)))   \
-    HPX_REGISTER_ACTION_DECLARATION(                                           \
-        hpx::lcos::server::channel<type>::close_action,                        \
-        HPX_PP_CAT(__channel_close_action, HPX_PP_CAT(type, name)))            \
-    /**/
-
-#define HPX_REGISTER_CHANNEL(...)                                              \
-    HPX_REGISTER_CHANNEL_(__VA_ARGS__)                                         \
-/**/
-#define HPX_REGISTER_CHANNEL_(...)                                             \
-    HPX_PP_EXPAND(HPX_PP_CAT(                                                  \
-        HPX_REGISTER_CHANNEL_, HPX_PP_NARGS(__VA_ARGS__))(__VA_ARGS__))        \
-    /**/
-
-#define HPX_REGISTER_CHANNEL_1(type)                                           \
-    HPX_REGISTER_CHANNEL_2(type, type)                                         \
-/**/
-#define HPX_REGISTER_CHANNEL_2(type, name)                                     \
-    using HPX_PP_CAT(__channel_, HPX_PP_CAT(type, name)) =                     \
-        ::hpx::lcos::server::channel<type>;                                    \
-    using HPX_PP_CAT(__channel_component_, name) =                             \
-        ::hpx::components::component<HPX_PP_CAT(                               \
-            __channel_, HPX_PP_CAT(type, name))>;                              \
-    HPX_REGISTER_DERIVED_COMPONENT_FACTORY(                                    \
-        HPX_PP_CAT(__channel_component_, name),                                \
-        HPX_PP_CAT(__channel_component_, name),                                \
-        HPX_PP_STRINGIZE(HPX_PP_CAT(__base_lco_with_value_channel_, name)))    \
-    HPX_REGISTER_ACTION(                                                       \
-        hpx::lcos::server::channel<type>::get_generation_action,               \
-        HPX_PP_CAT(__channel_get_generation_action, HPX_PP_CAT(type, name)))   \
-    HPX_REGISTER_ACTION(                                                       \
-        hpx::lcos::server::channel<type>::set_generation_action,               \
-        HPX_PP_CAT(__channel_set_generation_action, HPX_PP_CAT(type, name)))   \
-    HPX_REGISTER_ACTION(hpx::lcos::server::channel<type>::close_action,        \
-        HPX_PP_CAT(__channel_close_action, HPX_PP_CAT(type, name)))            \
-    /**/

--- a/libs/full/performance_counters/CMakeLists.txt
+++ b/libs/full/performance_counters/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2020 The STE||AR-Group
+# Copyright (c) 2019-2026 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -87,8 +87,24 @@ include(HPX_AddModule)
 add_hpx_module(
   full performance_counters
   GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_MODULE_GEN ON
   SOURCES ${performance_counters_sources}
   HEADERS ${performance_counters_headers}
+  EXCLUDE_FROM_GLOBAL_HEADER
+    "hpx/performance_counters/agas_namespace_action_code.hpp"
+    "hpx/performance_counters/apex_sample_value.hpp"
+    "hpx/performance_counters/counters_fwd.hpp"
+    "hpx/performance_counters/server/arithmetics_counter.hpp"
+    "hpx/performance_counters/server/arithmetics_counter_extended.hpp"
+    "hpx/performance_counters/server/base_performance_counter.hpp"
+    "hpx/performance_counters/server/component_namespace_counters.hpp"
+    "hpx/performance_counters/server/elapsed_time_counter.hpp"
+    "hpx/performance_counters/server/locality_namespace_counters.hpp"
+    "hpx/performance_counters/server/primary_namespace_counters.hpp"
+    "hpx/performance_counters/server/raw_counter.hpp"
+    "hpx/performance_counters/server/raw_values_counter.hpp"
+    "hpx/performance_counters/server/statistics_counter.hpp"
+    "hpx/performance_counters/server/symbol_namespace_counters.hpp"
   DEPENDENCIES hpx_core
   MODULE_DEPENDENCIES
     hpx_actions

--- a/libs/full/performance_counters/include/hpx/performance_counters/action_invocation_counter_discoverer.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/action_invocation_counter_discoverer.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2015-2022 Hartmut Kaiser
+//  Copyright (c) 2015-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -8,13 +8,14 @@
 
 #include <hpx/config.hpp>
 #include <hpx/modules/actions_base.hpp>
+
 #include <hpx/performance_counters/counters_fwd.hpp>
 
-namespace hpx { namespace performance_counters {
+namespace hpx::performance_counters {
 
-    HPX_EXPORT bool action_invocation_counter_discoverer(
+    HPX_CXX_EXPORT HPX_EXPORT bool action_invocation_counter_discoverer(
         hpx::actions::detail::invocation_count_registry const& registry,
         counter_info const& info, counter_path_elements& p,
         discover_counter_func const& f, discover_counters_mode mode,
         error_code& ec);
-}}    // namespace hpx::performance_counters
+}    // namespace hpx::performance_counters

--- a/libs/full/performance_counters/include/hpx/performance_counters/agas_counter_types.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/agas_counter_types.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2011-2021 Hartmut Kaiser
+//  Copyright (c) 2011-2026 Hartmut Kaiser
 //  Copyright (c) 2016 Parsa Amini
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -10,10 +10,10 @@
 #include <hpx/config.hpp>
 #include <hpx/modules/agas.hpp>
 
-namespace hpx { namespace performance_counters {
+namespace hpx::performance_counters {
 
     /// Install performance counter types exposing properties from the local
     /// cache.
-    void HPX_EXPORT register_agas_counter_types(
+    HPX_CXX_EXPORT void HPX_EXPORT register_agas_counter_types(
         agas::addressing_service& client);
-}}    // namespace hpx::performance_counters
+}    // namespace hpx::performance_counters

--- a/libs/full/performance_counters/include/hpx/performance_counters/agas_namespace_action_code.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/agas_namespace_action_code.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2011 Bryce Adelstein-Lelbach
-//  Copyright (c) 2012-2021 Hartmut Kaiser
+//  Copyright (c) 2012-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -246,10 +246,10 @@ namespace hpx::agas::detail {
 
     ///////////////////////////////////////////////////////////////////////////
     // get action code from counter type
-    HPX_EXPORT namespace_action_code retrieve_action_code(
+    namespace_action_code retrieve_action_code(
         std::string const& name, error_code& ec = throws);
 
     // get service action code from counter type
-    HPX_EXPORT namespace_action_code retrieve_action_service_code(
+    namespace_action_code retrieve_action_service_code(
         std::string const& name, error_code& ec = throws);
 }    // namespace hpx::agas::detail

--- a/libs/full/performance_counters/include/hpx/performance_counters/apex_sample_value.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/apex_sample_value.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2020 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -9,26 +9,26 @@
 #include <hpx/config.hpp>
 
 #ifdef HPX_HAVE_APEX
-
 #include <hpx/modules/threading_base.hpp>
+
 #include <hpx/performance_counters/counters.hpp>
 
 #include <cstdint>
 #include <string>
 
-namespace hpx { namespace util { namespace external_timer {
+namespace hpx::util::external_timer {
 
     // The actual function pointers. Some of them need to be exported,
     // because through the miracle of chained headers they get referenced
     // outside of the HPX library.
-    static inline void sample_value(std::string const& name, double value)
+    inline void sample_value(std::string const& name, double value)
     {
         if (sample_value_function != nullptr)
         {
             sample_value_function(name, value);
         }
     }
-    static inline void sample_value(
+    inline void sample_value(
         hpx::performance_counters::counter_info const& info, double value)
     {
         if (sample_value_function != nullptr)
@@ -36,6 +36,6 @@ namespace hpx { namespace util { namespace external_timer {
             sample_value_function(info.fullname_, value);
         }
     }
-}}}    // namespace hpx::util::external_timer
+}    // namespace hpx::util::external_timer
 
 #endif

--- a/libs/full/performance_counters/include/hpx/performance_counters/base_performance_counter.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/base_performance_counter.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2025 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -10,9 +10,11 @@
 #include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/runtime_local.hpp>
+
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/performance_counters/server/base_performance_counter.hpp>
 
+#if defined(DOXYGEN)
 ///////////////////////////////////////////////////////////////////////////////
 //[performance_counter_base_class
 namespace hpx::performance_counters {
@@ -21,11 +23,12 @@ namespace hpx::performance_counters {
     class base_performance_counter;
 }    // namespace hpx::performance_counters
 //]
+#endif
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx::performance_counters {
 
-    template <typename Derived>
+    HPX_CXX_EXPORT template <typename Derived>
     class base_performance_counter
       : public hpx::performance_counters::server::base_performance_counter
       , public hpx::components::component_base<Derived>

--- a/libs/full/performance_counters/include/hpx/performance_counters/component_namespace_counters.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/component_namespace_counters.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2011 Bryce Adelstein-Lelbach
-//  Copyright (c) 2012-2021 Hartmut Kaiser
+//  Copyright (c) 2012-2026 Hartmut Kaiser
 //  Copyright (c) 2016 Thomas Heller
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -12,9 +12,9 @@
 #include <hpx/modules/errors.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace agas {
+namespace hpx::agas {
 
     // Register all performance counter types exposed by the component_namespace
-    HPX_EXPORT void component_namespace_register_counter_types(
+    HPX_CXX_EXPORT HPX_EXPORT void component_namespace_register_counter_types(
         error_code& ec = throws);
-}}    // namespace hpx::agas
+}    // namespace hpx::agas

--- a/libs/full/performance_counters/include/hpx/performance_counters/counter_creators.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/counter_creators.hpp
@@ -147,9 +147,10 @@ namespace hpx::performance_counters {
         discover_counters_mode, error_code&);
 
 #if defined(HPX_HAVE_NETWORKING)
-    HPX_CXX_EXPORT HPX_EXPORT
-        naming::gid_type remote_action_invocation_counter_creator(
-            counter_info const&, error_code&);
+    // clang-format off
+    HPX_CXX_EXPORT HPX_EXPORT naming::gid_type
+    remote_action_invocation_counter_creator(counter_info const&, error_code&);
+    // clang-format on
 
     // Discoverer function for action invocation counters.
     HPX_CXX_EXPORT HPX_EXPORT bool remote_action_invocation_counter_discoverer(

--- a/libs/full/performance_counters/include/hpx/performance_counters/counter_creators.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/counter_creators.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2022 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -9,6 +9,7 @@
 #include <hpx/config.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/functional.hpp>
+
 #include <hpx/performance_counters/counters_fwd.hpp>
 
 #include <cstdint>
@@ -16,15 +17,17 @@
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace performance_counters {
+namespace hpx::performance_counters {
+
     ///////////////////////////////////////////////////////////////////////////
     // Discoverer functions to be registered with counter types
 
     /// Default discovery function for performance counters; to be registered
     /// with the counter types. It will pass the \a counter_info and the
     /// \a error_code to the supplied function.
-    HPX_EXPORT bool default_counter_discoverer(counter_info const&,
-        discover_counter_func const&, discover_counters_mode, error_code&);
+    HPX_CXX_EXPORT HPX_EXPORT bool default_counter_discoverer(
+        counter_info const&, discover_counter_func const&,
+        discover_counters_mode, error_code&);
 
     /// Default discoverer function for performance counters; to be registered
     /// with the counter types. It is suitable to be used for all counters
@@ -32,8 +35,9 @@ namespace hpx { namespace performance_counters {
     ///
     ///   /<objectname>(locality#<locality_id>/total)/<instancename>
     ///
-    HPX_EXPORT bool locality_counter_discoverer(counter_info const&,
-        discover_counter_func const&, discover_counters_mode, error_code&);
+    HPX_CXX_EXPORT HPX_EXPORT bool locality_counter_discoverer(
+        counter_info const&, discover_counter_func const&,
+        discover_counters_mode, error_code&);
 
     /// Default discoverer function for performance counters; to be registered
     /// with the counter types. It is suitable to be used for all counters
@@ -41,8 +45,9 @@ namespace hpx { namespace performance_counters {
     ///
     ///   /<objectname>(locality#<locality_id>/pool#<pool_name>/total)/<instancename>
     ///
-    HPX_EXPORT bool locality_pool_counter_discoverer(counter_info const&,
-        discover_counter_func const&, discover_counters_mode, error_code&);
+    HPX_CXX_EXPORT HPX_EXPORT bool locality_pool_counter_discoverer(
+        counter_info const&, discover_counter_func const&,
+        discover_counters_mode, error_code&);
 
     /// Default discoverer function for AGAS performance counters; to be
     /// registered with the counter types. It is suitable to be used for all
@@ -50,8 +55,9 @@ namespace hpx { namespace performance_counters {
     ///
     ///   /<objectname>{locality#0/total}/<instancename>
     ///
-    HPX_EXPORT bool locality0_counter_discoverer(counter_info const&,
-        discover_counter_func const&, discover_counters_mode, error_code&);
+    HPX_CXX_EXPORT HPX_EXPORT bool locality0_counter_discoverer(
+        counter_info const&, discover_counter_func const&,
+        discover_counters_mode, error_code&);
 
     /// Default discoverer function for performance counters; to be registered
     /// with the counter types. It is suitable to be used for all counters
@@ -59,8 +65,9 @@ namespace hpx { namespace performance_counters {
     ///
     ///   /<objectname>(locality#<locality_id>/worker-thread#<threadnum>)/<instancename>
     ///
-    HPX_EXPORT bool locality_thread_counter_discoverer(counter_info const&,
-        discover_counter_func const&, discover_counters_mode, error_code&);
+    HPX_CXX_EXPORT HPX_EXPORT bool locality_thread_counter_discoverer(
+        counter_info const&, discover_counter_func const&,
+        discover_counters_mode, error_code&);
 
     /// Default discoverer function for performance counters; to be registered
     /// with the counter types. It is suitable to be used for all counters
@@ -68,9 +75,9 @@ namespace hpx { namespace performance_counters {
     ///
     ///   /<objectname>{locality#<locality_id>/pool#<poolname>/thread#<threadnum>}/<instancename>
     ///
-    bool locality_pool_thread_counter_discoverer(counter_info const& info,
-        discover_counter_func const& f, discover_counters_mode mode,
-        error_code& ec);
+    HPX_CXX_EXPORT HPX_EXPORT bool locality_pool_thread_counter_discoverer(
+        counter_info const& info, discover_counter_func const& f,
+        discover_counters_mode mode, error_code& ec);
 
     /// Default discoverer function for performance counters; to be registered
     /// with the counter types. It is suitable to be used for all counters
@@ -80,9 +87,10 @@ namespace hpx { namespace performance_counters {
     ///
     /// This is essentially the same as above just that locality#*/total is not
     /// supported.
-    bool locality_pool_thread_no_total_counter_discoverer(
-        counter_info const& info, discover_counter_func const& f,
-        discover_counters_mode mode, error_code& ec);
+    HPX_CXX_EXPORT HPX_EXPORT bool
+    locality_pool_thread_no_total_counter_discoverer(counter_info const& info,
+        discover_counter_func const& f, discover_counters_mode mode,
+        error_code& ec);
 
     /// Default discoverer function for performance counters; to be registered
     /// with the counter types. It is suitable to be used for all counters
@@ -90,8 +98,9 @@ namespace hpx { namespace performance_counters {
     ///
     ///   /<objectname>(locality#<locality_id>/numa-node#<threadnum>)/<instancename>
     ///
-    HPX_EXPORT bool locality_numa_counter_discoverer(counter_info const&,
-        discover_counter_func const&, discover_counters_mode, error_code&);
+    HPX_CXX_EXPORT HPX_EXPORT bool locality_numa_counter_discoverer(
+        counter_info const&, discover_counter_func const&,
+        discover_counters_mode, error_code&);
 
     ///////////////////////////////////////////////////////////////////////////
     /// Creation function for raw counters. The passed function is encapsulating
@@ -100,12 +109,12 @@ namespace hpx { namespace performance_counters {
     ///
     ///   /<objectname>(locality#<locality_id>/total)/<instancename>
     ///
-    HPX_EXPORT naming::gid_type locality_raw_counter_creator(
+    HPX_CXX_EXPORT HPX_EXPORT naming::gid_type locality_raw_counter_creator(
         counter_info const&, hpx::function<std::int64_t(bool)> const&,
         error_code&);
 
-    HPX_EXPORT naming::gid_type locality_raw_values_counter_creator(
-        counter_info const&,
+    HPX_CXX_EXPORT HPX_EXPORT naming::gid_type
+    locality_raw_values_counter_creator(counter_info const&,
         hpx::function<std::vector<std::int64_t>(bool)> const&, error_code&);
 
     ///////////////////////////////////////////////////////////////////////////
@@ -115,7 +124,7 @@ namespace hpx { namespace performance_counters {
     ///
     ///   /agas(<objectinstance>/total)/<instancename>
     ///
-    HPX_EXPORT naming::gid_type agas_raw_counter_creator(
+    HPX_CXX_EXPORT HPX_EXPORT naming::gid_type agas_raw_counter_creator(
         counter_info const&, error_code&, char const* const);
 
     /// Default discoverer function for performance counters; to be registered
@@ -124,25 +133,26 @@ namespace hpx { namespace performance_counters {
     ///
     ///   /agas(<objectinstance>/total)/<instancename>
     ///
-    HPX_EXPORT bool agas_counter_discoverer(counter_info const&,
+    HPX_CXX_EXPORT HPX_EXPORT bool agas_counter_discoverer(counter_info const&,
         discover_counter_func const&, discover_counters_mode, error_code&);
 
     ///////////////////////////////////////////////////////////////////////////
     // Creation function for action invocation counters.
-    HPX_EXPORT naming::gid_type local_action_invocation_counter_creator(
-        counter_info const&, error_code&);
+    HPX_CXX_EXPORT HPX_EXPORT naming::gid_type
+    local_action_invocation_counter_creator(counter_info const&, error_code&);
 
     // Discoverer function for action invocation counters.
-    HPX_EXPORT bool local_action_invocation_counter_discoverer(
+    HPX_CXX_EXPORT HPX_EXPORT bool local_action_invocation_counter_discoverer(
         counter_info const&, discover_counter_func const&,
         discover_counters_mode, error_code&);
 
 #if defined(HPX_HAVE_NETWORKING)
-    HPX_EXPORT naming::gid_type remote_action_invocation_counter_creator(
-        counter_info const&, error_code&);
+    HPX_CXX_EXPORT HPX_EXPORT
+        naming::gid_type remote_action_invocation_counter_creator(
+            counter_info const&, error_code&);
 
     // Discoverer function for action invocation counters.
-    HPX_EXPORT bool remote_action_invocation_counter_discoverer(
+    HPX_CXX_EXPORT HPX_EXPORT bool remote_action_invocation_counter_discoverer(
         counter_info const&, discover_counter_func const&,
         discover_counters_mode, error_code&);
 
@@ -150,15 +160,15 @@ namespace hpx { namespace performance_counters {
     defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
     ///////////////////////////////////////////////////////////////////////////
     // Creation function for per-action parcel data counters
-    HPX_EXPORT naming::gid_type per_action_data_counter_creator(
+    HPX_CXX_EXPORT HPX_EXPORT naming::gid_type per_action_data_counter_creator(
         counter_info const& info,
         hpx::function<std::int64_t(std::string const&, bool)> const& f,
         error_code& ec);
 
     // Discoverer function for per-action parcel data counters
-    HPX_EXPORT bool per_action_data_counter_discoverer(counter_info const& info,
-        discover_counter_func const& f, discover_counters_mode mode,
-        error_code& ec);
+    HPX_CXX_EXPORT HPX_EXPORT bool per_action_data_counter_discoverer(
+        counter_info const& info, discover_counter_func const& f,
+        discover_counters_mode mode, error_code& ec);
 #endif
 #endif
-}}    // namespace hpx::performance_counters
+}    // namespace hpx::performance_counters

--- a/libs/full/performance_counters/include/hpx/performance_counters/counter_interface.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/counter_interface.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2021-2024 Hartmut Kaiser
+//  Copyright (c) 2021-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -10,17 +10,20 @@
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/naming_base.hpp>
-#include <hpx/performance_counters/counters.hpp>
 
-namespace hpx { namespace performance_counters {
+#include <hpx/performance_counters/counters.hpp>
+#include <hpx/performance_counters/detail/counter_interface_functions.hpp>
+
+namespace hpx::performance_counters {
 
     ///////////////////////////////////////////////////////////////////////////
     HPX_EXPORT hpx::future<id_type> create_performance_counter_async(
         id_type const& target_id, counter_info const& info);
 
-    inline id_type create_performance_counter(id_type const& target_id,
-        counter_info const& info, error_code& ec = throws)
+    HPX_CXX_EXPORT inline id_type create_performance_counter(
+        id_type const& target_id, counter_info const& info,
+        error_code& ec = throws)
     {
         return create_performance_counter_async(target_id, info).get(ec);
     }
-}}    // namespace hpx::performance_counters
+}    // namespace hpx::performance_counters

--- a/libs/full/performance_counters/include/hpx/performance_counters/counter_parser.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/counter_parser.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2016 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -11,22 +11,23 @@
 #include <string>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace performance_counters {
-    struct instance_name
+namespace hpx::performance_counters {
+
+    HPX_CXX_EXPORT struct instance_name
     {
         std::string name_;
         std::string index_;
         bool basename_ = false;
     };
 
-    struct instance_elements
+    HPX_CXX_EXPORT struct instance_elements
     {
         instance_name parent_;
         instance_name child_;
         instance_name subchild_;
     };
 
-    struct path_elements
+    HPX_CXX_EXPORT struct path_elements
     {
         std::string object_;
         instance_elements instance_;
@@ -34,6 +35,6 @@ namespace hpx { namespace performance_counters {
         std::string parameters_;
     };
 
-    HPX_EXPORT bool parse_counter_name(
+    HPX_CXX_EXPORT HPX_EXPORT bool parse_counter_name(
         std::string const& name, path_elements& elements);
-}}    // namespace hpx::performance_counters
+}    // namespace hpx::performance_counters

--- a/libs/full/performance_counters/include/hpx/performance_counters/counters.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/counters.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2023 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -12,6 +12,7 @@
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/naming_base.hpp>
 #include <hpx/modules/serialization.hpp>
+
 #include <hpx/performance_counters/counters_fwd.hpp>
 
 #include <cstddef>
@@ -23,39 +24,7 @@
 #include <hpx/config/warnings_prefix.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace performance_counters {
-    ///////////////////////////////////////////////////////////////////////////
-    constexpr char const counter_prefix[] = "/counters";
-    constexpr std::size_t counter_prefix_len = std::size(counter_prefix) - 1;
-
-    ///////////////////////////////////////////////////////////////////////////
-    inline std::string& ensure_counter_prefix(std::string& name)
-    {
-        if (name.compare(0, counter_prefix_len, counter_prefix) != 0)
-            name = counter_prefix + name;
-        return name;
-    }
-
-    inline std::string ensure_counter_prefix(    //-V659
-        std::string const& counter)
-    {
-        std::string name(counter);
-        return ensure_counter_prefix(name);
-    }
-
-    inline std::string& remove_counter_prefix(std::string& name)
-    {
-        if (name.compare(0, counter_prefix_len, counter_prefix) == 0)
-            name = name.substr(counter_prefix_len);
-        return name;
-    }
-
-    inline std::string remove_counter_prefix(    //-V659
-        std::string const& counter)
-    {
-        std::string name(counter);
-        return remove_counter_prefix(name);
-    }
+namespace hpx::performance_counters {
 
 #if defined(DOXYGEN)
     ///////////////////////////////////////////////////////////////////////////
@@ -174,13 +143,7 @@ namespace hpx { namespace performance_counters {
         /// through a separate \a get_counter_values_array() function.
         raw_values
     };
-#endif
 
-    ///////////////////////////////////////////////////////////////////////////
-    /// \brief Return the readable name of a given counter type
-    HPX_EXPORT char const* get_counter_type_name(counter_type state);
-
-#if defined(DOXYGEN)
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Status and error codes used by the functions related to
     ///        performance counters.
@@ -196,7 +159,13 @@ namespace hpx { namespace performance_counters {
     };
 #endif
 
-    inline bool status_is_valid(counter_status s)
+    ///////////////////////////////////////////////////////////////////////////
+    HPX_CXX_EXPORT inline constexpr char const counter_prefix[] = "/counters";
+    HPX_CXX_EXPORT inline constexpr std::size_t counter_prefix_len =
+        std::size(counter_prefix) - 1;
+
+    ///////////////////////////////////////////////////////////////////////////
+    HPX_CXX_EXPORT inline bool status_is_valid(counter_status s)
     {
         return s == counter_status::valid_data || s == counter_status::new_data;
     }
@@ -211,7 +180,7 @@ namespace hpx { namespace performance_counters {
     /// i.e.
     ///    /queue/length
     ///
-    struct counter_type_path_elements
+    HPX_CXX_EXPORT struct counter_type_path_elements
     {
         counter_type_path_elements() = default;
 
@@ -249,7 +218,7 @@ namespace hpx { namespace performance_counters {
     /// i.e.
     ///    /queue{localityprefix/thread#2}/length
     ///
-    struct counter_path_elements : counter_type_path_elements
+    HPX_CXX_EXPORT struct counter_path_elements : counter_type_path_elements
     {
         using base_type = counter_type_path_elements;
 
@@ -315,7 +284,7 @@ namespace hpx { namespace performance_counters {
     };
 
     ///////////////////////////////////////////////////////////////////////////
-    struct counter_info
+    HPX_CXX_EXPORT struct counter_info
     {
         explicit counter_info(counter_type type = counter_type::raw)
           : type_(type)
@@ -369,47 +338,185 @@ namespace hpx { namespace performance_counters {
     /// \brief This declares the type of a function, which will be
     ///        called by HPX whenever a new performance counter instance of a
     ///        particular type needs to be created.
-    using create_counter_func =
+    HPX_CXX_EXPORT using create_counter_func =
         hpx::function<naming::gid_type(counter_info const&, error_code&)>;
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief This declares a type of a function, which will be passed to
     ///        a \a discover_counters_func in order to be called for each
     ///        discovered performance counter instance.
-    using discover_counter_func =
+    HPX_CXX_EXPORT using discover_counter_func =
         hpx::function<bool(counter_info const&, error_code&)>;
 
     /// \brief This declares the type of a function, which will be called by
     ///        HPX whenever it needs to discover all performance counter
     ///        instances of a particular type.
-    using discover_counters_func = hpx::function<bool(counter_info const&,
-        discover_counter_func const&, discover_counters_mode, error_code&)>;
+    HPX_CXX_EXPORT using discover_counters_func =
+        hpx::function<bool(counter_info const&, discover_counter_func const&,
+            discover_counters_mode, error_code&)>;
 
-    ///////////////////////////////////////////////////////////////////////
-    inline counter_status add_counter_type(
-        counter_info const& info, error_code& ec)
+    ///////////////////////////////////////////////////////////////////////////
+    HPX_CXX_EXPORT struct counter_value
     {
-        return add_counter_type(
-            info, create_counter_func(), discover_counters_func(), ec);
-    }
+        counter_value(std::int64_t value = 0, std::int64_t scaling = 1,
+            bool scale_inverse = false)
+          : time_()
+          , count_(0)
+          , value_(value)
+          , scaling_(scaling)
+          , status_(counter_status::new_data)
+          , scale_inverse_(scale_inverse)
+        {
+        }
 
-    inline hpx::id_type get_counter(std::string const& name, error_code& ec)
+        std::uint64_t time_;       ///< The local time when data was collected
+        std::uint64_t count_;      ///< The invocation counter for the data
+        std::int64_t value_;       ///< The current counter value
+        std::int64_t scaling_;     ///< The scaling of the current counter value
+        counter_status status_;    ///< The status of the counter value
+        bool scale_inverse_;       ///< If true, value_ needs to be divided by
+                                   ///< scaling_, otherwise it has to be
+                                   ///< multiplied.
+
+        /// \brief Retrieve the 'real' value of the counter_value, converted to
+        ///        the requested type \a T
+        template <typename T>
+        T get_value(error_code& ec = throws) const
+        {
+            if (!status_is_valid(status_))
+            {
+                HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                    "counter_value::get_value<T>",
+                    "counter value is in invalid status");
+                return T();
+            }
+
+            T val = static_cast<T>(value_);
+
+            if (scaling_ != 1)
+            {
+                if (scaling_ == 0)
+                {
+                    HPX_THROWS_IF(ec, hpx::error::uninitialized_value,
+                        "counter_value::get_value<T>",
+                        "scaling should not be zero");
+                    return T();
+                }
+
+                // calculate and return the real counter value
+                if (scale_inverse_)
+                    return val / static_cast<T>(scaling_);
+
+                return val * static_cast<T>(scaling_);
+            }
+            return val;
+        }
+
+    private:
+        // serialization support
+        friend class hpx::serialization::access;
+
+        HPX_EXPORT void serialize(
+            serialization::output_archive& ar, unsigned int const) const;
+        HPX_EXPORT void serialize(
+            serialization::input_archive& ar, unsigned int const);
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    HPX_CXX_EXPORT struct counter_values_array
     {
-        hpx::future<hpx::id_type> f = get_counter_async(name, ec);
-        if (ec)
-            return hpx::invalid_id;
+        counter_values_array(
+            std::int64_t scaling = 1, bool scale_inverse = false)
+          : time_()
+          , count_(0)
+          , values_()
+          , scaling_(scaling)
+          , status_(counter_status::new_data)
+          , scale_inverse_(scale_inverse)
+        {
+        }
 
-        return f.get(ec);
-    }
+        counter_values_array(std::vector<std::int64_t>&& values,
+            std::int64_t scaling = 1, bool scale_inverse = false)
+          : time_()
+          , count_(0)
+          , values_(HPX_MOVE(values))
+          , scaling_(scaling)
+          , status_(counter_status::new_data)
+          , scale_inverse_(scale_inverse)
+        {
+        }
 
-    inline hpx::id_type get_counter(counter_info const& info, error_code& ec)
-    {
-        hpx::future<hpx::id_type> f = get_counter_async(info, ec);
-        if (ec)
-            return hpx::invalid_id;
+        counter_values_array(std::vector<std::int64_t> const& values,
+            std::int64_t scaling = 1, bool scale_inverse = false)
+          : time_()
+          , count_(0)
+          , values_(values)
+          , scaling_(scaling)
+          , status_(counter_status::new_data)
+          , scale_inverse_(scale_inverse)
+        {
+        }
 
-        return f.get(ec);
-    }
-}}    // namespace hpx::performance_counters
+        std::uint64_t time_;     ///< The local time when data was collected
+        std::uint64_t count_;    ///< The invocation counter for the data
+        std::vector<std::int64_t> values_;    ///< The current counter values
+        std::int64_t scaling_;    ///< The scaling of the current counter values
+        counter_status status_;    ///< The status of the counter value
+        bool scale_inverse_;       ///< If true, value_ needs to be divided by
+                                   ///< scaling_, otherwise it has to be
+                                   ///< multiplied.
+
+        /// \brief Retrieve the 'real' value of the counter_value, converted to
+        ///        the requested type \a T
+        template <typename T>
+        T get_value(std::size_t index, error_code& ec = throws) const
+        {
+            if (!status_is_valid(status_))
+            {
+                HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                    "counter_values_array::get_value<T>",
+                    "counter value is in invalid status");
+                return T();
+            }
+            if (index >= values_.size())
+            {
+                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                    "counter_values_array::get_value<T>",
+                    "index out of bounds");
+                return T();
+            }
+
+            T val = static_cast<T>(values_[index]);
+
+            if (scaling_ != 1)
+            {
+                if (scaling_ == 0)
+                {
+                    HPX_THROWS_IF(ec, hpx::error::uninitialized_value,
+                        "counter_values_array::get_value<T>",
+                        "scaling should not be zero");
+                    return T();
+                }
+
+                // calculate and return the real counter value
+                if (scale_inverse_)
+                    return val / static_cast<T>(scaling_);
+
+                return val * static_cast<T>(scaling_);
+            }
+            return val;
+        }
+
+    private:
+        // serialization support
+        friend class hpx::serialization::access;
+
+        HPX_EXPORT void serialize(
+            serialization::output_archive& ar, unsigned int const) const;
+        HPX_EXPORT void serialize(
+            serialization::input_archive& ar, unsigned int const);
+    };
+}    // namespace hpx::performance_counters
 
 #include <hpx/config/warnings_suffix.hpp>

--- a/libs/full/performance_counters/include/hpx/performance_counters/counters_fwd.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/counters_fwd.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017-2022 Hartmut Kaiser
+//  Copyright (c) 2017-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -11,7 +11,6 @@
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/naming_base.hpp>
-#include <hpx/modules/serialization.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -20,17 +19,20 @@
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace performance_counters {
+namespace hpx::performance_counters {
 
     ///////////////////////////////////////////////////////////////////////////
-    inline std::string& ensure_counter_prefix(std::string& name);
-    inline std::string ensure_counter_prefix(std::string const& counter);
-    inline std::string& remove_counter_prefix(std::string& name);
-    inline std::string remove_counter_prefix(std::string const& counter);
+    HPX_CXX_EXPORT HPX_EXPORT std::string& ensure_counter_prefix(
+        std::string& name);
+    HPX_CXX_EXPORT HPX_EXPORT std::string ensure_counter_prefix(
+        std::string const& counter);
+    HPX_CXX_EXPORT HPX_EXPORT std::string& remove_counter_prefix(
+        std::string& name);
+    HPX_CXX_EXPORT HPX_EXPORT std::string remove_counter_prefix(
+        std::string const& counter);
 
     ///////////////////////////////////////////////////////////////////////////
-    enum class counter_type
-    {
+    HPX_CXX_EXPORT enum class counter_type : std::uint8_t {
         // \a text counter shows a variable-length text string. It does not
         // deliver calculated values.
         //
@@ -144,14 +146,16 @@ namespace hpx { namespace performance_counters {
         raw_values
     };
 
-    inline constexpr bool operator<(counter_type lhs, counter_type rhs) noexcept
+    HPX_CXX_EXPORT inline constexpr bool operator<(
+        counter_type lhs, counter_type rhs) noexcept
     {
         return static_cast<int>(lhs) < static_cast<int>(rhs);
     }
 
-    inline constexpr bool operator>(counter_type lhs, counter_type rhs) noexcept
+    HPX_CXX_EXPORT inline constexpr bool operator>(
+        counter_type lhs, counter_type rhs) noexcept
     {
-        return static_cast<int>(lhs) > static_cast<int>(rhs);
+        return rhs < lhs;
     }
 
 #define HPX_COUNTER_TYPE_UNSCOPED_ENUM_DEPRECATION_MSG                         \
@@ -189,13 +193,13 @@ namespace hpx { namespace performance_counters {
 
     ///////////////////////////////////////////////////////////////////////////
     // Return the readable name of a given counter type
-    HPX_EXPORT char const* get_counter_type_name(counter_type state);
+    HPX_CXX_EXPORT HPX_EXPORT char const* get_counter_type_name(
+        counter_type state);
 
     ///////////////////////////////////////////////////////////////////////////
     // Status and error codes used by the functions related to
     // performance counters.
-    enum class counter_status
-    {
+    HPX_CXX_EXPORT enum class counter_status : std::uint8_t {
         valid_data,         // No error occurred, data is valid
         new_data,           // Data is valid and different from last call
         invalid_data,       // Some error occurred, data is not value
@@ -205,7 +209,8 @@ namespace hpx { namespace performance_counters {
         generic_error            // A unknown error occurred
     };
 
-    HPX_EXPORT std::ostream& operator<<(std::ostream& os, counter_status rhs);
+    HPX_CXX_EXPORT HPX_EXPORT std::ostream& operator<<(
+        std::ostream& os, counter_status rhs);
 
 #define HPX_COUNTER_STATUS_UNSCOPED_ENUM_DEPRECATION_MSG                       \
     "The unscoped counter_status names are deprecated. Please use "            \
@@ -234,88 +239,91 @@ namespace hpx { namespace performance_counters {
 
 #undef HPX_COUNTER_STATUS_UNSCOPED_ENUM_DEPRECATION_MSG
 
-    inline bool status_is_valid(counter_status s);
+    HPX_CXX_EXPORT inline bool status_is_valid(counter_status s);
 
     ///////////////////////////////////////////////////////////////////////////
     // A counter_type_path_elements holds the elements of a full name for a
     // counter type.
-    struct counter_type_path_elements;
+    HPX_CXX_EXPORT struct counter_type_path_elements;
 
     ///////////////////////////////////////////////////////////////////////////
     // A counter_path_elements holds the elements of a full name for a counter
     // instance.
-    struct counter_path_elements;
+    HPX_CXX_EXPORT struct counter_path_elements;
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Create a full name of a counter type from the contents of the
     ///        given \a counter_type_path_elements instance.The generated
     ///        counter type name will not contain any parameters.
-    HPX_EXPORT counter_status get_counter_type_name(
+    HPX_CXX_EXPORT HPX_EXPORT counter_status get_counter_type_name(
         counter_type_path_elements const& path, std::string& result,
         error_code& ec = throws);
 
     /// \brief Create a full name of a counter type from the contents of the
     ///        given \a counter_type_path_elements instance. The generated
     ///        counter type name will contain all parameters.
-    HPX_EXPORT counter_status get_full_counter_type_name(
+    HPX_CXX_EXPORT HPX_EXPORT counter_status get_full_counter_type_name(
         counter_type_path_elements const& path, std::string& result,
         error_code& ec = throws);
 
     /// \brief Create a full name of a counter from the contents of the given
     ///        \a counter_path_elements instance.
-    HPX_EXPORT counter_status get_counter_name(
+    HPX_CXX_EXPORT HPX_EXPORT counter_status get_counter_name(
         counter_path_elements const& path, std::string& result,
         error_code& ec = throws);
 
     /// \brief Create a name of a counter instance from the contents of the
     ///        given \a counter_path_elements instance.
-    HPX_EXPORT counter_status get_counter_instance_name(
+    HPX_CXX_EXPORT HPX_EXPORT counter_status get_counter_instance_name(
         counter_path_elements const& path, std::string& result,
         error_code& ec = throws);
 
     /// \brief Fill the given \a counter_type_path_elements instance from the
     ///        given full name of a counter type
-    HPX_EXPORT counter_status get_counter_type_path_elements(
+    HPX_CXX_EXPORT HPX_EXPORT counter_status get_counter_type_path_elements(
         std::string const& name, counter_type_path_elements& path,
         error_code& ec = throws);
 
     /// \brief Fill the given \a counter_path_elements instance from the given
     ///        full name of a counter
-    HPX_EXPORT counter_status get_counter_path_elements(std::string const& name,
-        counter_path_elements& path, error_code& ec = throws);
+    HPX_CXX_EXPORT HPX_EXPORT counter_status get_counter_path_elements(
+        std::string const& name, counter_path_elements& path,
+        error_code& ec = throws);
 
     /// \brief Return the canonical counter instance name from a given full
     ///        instance name
-    HPX_EXPORT counter_status get_counter_name(std::string const& name,
-        std::string& countername, error_code& ec = throws);
+    HPX_CXX_EXPORT HPX_EXPORT counter_status get_counter_name(
+        std::string const& name, std::string& countername,
+        error_code& ec = throws);
 
     /// \brief Return the canonical counter type name from a given (full)
     ///        instance name
-    HPX_EXPORT counter_status get_counter_type_name(std::string const& name,
-        std::string& type_name, error_code& ec = throws);
+    HPX_CXX_EXPORT HPX_EXPORT counter_status get_counter_type_name(
+        std::string const& name, std::string& type_name,
+        error_code& ec = throws);
 
     // default version of performance counter structures
-#define HPX_PERFORMANCE_COUNTER_V1 0x01000000
+    HPX_CXX_EXPORT inline constexpr std::uint32_t HPX_PERFORMANCE_COUNTER_V1 =
+        0x01000000;
 
     ///////////////////////////////////////////////////////////////////////////
-    struct counter_info;
+    HPX_CXX_EXPORT struct counter_info;
 
     ///////////////////////////////////////////////////////////////////////////
     // This declares the type of a function, which will be
     // called by HPX whenever a new performance counter instance of a
     // particular type needs to be created.
-    using create_counter_func =
+    HPX_CXX_EXPORT using create_counter_func =
         hpx::function<naming::gid_type(counter_info const&, error_code&)>;
 
     ///////////////////////////////////////////////////////////////////////////
     // This declares a type of a function, which will be passed to
     // a \a discover_counters_func in order to be called for each
     // discovered performance counter instance.
-    using discover_counter_func =
+    HPX_CXX_EXPORT using discover_counter_func =
         hpx::function<bool(counter_info const&, error_code&)>;
 
-    enum class discover_counters_mode
-    {
+    HPX_CXX_EXPORT enum class discover_counters_mode : std::uint8_t {
         minimal,
         full    // fully expand all wild cards
     };
@@ -338,218 +346,61 @@ namespace hpx { namespace performance_counters {
     // This declares the type of a function, which will be called by
     // HPX whenever it needs to discover all performance counter
     // instances of a particular type.
-    using discover_counters_func = hpx::function<bool(counter_info const&,
-        discover_counter_func const&, discover_counters_mode, error_code&)>;
+    HPX_CXX_EXPORT using discover_counters_func =
+        hpx::function<bool(counter_info const&, discover_counter_func const&,
+            discover_counters_mode, error_code&)>;
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Complement the counter info if parent instance name is missing
-    HPX_EXPORT counter_status complement_counter_info(counter_info& info,
-        counter_info const& type_info, error_code& ec = throws);
+    HPX_CXX_EXPORT HPX_EXPORT counter_status complement_counter_info(
+        counter_info& info, counter_info const& type_info,
+        error_code& ec = throws);
 
-    HPX_EXPORT counter_status complement_counter_info(
+    HPX_CXX_EXPORT HPX_EXPORT counter_status complement_counter_info(
         counter_info& info, error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
-    struct counter_value
-    {
-        counter_value(std::int64_t value = 0, std::int64_t scaling = 1,
-            bool scale_inverse = false)
-          : time_()
-          , count_(0)
-          , value_(value)
-          , scaling_(scaling)
-          , status_(counter_status::new_data)
-          , scale_inverse_(scale_inverse)
-        {
-        }
-
-        std::uint64_t time_;       ///< The local time when data was collected
-        std::uint64_t count_;      ///< The invocation counter for the data
-        std::int64_t value_;       ///< The current counter value
-        std::int64_t scaling_;     ///< The scaling of the current counter value
-        counter_status status_;    ///< The status of the counter value
-        bool scale_inverse_;       ///< If true, value_ needs to be divided by
-                                   ///< scaling_, otherwise it has to be
-                                   ///< multiplied.
-
-        /// \brief Retrieve the 'real' value of the counter_value, converted to
-        ///        the requested type \a T
-        template <typename T>
-        T get_value(error_code& ec = throws) const
-        {
-            if (!status_is_valid(status_))
-            {
-                HPX_THROWS_IF(ec, hpx::error::invalid_status,
-                    "counter_value::get_value<T>",
-                    "counter value is in invalid status");
-                return T();
-            }
-
-            T val = static_cast<T>(value_);
-
-            if (scaling_ != 1)
-            {
-                if (scaling_ == 0)
-                {
-                    HPX_THROWS_IF(ec, hpx::error::uninitialized_value,
-                        "counter_value::get_value<T>",
-                        "scaling should not be zero");
-                    return T();
-                }
-
-                // calculate and return the real counter value
-                if (scale_inverse_)
-                    return val / static_cast<T>(scaling_);
-
-                return val * static_cast<T>(scaling_);
-            }
-            return val;
-        }
-
-    private:
-        // serialization support
-        friend class hpx::serialization::access;
-
-        HPX_EXPORT void serialize(
-            serialization::output_archive& ar, unsigned int const) const;
-        HPX_EXPORT void serialize(
-            serialization::input_archive& ar, unsigned int const);
-    };
-
-    ///////////////////////////////////////////////////////////////////////////
-    struct counter_values_array
-    {
-        counter_values_array(
-            std::int64_t scaling = 1, bool scale_inverse = false)
-          : time_()
-          , count_(0)
-          , values_()
-          , scaling_(scaling)
-          , status_(counter_status::new_data)
-          , scale_inverse_(scale_inverse)
-        {
-        }
-
-        counter_values_array(std::vector<std::int64_t>&& values,
-            std::int64_t scaling = 1, bool scale_inverse = false)
-          : time_()
-          , count_(0)
-          , values_(HPX_MOVE(values))
-          , scaling_(scaling)
-          , status_(counter_status::new_data)
-          , scale_inverse_(scale_inverse)
-        {
-        }
-
-        counter_values_array(std::vector<std::int64_t> const& values,
-            std::int64_t scaling = 1, bool scale_inverse = false)
-          : time_()
-          , count_(0)
-          , values_(values)
-          , scaling_(scaling)
-          , status_(counter_status::new_data)
-          , scale_inverse_(scale_inverse)
-        {
-        }
-
-        std::uint64_t time_;     ///< The local time when data was collected
-        std::uint64_t count_;    ///< The invocation counter for the data
-        std::vector<std::int64_t> values_;    ///< The current counter values
-        std::int64_t scaling_;    ///< The scaling of the current counter values
-        counter_status status_;    ///< The status of the counter value
-        bool scale_inverse_;       ///< If true, value_ needs to be divided by
-                                   ///< scaling_, otherwise it has to be
-                                   ///< multiplied.
-
-        /// \brief Retrieve the 'real' value of the counter_value, converted to
-        ///        the requested type \a T
-        template <typename T>
-        T get_value(std::size_t index, error_code& ec = throws) const
-        {
-            if (!status_is_valid(status_))
-            {
-                HPX_THROWS_IF(ec, hpx::error::invalid_status,
-                    "counter_values_array::get_value<T>",
-                    "counter value is in invalid status");
-                return T();
-            }
-            if (index >= values_.size())
-            {
-                HPX_THROWS_IF(ec, hpx::error::bad_parameter,
-                    "counter_values_array::get_value<T>",
-                    "index out of bounds");
-                return T();
-            }
-
-            T val = static_cast<T>(values_[index]);
-
-            if (scaling_ != 1)
-            {
-                if (scaling_ == 0)
-                {
-                    HPX_THROWS_IF(ec, hpx::error::uninitialized_value,
-                        "counter_values_array::get_value<T>",
-                        "scaling should not be zero");
-                    return T();
-                }
-
-                // calculate and return the real counter value
-                if (scale_inverse_)
-                    return val / static_cast<T>(scaling_);
-
-                return val * static_cast<T>(scaling_);
-            }
-            return val;
-        }
-
-    private:
-        // serialization support
-        friend class hpx::serialization::access;
-
-        HPX_EXPORT void serialize(
-            serialization::output_archive& ar, unsigned int const) const;
-        HPX_EXPORT void serialize(
-            serialization::input_archive& ar, unsigned int const);
-    };
+    HPX_CXX_EXPORT struct counter_value;
+    HPX_CXX_EXPORT struct counter_values_array;
 
     ///////////////////////////////////////////////////////////////////////
     // Add a new performance counter type to the (local) registry
-    HPX_EXPORT counter_status add_counter_type(counter_info const& info,
-        create_counter_func const& create_counter,
+    HPX_CXX_EXPORT HPX_EXPORT counter_status add_counter_type(
+        counter_info const& info, create_counter_func const& create_counter,
         discover_counters_func const& discover_counters,
         error_code& ec = throws);
 
-    inline counter_status add_counter_type(
+    HPX_CXX_EXPORT HPX_EXPORT counter_status add_counter_type(
         counter_info const& info, error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Call the supplied function for each registered counter type
-    HPX_EXPORT counter_status discover_counter_types(
+    HPX_CXX_EXPORT HPX_EXPORT counter_status discover_counter_types(
         discover_counter_func const& discover_counter,
         discover_counters_mode mode = discover_counters_mode::minimal,
         error_code& ec = throws);
 
     /// \brief Return a list of all available counter descriptions.
-    HPX_EXPORT counter_status discover_counter_types(
+    HPX_CXX_EXPORT HPX_EXPORT counter_status discover_counter_types(
         std::vector<counter_info>& counters,
         discover_counters_mode mode = discover_counters_mode::minimal,
         error_code& ec = throws);
 
     /// \brief Call the supplied function for the given registered counter type.
-    HPX_EXPORT counter_status discover_counter_type(std::string const& name,
-        discover_counter_func const& discover_counter,
+    HPX_CXX_EXPORT HPX_EXPORT counter_status discover_counter_type(
+        std::string const& name, discover_counter_func const& discover_counter,
         discover_counters_mode mode = discover_counters_mode::minimal,
         error_code& ec = throws);
 
-    HPX_EXPORT counter_status discover_counter_type(counter_info const& info,
-        discover_counter_func const& discover_counter,
+    HPX_CXX_EXPORT HPX_EXPORT counter_status discover_counter_type(
+        counter_info const& info, discover_counter_func const& discover_counter,
         discover_counters_mode mode = discover_counters_mode::minimal,
         error_code& ec = throws);
 
     /// \brief Return a list of matching counter descriptions for the given
     ///        registered counter type.
-    HPX_EXPORT counter_status discover_counter_type(std::string const& name,
-        std::vector<counter_info>& counters,
+    HPX_CXX_EXPORT HPX_EXPORT counter_status discover_counter_type(
+        std::string const& name, std::vector<counter_info>& counters,
         discover_counters_mode mode = discover_counters_mode::minimal,
         error_code& ec = throws);
 
@@ -563,52 +414,61 @@ namespace hpx { namespace performance_counters {
     ///
     /// This function expands all locality#* and worker-thread#* wild
     /// cards only.
-    HPX_EXPORT bool expand_counter_info(
+    HPX_CXX_EXPORT HPX_EXPORT bool expand_counter_info(
         counter_info const&, discover_counter_func const&, error_code&);
 
     /// \brief Remove an existing counter type from the (local) registry
     ///
     /// \note This doesn't remove existing counters of this type, it just
     ///       inhibits defining new counters using this type.
-    HPX_EXPORT counter_status remove_counter_type(
+    HPX_CXX_EXPORT HPX_EXPORT counter_status remove_counter_type(
         counter_info const& info, error_code& ec = throws);
 
     /// \brief Retrieve the counter type for the given counter name from the
     ///        (local) registry
-    HPX_EXPORT counter_status get_counter_type(
+    HPX_CXX_EXPORT HPX_EXPORT counter_status get_counter_type(
         std::string const& name, counter_info& info, error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Get the global id of an existing performance counter, if the
     ///        counter does not exist yet, the function attempts to create the
     ///        counter based on the given counter name.
-    HPX_EXPORT hpx::future<hpx::id_type> get_counter_async(
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future<hpx::id_type> get_counter_async(
         std::string name, error_code& ec = throws);
-
-    inline hpx::id_type get_counter(
-        std::string const& name, error_code& ec = throws);
 
     /// \brief Get the global id of an existing performance counter, if the
     ///        counter does not exist yet, the function attempts to create the
     ///        counter based on the given counter info.
-    HPX_EXPORT hpx::future<hpx::id_type> get_counter_async(
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future<hpx::id_type> get_counter_async(
         counter_info const& info, error_code& ec = throws);
 
-    inline hpx::id_type get_counter(
+    ///////////////////////////////////////////////////////////////////////////
+    /// \brief Get the global id of an existing performance counter, if the
+    ///        counter does not exist yet, the function attempts to create the
+    ///        counter based on the given counter name.
+    HPX_CXX_EXPORT HPX_EXPORT hpx::id_type get_counter(
+        std::string const& name, error_code& ec);
+
+    /// \brief Get the global id of an existing performance counter, if the
+    ///        counter does not exist yet, the function attempts to create the
+    ///        counter based on the given counter info.
+    HPX_CXX_EXPORT HPX_EXPORT hpx::id_type get_counter(
         counter_info const& info, error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Retrieve the meta data specific for the given counter instance
-    HPX_EXPORT void get_counter_infos(counter_info const& info,
+    HPX_CXX_EXPORT HPX_EXPORT void get_counter_infos(counter_info const& info,
         counter_type& type, std::string& helptext, std::uint32_t& version,
         error_code& ec = throws);
 
     /// \brief Retrieve the meta data specific for the given counter instance
-    HPX_EXPORT void get_counter_infos(std::string name, counter_type& type,
-        std::string& helptext, std::uint32_t& version, error_code& ec = throws);
+    HPX_CXX_EXPORT HPX_EXPORT void get_counter_infos(std::string name,
+        counter_type& type, std::string& helptext, std::uint32_t& version,
+        error_code& ec = throws);
 
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
+
         /// \brief Add an existing performance counter instance to the registry
         HPX_EXPORT counter_status add_counter(hpx::id_type const& id,
             counter_info const& info, error_code& ec = throws);
@@ -698,4 +558,4 @@ namespace hpx { namespace performance_counters {
         HPX_EXPORT naming::gid_type create_counter_local(
             counter_info const& info);
     }    // namespace detail
-}}    // namespace hpx::performance_counters
+}    // namespace hpx::performance_counters

--- a/libs/full/performance_counters/include/hpx/performance_counters/counters_fwd.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/counters_fwd.hpp
@@ -49,7 +49,7 @@ namespace hpx::performance_counters {
         // Type:     Instantaneous
         raw,
 
-        // \a monotinacally_increasing counter shows the cumulatively
+        // \a monotonically_increasing counter shows the cumulatively
         // accumulated observed value. It does not deliver an average.
         //
         // Formula:  None. Shows cumulatively accumulated data as collected.
@@ -206,7 +206,7 @@ namespace hpx::performance_counters {
         already_defined,    // The type or instance already has been defined
         counter_unknown,    // The counter instance is unknown
         counter_type_unknown,    // The counter type is unknown
-        generic_error            // A unknown error occurred
+        generic_error            // An unknown error occurred
     };
 
     HPX_CXX_EXPORT HPX_EXPORT std::ostream& operator<<(
@@ -310,14 +310,14 @@ namespace hpx::performance_counters {
     HPX_CXX_EXPORT struct counter_info;
 
     ///////////////////////////////////////////////////////////////////////////
-    // This declares the type of a function, which will be
+    // This declares the type of function, which will be
     // called by HPX whenever a new performance counter instance of a
     // particular type needs to be created.
     HPX_CXX_EXPORT using create_counter_func =
         hpx::function<naming::gid_type(counter_info const&, error_code&)>;
 
     ///////////////////////////////////////////////////////////////////////////
-    // This declares a type of a function, which will be passed to
+    // This declares a type of function, which will be passed to
     // a \a discover_counters_func in order to be called for each
     // discovered performance counter instance.
     HPX_CXX_EXPORT using discover_counter_func =
@@ -343,7 +343,7 @@ namespace hpx::performance_counters {
 
 #undef HPX_DISCOVER_COUNTERS_MODE_UNSCOPED_ENUM_DEPRECATION_MSG
 
-    // This declares the type of a function, which will be called by
+    // This declares the type of function, which will be called by
     // HPX whenever it needs to discover all performance counter
     // instances of a particular type.
     HPX_CXX_EXPORT using discover_counters_func =
@@ -470,92 +470,98 @@ namespace hpx::performance_counters {
     namespace detail {
 
         /// \brief Add an existing performance counter instance to the registry
-        HPX_EXPORT counter_status add_counter(hpx::id_type const& id,
-            counter_info const& info, error_code& ec = throws);
+        HPX_CXX_EXPORT HPX_EXPORT counter_status add_counter(
+            hpx::id_type const& id, counter_info const& info,
+            error_code& ec = throws);
 
         /// \brief Remove an existing performance counter instance with the
         ///        given id (as returned from \a create_counter)
-        HPX_EXPORT counter_status remove_counter(counter_info const& info,
-            hpx::id_type const& id, error_code& ec = throws);
+        HPX_CXX_EXPORT HPX_EXPORT counter_status remove_counter(
+            counter_info const& info, hpx::id_type const& id,
+            error_code& ec = throws);
 
         ///////////////////////////////////////////////////////////////////////
         // Helper function for creating counters encapsulating a function
         // returning the counter value.
-        HPX_EXPORT naming::gid_type create_raw_counter(counter_info const&,
-            hpx::function<std::int64_t()> const&, error_code&);
+        HPX_CXX_EXPORT HPX_EXPORT naming::gid_type create_raw_counter(
+            counter_info const&, hpx::function<std::int64_t()> const&,
+            error_code&);
 
         // Helper function for creating counters encapsulating a function
         // returning the counter value.
-        HPX_EXPORT naming::gid_type create_raw_counter(counter_info const&,
-            hpx::function<std::int64_t(bool)> const&, error_code&);
+        HPX_CXX_EXPORT HPX_EXPORT naming::gid_type create_raw_counter(
+            counter_info const&, hpx::function<std::int64_t(bool)> const&,
+            error_code&);
 
         // Helper function for creating counters encapsulating a function
         // returning the counter values array.
-        HPX_EXPORT naming::gid_type create_raw_counter(counter_info const&,
+        HPX_CXX_EXPORT HPX_EXPORT naming::gid_type create_raw_counter(
+            counter_info const&,
             hpx::function<std::vector<std::int64_t>()> const&, error_code&);
 
         // Helper function for creating counters encapsulating a function
         // returning the counter values array.
-        HPX_EXPORT naming::gid_type create_raw_counter(counter_info const&,
+        HPX_CXX_EXPORT HPX_EXPORT naming::gid_type create_raw_counter(
+            counter_info const&,
             hpx::function<std::vector<std::int64_t>(bool)> const&, error_code&);
 
         // Helper function for creating a new performance counter instance
         // based on a given counter value.
-        HPX_EXPORT naming::gid_type create_raw_counter_value(
+        HPX_CXX_EXPORT HPX_EXPORT naming::gid_type create_raw_counter_value(
             counter_info const&, std::int64_t*, error_code&);
 
         // Creation function for aggregating performance counters; to be
         // registered with the counter types.
-        HPX_EXPORT naming::gid_type statistics_counter_creator(
+        HPX_CXX_EXPORT HPX_EXPORT naming::gid_type statistics_counter_creator(
             counter_info const&, error_code&);
 
         // Creation function for aggregating performance counters; to be
         // registered with the counter types.
-        HPX_EXPORT naming::gid_type arithmetics_counter_creator(
+        HPX_CXX_EXPORT HPX_EXPORT naming::gid_type arithmetics_counter_creator(
             counter_info const&, error_code&);
 
         // Creation function for extended aggregating performance counters; to
         // be registered with the counter types.
-        HPX_EXPORT naming::gid_type arithmetics_counter_extended_creator(
-            counter_info const&, error_code&);
+        HPX_CXX_EXPORT HPX_EXPORT naming::gid_type
+        arithmetics_counter_extended_creator(counter_info const&, error_code&);
 
         // Creation function for uptime counters.
-        HPX_EXPORT naming::gid_type uptime_counter_creator(
+        HPX_CXX_EXPORT HPX_EXPORT naming::gid_type uptime_counter_creator(
             counter_info const&, error_code&);
 
         // Creation function for instance counters.
-        HPX_EXPORT naming::gid_type component_instance_counter_creator(
-            counter_info const&, error_code&);
+        HPX_CXX_EXPORT HPX_EXPORT naming::gid_type
+        component_instance_counter_creator(counter_info const&, error_code&);
 
         // \brief Create a new statistics performance counter instance based on
         //        the given base counter name and given base time interval
         //        (milliseconds).
-        HPX_EXPORT naming::gid_type create_statistics_counter(
+        HPX_CXX_EXPORT HPX_EXPORT naming::gid_type create_statistics_counter(
             counter_info const& info, std::string const& base_counter_name,
             std::vector<std::size_t> const& parameters,
             error_code& ec = throws);
 
         // \brief Create a new arithmetics performance counter instance based on
         //        the given base counter names
-        HPX_EXPORT naming::gid_type create_arithmetics_counter(
+        HPX_CXX_EXPORT HPX_EXPORT naming::gid_type create_arithmetics_counter(
             counter_info const& info,
             std::vector<std::string> const& base_counter_names,
             error_code& ec = throws);
 
         // \brief Create a new extended arithmetics performance counter instance
         //        based on the given base counter names
-        HPX_EXPORT naming::gid_type create_arithmetics_counter_extended(
-            counter_info const& info,
+        HPX_CXX_EXPORT HPX_EXPORT naming::gid_type
+        create_arithmetics_counter_extended(counter_info const& info,
             std::vector<std::string> const& base_counter_names,
             error_code& ec = throws);
 
         // \brief Create a new performance counter instance based on given
         //        counter info
-        HPX_EXPORT naming::gid_type create_counter(
+        HPX_CXX_EXPORT HPX_EXPORT naming::gid_type create_counter(
             counter_info const& info, error_code& ec = throws);
 
         // \brief Create an arbitrary counter on this locality
-        HPX_EXPORT naming::gid_type create_counter_local(
+        HPX_CXX_EXPORT HPX_EXPORT naming::gid_type create_counter_local(
             counter_info const& info);
     }    // namespace detail
 }    // namespace hpx::performance_counters

--- a/libs/full/performance_counters/include/hpx/performance_counters/detail/counter_interface_functions.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/detail/counter_interface_functions.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2021-2024 Hartmut Kaiser
+//  Copyright (c) 2021-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/full/performance_counters/include/hpx/performance_counters/locality_namespace_counters.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/locality_namespace_counters.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2011 Bryce Adelstein-Lelbach
-//  Copyright (c) 2012-2021 Hartmut Kaiser
+//  Copyright (c) 2012-2026 Hartmut Kaiser
 //  Copyright (c) 2016 Thomas Heller
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -12,9 +12,9 @@
 #include <hpx/modules/errors.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace agas {
+namespace hpx::agas {
 
     // Register all performance counter types exposed by the locality_namespace
-    HPX_EXPORT void locality_namespace_register_counter_types(
+    HPX_CXX_EXPORT HPX_EXPORT void locality_namespace_register_counter_types(
         error_code& ec = throws);
-}}    // namespace hpx::agas
+}    // namespace hpx::agas

--- a/libs/full/performance_counters/include/hpx/performance_counters/manage_counter.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/manage_counter.hpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-//  Copyright (c) 2007-2012 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c) 2011 Bryce Adelstein-Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -12,11 +12,13 @@
 #include <hpx/config.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/naming.hpp>
+
 #include <hpx/performance_counters/counters_fwd.hpp>
 
-namespace hpx { namespace performance_counters {
+namespace hpx::performance_counters {
+
     /// Install a new performance counter in a way, which will uninstall it
     /// automatically during shutdown.
-    HPX_EXPORT void install_counter(hpx::id_type const& id,
+    HPX_CXX_EXPORT HPX_EXPORT void install_counter(hpx::id_type const& id,
         counter_info const& info, error_code& ec = throws);
-}}    // namespace hpx::performance_counters
+}    // namespace hpx::performance_counters

--- a/libs/full/performance_counters/include/hpx/performance_counters/manage_counter_type.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/manage_counter_type.hpp
@@ -1,5 +1,5 @@
 ////////////////////////////////////////////////////////////////////////////////
-//  Copyright (c) 2007-2018 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c) 2011 Bryce Adelstein-Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -14,6 +14,7 @@
 #include <hpx/config.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/functional.hpp>
+
 #include <hpx/performance_counters/counters_fwd.hpp>
 
 #include <cstddef>
@@ -21,7 +22,7 @@
 #include <string>
 #include <vector>
 
-namespace hpx { namespace performance_counters {
+namespace hpx::performance_counters {
 
     /// \brief Install a new generic performance counter type in a way, which
     ///        will uninstall it automatically during shutdown.
@@ -65,7 +66,8 @@ namespace hpx { namespace performance_counters {
     /// \note The counter type registry is a locality based service. You will
     ///       have to register each counter type on every locality where a
     ///       corresponding performance counter will be created.
-    HPX_EXPORT counter_status install_counter_type(std::string const& name,
+    HPX_CXX_EXPORT HPX_EXPORT counter_status install_counter_type(
+        std::string const& name,
         hpx::function<std::int64_t(bool)> const& counter_value,
         std::string const& helptext = "", std::string const& uom = "",
         counter_type type = counter_type::raw, error_code& ec = throws);
@@ -113,7 +115,8 @@ namespace hpx { namespace performance_counters {
     /// \note The counter type registry is a locality based service. You will
     ///       have to register each counter type on every locality where a
     ///       corresponding performance counter will be created.
-    HPX_EXPORT counter_status install_counter_type(std::string const& name,
+    HPX_CXX_EXPORT HPX_EXPORT counter_status install_counter_type(
+        std::string const& name,
         hpx::function<std::vector<std::int64_t>(bool)> const& counter_value,
         std::string const& helptext = "", std::string const& uom = "",
         error_code& ec = throws);
@@ -144,7 +147,7 @@ namespace hpx { namespace performance_counters {
     /// \note As long as \a ec is not pre-initialized to \a hpx#throws this
     ///       function doesn't throw but returns the result code using the
     ///       parameter \a ec. Otherwise it throws an instance of hpx#exception.
-    HPX_EXPORT void install_counter_type(
+    HPX_CXX_EXPORT HPX_EXPORT void install_counter_type(
         std::string const& name, counter_type type, error_code& ec = throws);
 
     /// \brief Install a new performance counter type in a way, which will
@@ -180,8 +183,8 @@ namespace hpx { namespace performance_counters {
     /// \note As long as \a ec is not pre-initialized to \a hpx#throws this
     ///       function doesn't throw but returns the result code using the
     ///       parameter \a ec. Otherwise it throws an instance of hpx#exception.
-    HPX_EXPORT counter_status install_counter_type(std::string const& name,
-        counter_type type, std::string const& helptext,
+    HPX_CXX_EXPORT HPX_EXPORT counter_status install_counter_type(
+        std::string const& name, counter_type type, std::string const& helptext,
         std::string const& uom = "",
         std::uint32_t version = HPX_PERFORMANCE_COUNTER_V1,
         error_code& ec = throws);
@@ -222,8 +225,8 @@ namespace hpx { namespace performance_counters {
     /// \note The counter type registry is a locality based service. You will
     ///       have to register each counter type on every locality where a
     ///       corresponding performance counter will be created.
-    HPX_EXPORT counter_status install_counter_type(std::string const& name,
-        counter_type type, std::string const& helptext,
+    HPX_CXX_EXPORT HPX_EXPORT counter_status install_counter_type(
+        std::string const& name, counter_type type, std::string const& helptext,
         create_counter_func const& create_counter,
         discover_counters_func const& discover_counters,
         std::uint32_t version = HPX_PERFORMANCE_COUNTER_V1,
@@ -232,7 +235,7 @@ namespace hpx { namespace performance_counters {
     /// \cond NOINTERNAL
 
     /// A small data structure holding all data needed to install a counter type
-    struct generic_counter_type_data
+    HPX_CXX_EXPORT struct generic_counter_type_data
     {
         std::string name_;         ///< Name of the counter type
         counter_type type_;        ///< Type of the counter instances of this
@@ -253,8 +256,9 @@ namespace hpx { namespace performance_counters {
 
     /// Install several new performance counter types in a way, which will
     /// uninstall them automatically during shutdown.
-    HPX_EXPORT void install_counter_types(generic_counter_type_data const* data,
-        std::size_t count, error_code& ec = throws);
+    HPX_CXX_EXPORT HPX_EXPORT void install_counter_types(
+        generic_counter_type_data const* data, std::size_t count,
+        error_code& ec = throws);
 
     /// \endcond
-}}    // namespace hpx::performance_counters
+}    // namespace hpx::performance_counters

--- a/libs/full/performance_counters/include/hpx/performance_counters/parcelhandler_counter_types.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/parcelhandler_counter_types.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2021 Hartmut Kaiser
+//  Copyright (c) 2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -13,7 +13,7 @@
 
 namespace hpx::performance_counters {
 
-    HPX_EXPORT void register_parcelhandler_counter_types(
+    HPX_CXX_EXPORT HPX_EXPORT void register_parcelhandler_counter_types(
         parcelset::parcelhandler& ph);
 }    // namespace hpx::performance_counters
 

--- a/libs/full/performance_counters/include/hpx/performance_counters/per_action_data_counter_discoverer.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/per_action_data_counter_discoverer.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2015-2022 Hartmut Kaiser
+//  Copyright (c) 2015-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -12,16 +12,17 @@
     defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS) &&                            \
     defined(HPX_HAVE_NETWORKING)
 #include <hpx/modules/actions_base.hpp>
+
 #include <hpx/performance_counters/counters_fwd.hpp>
 
-namespace hpx { namespace performance_counters {
+namespace hpx::performance_counters {
 
-    HPX_EXPORT bool per_action_counter_counter_discoverer(
+    HPX_CXX_EXPORT HPX_EXPORT bool per_action_counter_counter_discoverer(
         hpx::actions::detail::per_action_data_counter_registry const& registry,
         performance_counters::counter_info const& info,
         performance_counters::counter_path_elements& p,
         performance_counters::discover_counter_func const& f,
         performance_counters::discover_counters_mode mode, error_code& ec);
-}}    // namespace hpx::performance_counters
+}    // namespace hpx::performance_counters
 
 #endif

--- a/libs/full/performance_counters/include/hpx/performance_counters/performance_counter.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/performance_counter.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2023 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -26,7 +26,7 @@
 namespace hpx::performance_counters {
 
     ///////////////////////////////////////////////////////////////////////////
-    struct HPX_EXPORT performance_counter
+    HPX_CXX_EXPORT struct HPX_EXPORT performance_counter
       : components::client_base<performance_counter,
             server::base_performance_counter>
     {
@@ -130,8 +130,8 @@ namespace hpx::performance_counters {
     };
 
     // Return all counters matching the given name (with optional wild cards).
-    HPX_EXPORT std::vector<performance_counter> discover_counters(
-        std::string const& name, error_code& ec = throws);
+    HPX_CXX_EXPORT HPX_EXPORT std::vector<performance_counter>
+    discover_counters(std::string const& name, error_code& ec = throws);
 }    // namespace hpx::performance_counters
 
 #include <hpx/config/warnings_suffix.hpp>

--- a/libs/full/performance_counters/include/hpx/performance_counters/performance_counter_base.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/performance_counter_base.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2018 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -7,19 +7,20 @@
 #pragma once
 
 #include <hpx/config.hpp>
+
 #include <hpx/performance_counters/counters_fwd.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace performance_counters {
+namespace hpx::performance_counters {
+
     //[performance_counter_interface
     // Abstract base interface for all Performance Counters.
-    struct performance_counter_base
+    HPX_CXX_EXPORT struct performance_counter_base
     {
-        //<-
-        /// Destructor, needs to be virtual to allow for clean destruction of
-        /// derived objects
+        // Destructor, needs to be virtual to allow for clean destruction of
+        // derived objects
         virtual ~performance_counter_base() = default;
-        //->
+
         // Retrieve the descriptive information about the Performance Counter.
         virtual counter_info get_counter_info() const = 0;
 
@@ -46,4 +47,4 @@ namespace hpx { namespace performance_counters {
         virtual void reinit(bool reset) = 0;
     };
     //]
-}}    // namespace hpx::performance_counters
+}    // namespace hpx::performance_counters

--- a/libs/full/performance_counters/include/hpx/performance_counters/performance_counter_set.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/performance_counter_set.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2016-2018 Hartmut Kaiser
+//  Copyright (c) 2016-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -13,6 +13,7 @@
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/pack_traversal.hpp>
 #include <hpx/modules/synchronization.hpp>
+
 #include <hpx/performance_counters/counters.hpp>
 
 #include <cstddef>
@@ -24,15 +25,16 @@
 #include <hpx/config/warnings_prefix.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace performance_counters {
+namespace hpx::performance_counters {
+
     // Make a collection of performance counters available as a set
-    class HPX_EXPORT performance_counter_set
+    HPX_CXX_EXPORT class HPX_EXPORT performance_counter_set
     {
         using mutex_type = hpx::spinlock;
 
     public:
         /// Create an empty set of performance counters
-        performance_counter_set(bool print_counters_locally = false)
+        explicit performance_counter_set(bool print_counters_locally = false)
           : invocation_count_(0)
           , print_counters_locally_(print_counters_locally)
         {
@@ -132,6 +134,6 @@ namespace hpx { namespace performance_counters {
         mutable std::uint64_t invocation_count_;
         bool print_counters_locally_;    // handle only local counters
     };
-}}    // namespace hpx::performance_counters
+}    // namespace hpx::performance_counters
 
 #include <hpx/config/warnings_suffix.hpp>

--- a/libs/full/performance_counters/include/hpx/performance_counters/primary_namespace_counters.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/primary_namespace_counters.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2011 Bryce Adelstein-Lelbach
-//  Copyright (c) 2012-2020 Hartmut Kaiser
+//  Copyright (c) 2012-2026 Hartmut Kaiser
 //  Copyright (c) 2016 Thomas Heller
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -12,9 +12,9 @@
 #include <hpx/modules/errors.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace agas {
+namespace hpx::agas {
 
     // Register all performance counter types exposed by the primary_namespace
-    HPX_EXPORT void primary_namespace_register_counter_types(
+    HPX_CXX_EXPORT HPX_EXPORT void primary_namespace_register_counter_types(
         error_code& ec = throws);
-}}    // namespace hpx::agas
+}    // namespace hpx::agas

--- a/libs/full/performance_counters/include/hpx/performance_counters/query_counters.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/query_counters.hpp
@@ -11,6 +11,7 @@
 #include <hpx/modules/itt_notify.hpp>
 #include <hpx/modules/runtime_local.hpp>
 #include <hpx/modules/synchronization.hpp>
+
 #include <hpx/performance_counters/counters_fwd.hpp>
 #include <hpx/performance_counters/performance_counter_set.hpp>
 
@@ -32,7 +33,7 @@
 namespace hpx::util {
 
     ///////////////////////////////////////////////////////////////////////////
-    class HPX_EXPORT query_counters
+    HPX_CXX_EXPORT class HPX_EXPORT query_counters
     {
         // avoid warning about using this in member initializer list
         query_counters* this_()

--- a/libs/full/performance_counters/include/hpx/performance_counters/registry.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/registry.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2024 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -18,10 +18,10 @@
 #include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace performance_counters {
+namespace hpx::performance_counters {
 
     ///////////////////////////////////////////////////////////////////////////
-    class registry
+    HPX_CXX_EXPORT class registry
     {
     private:
         struct counter_data
@@ -171,4 +171,4 @@ namespace hpx { namespace performance_counters {
     public:
         static registry& instance();
     };
-}}    // namespace hpx::performance_counters
+}    // namespace hpx::performance_counters

--- a/libs/full/performance_counters/include/hpx/performance_counters/server/arithmetics_counter.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/server/arithmetics_counter.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -8,6 +8,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/modules/components_base.hpp>
+
 #include <hpx/performance_counters/performance_counter_set.hpp>
 #include <hpx/performance_counters/server/base_performance_counter.hpp>
 
@@ -18,7 +19,8 @@
 #include <hpx/config/warnings_prefix.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace performance_counters { namespace server {
+namespace hpx::performance_counters::server {
+
     ///////////////////////////////////////////////////////////////////////////
     // This counter exposes the result of an arithmetic operation The counter
     // relies on querying two base counters.
@@ -55,6 +57,6 @@ namespace hpx { namespace performance_counters { namespace server {
         // base counters to be queried
         performance_counter_set counters_;
     };
-}}}    // namespace hpx::performance_counters::server
+}    // namespace hpx::performance_counters::server
 
 #include <hpx/config/warnings_suffix.hpp>

--- a/libs/full/performance_counters/include/hpx/performance_counters/server/arithmetics_counter_extended.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/server/arithmetics_counter_extended.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2021 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -8,6 +8,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/modules/components_base.hpp>
+
 #include <hpx/performance_counters/performance_counter_set.hpp>
 #include <hpx/performance_counters/server/base_performance_counter.hpp>
 

--- a/libs/full/performance_counters/include/hpx/performance_counters/server/base_performance_counter.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/server/base_performance_counter.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2025 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -12,15 +12,16 @@
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/thread_support.hpp>
+
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/performance_counters/performance_counter_base.hpp>
 
 #include <hpx/config/warnings_prefix.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace performance_counters { namespace server {
+namespace hpx::performance_counters::server {
 
-    class HPX_EXPORT base_performance_counter
+    HPX_CXX_EXPORT class HPX_EXPORT base_performance_counter
       : public hpx::performance_counters::performance_counter_base
       , public hpx::traits::detail::component_tag
     {
@@ -111,7 +112,7 @@ namespace hpx { namespace performance_counters { namespace server {
         hpx::performance_counters::counter_info info_;
         util::atomic_count invocation_count_;
     };
-}}}    // namespace hpx::performance_counters::server
+}    // namespace hpx::performance_counters::server
 
 #include <hpx/config/warnings_suffix.hpp>
 

--- a/libs/full/performance_counters/include/hpx/performance_counters/server/component_namespace_counters.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/server/component_namespace_counters.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2011 Bryce Adelstein-Lelbach
-//  Copyright (c) 2012-2021 Hartmut Kaiser
+//  Copyright (c) 2012-2026 Hartmut Kaiser
 //  Copyright (c) 2016 Thomas Heller
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -16,15 +16,16 @@
 #include <string>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace agas {
+namespace hpx::agas {
 
     // Create statistics counter for component namespace on this component
-    HPX_EXPORT naming::gid_type component_namespace_statistics_counter(
-        std::string const& name);
+    HPX_CXX_EXPORT HPX_EXPORT naming::gid_type
+    component_namespace_statistics_counter(std::string const& name);
 
-    HPX_DEFINE_PLAIN_ACTION(component_namespace_statistics_counter,
+    HPX_DEFINE_PLAIN_ACTION(HPX_CXX_EXPORT,
+        component_namespace_statistics_counter,
         component_namespace_statistics_counter_action);
-}}    // namespace hpx::agas
+}    // namespace hpx::agas
 
 HPX_ACTION_USES_MEDIUM_STACK(
     hpx::agas::component_namespace_statistics_counter_action)

--- a/libs/full/performance_counters/include/hpx/performance_counters/server/elapsed_time_counter.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/server/elapsed_time_counter.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2024 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -8,6 +8,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/modules/components_base.hpp>
+
 #include <hpx/performance_counters/server/base_performance_counter.hpp>
 
 #include <hpx/config/warnings_prefix.hpp>
@@ -15,7 +16,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx::performance_counters::server {
 
-    class HPX_EXPORT elapsed_time_counter
+    class elapsed_time_counter
       : public base_performance_counter
       , public components::component_base<elapsed_time_counter>
     {

--- a/libs/full/performance_counters/include/hpx/performance_counters/server/locality_namespace_counters.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/server/locality_namespace_counters.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2011 Bryce Adelstein-Lelbach
-//  Copyright (c) 2012-2021 Hartmut Kaiser
+//  Copyright (c) 2012-2026 Hartmut Kaiser
 //  Copyright (c) 2016 Thomas Heller
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -16,15 +16,16 @@
 #include <string>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace agas {
+namespace hpx::agas {
 
     // Create statistics counter for locality namespace on this locality
-    HPX_EXPORT naming::gid_type locality_namespace_statistics_counter(
-        std::string const& name);
+    HPX_CXX_EXPORT HPX_EXPORT naming::gid_type
+    locality_namespace_statistics_counter(std::string const& name);
 
-    HPX_DEFINE_PLAIN_ACTION(locality_namespace_statistics_counter,
+    HPX_DEFINE_PLAIN_ACTION(HPX_CXX_EXPORT,
+        locality_namespace_statistics_counter,
         locality_namespace_statistics_counter_action);
-}}    // namespace hpx::agas
+}    // namespace hpx::agas
 
 HPX_ACTION_USES_MEDIUM_STACK(
     hpx::agas::locality_namespace_statistics_counter_action)

--- a/libs/full/performance_counters/include/hpx/performance_counters/server/primary_namespace_counters.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/server/primary_namespace_counters.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2011 Bryce Adelstein-Lelbach
-//  Copyright (c) 2012-2020 Hartmut Kaiser
+//  Copyright (c) 2012-2026 Hartmut Kaiser
 //  Copyright (c) 2016 Thomas Heller
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -16,15 +16,16 @@
 #include <string>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace agas {
+namespace hpx::agas {
 
     // Create statistics counter for primary namespace on this locality
-    HPX_EXPORT naming::gid_type primary_namespace_statistics_counter(
-        std::string const& name);
+    HPX_CXX_EXPORT HPX_EXPORT naming::gid_type
+    primary_namespace_statistics_counter(std::string const& name);
 
-    HPX_DEFINE_PLAIN_ACTION(primary_namespace_statistics_counter,
+    HPX_DEFINE_PLAIN_ACTION(HPX_CXX_EXPORT,
+        primary_namespace_statistics_counter,
         primary_namespace_statistics_counter_action);
-}}    // namespace hpx::agas
+}    // namespace hpx::agas
 
 HPX_ACTION_USES_MEDIUM_STACK(
     hpx::agas::primary_namespace_statistics_counter_action)

--- a/libs/full/performance_counters/include/hpx/performance_counters/server/raw_counter.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/server/raw_counter.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2024 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -9,6 +9,7 @@
 #include <hpx/config.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/functional.hpp>
+
 #include <hpx/performance_counters/server/base_performance_counter.hpp>
 
 #include <cstdint>
@@ -18,7 +19,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx::performance_counters::server {
 
-    class HPX_EXPORT raw_counter
+    HPX_CXX_EXPORT class HPX_EXPORT raw_counter
       : public base_performance_counter
       , public components::component_base<raw_counter>
     {

--- a/libs/full/performance_counters/include/hpx/performance_counters/server/raw_values_counter.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/server/raw_values_counter.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2024 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -9,6 +9,7 @@
 #include <hpx/config.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/functional.hpp>
+
 #include <hpx/performance_counters/server/base_performance_counter.hpp>
 
 #include <cstdint>
@@ -19,7 +20,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx::performance_counters::server {
 
-    class HPX_EXPORT raw_values_counter
+    HPX_CXX_EXPORT class HPX_EXPORT raw_values_counter
       : public base_performance_counter
       , public components::component_base<raw_values_counter>
     {

--- a/libs/full/performance_counters/include/hpx/performance_counters/server/statistics_counter.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/server/statistics_counter.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2015 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -11,6 +11,7 @@
 #include <hpx/modules/naming_base.hpp>
 #include <hpx/modules/runtime_local.hpp>
 #include <hpx/modules/synchronization.hpp>
+
 #include <hpx/performance_counters/server/base_performance_counter.hpp>
 
 #include <cstddef>
@@ -21,7 +22,7 @@
 #include <hpx/config/warnings_prefix.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace performance_counters { namespace server {
+namespace hpx::performance_counters::server {
 
     namespace detail {
 
@@ -103,6 +104,6 @@ namespace hpx { namespace performance_counters { namespace server {
         std::size_t parameter1_, parameter2_;
         bool reset_base_counter_;
     };
-}}}    // namespace hpx::performance_counters::server
+}    // namespace hpx::performance_counters::server
 
 #include <hpx/config/warnings_suffix.hpp>

--- a/libs/full/performance_counters/include/hpx/performance_counters/server/symbol_namespace_counters.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/server/symbol_namespace_counters.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2011 Bryce Adelstein-Lelbach
-//  Copyright (c) 2012-2020 Hartmut Kaiser
+//  Copyright (c) 2012-2026 Hartmut Kaiser
 //  Copyright (c) 2016 Thomas Heller
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -16,15 +16,15 @@
 #include <string>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace agas {
+namespace hpx::agas {
 
     // Create statistics counter for symbol namespace on this locality
-    HPX_EXPORT naming::gid_type symbol_namespace_statistics_counter(
-        std::string const& name);
+    HPX_CXX_EXPORT HPX_EXPORT naming::gid_type
+    symbol_namespace_statistics_counter(std::string const& name);
 
-    HPX_DEFINE_PLAIN_ACTION(symbol_namespace_statistics_counter,
+    HPX_DEFINE_PLAIN_ACTION(HPX_CXX_EXPORT, symbol_namespace_statistics_counter,
         symbol_namespace_statistics_counter_action);
-}}    // namespace hpx::agas
+}    // namespace hpx::agas
 
 HPX_ACTION_USES_MEDIUM_STACK(
     hpx::agas::symbol_namespace_statistics_counter_action)

--- a/libs/full/performance_counters/include/hpx/performance_counters/symbol_namespace_counters.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/symbol_namespace_counters.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2011 Bryce Adelstein-Lelbach
-//  Copyright (c) 2012-2020 Hartmut Kaiser
+//  Copyright (c) 2012-2026 Hartmut Kaiser
 //  Copyright (c) 2016 Thomas Heller
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -12,9 +12,9 @@
 #include <hpx/modules/errors.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace agas {
+namespace hpx::agas {
 
     // Register all performance counter types exposed by the symbol_namespace
-    HPX_EXPORT void symbol_namespace_register_counter_types(
+    HPX_CXX_EXPORT HPX_EXPORT void symbol_namespace_register_counter_types(
         error_code& ec = throws);
-}}    // namespace hpx::agas
+}    // namespace hpx::agas

--- a/libs/full/performance_counters/include/hpx/performance_counters/threadmanager_counter_types.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/threadmanager_counter_types.hpp
@@ -1,7 +1,8 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c) 2007-2009 Chirag Dekate, Anshul Tandon
 //  Copyright (c)      2011 Bryce Lelbach, Katelyn Kufahl
 //  Copyright (c)      2017 Shoshana Jakobovits
+//
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -11,8 +12,8 @@
 #include <hpx/config.hpp>
 #include <hpx/modules/threadmanager.hpp>
 
-namespace hpx { namespace performance_counters {
+namespace hpx::performance_counters {
 
-    HPX_EXPORT void register_threadmanager_counter_types(
+    HPX_CXX_EXPORT HPX_EXPORT void register_threadmanager_counter_types(
         threads::threadmanager& tm);
-}}    // namespace hpx::performance_counters
+}    // namespace hpx::performance_counters

--- a/libs/full/performance_counters/src/action_invocation_counter_discoverer.cpp
+++ b/libs/full/performance_counters/src/action_invocation_counter_discoverer.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2022 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -9,6 +9,7 @@
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/modules/util.hpp>
+
 #include <hpx/performance_counters/action_invocation_counter_discoverer.hpp>
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/performance_counters/registry.hpp>
@@ -18,7 +19,7 @@
 #include <string>
 #include <utility>
 
-namespace hpx { namespace performance_counters {
+namespace hpx::performance_counters {
 
     bool action_invocation_counter_discoverer(
         hpx::actions::detail::invocation_count_registry const& registry,
@@ -164,4 +165,4 @@ namespace hpx { namespace performance_counters {
 
         return true;
     }
-}}    // namespace hpx::performance_counters
+}    // namespace hpx::performance_counters

--- a/libs/full/performance_counters/src/agas_counter_types.cpp
+++ b/libs/full/performance_counters/src/agas_counter_types.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2011-2021 Hartmut Kaiser
+//  Copyright (c) 2011-2026 Hartmut Kaiser
 //  Copyright (c) 2016 Parsa Amini
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -19,7 +19,7 @@
 
 #include <cstdint>
 
-namespace hpx { namespace performance_counters {
+namespace hpx::performance_counters {
 
     /// Install performance counter types exposing properties from the local cache.
     void register_agas_counter_types(agas::addressing_service& client)
@@ -209,4 +209,4 @@ namespace hpx { namespace performance_counters {
         }
         agas::symbol_namespace_register_counter_types();
     }
-}}    // namespace hpx::performance_counters
+}    // namespace hpx::performance_counters

--- a/libs/full/performance_counters/src/agas_namespace_action_code.cpp
+++ b/libs/full/performance_counters/src/agas_namespace_action_code.cpp
@@ -1,10 +1,11 @@
-//  Copyright (c) 2012-2021 Hartmut Kaiser
+//  Copyright (c) 2012-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/modules/errors.hpp>
+
 #include <hpx/performance_counters/agas_namespace_action_code.hpp>
 #include <hpx/performance_counters/counters.hpp>
 

--- a/libs/full/performance_counters/src/component_namespace_counters.cpp
+++ b/libs/full/performance_counters/src/component_namespace_counters.cpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2011 Bryce Adelstein-Lelbach
-//  Copyright (c) 2012-2021 Hartmut Kaiser
+//  Copyright (c) 2012-2026 Hartmut Kaiser
 //  Copyright (c) 2016 Thomas Heller
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -73,8 +73,8 @@ namespace hpx::agas::server {
             performance_counters::install_counter_type(
                 agas::performance_counter_basename + name, type, help, creator,
                 &performance_counters::locality0_counter_discoverer,
-                HPX_PERFORMANCE_COUNTER_V1, component_namespace_service.uom_,
-                ec);
+                performance_counters::HPX_PERFORMANCE_COUNTER_V1,
+                component_namespace_service.uom_, ec);
             if (ec)
             {
                 return;
@@ -120,8 +120,8 @@ namespace hpx::agas::server {
                     component_namespace_service.name_,
                 type, help, creator,
                 &performance_counters::locality0_counter_discoverer,
-                HPX_PERFORMANCE_COUNTER_V1, component_namespace_service.uom_,
-                ec);
+                performance_counters::HPX_PERFORMANCE_COUNTER_V1,
+                component_namespace_service.uom_, ec);
             if (ec)
             {
                 return;

--- a/libs/full/performance_counters/src/counter_creators.cpp
+++ b/libs/full/performance_counters/src/counter_creators.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2022 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -31,7 +31,7 @@
 #include <hpx/config/warnings_prefix.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace performance_counters {
+namespace hpx::performance_counters {
 
     ///////////////////////////////////////////////////////////////////////////
     // Creation functions to be registered with counter types
@@ -629,4 +629,4 @@ namespace hpx { namespace performance_counters {
             "invalid counter type name: " + paths.instancename_);
         return naming::invalid_gid;
     }
-}}    // namespace hpx::performance_counters
+}    // namespace hpx::performance_counters

--- a/libs/full/performance_counters/src/counter_interface.cpp
+++ b/libs/full/performance_counters/src/counter_interface.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2021-2024 Hartmut Kaiser
+//  Copyright (c) 2021-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -7,6 +7,7 @@
 #include <hpx/config.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/naming_base.hpp>
+
 #include <hpx/performance_counters/counter_interface.hpp>
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/performance_counters/detail/counter_interface_functions.hpp>

--- a/libs/full/performance_counters/src/counter_parser.cpp
+++ b/libs/full/performance_counters/src/counter_parser.cpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2020 Agustin Berge
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c) 2011 Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0

--- a/libs/full/performance_counters/src/counters.cpp
+++ b/libs/full/performance_counters/src/counters.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2025 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -19,6 +19,7 @@
 #include <hpx/modules/runtime_local.hpp>
 #include <hpx/modules/serialization.hpp>
 #include <hpx/modules/threading_base.hpp>
+
 #include <hpx/performance_counters/base_performance_counter.hpp>
 #include <hpx/performance_counters/counter_creators.hpp>
 #include <hpx/performance_counters/counter_interface.hpp>
@@ -84,6 +85,56 @@ HPX_DEFINE_GET_COMPONENT_TYPE(
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx::performance_counters {
+
+    std::string& ensure_counter_prefix(std::string& name)
+    {
+        if (name.compare(0, counter_prefix_len, counter_prefix) != 0)
+            name = counter_prefix + name;
+        return name;
+    }
+
+    std::string ensure_counter_prefix(std::string const& counter)    //-V659
+    {
+        std::string name(counter);
+        return ensure_counter_prefix(name);
+    }
+
+    std::string& remove_counter_prefix(std::string& name)
+    {
+        if (name.compare(0, counter_prefix_len, counter_prefix) == 0)
+            name = name.substr(counter_prefix_len);
+        return name;
+    }
+
+    std::string remove_counter_prefix(std::string const& counter)    //-V659
+    {
+        std::string name(counter);
+        return remove_counter_prefix(name);
+    }
+
+    counter_status add_counter_type(counter_info const& info, error_code& ec)
+    {
+        return add_counter_type(
+            info, create_counter_func(), discover_counters_func(), ec);
+    }
+
+    hpx::id_type get_counter(std::string const& name, error_code& ec)
+    {
+        hpx::future<hpx::id_type> f = get_counter_async(name, ec);
+        if (ec)
+            return hpx::invalid_id;
+
+        return f.get(ec);
+    }
+
+    hpx::id_type get_counter(counter_info const& info, error_code& ec)
+    {
+        hpx::future<hpx::id_type> f = get_counter_async(info, ec);
+        if (ec)
+            return hpx::invalid_id;
+
+        return f.get(ec);
+    }
 
     std::ostream& operator<<(std::ostream& os, counter_status rhs)
     {

--- a/libs/full/performance_counters/src/detail/counter_interface_functions.cpp
+++ b/libs/full/performance_counters/src/detail/counter_interface_functions.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2021-2024 Hartmut Kaiser
+//  Copyright (c) 2021-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -6,6 +6,7 @@
 
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/naming_base.hpp>
+
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/performance_counters/detail/counter_interface_functions.hpp>
 

--- a/libs/full/performance_counters/src/locality_namespace_counters.cpp
+++ b/libs/full/performance_counters/src/locality_namespace_counters.cpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2011 Bryce Adelstein-Lelbach
-//  Copyright (c) 2012-2021 Hartmut Kaiser
+//  Copyright (c) 2012-2026 Hartmut Kaiser
 //  Copyright (c) 2016 Thomas Heller
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -73,7 +73,7 @@ namespace hpx::agas::server {
             performance_counters::install_counter_type(
                 agas::performance_counter_basename + name, type, help, creator,
                 &performance_counters::locality0_counter_discoverer,
-                HPX_PERFORMANCE_COUNTER_V1,
+                performance_counters::HPX_PERFORMANCE_COUNTER_V1,
                 detail::locality_namespace_services[i].uom_, ec);
             if (ec)
             {
@@ -122,7 +122,7 @@ namespace hpx::agas::server {
                     detail::locality_namespace_services[i].name_,
                 type, help, creator,
                 &performance_counters::locality0_counter_discoverer,
-                HPX_PERFORMANCE_COUNTER_V1,
+                performance_counters::HPX_PERFORMANCE_COUNTER_V1,
                 detail::locality_namespace_services[i].uom_, ec);
             if (ec)
             {

--- a/libs/full/performance_counters/src/manage_counter.cpp
+++ b/libs/full/performance_counters/src/manage_counter.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2017 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -10,14 +10,16 @@
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/runtime_local.hpp>
+#include <hpx/version.hpp>
+
 #include <hpx/performance_counters/counter_creators.hpp>
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/performance_counters/manage_counter.hpp>
-#include <hpx/version.hpp>
 
 #include <memory>
 
-namespace hpx { namespace performance_counters {
+namespace hpx::performance_counters {
+
     struct manage_counter
     {
         manage_counter()
@@ -70,11 +72,14 @@ namespace hpx { namespace performance_counters {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    static void counter_shutdown(std::shared_ptr<manage_counter> const& p)
-    {
-        HPX_ASSERT(p);
-        p->uninstall();
-    }
+    namespace {
+
+        void counter_shutdown(std::shared_ptr<manage_counter> const& p)
+        {
+            HPX_ASSERT(p);
+            p->uninstall();
+        }
+    }    // namespace
 
     void install_counter(
         hpx::id_type const& id, counter_info const& info, error_code& ec)
@@ -88,4 +93,4 @@ namespace hpx { namespace performance_counters {
         get_runtime().add_shutdown_function(
             hpx::bind_front(&counter_shutdown, p));
     }
-}}    // namespace hpx::performance_counters
+}    // namespace hpx::performance_counters

--- a/libs/full/performance_counters/src/manage_counter_type.cpp
+++ b/libs/full/performance_counters/src/manage_counter_type.cpp
@@ -12,10 +12,11 @@
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/runtime_local.hpp>
+#include <hpx/version.hpp>
+
 #include <hpx/performance_counters/counter_creators.hpp>
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/performance_counters/manage_counter_type.hpp>
-#include <hpx/version.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -23,7 +24,8 @@
 #include <string>
 #include <vector>
 
-namespace hpx { namespace performance_counters {
+namespace hpx::performance_counters {
+
     struct manage_counter_type
     {
         manage_counter_type(counter_info const& info)
@@ -80,12 +82,15 @@ namespace hpx { namespace performance_counters {
         counter_info info_;
     };
 
-    static void counter_type_shutdown(
-        std::shared_ptr<manage_counter_type> const& p)
-    {
-        error_code ec(throwmode::lightweight);
-        p->uninstall(ec);
-    }
+    namespace {
+
+        void counter_type_shutdown(
+            std::shared_ptr<manage_counter_type> const& p)
+        {
+            error_code ec(throwmode::lightweight);
+            p->uninstall(ec);
+        }
+    }    // namespace
 
     ///////////////////////////////////////////////////////////////////////////
     counter_status install_counter_type(std::string const& name,
@@ -175,4 +180,4 @@ namespace hpx { namespace performance_counters {
                 break;
         }
     }
-}}    // namespace hpx::performance_counters
+}    // namespace hpx::performance_counters

--- a/libs/full/performance_counters/src/parcelhandler_counter_types.cpp
+++ b/libs/full/performance_counters/src/parcelhandler_counter_types.cpp
@@ -132,7 +132,7 @@ namespace hpx::performance_counters {
                 hpx::bind_front(
                     &parcelhandler::get_zchunks_recv_size_max, &ph, pp_type));
 
-            constexpr performance_counters::generic_counter_type_data
+            performance_counters::generic_counter_type_data const
                 counter_types[] = {
                     {hpx::util::format("/parcels/count/{}/sent", pp_type),
                         performance_counters::counter_type::
@@ -550,7 +550,7 @@ namespace hpx::performance_counters {
                     &ph, pp_type,
                     parcelport::connection_cache_max_connections));
 
-            constexpr performance_counters::generic_counter_type_data
+            performance_counters::generic_counter_type_data const
                 connection_cache_types[] = {
                     {hpx::util::format(
                          "/parcelport/count/{}/cache-insertions", pp_type),
@@ -706,18 +706,16 @@ namespace hpx::performance_counters {
         hpx::function<std::int64_t(bool)> outgoing_routed_count(
             hpx::bind_front(&parcelhandler::get_parcel_routed_count, &ph));
 
-        constexpr performance_counters::generic_counter_type_data
-            counter_types[] = {
-                {"/parcelqueue/length/receive",
-                    performance_counters::counter_type::raw,
-                    "returns the number current length of the queue of "
-                    "incoming "
-                    "parcels",
-                    HPX_PERFORMANCE_COUNTER_V1,
-                    hpx::bind(
-                        &performance_counters::locality_raw_counter_creator, _1,
-                        incoming_queue_length, _2),
-                    &performance_counters::locality_counter_discoverer, ""},
+        performance_counters::generic_counter_type_data const counter_types[] =
+            {{"/parcelqueue/length/receive",
+                 performance_counters::counter_type::raw,
+                 "returns the number current length of the queue of "
+                 "incoming "
+                 "parcels",
+                 HPX_PERFORMANCE_COUNTER_V1,
+                 hpx::bind(&performance_counters::locality_raw_counter_creator,
+                     _1, incoming_queue_length, _2),
+                 &performance_counters::locality_counter_discoverer, ""},
                 {"/parcelqueue/length/send",
                     performance_counters::counter_type::raw,
                     "returns the number current length of the queue of "

--- a/libs/full/performance_counters/src/parcelhandler_counter_types.cpp
+++ b/libs/full/performance_counters/src/parcelhandler_counter_types.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2021-2024 Hartmut Kaiser
+//  Copyright (c) 2021-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -10,6 +10,7 @@
 #include <hpx/modules/format.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/parcelset.hpp>
+
 #include <hpx/performance_counters/counter_creators.hpp>
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/performance_counters/manage_counter_type.hpp>
@@ -22,601 +23,657 @@ namespace hpx::performance_counters {
 
 #if defined(HPX_HAVE_PARCELPORT_COUNTERS)
     ///////////////////////////////////////////////////////////////////////////
-    static void register_parcelhandler_counter_types(
-        parcelset::parcelhandler& ph, std::string const& pp_type)
-    {
-        using placeholders::_1;
-        using placeholders::_2;
+    namespace {
 
-        using parcelset::parcelhandler;
+        void register_parcelhandler_counter_types(
+            parcelset::parcelhandler& ph, std::string const& pp_type)
+        {
+            using placeholders::_1;
+            using placeholders::_2;
+
+            using parcelset::parcelhandler;
 #if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
-        hpx::function<std::int64_t(std::string const&, bool)> num_parcel_sends(
-            hpx::bind_front(
-                &parcelhandler::get_action_parcel_send_count, &ph, pp_type));
-        hpx::function<std::int64_t(std::string const&, bool)>
-            num_parcel_receives(hpx::bind_front(
-                &parcelhandler::get_action_parcel_receive_count, &ph, pp_type));
+            hpx::function<std::int64_t(std::string const&, bool)>
+                num_parcel_sends(hpx::bind_front(
+                    &parcelhandler::get_action_parcel_send_count, &ph,
+                    pp_type));
+            hpx::function<std::int64_t(std::string const&, bool)>
+                num_parcel_receives(hpx::bind_front(
+                    &parcelhandler::get_action_parcel_receive_count, &ph,
+                    pp_type));
 #else
-        hpx::function<std::int64_t(bool)> num_parcel_sends(hpx::bind_front(
-            &parcelhandler::get_parcel_send_count, &ph, pp_type));
-        hpx::function<std::int64_t(bool)> num_parcel_receives(hpx::bind_front(
-            &parcelhandler::get_parcel_receive_count, &ph, pp_type));
+            hpx::function<std::int64_t(bool)> num_parcel_sends(hpx::bind_front(
+                &parcelhandler::get_parcel_send_count, &ph, pp_type));
+            hpx::function<std::int64_t(bool)> num_parcel_receives(
+                hpx::bind_front(
+                    &parcelhandler::get_parcel_receive_count, &ph, pp_type));
 #endif
 
-        hpx::function<std::int64_t(bool)> num_message_sends(hpx::bind_front(
-            &parcelhandler::get_message_send_count, &ph, pp_type));
-        hpx::function<std::int64_t(bool)> num_message_receives(hpx::bind_front(
-            &parcelhandler::get_message_receive_count, &ph, pp_type));
+            hpx::function<std::int64_t(bool)> num_message_sends(hpx::bind_front(
+                &parcelhandler::get_message_send_count, &ph, pp_type));
+            hpx::function<std::int64_t(bool)> num_message_receives(
+                hpx::bind_front(
+                    &parcelhandler::get_message_receive_count, &ph, pp_type));
 
-        hpx::function<std::int64_t(bool)> sending_time(
-            hpx::bind_front(&parcelhandler::get_sending_time, &ph, pp_type));
-        hpx::function<std::int64_t(bool)> receiving_time(
-            hpx::bind_front(&parcelhandler::get_receiving_time, &ph, pp_type));
+            hpx::function<std::int64_t(bool)> sending_time(hpx::bind_front(
+                &parcelhandler::get_sending_time, &ph, pp_type));
+            hpx::function<std::int64_t(bool)> receiving_time(hpx::bind_front(
+                &parcelhandler::get_receiving_time, &ph, pp_type));
 
 #if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
-        hpx::function<std::int64_t(std::string const&, bool)>
-            sending_serialization_time(hpx::bind_front(
-                &parcelhandler::get_action_sending_serialization_time, &ph,
-                pp_type));
-        hpx::function<std::int64_t(std::string const&, bool)>
-            receiving_serialization_time(hpx::bind_front(
-                &parcelhandler::get_action_receiving_serialization_time, &ph,
-                pp_type));
+            hpx::function<std::int64_t(std::string const&, bool)>
+                sending_serialization_time(hpx::bind_front(
+                    &parcelhandler::get_action_sending_serialization_time, &ph,
+                    pp_type));
+            hpx::function<std::int64_t(std::string const&, bool)>
+                receiving_serialization_time(hpx::bind_front(
+                    &parcelhandler::get_action_receiving_serialization_time,
+                    &ph, pp_type));
 #else
-        hpx::function<std::int64_t(bool)> sending_serialization_time(
-            hpx::bind_front(
-                &parcelhandler::get_sending_serialization_time, &ph, pp_type));
-        hpx::function<std::int64_t(bool)> receiving_serialization_time(
-            hpx::bind_front(&parcelhandler::get_receiving_serialization_time,
-                &ph, pp_type));
+            hpx::function<std::int64_t(bool)> sending_serialization_time(
+                hpx::bind_front(&parcelhandler::get_sending_serialization_time,
+                    &ph, pp_type));
+            hpx::function<std::int64_t(bool)> receiving_serialization_time(
+                hpx::bind_front(
+                    &parcelhandler::get_receiving_serialization_time, &ph,
+                    pp_type));
 #endif
 
 #if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
-        hpx::function<std::int64_t(std::string const&, bool)> data_sent(
-            hpx::bind_front(
-                &parcelhandler::get_action_data_sent, &ph, pp_type));
-        hpx::function<std::int64_t(std::string const&, bool)> data_received(
-            hpx::bind_front(
-                &parcelhandler::get_action_data_received, &ph, pp_type));
+            hpx::function<std::int64_t(std::string const&, bool)> data_sent(
+                hpx::bind_front(
+                    &parcelhandler::get_action_data_sent, &ph, pp_type));
+            hpx::function<std::int64_t(std::string const&, bool)> data_received(
+                hpx::bind_front(
+                    &parcelhandler::get_action_data_received, &ph, pp_type));
 #else
-        hpx::function<std::int64_t(bool)> data_sent(
-            hpx::bind_front(&parcelhandler::get_data_sent, &ph, pp_type));
-        hpx::function<std::int64_t(bool)> data_received(
-            hpx::bind_front(&parcelhandler::get_data_received, &ph, pp_type));
+            hpx::function<std::int64_t(bool)> data_sent(
+                hpx::bind_front(&parcelhandler::get_data_sent, &ph, pp_type));
+            hpx::function<std::int64_t(bool)> data_received(hpx::bind_front(
+                &parcelhandler::get_data_received, &ph, pp_type));
 #endif
 
-        hpx::function<std::int64_t(bool)> data_raw_sent(
-            hpx::bind_front(&parcelhandler::get_raw_data_sent, &ph, pp_type));
-        hpx::function<std::int64_t(bool)> data_raw_received(hpx::bind_front(
-            &parcelhandler::get_raw_data_received, &ph, pp_type));
+            hpx::function<std::int64_t(bool)> data_raw_sent(hpx::bind_front(
+                &parcelhandler::get_raw_data_sent, &ph, pp_type));
+            hpx::function<std::int64_t(bool)> data_raw_received(hpx::bind_front(
+                &parcelhandler::get_raw_data_received, &ph, pp_type));
 
-        hpx::function<std::int64_t(bool)> buffer_allocate_time_sent(
-            hpx::bind_front(
-                &parcelhandler::get_buffer_allocate_time_sent, &ph, pp_type));
-        hpx::function<std::int64_t(bool)> buffer_allocate_time_received(
-            hpx::bind_front(&parcelhandler::get_buffer_allocate_time_received,
-                &ph, pp_type));
+            hpx::function<std::int64_t(bool)> buffer_allocate_time_sent(
+                hpx::bind_front(&parcelhandler::get_buffer_allocate_time_sent,
+                    &ph, pp_type));
+            hpx::function<std::int64_t(bool)> buffer_allocate_time_received(
+                hpx::bind_front(
+                    &parcelhandler::get_buffer_allocate_time_received, &ph,
+                    pp_type));
 
-        hpx::function<std::int64_t(bool)> num_zchunks_send(hpx::bind_front(
-            &parcelhandler::get_zchunks_send_count, &ph, pp_type));
-        hpx::function<std::int64_t(bool)> num_zchunks_recv(hpx::bind_front(
-            &parcelhandler::get_zchunks_recv_count, &ph, pp_type));
+            hpx::function<std::int64_t(bool)> num_zchunks_send(hpx::bind_front(
+                &parcelhandler::get_zchunks_send_count, &ph, pp_type));
+            hpx::function<std::int64_t(bool)> num_zchunks_recv(hpx::bind_front(
+                &parcelhandler::get_zchunks_recv_count, &ph, pp_type));
 
-        hpx::function<std::int64_t(bool)> num_zchunks_send_per_msg_max(
-            hpx::bind_front(&parcelhandler::get_zchunks_send_per_msg_count_max,
-                &ph, pp_type));
-        hpx::function<std::int64_t(bool)> num_zchunks_recv_per_msg_max(
-            hpx::bind_front(&parcelhandler::get_zchunks_recv_per_msg_count_max,
-                &ph, pp_type));
+            hpx::function<std::int64_t(bool)> num_zchunks_send_per_msg_max(
+                hpx::bind_front(
+                    &parcelhandler::get_zchunks_send_per_msg_count_max, &ph,
+                    pp_type));
+            hpx::function<std::int64_t(bool)> num_zchunks_recv_per_msg_max(
+                hpx::bind_front(
+                    &parcelhandler::get_zchunks_recv_per_msg_count_max, &ph,
+                    pp_type));
 
-        hpx::function<std::int64_t(bool)> size_zchunks_send(hpx::bind_front(
-            &parcelhandler::get_zchunks_send_size, &ph, pp_type));
-        hpx::function<std::int64_t(bool)> size_zchunks_recv(hpx::bind_front(
-            &parcelhandler::get_zchunks_recv_size, &ph, pp_type));
+            hpx::function<std::int64_t(bool)> size_zchunks_send(hpx::bind_front(
+                &parcelhandler::get_zchunks_send_size, &ph, pp_type));
+            hpx::function<std::int64_t(bool)> size_zchunks_recv(hpx::bind_front(
+                &parcelhandler::get_zchunks_recv_size, &ph, pp_type));
 
-        hpx::function<std::int64_t(bool)> size_zchunks_send_per_msg_max(
-            hpx::bind_front(
-                &parcelhandler::get_zchunks_send_size_max, &ph, pp_type));
-        hpx::function<std::int64_t(bool)> size_zchunks_recv_per_msg_max(
-            hpx::bind_front(
-                &parcelhandler::get_zchunks_recv_size_max, &ph, pp_type));
+            hpx::function<std::int64_t(bool)> size_zchunks_send_per_msg_max(
+                hpx::bind_front(
+                    &parcelhandler::get_zchunks_send_size_max, &ph, pp_type));
+            hpx::function<std::int64_t(bool)> size_zchunks_recv_per_msg_max(
+                hpx::bind_front(
+                    &parcelhandler::get_zchunks_recv_size_max, &ph, pp_type));
 
-        performance_counters::generic_counter_type_data const counter_types[] =
-            {
-                {hpx::util::format("/parcels/count/{}/sent", pp_type),
-                    performance_counters::counter_type::
-                        monotonically_increasing,
-                    hpx::util::format(
-                        "returns the number of parcels sent using the {} "
-                        "connection type for the referenced locality",
-                        pp_type),
-                    HPX_PERFORMANCE_COUNTER_V1,
+            constexpr performance_counters::generic_counter_type_data
+                counter_types[] = {
+                    {hpx::util::format("/parcels/count/{}/sent", pp_type),
+                        performance_counters::counter_type::
+                            monotonically_increasing,
+                        hpx::util::format(
+                            "returns the number of parcels sent using the {} "
+                            "connection type for the referenced locality",
+                            pp_type),
+                        HPX_PERFORMANCE_COUNTER_V1,
 #if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
-                    hpx::bind(
-                        &performance_counters::per_action_data_counter_creator,
-                        _1, HPX_MOVE(num_parcel_sends), _2),
-                    &performance_counters::per_action_data_counter_discoverer,
+                        hpx::bind(&performance_counters::
+                                      per_action_data_counter_creator,
+                            _1, HPX_MOVE(num_parcel_sends), _2),
+                        &performance_counters::
+                            per_action_data_counter_discoverer,
 #else
-                    hpx::bind(
-                        &performance_counters::locality_raw_counter_creator, _1,
-                        HPX_MOVE(num_parcel_sends), _2),
-                    &performance_counters::locality_counter_discoverer,
+                        hpx::bind(
+                            &performance_counters::locality_raw_counter_creator,
+                            _1, HPX_MOVE(num_parcel_sends), _2),
+                        &performance_counters::locality_counter_discoverer,
 #endif
-                    ""},
-                {hpx::util::format("/parcels/count/{}/received", pp_type),
-                    performance_counters::counter_type::
-                        monotonically_increasing,
-                    hpx::util::format(
-                        "returns the number of parcels received using the {} "
-                        "connection type for the referenced locality",
-                        pp_type),
-                    HPX_PERFORMANCE_COUNTER_V1,
+                        ""},
+                    {hpx::util::format("/parcels/count/{}/received", pp_type),
+                        performance_counters::counter_type::
+                            monotonically_increasing,
+                        hpx::util::format(
+                            "returns the number of parcels received using the "
+                            "{} "
+                            "connection type for the referenced locality",
+                            pp_type),
+                        HPX_PERFORMANCE_COUNTER_V1,
 #if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
-                    hpx::bind(
-                        &performance_counters::per_action_data_counter_creator,
-                        _1, HPX_MOVE(num_parcel_receives), _2),
-                    &performance_counters::per_action_data_counter_discoverer,
+                        hpx::bind(&performance_counters::
+                                      per_action_data_counter_creator,
+                            _1, HPX_MOVE(num_parcel_receives), _2),
+                        &performance_counters::
+                            per_action_data_counter_discoverer,
 #else
-                    hpx::bind(
-                        &performance_counters::locality_raw_counter_creator, _1,
-                        HPX_MOVE(num_parcel_receives), _2),
-                    &performance_counters::locality_counter_discoverer,
+                        hpx::bind(
+                            &performance_counters::locality_raw_counter_creator,
+                            _1, HPX_MOVE(num_parcel_receives), _2),
+                        &performance_counters::locality_counter_discoverer,
 #endif
-                    ""},
-                {hpx::util::format("/messages/count/{}/sent", pp_type),
-                    performance_counters::counter_type::
-                        monotonically_increasing,
-                    hpx::util::format(
-                        "returns the number of messages sent using the {} "
-                        "connection type for the referenced locality",
-                        pp_type),
-                    HPX_PERFORMANCE_COUNTER_V1,
-                    hpx::bind(
-                        &performance_counters::locality_raw_counter_creator, _1,
-                        HPX_MOVE(num_message_sends), _2),
-                    &performance_counters::locality_counter_discoverer, ""},
-                {hpx::util::format("/messages/count/{}/received", pp_type),
-                    performance_counters::counter_type::
-                        monotonically_increasing,
-                    hpx::util::format(
-                        "returns the number of messages received using the {} "
-                        "connection type for the referenced locality",
-                        pp_type),
-                    HPX_PERFORMANCE_COUNTER_V1,
-                    hpx::bind(
-                        &performance_counters::locality_raw_counter_creator, _1,
-                        HPX_MOVE(num_message_receives), _2),
-                    &performance_counters::locality_counter_discoverer, ""},
+                        ""},
+                    {hpx::util::format("/messages/count/{}/sent", pp_type),
+                        performance_counters::counter_type::
+                            monotonically_increasing,
+                        hpx::util::format(
+                            "returns the number of messages sent using the {} "
+                            "connection type for the referenced locality",
+                            pp_type),
+                        HPX_PERFORMANCE_COUNTER_V1,
+                        hpx::bind(
+                            &performance_counters::locality_raw_counter_creator,
+                            _1, HPX_MOVE(num_message_sends), _2),
+                        &performance_counters::locality_counter_discoverer, ""},
+                    {hpx::util::format("/messages/count/{}/received", pp_type),
+                        performance_counters::counter_type::
+                            monotonically_increasing,
+                        hpx::util::format(
+                            "returns the number of messages received using the "
+                            "{} "
+                            "connection type for the referenced locality",
+                            pp_type),
+                        HPX_PERFORMANCE_COUNTER_V1,
+                        hpx::bind(
+                            &performance_counters::locality_raw_counter_creator,
+                            _1, HPX_MOVE(num_message_receives), _2),
+                        &performance_counters::locality_counter_discoverer, ""},
 
-                {hpx::util::format("/data/time/{}/sent", pp_type),
-                    performance_counters::counter_type::elapsed_time,
-                    hpx::util::format(
-                        "returns the total time between the start of each "
-                        "asynchronous write and the invocation of the write "
-                        "callback using the {} connection type for the "
-                        "referenced locality",
-                        pp_type),
-                    HPX_PERFORMANCE_COUNTER_V1,
-                    hpx::bind(
-                        &performance_counters::locality_raw_counter_creator, _1,
-                        HPX_MOVE(sending_time), _2),
-                    &performance_counters::locality_counter_discoverer, "ns"},
-                {hpx::util::format("/data/time/{}/received", pp_type),
-                    performance_counters::counter_type::elapsed_time,
-                    hpx::util::format(
-                        "returns the total time between the start of each "
-                        "asynchronous read and the invocation of the read "
-                        "callback using the {} connection type for the "
-                        "referenced locality",
-                        pp_type),
-                    HPX_PERFORMANCE_COUNTER_V1,
-                    hpx::bind(
-                        &performance_counters::locality_raw_counter_creator, _1,
-                        HPX_MOVE(receiving_time), _2),
-                    &performance_counters::locality_counter_discoverer, "ns"},
-                {hpx::util::format("/serialize/time/{}/sent", pp_type),
-                    performance_counters::counter_type::elapsed_time,
-                    hpx::util::format(
-                        "returns the total time required to serialize all sent "
-                        "parcels using the {} connection type for the "
-                        "referenced locality",
-                        pp_type),
-                    HPX_PERFORMANCE_COUNTER_V1,
+                    {hpx::util::format("/data/time/{}/sent", pp_type),
+                        performance_counters::counter_type::elapsed_time,
+                        hpx::util::format(
+                            "returns the total time between the start of each "
+                            "asynchronous write and the invocation of the "
+                            "write "
+                            "callback using the {} connection type for the "
+                            "referenced locality",
+                            pp_type),
+                        HPX_PERFORMANCE_COUNTER_V1,
+                        hpx::bind(
+                            &performance_counters::locality_raw_counter_creator,
+                            _1, HPX_MOVE(sending_time), _2),
+                        &performance_counters::locality_counter_discoverer,
+                        "ns"},
+                    {hpx::util::format("/data/time/{}/received", pp_type),
+                        performance_counters::counter_type::elapsed_time,
+                        hpx::util::format(
+                            "returns the total time between the start of each "
+                            "asynchronous read and the invocation of the read "
+                            "callback using the {} connection type for the "
+                            "referenced locality",
+                            pp_type),
+                        HPX_PERFORMANCE_COUNTER_V1,
+                        hpx::bind(
+                            &performance_counters::locality_raw_counter_creator,
+                            _1, HPX_MOVE(receiving_time), _2),
+                        &performance_counters::locality_counter_discoverer,
+                        "ns"},
+                    {hpx::util::format("/serialize/time/{}/sent", pp_type),
+                        performance_counters::counter_type::elapsed_time,
+                        hpx::util::format(
+                            "returns the total time required to serialize all "
+                            "sent "
+                            "parcels using the {} connection type for the "
+                            "referenced locality",
+                            pp_type),
+                        HPX_PERFORMANCE_COUNTER_V1,
 #if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
-                    hpx::bind(
-                        &performance_counters::per_action_data_counter_creator,
-                        _1, HPX_MOVE(sending_serialization_time), _2),
-                    &performance_counters::per_action_data_counter_discoverer,
+                        hpx::bind(&performance_counters::
+                                      per_action_data_counter_creator,
+                            _1, HPX_MOVE(sending_serialization_time), _2),
+                        &performance_counters::
+                            per_action_data_counter_discoverer,
 #else
-                    hpx::bind(
-                        &performance_counters::locality_raw_counter_creator, _1,
-                        HPX_MOVE(sending_serialization_time), _2),
-                    &performance_counters::locality_counter_discoverer,
+                        hpx::bind(
+                            &performance_counters::locality_raw_counter_creator,
+                            _1, HPX_MOVE(sending_serialization_time), _2),
+                        &performance_counters::locality_counter_discoverer,
 #endif
-                    "ns"},
-                {hpx::util::format("/serialize/time/{}/received", pp_type),
-                    performance_counters::counter_type::elapsed_time,
-                    hpx::util::format(
-                        "returns the total time required to de-serialize all "
-                        "received parcels using the {} connection type for the "
-                        "referenced locality",
-                        pp_type),
-                    HPX_PERFORMANCE_COUNTER_V1,
+                        "ns"},
+                    {hpx::util::format("/serialize/time/{}/received", pp_type),
+                        performance_counters::counter_type::elapsed_time,
+                        hpx::util::format("returns the total time required to "
+                                          "de-serialize all "
+                                          "received parcels using the {} "
+                                          "connection type for the "
+                                          "referenced locality",
+                            pp_type),
+                        HPX_PERFORMANCE_COUNTER_V1,
 #if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
-                    hpx::bind(
-                        &performance_counters::per_action_data_counter_creator,
-                        _1, HPX_MOVE(receiving_serialization_time), _2),
-                    &performance_counters::per_action_data_counter_discoverer,
+                        hpx::bind(&performance_counters::
+                                      per_action_data_counter_creator,
+                            _1, HPX_MOVE(receiving_serialization_time), _2),
+                        &performance_counters::
+                            per_action_data_counter_discoverer,
 #else
-                    hpx::bind(
-                        &performance_counters::locality_raw_counter_creator, _1,
-                        HPX_MOVE(receiving_serialization_time), _2),
-                    &performance_counters::locality_counter_discoverer,
+                        hpx::bind(
+                            &performance_counters::locality_raw_counter_creator,
+                            _1, HPX_MOVE(receiving_serialization_time), _2),
+                        &performance_counters::locality_counter_discoverer,
 #endif
-                    "ns"},
+                        "ns"},
 
-                {hpx::util::format("/data/count/{}/sent", pp_type),
-                    performance_counters::counter_type::
-                        monotonically_increasing,
-                    hpx::util::format(
-                        "returns the amount of (uncompressed) parcel argument "
-                        "data sent using the {} connection type by the "
-                        "referenced locality",
-                        pp_type),
-                    HPX_PERFORMANCE_COUNTER_V1,
-                    hpx::bind(
-                        &performance_counters::locality_raw_counter_creator, _1,
-                        HPX_MOVE(data_raw_sent), _2),
-                    &performance_counters::locality_counter_discoverer,
-                    "bytes"},
-                {hpx::util::format("/data/count/{}/received", pp_type),
-                    performance_counters::counter_type::
-                        monotonically_increasing,
-                    hpx::util::format(
-                        "returns the amount of (uncompressed) parcel argument "
-                        "data received using the {} connection type by the "
-                        "referenced locality",
-                        pp_type),
-                    HPX_PERFORMANCE_COUNTER_V1,
-                    hpx::bind(
-                        &performance_counters::locality_raw_counter_creator, _1,
-                        HPX_MOVE(data_raw_received), _2),
-                    &performance_counters::locality_counter_discoverer,
-                    "bytes"},
-                {hpx::util::format("/serialize/count/{}/sent", pp_type),
-                    performance_counters::counter_type::
-                        monotonically_increasing,
-                    hpx::util::format(
-                        "returns the amount of parcel data (including headers, "
-                        "possibly compressed) sent using the {} connection "
-                        "type by the referenced locality",
-                        pp_type),
-                    HPX_PERFORMANCE_COUNTER_V1,
+                    {hpx::util::format("/data/count/{}/sent", pp_type),
+                        performance_counters::counter_type::
+                            monotonically_increasing,
+                        hpx::util::format(
+                            "returns the amount of (uncompressed) parcel "
+                            "argument "
+                            "data sent using the {} connection type by the "
+                            "referenced locality",
+                            pp_type),
+                        HPX_PERFORMANCE_COUNTER_V1,
+                        hpx::bind(
+                            &performance_counters::locality_raw_counter_creator,
+                            _1, HPX_MOVE(data_raw_sent), _2),
+                        &performance_counters::locality_counter_discoverer,
+                        "bytes"},
+                    {hpx::util::format("/data/count/{}/received", pp_type),
+                        performance_counters::counter_type::
+                            monotonically_increasing,
+                        hpx::util::format(
+                            "returns the amount of (uncompressed) parcel "
+                            "argument "
+                            "data received using the {} connection type by the "
+                            "referenced locality",
+                            pp_type),
+                        HPX_PERFORMANCE_COUNTER_V1,
+                        hpx::bind(
+                            &performance_counters::locality_raw_counter_creator,
+                            _1, HPX_MOVE(data_raw_received), _2),
+                        &performance_counters::locality_counter_discoverer,
+                        "bytes"},
+                    {hpx::util::format("/serialize/count/{}/sent", pp_type),
+                        performance_counters::counter_type::
+                            monotonically_increasing,
+                        hpx::util::format(
+                            "returns the amount of parcel data (including "
+                            "headers, "
+                            "possibly compressed) sent using the {} connection "
+                            "type by the referenced locality",
+                            pp_type),
+                        HPX_PERFORMANCE_COUNTER_V1,
 #if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
-                    hpx::bind(
-                        &performance_counters::per_action_data_counter_creator,
-                        _1, HPX_MOVE(data_sent), _2),
-                    &performance_counters::per_action_data_counter_discoverer,
+                        hpx::bind(&performance_counters::
+                                      per_action_data_counter_creator,
+                            _1, HPX_MOVE(data_sent), _2),
+                        &performance_counters::
+                            per_action_data_counter_discoverer,
 #else
-                    hpx::bind(
-                        &performance_counters::locality_raw_counter_creator, _1,
-                        HPX_MOVE(data_sent), _2),
-                    &performance_counters::locality_counter_discoverer,
+                        hpx::bind(
+                            &performance_counters::locality_raw_counter_creator,
+                            _1, HPX_MOVE(data_sent), _2),
+                        &performance_counters::locality_counter_discoverer,
 #endif
-                    "bytes"},
-                {hpx::util::format("/serialize/count/{}/received", pp_type),
-                    performance_counters::counter_type::
-                        monotonically_increasing,
-                    hpx::util::format(
-                        "returns the amount of parcel data (including headers, "
-                        "possibly compressed) received using the {} connection "
-                        "type by the referenced locality",
-                        pp_type),
-                    HPX_PERFORMANCE_COUNTER_V1,
+                        "bytes"},
+                    {hpx::util::format("/serialize/count/{}/received", pp_type),
+                        performance_counters::counter_type::
+                            monotonically_increasing,
+                        hpx::util::format("returns the amount of parcel data "
+                                          "(including headers, "
+                                          "possibly compressed) received using "
+                                          "the {} connection "
+                                          "type by the referenced locality",
+                            pp_type),
+                        HPX_PERFORMANCE_COUNTER_V1,
 #if defined(HPX_HAVE_PARCELPORT_ACTION_COUNTERS)
-                    hpx::bind(
-                        &performance_counters::per_action_data_counter_creator,
-                        _1, HPX_MOVE(data_received), _2),
-                    &performance_counters::per_action_data_counter_discoverer,
+                        hpx::bind(&performance_counters::
+                                      per_action_data_counter_creator,
+                            _1, HPX_MOVE(data_received), _2),
+                        &performance_counters::
+                            per_action_data_counter_discoverer,
 #else
-                    hpx::bind(
-                        &performance_counters::locality_raw_counter_creator, _1,
-                        HPX_MOVE(data_received), _2),
-                    &performance_counters::locality_counter_discoverer,
+                        hpx::bind(
+                            &performance_counters::locality_raw_counter_creator,
+                            _1, HPX_MOVE(data_received), _2),
+                        &performance_counters::locality_counter_discoverer,
 #endif
-                    "bytes"},
-                {hpx::util::format(
-                     "/parcels/time/{}/buffer_allocate/received", pp_type),
-                    performance_counters::counter_type::elapsed_time,
-                    hpx::util::format(
-                        "returns the time needed to allocate the buffers for "
-                        "serializing using the {} connection type",
-                        pp_type),
-                    HPX_PERFORMANCE_COUNTER_V1,
-                    hpx::bind(
-                        &performance_counters::locality_raw_counter_creator, _1,
-                        HPX_MOVE(buffer_allocate_time_received), _2),
-                    &performance_counters::locality_counter_discoverer, "ns"},
-                {hpx::util::format(
-                     "/parcels/time/{}/buffer_allocate/sent", pp_type),
-                    performance_counters::counter_type::elapsed_time,
-                    hpx::util::format(
-                        "returns the time needed to allocate the buffers for "
-                        "serializing using the {} connection type",
-                        pp_type),
-                    HPX_PERFORMANCE_COUNTER_V1,
-                    hpx::bind(
-                        &performance_counters::locality_raw_counter_creator, _1,
-                        HPX_MOVE(buffer_allocate_time_sent), _2),
-                    &performance_counters::locality_counter_discoverer, "ns"},
-                {hpx::util::format(
-                     "/parcelport/count/{}/zero_copy_chunks/sent", pp_type),
-                    performance_counters::counter_type::
-                        monotonically_increasing,
-                    hpx::util::format(
-                        "returns the total number of zero-copy chunks sent "
-                        "using the {} connection type for the referenced "
-                        "locality",
-                        pp_type),
-                    HPX_PERFORMANCE_COUNTER_V1,
-                    hpx::bind(
-                        &performance_counters::locality_raw_counter_creator, _1,
-                        HPX_MOVE(num_zchunks_send), _2),
-                    &performance_counters::locality_counter_discoverer, ""},
-                {hpx::util::format(
-                     "/parcelport/count/{}/zero_copy_chunks/received", pp_type),
-                    performance_counters::counter_type::
-                        monotonically_increasing,
-                    hpx::util::format(
-                        "returns the total number of zero-copy chunks received "
-                        "using the {} connection type for the referenced "
-                        "locality",
-                        pp_type),
-                    HPX_PERFORMANCE_COUNTER_V1,
-                    hpx::bind(
-                        &performance_counters::locality_raw_counter_creator, _1,
-                        HPX_MOVE(num_zchunks_recv), _2),
-                    &performance_counters::locality_counter_discoverer, ""},
-                {hpx::util::format(
-                     "/parcelport/count-max/{}/zero_copy_chunks/sent", pp_type),
-                    performance_counters::counter_type::
-                        monotonically_increasing,
-                    hpx::util::format(
-                        "returns the maximum number of zero-copy chunks per "
-                        "message sent using the {} connection type for the "
-                        "referenced locality",
-                        pp_type),
-                    HPX_PERFORMANCE_COUNTER_V1,
-                    hpx::bind(
-                        &performance_counters::locality_raw_counter_creator, _1,
-                        HPX_MOVE(num_zchunks_send_per_msg_max), _2),
-                    &performance_counters::locality_counter_discoverer, ""},
-                {hpx::util::format(
-                     "/parcelport/count-max/{}/zero_copy_chunks/received",
-                     pp_type),
-                    performance_counters::counter_type::
-                        monotonically_increasing,
-                    hpx::util::format(
-                        "returns the maximum number of zero-copy chunks per "
-                        "message received using the {} connection type for the "
-                        "referenced locality",
-                        pp_type),
-                    HPX_PERFORMANCE_COUNTER_V1,
-                    hpx::bind(
-                        &performance_counters::locality_raw_counter_creator, _1,
-                        HPX_MOVE(num_zchunks_recv_per_msg_max), _2),
-                    &performance_counters::locality_counter_discoverer, ""},
-                {hpx::util::format(
-                     "/parcelport/size/{}/zero_copy_chunks/sent", pp_type),
-                    performance_counters::counter_type::
-                        monotonically_increasing,
-                    hpx::util::format(
-                        "returns the total size of zero-copy chunks sent using "
-                        "the {} connection type for the referenced locality",
-                        pp_type),
-                    HPX_PERFORMANCE_COUNTER_V1,
-                    hpx::bind(
-                        &performance_counters::locality_raw_counter_creator, _1,
-                        HPX_MOVE(size_zchunks_send), _2),
-                    &performance_counters::locality_counter_discoverer, ""},
-                {hpx::util::format(
-                     "/parcelport/size/{}/zero_copy_chunks/received", pp_type),
-                    performance_counters::counter_type::
-                        monotonically_increasing,
-                    hpx::util::format(
-                        "returns the total size of zero-copy chunks received "
-                        "using the {} connection type for the referenced "
-                        "locality",
-                        pp_type),
-                    HPX_PERFORMANCE_COUNTER_V1,
-                    hpx::bind(
-                        &performance_counters::locality_raw_counter_creator, _1,
-                        HPX_MOVE(size_zchunks_recv), _2),
-                    &performance_counters::locality_counter_discoverer, ""},
-                {hpx::util::format(
-                     "/parcelport/size-max/{}/zero_copy_chunks/sent", pp_type),
-                    performance_counters::counter_type::
-                        monotonically_increasing,
-                    hpx::util::format(
-                        "returns the maximum size of zero-copy chunks sent "
-                        "using the {} connection type for the referenced "
-                        "locality",
-                        pp_type),
-                    HPX_PERFORMANCE_COUNTER_V1,
-                    hpx::bind(
-                        &performance_counters::locality_raw_counter_creator, _1,
-                        HPX_MOVE(size_zchunks_send_per_msg_max), _2),
-                    &performance_counters::locality_counter_discoverer, ""},
-                {hpx::util::format(
-                     "/parcelport/size-max/{}/zero_copy_chunks/received",
-                     pp_type),
-                    performance_counters::counter_type::
-                        monotonically_increasing,
-                    hpx::util::format(
-                        "returns the maximum size of zero-copy chunks received "
-                        "using the {} connection type for the referenced "
-                        "locality",
-                        pp_type),
-                    HPX_PERFORMANCE_COUNTER_V1,
-                    hpx::bind(
-                        &performance_counters::locality_raw_counter_creator, _1,
-                        HPX_MOVE(size_zchunks_recv_per_msg_max), _2),
-                    &performance_counters::locality_counter_discoverer, ""},
-            };
+                        "bytes"},
+                    {hpx::util::format(
+                         "/parcels/time/{}/buffer_allocate/received", pp_type),
+                        performance_counters::counter_type::elapsed_time,
+                        hpx::util::format(
+                            "returns the time needed to allocate the buffers "
+                            "for "
+                            "serializing using the {} connection type",
+                            pp_type),
+                        HPX_PERFORMANCE_COUNTER_V1,
+                        hpx::bind(
+                            &performance_counters::locality_raw_counter_creator,
+                            _1, HPX_MOVE(buffer_allocate_time_received), _2),
+                        &performance_counters::locality_counter_discoverer,
+                        "ns"},
+                    {hpx::util::format(
+                         "/parcels/time/{}/buffer_allocate/sent", pp_type),
+                        performance_counters::counter_type::elapsed_time,
+                        hpx::util::format(
+                            "returns the time needed to allocate the buffers "
+                            "for "
+                            "serializing using the {} connection type",
+                            pp_type),
+                        HPX_PERFORMANCE_COUNTER_V1,
+                        hpx::bind(
+                            &performance_counters::locality_raw_counter_creator,
+                            _1, HPX_MOVE(buffer_allocate_time_sent), _2),
+                        &performance_counters::locality_counter_discoverer,
+                        "ns"},
+                    {hpx::util::format(
+                         "/parcelport/count/{}/zero_copy_chunks/sent", pp_type),
+                        performance_counters::counter_type::
+                            monotonically_increasing,
+                        hpx::util::format(
+                            "returns the total number of zero-copy chunks sent "
+                            "using the {} connection type for the referenced "
+                            "locality",
+                            pp_type),
+                        HPX_PERFORMANCE_COUNTER_V1,
+                        hpx::bind(
+                            &performance_counters::locality_raw_counter_creator,
+                            _1, HPX_MOVE(num_zchunks_send), _2),
+                        &performance_counters::locality_counter_discoverer, ""},
+                    {hpx::util::format(
+                         "/parcelport/count/{}/zero_copy_chunks/received",
+                         pp_type),
+                        performance_counters::counter_type::
+                            monotonically_increasing,
+                        hpx::util::format(
+                            "returns the total number of zero-copy chunks "
+                            "received "
+                            "using the {} connection type for the referenced "
+                            "locality",
+                            pp_type),
+                        HPX_PERFORMANCE_COUNTER_V1,
+                        hpx::bind(
+                            &performance_counters::locality_raw_counter_creator,
+                            _1, HPX_MOVE(num_zchunks_recv), _2),
+                        &performance_counters::locality_counter_discoverer, ""},
+                    {hpx::util::format(
+                         "/parcelport/count-max/{}/zero_copy_chunks/sent",
+                         pp_type),
+                        performance_counters::counter_type::
+                            monotonically_increasing,
+                        hpx::util::format(
+                            "returns the maximum number of zero-copy chunks "
+                            "per "
+                            "message sent using the {} connection type for the "
+                            "referenced locality",
+                            pp_type),
+                        HPX_PERFORMANCE_COUNTER_V1,
+                        hpx::bind(
+                            &performance_counters::locality_raw_counter_creator,
+                            _1, HPX_MOVE(num_zchunks_send_per_msg_max), _2),
+                        &performance_counters::locality_counter_discoverer, ""},
+                    {hpx::util::format(
+                         "/parcelport/count-max/{}/zero_copy_chunks/received",
+                         pp_type),
+                        performance_counters::counter_type::
+                            monotonically_increasing,
+                        hpx::util::format("returns the maximum number of "
+                                          "zero-copy chunks per "
+                                          "message received using the {} "
+                                          "connection type for the "
+                                          "referenced locality",
+                            pp_type),
+                        HPX_PERFORMANCE_COUNTER_V1,
+                        hpx::bind(
+                            &performance_counters::locality_raw_counter_creator,
+                            _1, HPX_MOVE(num_zchunks_recv_per_msg_max), _2),
+                        &performance_counters::locality_counter_discoverer, ""},
+                    {hpx::util::format(
+                         "/parcelport/size/{}/zero_copy_chunks/sent", pp_type),
+                        performance_counters::counter_type::
+                            monotonically_increasing,
+                        hpx::util::format("returns the total size of zero-copy "
+                                          "chunks sent using "
+                                          "the {} connection type for the "
+                                          "referenced locality",
+                            pp_type),
+                        HPX_PERFORMANCE_COUNTER_V1,
+                        hpx::bind(
+                            &performance_counters::locality_raw_counter_creator,
+                            _1, HPX_MOVE(size_zchunks_send), _2),
+                        &performance_counters::locality_counter_discoverer, ""},
+                    {hpx::util::format(
+                         "/parcelport/size/{}/zero_copy_chunks/received",
+                         pp_type),
+                        performance_counters::counter_type::
+                            monotonically_increasing,
+                        hpx::util::format(
+                            "returns the total size of zero-copy chunks "
+                            "received "
+                            "using the {} connection type for the referenced "
+                            "locality",
+                            pp_type),
+                        HPX_PERFORMANCE_COUNTER_V1,
+                        hpx::bind(
+                            &performance_counters::locality_raw_counter_creator,
+                            _1, HPX_MOVE(size_zchunks_recv), _2),
+                        &performance_counters::locality_counter_discoverer, ""},
+                    {hpx::util::format(
+                         "/parcelport/size-max/{}/zero_copy_chunks/sent",
+                         pp_type),
+                        performance_counters::counter_type::
+                            monotonically_increasing,
+                        hpx::util::format(
+                            "returns the maximum size of zero-copy chunks sent "
+                            "using the {} connection type for the referenced "
+                            "locality",
+                            pp_type),
+                        HPX_PERFORMANCE_COUNTER_V1,
+                        hpx::bind(
+                            &performance_counters::locality_raw_counter_creator,
+                            _1, HPX_MOVE(size_zchunks_send_per_msg_max), _2),
+                        &performance_counters::locality_counter_discoverer, ""},
+                    {hpx::util::format(
+                         "/parcelport/size-max/{}/zero_copy_chunks/received",
+                         pp_type),
+                        performance_counters::counter_type::
+                            monotonically_increasing,
+                        hpx::util::format(
+                            "returns the maximum size of zero-copy chunks "
+                            "received "
+                            "using the {} connection type for the referenced "
+                            "locality",
+                            pp_type),
+                        HPX_PERFORMANCE_COUNTER_V1,
+                        hpx::bind(
+                            &performance_counters::locality_raw_counter_creator,
+                            _1, HPX_MOVE(size_zchunks_recv_per_msg_max), _2),
+                        &performance_counters::locality_counter_discoverer, ""},
+                };
 
-        performance_counters::install_counter_types(
-            counter_types, std::size(counter_types));
-    }
+            performance_counters::install_counter_types(
+                counter_types, std::size(counter_types));
+        }
 
-    ///////////////////////////////////////////////////////////////////////////
-    // register connection specific performance counters related to connection
-    // caches
-    static void register_connection_cache_counter_types(
-        parcelset::parcelhandler& ph, std::string const& pp_type)
-    {
-        using hpx::placeholders::_1;
-        using hpx::placeholders::_2;
+        ///////////////////////////////////////////////////////////////////////
+        // register connection specific performance counters related to
+        // connection caches
+        void register_connection_cache_counter_types(
+            parcelset::parcelhandler& ph, std::string const& pp_type)
+        {
+            using hpx::placeholders::_1;
+            using hpx::placeholders::_2;
 
-        using parcelset::parcelhandler;
-        using parcelset::parcelport;
+            using parcelset::parcelhandler;
+            using parcelset::parcelport;
 
-        hpx::function<std::int64_t(bool)> cache_insertions(
-            hpx::bind_front(&parcelhandler::get_connection_cache_statistics,
-                &ph, pp_type, parcelport::connection_cache_insertions));
-        hpx::function<std::int64_t(bool)> cache_evictions(
-            hpx::bind_front(&parcelhandler::get_connection_cache_statistics,
-                &ph, pp_type, parcelport::connection_cache_evictions));
-        hpx::function<std::int64_t(bool)> cache_hits(
-            hpx::bind_front(&parcelhandler::get_connection_cache_statistics,
-                &ph, pp_type, parcelport::connection_cache_hits));
-        hpx::function<std::int64_t(bool)> cache_misses(
-            hpx::bind_front(&parcelhandler::get_connection_cache_statistics,
-                &ph, pp_type, parcelport::connection_cache_misses));
-        hpx::function<std::int64_t(bool)> cache_reclaims(
-            hpx::bind_front(&parcelhandler::get_connection_cache_statistics,
-                &ph, pp_type, parcelport::connection_cache_reclaims));
-        hpx::function<std::int64_t(bool)> cache_reservation_failures(
-            hpx::bind_front(&parcelhandler::get_connection_cache_statistics,
-                &ph, pp_type,
-                parcelport::connection_cache_reservation_failures));
-        hpx::function<std::int64_t(bool)> cache_num_connections(
-            hpx::bind_front(&parcelhandler::get_connection_cache_statistics,
-                &ph, pp_type, parcelport::connection_cache_num_connections));
-        hpx::function<std::int64_t(bool)> cache_max_connections(
-            hpx::bind_front(&parcelhandler::get_connection_cache_statistics,
-                &ph, pp_type, parcelport::connection_cache_max_connections));
+            hpx::function<std::int64_t(bool)> cache_insertions(
+                hpx::bind_front(&parcelhandler::get_connection_cache_statistics,
+                    &ph, pp_type, parcelport::connection_cache_insertions));
+            hpx::function<std::int64_t(bool)> cache_evictions(
+                hpx::bind_front(&parcelhandler::get_connection_cache_statistics,
+                    &ph, pp_type, parcelport::connection_cache_evictions));
+            hpx::function<std::int64_t(bool)> cache_hits(
+                hpx::bind_front(&parcelhandler::get_connection_cache_statistics,
+                    &ph, pp_type, parcelport::connection_cache_hits));
+            hpx::function<std::int64_t(bool)> cache_misses(
+                hpx::bind_front(&parcelhandler::get_connection_cache_statistics,
+                    &ph, pp_type, parcelport::connection_cache_misses));
+            hpx::function<std::int64_t(bool)> cache_reclaims(
+                hpx::bind_front(&parcelhandler::get_connection_cache_statistics,
+                    &ph, pp_type, parcelport::connection_cache_reclaims));
+            hpx::function<std::int64_t(bool)> cache_reservation_failures(
+                hpx::bind_front(&parcelhandler::get_connection_cache_statistics,
+                    &ph, pp_type,
+                    parcelport::connection_cache_reservation_failures));
+            hpx::function<std::int64_t(bool)> cache_num_connections(
+                hpx::bind_front(&parcelhandler::get_connection_cache_statistics,
+                    &ph, pp_type,
+                    parcelport::connection_cache_num_connections));
+            hpx::function<std::int64_t(bool)> cache_max_connections(
+                hpx::bind_front(&parcelhandler::get_connection_cache_statistics,
+                    &ph, pp_type,
+                    parcelport::connection_cache_max_connections));
 
-        performance_counters::generic_counter_type_data const
-            connection_cache_types[] = {
-                {hpx::util::format(
-                     "/parcelport/count/{}/cache-insertions", pp_type),
-                    performance_counters::counter_type::raw,
-                    hpx::util::format(
-                        "returns the number of cache insertions while "
-                        "accessing the connection cache for the {} connection "
-                        "type on the referenced locality",
-                        pp_type),
-                    HPX_PERFORMANCE_COUNTER_V1,
-                    hpx::bind(
-                        &performance_counters::locality_raw_counter_creator, _1,
-                        HPX_MOVE(cache_insertions), _2),
-                    &performance_counters::locality_counter_discoverer, ""},
-                {hpx::util::format(
-                     "/parcelport/count/{}/cache-evictions", pp_type),
-                    performance_counters::counter_type::raw,
-                    hpx::util::format(
-                        "returns the number of cache evictions while accessing "
-                        "the connection cache for the {} connection type on "
-                        "the referenced locality",
-                        pp_type),
-                    HPX_PERFORMANCE_COUNTER_V1,
-                    hpx::bind(
-                        &performance_counters::locality_raw_counter_creator, _1,
-                        HPX_MOVE(cache_evictions), _2),
-                    &performance_counters::locality_counter_discoverer, ""},
-                {hpx::util::format("/parcelport/count/{}/cache-hits", pp_type),
-                    performance_counters::counter_type::raw,
-                    hpx::util::format(
-                        "returns the number of cache hits while accessing the "
-                        "connection cache for the {} connection type on the "
-                        "referenced locality",
-                        pp_type),
-                    HPX_PERFORMANCE_COUNTER_V1,
-                    hpx::bind(
-                        &performance_counters::locality_raw_counter_creator, _1,
-                        HPX_MOVE(cache_hits), _2),
-                    &performance_counters::locality_counter_discoverer, ""},
-                {hpx::util::format(
-                     "/parcelport/count/{}/cache-misses", pp_type),
-                    performance_counters::counter_type::raw,
-                    hpx::util::format(
-                        "returns the number of cache misses while accessing "
-                        "the connection cache for the {} connection type on "
-                        "the referenced locality",
-                        pp_type),
-                    HPX_PERFORMANCE_COUNTER_V1,
-                    hpx::bind(
-                        &performance_counters::locality_raw_counter_creator, _1,
-                        HPX_MOVE(cache_misses), _2),
-                    &performance_counters::locality_counter_discoverer, ""},
-                {hpx::util::format(
-                     "/parcelport/count/{}/cache-reclaims", pp_type),
-                    performance_counters::counter_type::raw,
-                    hpx::util::format(
-                        "returns the number of cache reclaims while accessing "
-                        "the connection cache for the {} connection type on "
-                        "the referenced locality",
-                        pp_type),
-                    HPX_PERFORMANCE_COUNTER_V1,
-                    hpx::bind(
-                        &performance_counters::locality_raw_counter_creator, _1,
-                        HPX_MOVE(cache_reclaims), _2),
-                    &performance_counters::locality_counter_discoverer, ""},
-                {hpx::util::format(
-                     "/parcelport/count/{}/cache-reservation-failures",
-                     pp_type),
-                    performance_counters::counter_type::raw,
-                    hpx::util::format(
-                        "returns the number of times a connection reservation "
-                        "failed because the {} connection cache was fully "
-                        "checked out (pool saturation); parcels are silently "
-                        "deferred on each such event",
-                        pp_type),
-                    HPX_PERFORMANCE_COUNTER_V1,
-                    hpx::bind(
-                        &performance_counters::locality_raw_counter_creator, _1,
-                        HPX_MOVE(cache_reservation_failures), _2),
-                    &performance_counters::locality_counter_discoverer, ""},
-                {hpx::util::format(
-                     "/parcelport/count/{}/cache-connections", pp_type),
-                    performance_counters::counter_type::raw,
-                    hpx::util::format(
-                        "returns the current number of connections tracked by "
-                        "the {} connection cache (in-use plus idle); compare "
-                        "with cache-max-connections to compute utilisation",
-                        pp_type),
-                    HPX_PERFORMANCE_COUNTER_V1,
-                    hpx::bind(
-                        &performance_counters::locality_raw_counter_creator, _1,
-                        HPX_MOVE(cache_num_connections), _2),
-                    &performance_counters::locality_counter_discoverer, ""},
-                {hpx::util::format(
-                     "/parcelport/count/{}/cache-max-connections", pp_type),
-                    performance_counters::counter_type::raw,
-                    hpx::util::format(
-                        "returns the configured maximum number of connections "
-                        "for the {} connection cache (hpx.max_connections ini "
-                        "key); fixed at startup",
-                        pp_type),
-                    HPX_PERFORMANCE_COUNTER_V1,
-                    hpx::bind(
-                        &performance_counters::locality_raw_counter_creator, _1,
-                        HPX_MOVE(cache_max_connections), _2),
-                    &performance_counters::locality_counter_discoverer, ""}};
+            constexpr performance_counters::generic_counter_type_data
+                connection_cache_types[] = {
+                    {hpx::util::format(
+                         "/parcelport/count/{}/cache-insertions", pp_type),
+                        performance_counters::counter_type::raw,
+                        hpx::util::format(
+                            "returns the number of cache insertions while "
+                            "accessing the connection cache for the {} "
+                            "connection "
+                            "type on the referenced locality",
+                            pp_type),
+                        HPX_PERFORMANCE_COUNTER_V1,
+                        hpx::bind(
+                            &performance_counters::locality_raw_counter_creator,
+                            _1, HPX_MOVE(cache_insertions), _2),
+                        &performance_counters::locality_counter_discoverer, ""},
+                    {hpx::util::format(
+                         "/parcelport/count/{}/cache-evictions", pp_type),
+                        performance_counters::counter_type::raw,
+                        hpx::util::format("returns the number of cache "
+                                          "evictions while accessing "
+                                          "the connection cache for the {} "
+                                          "connection type on "
+                                          "the referenced locality",
+                            pp_type),
+                        HPX_PERFORMANCE_COUNTER_V1,
+                        hpx::bind(
+                            &performance_counters::locality_raw_counter_creator,
+                            _1, HPX_MOVE(cache_evictions), _2),
+                        &performance_counters::locality_counter_discoverer, ""},
+                    {hpx::util::format(
+                         "/parcelport/count/{}/cache-hits", pp_type),
+                        performance_counters::counter_type::raw,
+                        hpx::util::format("returns the number of cache hits "
+                                          "while accessing the "
+                                          "connection cache for the {} "
+                                          "connection type on the "
+                                          "referenced locality",
+                            pp_type),
+                        HPX_PERFORMANCE_COUNTER_V1,
+                        hpx::bind(
+                            &performance_counters::locality_raw_counter_creator,
+                            _1, HPX_MOVE(cache_hits), _2),
+                        &performance_counters::locality_counter_discoverer, ""},
+                    {hpx::util::format(
+                         "/parcelport/count/{}/cache-misses", pp_type),
+                        performance_counters::counter_type::raw,
+                        hpx::util::format("returns the number of cache misses "
+                                          "while accessing "
+                                          "the connection cache for the {} "
+                                          "connection type on "
+                                          "the referenced locality",
+                            pp_type),
+                        HPX_PERFORMANCE_COUNTER_V1,
+                        hpx::bind(
+                            &performance_counters::locality_raw_counter_creator,
+                            _1, HPX_MOVE(cache_misses), _2),
+                        &performance_counters::locality_counter_discoverer, ""},
+                    {hpx::util::format(
+                         "/parcelport/count/{}/cache-reclaims", pp_type),
+                        performance_counters::counter_type::raw,
+                        hpx::util::format("returns the number of cache "
+                                          "reclaims while accessing "
+                                          "the connection cache for the {} "
+                                          "connection type on "
+                                          "the referenced locality",
+                            pp_type),
+                        HPX_PERFORMANCE_COUNTER_V1,
+                        hpx::bind(
+                            &performance_counters::locality_raw_counter_creator,
+                            _1, HPX_MOVE(cache_reclaims), _2),
+                        &performance_counters::locality_counter_discoverer, ""},
+                    {hpx::util::format(
+                         "/parcelport/count/{}/cache-reservation-failures",
+                         pp_type),
+                        performance_counters::counter_type::raw,
+                        hpx::util::format(
+                            "returns the number of times a connection "
+                            "reservation "
+                            "failed because the {} connection cache was fully "
+                            "checked out (pool saturation); parcels are "
+                            "silently "
+                            "deferred on each such event",
+                            pp_type),
+                        HPX_PERFORMANCE_COUNTER_V1,
+                        hpx::bind(
+                            &performance_counters::locality_raw_counter_creator,
+                            _1, HPX_MOVE(cache_reservation_failures), _2),
+                        &performance_counters::locality_counter_discoverer, ""},
+                    {hpx::util::format(
+                         "/parcelport/count/{}/cache-connections", pp_type),
+                        performance_counters::counter_type::raw,
+                        hpx::util::format(
+                            "returns the current number of connections tracked "
+                            "by "
+                            "the {} connection cache (in-use plus idle); "
+                            "compare "
+                            "with cache-max-connections to compute utilisation",
+                            pp_type),
+                        HPX_PERFORMANCE_COUNTER_V1,
+                        hpx::bind(
+                            &performance_counters::locality_raw_counter_creator,
+                            _1, HPX_MOVE(cache_num_connections), _2),
+                        &performance_counters::locality_counter_discoverer, ""},
+                    {hpx::util::format(
+                         "/parcelport/count/{}/cache-max-connections", pp_type),
+                        performance_counters::counter_type::raw,
+                        hpx::util::format("returns the configured maximum "
+                                          "number of connections "
+                                          "for the {} connection cache "
+                                          "(hpx.max_connections ini "
+                                          "key); fixed at startup",
+                            pp_type),
+                        HPX_PERFORMANCE_COUNTER_V1,
+                        hpx::bind(
+                            &performance_counters::locality_raw_counter_creator,
+                            _1, HPX_MOVE(cache_max_connections), _2),
+                        &performance_counters::locality_counter_discoverer,
+                        ""}};
 
-        performance_counters::install_counter_types(
-            connection_cache_types, std::size(connection_cache_types));
-    }
+            performance_counters::install_counter_types(
+                connection_cache_types, std::size(connection_cache_types));
+        }
+    }    // namespace
 #endif
 
     ///////////////////////////////////////////////////////////////////////////
@@ -649,15 +706,18 @@ namespace hpx::performance_counters {
         hpx::function<std::int64_t(bool)> outgoing_routed_count(
             hpx::bind_front(&parcelhandler::get_parcel_routed_count, &ph));
 
-        performance_counters::generic_counter_type_data const counter_types[] =
-            {{"/parcelqueue/length/receive",
-                 performance_counters::counter_type::raw,
-                 "returns the number current length of the queue of incoming "
-                 "parcels",
-                 HPX_PERFORMANCE_COUNTER_V1,
-                 hpx::bind(&performance_counters::locality_raw_counter_creator,
-                     _1, incoming_queue_length, _2),
-                 &performance_counters::locality_counter_discoverer, ""},
+        constexpr performance_counters::generic_counter_type_data
+            counter_types[] = {
+                {"/parcelqueue/length/receive",
+                    performance_counters::counter_type::raw,
+                    "returns the number current length of the queue of "
+                    "incoming "
+                    "parcels",
+                    HPX_PERFORMANCE_COUNTER_V1,
+                    hpx::bind(
+                        &performance_counters::locality_raw_counter_creator, _1,
+                        incoming_queue_length, _2),
+                    &performance_counters::locality_counter_discoverer, ""},
                 {"/parcelqueue/length/send",
                     performance_counters::counter_type::raw,
                     "returns the number current length of the queue of "

--- a/libs/full/performance_counters/src/per_action_data_counter_discoverer.cpp
+++ b/libs/full/performance_counters/src/per_action_data_counter_discoverer.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2022 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -12,6 +12,7 @@
 #include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/util.hpp>
+
 #include <hpx/performance_counters/counter_creators.hpp>
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/performance_counters/per_action_data_counter_discoverer.hpp>
@@ -21,7 +22,7 @@
 #include <string>
 #include <utility>
 
-namespace hpx { namespace performance_counters {
+namespace hpx::performance_counters {
 
     bool per_action_counter_counter_discoverer(
         hpx::actions::detail::per_action_data_counter_registry const& registry,
@@ -149,6 +150,6 @@ namespace hpx { namespace performance_counters {
 
         return true;
     }
-}}    // namespace hpx::performance_counters
+}    // namespace hpx::performance_counters
 
 #endif

--- a/libs/full/performance_counters/src/performance_counter.cpp
+++ b/libs/full/performance_counters/src/performance_counter.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2023 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -184,6 +184,7 @@ namespace hpx::performance_counters {
         return hpx::make_ready_future(true);
 #endif
     }
+
     bool performance_counter::stop(
         launch::sync_policy, [[maybe_unused]] error_code& ec) const
     {
@@ -210,6 +211,7 @@ namespace hpx::performance_counters {
         return hpx::make_ready_future();
 #endif
     }
+
     void performance_counter::reset(
         launch::sync_policy, [[maybe_unused]] error_code& ec) const
     {
@@ -236,6 +238,7 @@ namespace hpx::performance_counters {
         return hpx::make_ready_future();
 #endif
     }
+
     void performance_counter::reinit(
         launch::sync_policy, bool reset, error_code& ec) const
     {

--- a/libs/full/performance_counters/src/performance_counter_set.cpp
+++ b/libs/full/performance_counters/src/performance_counter_set.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2016-2022 Hartmut Kaiser
+//  Copyright (c) 2016-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -12,6 +12,7 @@
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/pack_traversal.hpp>
 #include <hpx/modules/runtime_local.hpp>
+
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/performance_counters/performance_counter.hpp>
 #include <hpx/performance_counters/performance_counter_set.hpp>
@@ -26,7 +27,8 @@
 #include <hpx/config/warnings_prefix.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace performance_counters {
+namespace hpx::performance_counters {
+
     performance_counter_set::performance_counter_set(
         std::string const& name, bool reset)
       : invocation_count_(0)
@@ -398,4 +400,4 @@ namespace hpx { namespace performance_counters {
         std::unique_lock<mutex_type> l(mtx_);
         return invocation_count_;
     }
-}}    // namespace hpx::performance_counters
+}    // namespace hpx::performance_counters

--- a/libs/full/performance_counters/src/primary_namespace_counters.cpp
+++ b/libs/full/performance_counters/src/primary_namespace_counters.cpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2011 Bryce Adelstein-Lelbach
-//  Copyright (c) 2012-2020 Hartmut Kaiser
+//  Copyright (c) 2012-2026 Hartmut Kaiser
 //  Copyright (c) 2016 Thomas Heller
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -28,7 +28,7 @@
 
 #include <hpx/config/warnings_prefix.hpp>
 
-namespace hpx { namespace agas { namespace server {
+namespace hpx::agas::server {
 
     // register all performance counter types exposed by this component
     void primary_namespace_register_counter_types(error_code& ec)
@@ -73,7 +73,7 @@ namespace hpx { namespace agas { namespace server {
             performance_counters::install_counter_type(
                 agas::performance_counter_basename + name, type, help, creator,
                 &performance_counters::locality_counter_discoverer,
-                HPX_PERFORMANCE_COUNTER_V1,
+                performance_counters::HPX_PERFORMANCE_COUNTER_V1,
                 agas::detail::primary_namespace_services[i].uom_, ec);
             if (ec)
             {
@@ -120,7 +120,7 @@ namespace hpx { namespace agas { namespace server {
                     agas::detail::primary_namespace_services[i].name_,
                 type, help, creator,
                 &performance_counters::locality_counter_discoverer,
-                HPX_PERFORMANCE_COUNTER_V1,
+                performance_counters::HPX_PERFORMANCE_COUNTER_V1,
                 agas::detail::primary_namespace_services[i].uom_, ec);
             if (ec)
             {
@@ -321,9 +321,9 @@ namespace hpx { namespace agas { namespace server {
         }
         return naming::detail::strip_credits_from_gid(gid);
     }
-}}}    // namespace hpx::agas::server
+}    // namespace hpx::agas::server
 
-namespace hpx { namespace agas {
+namespace hpx::agas {
 
     // register performance counters for primary_namespace service
     void primary_namespace_register_counter_types(error_code& ec)
@@ -343,7 +343,7 @@ namespace hpx { namespace agas {
             naming::get_agas_client().get_local_primary_namespace_service(),
             name);
     }
-}}    // namespace hpx::agas
+}    // namespace hpx::agas
 
 HPX_REGISTER_ACTION_ID(hpx::agas::primary_namespace_statistics_counter_action,
     primary_namespace_statistics_counter_action,

--- a/libs/full/performance_counters/src/query_counters.cpp
+++ b/libs/full/performance_counters/src/query_counters.cpp
@@ -18,6 +18,7 @@
 #include <hpx/modules/threading_base.hpp>
 #include <hpx/modules/timing.hpp>
 #include <hpx/modules/type_support.hpp>
+
 #include <hpx/performance_counters/apex_sample_value.hpp>
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/performance_counters/performance_counter.hpp>

--- a/libs/full/performance_counters/src/registry.cpp
+++ b/libs/full/performance_counters/src/registry.cpp
@@ -12,6 +12,7 @@
 #include <hpx/modules/logging.hpp>
 #include <hpx/modules/statistics.hpp>
 #include <hpx/modules/util.hpp>
+
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/performance_counters/registry.hpp>
 #include <hpx/performance_counters/server/arithmetics_counter.hpp>
@@ -35,7 +36,7 @@
 #include <hpx/config/warnings_prefix.hpp>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace performance_counters {
+namespace hpx::performance_counters {
 
     ///////////////////////////////////////////////////////////////////////////
     void registry::clear()
@@ -1214,5 +1215,4 @@ namespace hpx { namespace performance_counters {
         static registry instance_;
         return instance_;
     }
-
-}}    // namespace hpx::performance_counters
+}    // namespace hpx::performance_counters

--- a/libs/full/performance_counters/src/server/action_invocation_counter.cpp
+++ b/libs/full/performance_counters/src/server/action_invocation_counter.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2025 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -8,6 +8,7 @@
 #include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/functional.hpp>
+
 #include <hpx/performance_counters/action_invocation_counter_discoverer.hpp>
 #include <hpx/performance_counters/counter_creators.hpp>
 #include <hpx/performance_counters/counters.hpp>

--- a/libs/full/performance_counters/src/server/arithmetics_counter.cpp
+++ b/libs/full/performance_counters/src/server/arithmetics_counter.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2025 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -12,6 +12,7 @@
 #include <hpx/modules/runtime_components.hpp>
 #include <hpx/modules/runtime_local.hpp>
 #include <hpx/modules/string_util.hpp>
+
 #include <hpx/performance_counters/counter_creators.hpp>
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/performance_counters/performance_counter.hpp>

--- a/libs/full/performance_counters/src/server/arithmetics_counter_extended.cpp
+++ b/libs/full/performance_counters/src/server/arithmetics_counter_extended.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2025 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -10,6 +10,7 @@
 #include <hpx/modules/runtime_components.hpp>
 #include <hpx/modules/runtime_local.hpp>
 #include <hpx/modules/string_util.hpp>
+
 #include <hpx/performance_counters/counter_creators.hpp>
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/performance_counters/performance_counter.hpp>

--- a/libs/full/performance_counters/src/server/base_performance_counter.cpp
+++ b/libs/full/performance_counters/src/server/base_performance_counter.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2025 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -11,6 +11,7 @@
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/thread_support.hpp>
+
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/performance_counters/performance_counter_base.hpp>
 #include <hpx/performance_counters/server/base_performance_counter.hpp>
@@ -19,7 +20,7 @@ HPX_DEFINE_GET_COMPONENT_TYPE(hpx::components::component<
     hpx::performance_counters::server::base_performance_counter>)
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace performance_counters { namespace server {
+namespace hpx::performance_counters::server {
 
     void base_performance_counter::reset_counter_value()
     {
@@ -122,4 +123,4 @@ namespace hpx { namespace performance_counters { namespace server {
     {
         reinit(reset);
     }
-}}}    // namespace hpx::performance_counters::server
+}    // namespace hpx::performance_counters::server

--- a/libs/full/performance_counters/src/server/component_instance_counter.cpp
+++ b/libs/full/performance_counters/src/server/component_instance_counter.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2025 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -8,6 +8,7 @@
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/functional.hpp>
+
 #include <hpx/performance_counters/counter_creators.hpp>
 #include <hpx/performance_counters/counters.hpp>
 

--- a/libs/full/performance_counters/src/server/elapsed_time_counter.cpp
+++ b/libs/full/performance_counters/src/server/elapsed_time_counter.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2025 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -9,6 +9,7 @@
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/runtime_components.hpp>
 #include <hpx/modules/runtime_local.hpp>
+
 #include <hpx/performance_counters/counter_creators.hpp>
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/performance_counters/server/elapsed_time_counter.hpp>

--- a/libs/full/performance_counters/src/server/per_action_data_counters.cpp
+++ b/libs/full/performance_counters/src/server/per_action_data_counters.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2016-2025 Hartmut Kaiser
+//  Copyright (c) 2016-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -11,6 +11,7 @@
     defined(HPX_HAVE_NETWORKING)
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/functional.hpp>
+
 #include <hpx/performance_counters/counter_creators.hpp>
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/performance_counters/per_action_data_counter_discoverer.hpp>
@@ -20,7 +21,7 @@
 #include <utility>
 
 ///////////////////////////////////////////////////////////////////////////////
-namespace hpx { namespace performance_counters {
+namespace hpx::performance_counters {
 
     ///////////////////////////////////////////////////////////////////////////
     // Discoverer function for per-action parcel data counters
@@ -118,6 +119,6 @@ namespace hpx { namespace performance_counters {
         return per_action_data_counter_creator(
             info, per_action_data_counter_registry::instance(), f, ec);
     }
-}}    // namespace hpx::performance_counters
+}    // namespace hpx::performance_counters
 
 #endif

--- a/libs/full/performance_counters/src/server/raw_counter.cpp
+++ b/libs/full/performance_counters/src/server/raw_counter.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2025 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -10,6 +10,7 @@
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/runtime_components.hpp>
 #include <hpx/modules/runtime_local.hpp>
+
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/performance_counters/server/raw_counter.hpp>
 

--- a/libs/full/performance_counters/src/server/raw_values_counter.cpp
+++ b/libs/full/performance_counters/src/server/raw_values_counter.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2025 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -10,6 +10,7 @@
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/runtime_components.hpp>
 #include <hpx/modules/runtime_local.hpp>
+
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/performance_counters/server/raw_values_counter.hpp>
 

--- a/libs/full/performance_counters/src/server/statistics_counter.cpp
+++ b/libs/full/performance_counters/src/server/statistics_counter.cpp
@@ -13,6 +13,7 @@
 #include <hpx/modules/runtime_components.hpp>
 #include <hpx/modules/runtime_local.hpp>
 #include <hpx/modules/thread_support.hpp>
+
 #include <hpx/performance_counters/counter_creators.hpp>
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/performance_counters/performance_counter.hpp>

--- a/libs/full/performance_counters/src/symbol_namespace_counters.cpp
+++ b/libs/full/performance_counters/src/symbol_namespace_counters.cpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2011 Bryce Adelstein-Lelbach
-//  Copyright (c) 2012-2023 Hartmut Kaiser
+//  Copyright (c) 2012-2026 Hartmut Kaiser
 //  Copyright (c) 2016 Thomas Heller
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -70,7 +70,8 @@ namespace hpx::agas::server {
             performance_counters::install_counter_type(
                 agas::performance_counter_basename + name, type, help, creator,
                 &performance_counters::locality_counter_discoverer,
-                HPX_PERFORMANCE_COUNTER_V1, symbol_namespace_service.uom_, ec);
+                performance_counters::HPX_PERFORMANCE_COUNTER_V1,
+                symbol_namespace_service.uom_, ec);
             if (ec)
                 return;
         }
@@ -113,7 +114,8 @@ namespace hpx::agas::server {
                     symbol_namespace_service.name_,
                 type, help, creator,
                 &performance_counters::locality_counter_discoverer,
-                HPX_PERFORMANCE_COUNTER_V1, symbol_namespace_service.uom_, ec);
+                performance_counters::HPX_PERFORMANCE_COUNTER_V1,
+                symbol_namespace_service.uom_, ec);
             if (ec)
             {
                 return;

--- a/libs/full/performance_counters/src/threadmanager_counter_types.cpp
+++ b/libs/full/performance_counters/src/threadmanager_counter_types.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2024 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach, Katelyn Kufahl
 //  Copyright (c) 2008-2009 Chirag Dekate, Anshul Tandon
 //  Copyright (c) 2015 Patricia Grubel
@@ -13,14 +13,15 @@
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/runtime_local.hpp>
+#ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
+#include <hpx/modules/schedulers.hpp>
+#endif
 #include <hpx/modules/threadmanager.hpp>
+
 #include <hpx/performance_counters/counter_creators.hpp>
 #include <hpx/performance_counters/counters.hpp>
 #include <hpx/performance_counters/manage_counter_type.hpp>
 #include <hpx/performance_counters/threadmanager_counter_types.hpp>
-#ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
-#include <hpx/modules/schedulers.hpp>
-#endif
 
 #include <cstddef>
 #include <cstdint>
@@ -639,8 +640,7 @@ namespace hpx::performance_counters {
             {"/threads/count/stolen-from-pending",
                 counter_type::monotonically_increasing,
                 "returns the overall number of pending HPX-threads stolen by "
-                "neighboring"
-                "schedulers from &tm scheduler for the referenced locality",
+                "neighboring schedulers from &tm scheduler for the referenced locality",
                 HPX_PERFORMANCE_COUNTER_V1,
                 hpx::bind_front(&detail::locality_pool_thread_counter_creator,
                     &tm, &threads::threadmanager::get_num_stolen_from_pending,
@@ -649,8 +649,7 @@ namespace hpx::performance_counters {
             {"/threads/count/stolen-from-staged",
                 counter_type::monotonically_increasing,
                 "returns the overall number of task descriptions stolen by "
-                "neighboring"
-                "schedulers from tm scheduler for the referenced locality",
+                "neighboring schedulers from tm scheduler for the referenced locality",
                 HPX_PERFORMANCE_COUNTER_V1,
                 hpx::bind_front(&detail::locality_pool_thread_counter_creator,
                     &tm, &threads::threadmanager::get_num_stolen_from_staged,
@@ -659,8 +658,7 @@ namespace hpx::performance_counters {
             {"/threads/count/stolen-to-pending",
                 counter_type::monotonically_increasing,
                 "returns the overall number of pending HPX-threads stolen from "
-                "neighboring"
-                "schedulers for the referenced locality",
+                "neighboring schedulers for the referenced locality",
                 HPX_PERFORMANCE_COUNTER_V1,
                 hpx::bind_front(&detail::locality_pool_thread_counter_creator,
                     &tm, &threads::threadmanager::get_num_stolen_to_pending,
@@ -669,8 +667,7 @@ namespace hpx::performance_counters {
             {"/threads/count/stolen-to-staged",
                 counter_type::monotonically_increasing,
                 "returns the overall number of task descriptions stolen from "
-                "neighboring"
-                "schedulers for the referenced locality",
+                "neighboring schedulers for the referenced locality",
                 HPX_PERFORMANCE_COUNTER_V1,
                 hpx::bind_front(&detail::locality_pool_thread_counter_creator,
                     &tm, &threads::threadmanager::get_num_stolen_to_staged,

--- a/libs/full/performance_counters/src/threadmanager_counter_types.cpp
+++ b/libs/full/performance_counters/src/threadmanager_counter_types.cpp
@@ -640,7 +640,8 @@ namespace hpx::performance_counters {
             {"/threads/count/stolen-from-pending",
                 counter_type::monotonically_increasing,
                 "returns the overall number of pending HPX-threads stolen by "
-                "neighboring schedulers from &tm scheduler for the referenced locality",
+                "neighboring schedulers from &tm scheduler for the referenced "
+                "locality",
                 HPX_PERFORMANCE_COUNTER_V1,
                 hpx::bind_front(&detail::locality_pool_thread_counter_creator,
                     &tm, &threads::threadmanager::get_num_stolen_from_pending,
@@ -649,7 +650,8 @@ namespace hpx::performance_counters {
             {"/threads/count/stolen-from-staged",
                 counter_type::monotonically_increasing,
                 "returns the overall number of task descriptions stolen by "
-                "neighboring schedulers from tm scheduler for the referenced locality",
+                "neighboring schedulers from tm scheduler for the referenced "
+                "locality",
                 HPX_PERFORMANCE_COUNTER_V1,
                 hpx::bind_front(&detail::locality_pool_thread_counter_creator,
                     &tm, &threads::threadmanager::get_num_stolen_from_staged,

--- a/libs/full/performance_counters/tests/unit/reinit_counters.cpp
+++ b/libs/full/performance_counters/tests/unit/reinit_counters.cpp
@@ -133,7 +133,7 @@ void register_counter_type()
         "reinit",
         &test_counter_creator,
         &hpx::performance_counters::locality_counter_discoverer,
-        HPX_PERFORMANCE_COUNTER_V1);
+        hpx::performance_counters::HPX_PERFORMANCE_COUNTER_V1);
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed.hpp
@@ -13,11 +13,10 @@
 #include <hpx/modules/io_service.hpp>
 #include <hpx/modules/parcelset.hpp>
 #include <hpx/modules/parcelset_base.hpp>
+#include <hpx/modules/performance_counters.hpp>
 #include <hpx/modules/runtime_components.hpp>
 #include <hpx/modules/runtime_local.hpp>
 #include <hpx/modules/threading_base.hpp>
-#include <hpx/performance_counters/query_counters.hpp>
-#include <hpx/performance_counters/registry.hpp>
 
 #include <hpx/runtime_distributed/applier.hpp>
 #include <hpx/runtime_distributed/find_localities.hpp>

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/migrate_component.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/migrate_component.hpp
@@ -10,12 +10,12 @@
 
 #include <hpx/config.hpp>
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
-#include <hpx/distribution_policies/target_distribution_policy.hpp>
 #include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_colocated.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/components.hpp>
 #include <hpx/modules/components_base.hpp>
+#include <hpx/modules/distribution_policies.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/naming_base.hpp>
 

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed/server/runtime_support.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed/server/runtime_support.hpp
@@ -18,13 +18,13 @@
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/logging.hpp>
 #include <hpx/modules/parcelset_base.hpp>
+#include <hpx/modules/performance_counters.hpp>
 #include <hpx/modules/plugin.hpp>
 #include <hpx/modules/plugin_factories.hpp>
 #include <hpx/modules/program_options.hpp>
 #include <hpx/modules/runtime_components.hpp>
 #include <hpx/modules/runtime_configuration.hpp>
 #include <hpx/modules/synchronization.hpp>
-#include <hpx/performance_counters/counters.hpp>
 
 #include <hpx/runtime_distributed/find_here.hpp>
 

--- a/libs/full/runtime_distributed/src/runtime_distributed.cpp
+++ b/libs/full/runtime_distributed/src/runtime_distributed.cpp
@@ -21,6 +21,7 @@
 #include <hpx/modules/logging.hpp>
 #include <hpx/modules/naming_base.hpp>
 #include <hpx/modules/parcelset.hpp>
+#include <hpx/modules/performance_counters.hpp>
 #include <hpx/modules/runtime_components.hpp>
 #include <hpx/modules/runtime_configuration.hpp>
 #include <hpx/modules/runtime_local.hpp>
@@ -32,11 +33,6 @@
 #include <hpx/modules/timing.hpp>
 #include <hpx/modules/topology.hpp>
 #include <hpx/modules/type_support.hpp>
-#include <hpx/performance_counters/counter_creators.hpp>
-#include <hpx/performance_counters/counters.hpp>
-#include <hpx/performance_counters/manage_counter_type.hpp>
-#include <hpx/performance_counters/query_counters.hpp>
-#include <hpx/performance_counters/registry.hpp>
 #include <hpx/version.hpp>
 
 #include <hpx/runtime_distributed.hpp>
@@ -949,9 +945,8 @@ namespace hpx {
                 performance_counters::counter_type::aggregating,
                 "returns the averaged value of its base counter over "
                 "an arbitrary time line; pass required base counter as the "
-                "instance "
-                "name: /statistics{<base_counter_name>}/average",
-                HPX_PERFORMANCE_COUNTER_V1,
+                "instance name: /statistics{<base_counter_name>}/average",
+                performance_counters::HPX_PERFORMANCE_COUNTER_V1,
                 &performance_counters::detail::statistics_counter_creator,
                 &performance_counters::default_counter_discoverer, ""},
 
@@ -959,11 +954,9 @@ namespace hpx {
             {"/statistics/stddev",
                 performance_counters::counter_type::aggregating,
                 "returns the standard deviation value of its base counter "
-                "over "
-                "an arbitrary time line; pass required base counter as the "
-                "instance "
-                "name: /statistics{<base_counter_name>}/stddev",
-                HPX_PERFORMANCE_COUNTER_V1,
+                "over an arbitrary time line; pass required base counter as the "
+                "instance name: /statistics{<base_counter_name>}/stddev",
+                performance_counters::HPX_PERFORMANCE_COUNTER_V1,
                 &performance_counters::detail::statistics_counter_creator,
                 &performance_counters::default_counter_discoverer, ""},
 
@@ -971,11 +964,9 @@ namespace hpx {
             {"/statistics/rolling_average",
                 performance_counters::counter_type::aggregating,
                 "returns the rolling average value of its base counter "
-                "over "
-                "an arbitrary time line; pass required base counter as the "
-                "instance "
-                "name: /statistics{<base_counter_name>}/rolling_averaging",
-                HPX_PERFORMANCE_COUNTER_V1,
+                "over an arbitrary time line; pass required base counter as the "
+                "instance name: /statistics{<base_counter_name>}/rolling_averaging",
+                performance_counters::HPX_PERFORMANCE_COUNTER_V1,
                 &performance_counters::detail::statistics_counter_creator,
                 &performance_counters::default_counter_discoverer, ""},
 
@@ -983,11 +974,9 @@ namespace hpx {
             {"/statistics/rolling_stddev",
                 performance_counters::counter_type::aggregating,
                 "returns the rolling standard deviation value of its base "
-                "counter over "
-                "an arbitrary time line; pass required base counter as the "
-                "instance "
-                "name: /statistics{<base_counter_name>}/rolling_stddev",
-                HPX_PERFORMANCE_COUNTER_V1,
+                "counter over an arbitrary time line; pass required base counter "
+                "as the instance name: /statistics{<base_counter_name>}/rolling_stddev",
+                performance_counters::HPX_PERFORMANCE_COUNTER_V1,
                 &performance_counters::detail::statistics_counter_creator,
                 &performance_counters::default_counter_discoverer, ""},
 
@@ -996,9 +985,8 @@ namespace hpx {
                 performance_counters::counter_type::aggregating,
                 "returns the median value of its base counter over "
                 "an arbitrary time line; pass required base counter as the "
-                "instance "
-                "name: /statistics{<base_counter_name>}/median",
-                HPX_PERFORMANCE_COUNTER_V1,
+                "instance name: /statistics{<base_counter_name>}/median",
+                performance_counters::HPX_PERFORMANCE_COUNTER_V1,
                 &performance_counters::detail::statistics_counter_creator,
                 &performance_counters::default_counter_discoverer, ""},
 
@@ -1006,9 +994,8 @@ namespace hpx {
             {"/statistics/max", performance_counters::counter_type::aggregating,
                 "returns the maximum value of its base counter over "
                 "an arbitrary time line; pass required base counter as the "
-                "instance "
-                "name: /statistics{<base_counter_name>}/max",
-                HPX_PERFORMANCE_COUNTER_V1,
+                "instance name: /statistics{<base_counter_name>}/max",
+                performance_counters::HPX_PERFORMANCE_COUNTER_V1,
                 &performance_counters::detail::statistics_counter_creator,
                 &performance_counters::default_counter_discoverer, ""},
 
@@ -1016,9 +1003,8 @@ namespace hpx {
             {"/statistics/min", performance_counters::counter_type::aggregating,
                 "returns the minimum value of its base counter over "
                 "an arbitrary time line; pass required base counter as the "
-                "instance "
-                "name: /statistics{<base_counter_name>}/min",
-                HPX_PERFORMANCE_COUNTER_V1,
+                "instance name: /statistics{<base_counter_name>}/min",
+                performance_counters::HPX_PERFORMANCE_COUNTER_V1,
                 &performance_counters::detail::statistics_counter_creator,
                 &performance_counters::default_counter_discoverer, ""},
 
@@ -1026,11 +1012,9 @@ namespace hpx {
             {"/statistics/rolling_max",
                 performance_counters::counter_type::aggregating,
                 "returns the rolling maximum value of its base counter "
-                "over "
-                "an arbitrary time line; pass required base counter as the "
-                "instance "
-                "name: /statistics{<base_counter_name>}/rolling_max",
-                HPX_PERFORMANCE_COUNTER_V1,
+                "over an arbitrary time line; pass required base counter as the "
+                "instance name: /statistics{<base_counter_name>}/rolling_max",
+                performance_counters::HPX_PERFORMANCE_COUNTER_V1,
                 &performance_counters::detail::statistics_counter_creator,
                 &performance_counters::default_counter_discoverer, ""},
 
@@ -1038,11 +1022,9 @@ namespace hpx {
             {"/statistics/rolling_min",
                 performance_counters::counter_type::aggregating,
                 "returns the rolling minimum value of its base counter "
-                "over "
-                "an arbitrary time line; pass required base counter as the "
-                "instance "
-                "name: /statistics{<base_counter_name>}/rolling_min",
-                HPX_PERFORMANCE_COUNTER_V1,
+                "over an arbitrary time line; pass required base counter as the "
+                "instance name: /statistics{<base_counter_name>}/rolling_min",
+                performance_counters::HPX_PERFORMANCE_COUNTER_V1,
                 &performance_counters::detail::statistics_counter_creator,
                 &performance_counters::default_counter_discoverer, ""},
 
@@ -1051,9 +1033,8 @@ namespace hpx {
                 "/runtime/uptime",
                 performance_counters::counter_type::elapsed_time,
                 "returns the up time of the runtime instance for the "
-                "referenced "
-                "locality",
-                HPX_PERFORMANCE_COUNTER_V1,
+                "referenced locality",
+                performance_counters::HPX_PERFORMANCE_COUNTER_V1,
                 &performance_counters::detail::uptime_counter_creator,
                 &performance_counters::locality_counter_discoverer,
                 "s"    // unit of measure is seconds
@@ -1063,11 +1044,9 @@ namespace hpx {
             {"/runtime/count/component",
                 performance_counters::counter_type::raw,
                 "returns the number of component instances currently alive "
-                "on "
-                "this locality (the component type has to be specified as "
-                "the "
-                "counter parameter)",
-                HPX_PERFORMANCE_COUNTER_V1,
+                "on this locality (the component type has to be specified as "
+                "the counter parameter)",
+                performance_counters::HPX_PERFORMANCE_COUNTER_V1,
                 &performance_counters::detail::
                     component_instance_counter_creator,
                 &performance_counters::locality_counter_discoverer, ""},
@@ -1076,11 +1055,9 @@ namespace hpx {
             {"/runtime/count/action-invocation",
                 performance_counters::counter_type::raw,
                 "returns the number of (local) invocations of a specific "
-                "action "
-                "on this locality (the action type has to be specified as "
-                "the "
-                "counter parameter)",
-                HPX_PERFORMANCE_COUNTER_V1,
+                "action on this locality (the action type has to be specified as "
+                "the counter parameter)",
+                performance_counters::HPX_PERFORMANCE_COUNTER_V1,
                 &performance_counters::local_action_invocation_counter_creator,
                 &performance_counters::
                     local_action_invocation_counter_discoverer,
@@ -1090,11 +1067,9 @@ namespace hpx {
             {"/runtime/count/remote-action-invocation",
                 performance_counters::counter_type::raw,
                 "returns the number of (remote) invocations of a specific "
-                "action "
-                "on this locality (the action type has to be specified as "
-                "the "
-                "counter parameter)",
-                HPX_PERFORMANCE_COUNTER_V1,
+                "action on this locality (the action type has to be specified as "
+                "the counter parameter)",
+                performance_counters::HPX_PERFORMANCE_COUNTER_V1,
                 &performance_counters::remote_action_invocation_counter_creator,
                 &performance_counters::
                     remote_action_invocation_counter_discoverer,
@@ -1112,46 +1087,43 @@ namespace hpx {
                 {"/arithmetics/add",
                     performance_counters::counter_type::aggregating,
                     "returns the sum of the values of the specified base "
-                    "counters; "
-                    "pass required base counters as the parameters: "
+                    "counters; pass required base counters as the parameters: "
                     "/arithmetics/"
                     "add@<base_counter_name1>,<base_counter_name2>",
-                    HPX_PERFORMANCE_COUNTER_V1,
+                    performance_counters::HPX_PERFORMANCE_COUNTER_V1,
                     &performance_counters::detail::arithmetics_counter_creator,
                     &performance_counters::default_counter_discoverer, ""},
                 // minus counter
                 {"/arithmetics/subtract",
                     performance_counters::counter_type::aggregating,
                     "returns the difference of the values of the specified "
-                    "base counters; "
-                    "pass the required base counters as the parameters: "
+                    "base counters; pass the required base counters as the "
+                    "parameters: "
                     "/arithmetics/"
                     "subtract@<base_counter_name1>,<base_counter_name2>",
-                    HPX_PERFORMANCE_COUNTER_V1,
+                    performance_counters::HPX_PERFORMANCE_COUNTER_V1,
                     &performance_counters::detail::arithmetics_counter_creator,
                     &performance_counters::default_counter_discoverer, ""},
                 // multiply counter
                 {"/arithmetics/multiply",
                     performance_counters::counter_type::aggregating,
                     "returns the product of the values of the specified "
-                    "base "
-                    "counters; "
-                    "pass the required base counters as the parameters: "
+                    "base counters; pass the required base counters as the "
+                    "parameters: "
                     "/arithmetics/"
                     "multiply@<base_counter_name1>,<base_counter_name2>",
-                    HPX_PERFORMANCE_COUNTER_V1,
+                    performance_counters::HPX_PERFORMANCE_COUNTER_V1,
                     &performance_counters::detail::arithmetics_counter_creator,
                     &performance_counters::default_counter_discoverer, ""},
                 // divide counter
                 {"/arithmetics/divide",
                     performance_counters::counter_type::aggregating,
                     "returns the result of division of the values of the "
-                    "specified "
-                    "base counters; pass the required base counters as the "
-                    "parameters: "
+                    "specified base counters; pass the required base counters "
+                    "as the parameters: "
                     "/arithmetics/"
                     "divide@<base_counter_name1>,<base_counter_name2>",
-                    HPX_PERFORMANCE_COUNTER_V1,
+                    performance_counters::HPX_PERFORMANCE_COUNTER_V1,
                     &performance_counters::detail::arithmetics_counter_creator,
                     &performance_counters::default_counter_discoverer, ""},
 
@@ -1159,12 +1131,11 @@ namespace hpx {
                 {"/arithmetics/mean",
                     performance_counters::counter_type::aggregating,
                     "returns the average value of all values of the "
-                    "specified "
-                    "base counters; pass the required base counters as the "
-                    "parameters: "
+                    "specified base counters; pass the required base counters "
+                    "as the parameters: "
                     "/arithmetics/"
                     "mean@<base_counter_name1>,<base_counter_name2>",
-                    HPX_PERFORMANCE_COUNTER_V1,
+                    performance_counters::HPX_PERFORMANCE_COUNTER_V1,
                     &performance_counters::detail::
                         arithmetics_counter_extended_creator,
                     &performance_counters::default_counter_discoverer, ""},
@@ -1172,12 +1143,11 @@ namespace hpx {
                 {"/arithmetics/variance",
                     performance_counters::counter_type::aggregating,
                     "returns the standard deviation of all values of the "
-                    "specified "
-                    "base counters; pass the required base counters as the "
-                    "parameters: "
+                    "specified base counters; pass the required base counters "
+                    "as the parameters: "
                     "/arithmetics/"
                     "variance@<base_counter_name1>,<base_counter_name2>",
-                    HPX_PERFORMANCE_COUNTER_V1,
+                    performance_counters::HPX_PERFORMANCE_COUNTER_V1,
                     &performance_counters::detail::
                         arithmetics_counter_extended_creator,
                     &performance_counters::default_counter_discoverer, ""},
@@ -1189,7 +1159,7 @@ namespace hpx {
                     "parameters: "
                     "/arithmetics/"
                     "median@<base_counter_name1>,<base_counter_name2>",
-                    HPX_PERFORMANCE_COUNTER_V1,
+                    performance_counters::HPX_PERFORMANCE_COUNTER_V1,
                     &performance_counters::detail::
                         arithmetics_counter_extended_creator,
                     &performance_counters::default_counter_discoverer, ""},
@@ -1197,12 +1167,11 @@ namespace hpx {
                 {"/arithmetics/min",
                     performance_counters::counter_type::aggregating,
                     "returns the minimum value of all values of the "
-                    "specified "
-                    "base counters; pass the required base counters as the "
-                    "parameters: "
+                    "specified base counters; pass the required base counters "
+                    "as the parameters: "
                     "/arithmetics/"
                     "min@<base_counter_name1>,<base_counter_name2>",
-                    HPX_PERFORMANCE_COUNTER_V1,
+                    performance_counters::HPX_PERFORMANCE_COUNTER_V1,
                     &performance_counters::detail::
                         arithmetics_counter_extended_creator,
                     &performance_counters::default_counter_discoverer, ""},
@@ -1210,12 +1179,11 @@ namespace hpx {
                 {"/arithmetics/max",
                     performance_counters::counter_type::aggregating,
                     "returns the maximum value of all values of the "
-                    "specified "
-                    "base counters; pass the required base counters as the "
-                    "parameters: "
+                    "specified base counters; pass the required base counters "
+                    "as the parameters: "
                     "/arithmetics/"
                     "max@<base_counter_name1>,<base_counter_name2>",
-                    HPX_PERFORMANCE_COUNTER_V1,
+                    performance_counters::HPX_PERFORMANCE_COUNTER_V1,
                     &performance_counters::detail::
                         arithmetics_counter_extended_creator,
                     &performance_counters::default_counter_discoverer, ""},
@@ -1223,12 +1191,11 @@ namespace hpx {
                 {"/arithmetics/count",
                     performance_counters::counter_type::aggregating,
                     "returns the count value of all values of the "
-                    "specified "
-                    "base counters; pass the required base counters as the "
-                    "parameters: "
+                    "specified base counters; pass the required base counters "
+                    "as the parameters: "
                     "/arithmetics/"
                     "count@<base_counter_name1>,<base_counter_name2>",
-                    HPX_PERFORMANCE_COUNTER_V1,
+                    performance_counters::HPX_PERFORMANCE_COUNTER_V1,
                     &performance_counters::detail::
                         arithmetics_counter_extended_creator,
                     &performance_counters::default_counter_discoverer, ""},

--- a/libs/full/runtime_distributed/src/runtime_support.cpp
+++ b/libs/full/runtime_distributed/src/runtime_support.cpp
@@ -6,8 +6,8 @@
 
 #include <hpx/config.hpp>
 #include <hpx/modules/components_base.hpp>
+#include <hpx/modules/performance_counters.hpp>
 #include <hpx/modules/runtime_components.hpp>
-#include <hpx/performance_counters/detail/counter_interface_functions.hpp>
 #include <hpx/runtime_distributed/runtime_support.hpp>
 
 #include <mutex>

--- a/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
+++ b/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
@@ -20,6 +20,7 @@
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/ini.hpp>
 #include <hpx/modules/logging.hpp>
+#include <hpx/modules/performance_counters.hpp>
 #include <hpx/modules/plugin_factories.hpp>
 #include <hpx/modules/prefix.hpp>
 #include <hpx/modules/runtime_components.hpp>
@@ -32,7 +33,6 @@
 #include <hpx/modules/threadmanager.hpp>
 #include <hpx/modules/timing.hpp>
 #include <hpx/modules/type_support.hpp>
-#include <hpx/performance_counters/counters.hpp>
 
 #include <hpx/runtime_distributed.hpp>
 #include <hpx/runtime_distributed/find_localities.hpp>

--- a/libs/full/runtime_distributed/src/stubs/runtime_support_stubs.cpp
+++ b/libs/full/runtime_distributed/src/stubs/runtime_support_stubs.cpp
@@ -15,9 +15,9 @@
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/ini.hpp>
 #include <hpx/modules/naming_base.hpp>
+#include <hpx/modules/performance_counters.hpp>
 #include <hpx/modules/runtime_local.hpp>
 #include <hpx/modules/type_support.hpp>
-#include <hpx/performance_counters/counters.hpp>
 #include <hpx/runtime_distributed/applier.hpp>
 #include <hpx/runtime_distributed/stubs/runtime_support.hpp>
 

--- a/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/dispatch.hpp
+++ b/libs/full/segmented_algorithms/include/hpx/parallel/segmented_algorithms/detail/dispatch.hpp
@@ -9,9 +9,9 @@
 
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
-#include <hpx/distribution_policies/colocating_distribution_policy.hpp>
 #include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/algorithms.hpp>
+#include <hpx/modules/distribution_policies.hpp>
 #include <hpx/modules/executors.hpp>
 #include <hpx/modules/naming_base.hpp>
 #include <hpx/modules/type_support.hpp>

--- a/tests/performance/local/activate_counters.cpp
+++ b/tests/performance/local/activate_counters.cpp
@@ -15,10 +15,9 @@
 #include <hpx/modules/format.hpp>
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/pack_traversal.hpp>
+#include <hpx/modules/performance_counters.hpp>
 #include <hpx/modules/threading_base.hpp>
 #include <hpx/modules/timing.hpp>
-#include <hpx/performance_counters/counters.hpp>
-#include <hpx/performance_counters/performance_counter.hpp>
 
 #include "activate_counters.hpp"
 

--- a/tests/performance/local/activate_counters.hpp
+++ b/tests/performance/local/activate_counters.hpp
@@ -8,7 +8,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/modules/futures.hpp>
-#include <hpx/performance_counters/counters_fwd.hpp>
+#include <hpx/modules/performance_counters.hpp>
 
 #include <cstddef>
 #include <string>


### PR DESCRIPTION
This includes the HPX modules:

- lcos_distributed
- performance_counters
- distribution_policies
