### PR TITLE
replace tag_invoke(connect_t) friends with member connect()

### DIFF
--- a/libs/core/execution_base/include/hpx/execution_base/any_sender.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/any_sender.hpp
@@ -778,15 +778,13 @@ namespace hpx::execution::experimental {
                 set_value_t(Ts...), set_error_t(std::exception_ptr)>;
 
         template <typename R>
-        friend detail::any_operation_state tag_invoke(
-            hpx::execution::experimental::connect_t, unique_any_sender&& s,
-            R&& r)
+        detail::any_operation_state connect(R&& r) &&
         {
             // We first move the storage to a temporary variable so that this
             // any_sender is empty after this connect. Doing
             // HPX_MOVE(storage.get()).connect(...) would leave us with a
             // non-empty any_sender holding a moved-from sender.
-            auto moved_storage = HPX_MOVE(s.storage);
+            auto moved_storage = HPX_MOVE(storage);
             return HPX_MOVE(moved_storage.get())
                 .connect(detail::any_receiver<Ts...>{HPX_FORWARD(R, r)});
         }
@@ -855,22 +853,20 @@ namespace hpx::execution::experimental {
                 set_value_t(Ts...), set_error_t(std::exception_ptr)>;
 
         template <typename R>
-        friend detail::any_operation_state tag_invoke(
-            hpx::execution::experimental::connect_t, any_sender& s, R&& r)
+        detail::any_operation_state connect(R&& r) &
         {
-            return s.storage.get().connect(
+            return storage.get().connect(
                 detail::any_receiver<Ts...>{HPX_FORWARD(R, r)});
         }
 
         template <typename R>
-        friend detail::any_operation_state tag_invoke(
-            hpx::execution::experimental::connect_t, any_sender&& s, R&& r)
+        detail::any_operation_state connect(R&& r) &&
         {
             // We first move the storage to a temporary variable so that this
             // any_sender is empty after this connect. Doing
             // HPX_MOVE(storage.get()).connect(...) would leave us with a
             // non-empty any_sender holding a moved-from sender.
-            auto moved_storage = HPX_MOVE(s.storage);
+            auto moved_storage = HPX_MOVE(storage);
             return HPX_MOVE(moved_storage.get())
                 .connect(detail::any_receiver<Ts...>{HPX_FORWARD(R, r)});
         }


### PR DESCRIPTION
## Proposed Changes

 - Replace the three tag_invoke(connect_t, ...) friend overloads on unique_any_sender and any_sender with public member connect(R&&) overloads (rvalue on unique_any_sender, lvalue + rvalue on any_sender).
 - The change is safe because stdexec's connect_t CPO already prefers a .connect() member when present, and tag_invoke is deprecated as the dispatch mechanism for sender concepts.

## Any background context you want to provide?

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
