### PR TITLE
add S/R support for shift_left and shift_right

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/algorithms/shift_left.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/shift_left.hpp
@@ -121,6 +121,7 @@ namespace hpx {
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/reverse.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/result_types.hpp>
 #include <hpx/parallel/util/transfer.hpp>
 
@@ -219,6 +220,16 @@ namespace hpx::parallel {
                 FwdIter2>::type
             parallel(ExPolicy&& policy, FwdIter2 first, Sent last, Size n)
             {
+                constexpr bool has_scheduler_executor =
+                    hpx::execution_policy_has_scheduler_executor_v<ExPolicy>;
+
+                if constexpr (has_scheduler_executor)
+                {
+                    return util::detail::algorithm_result<ExPolicy,
+                        FwdIter2>::get(sequential(
+                        HPX_FORWARD(ExPolicy, policy), first, last, n));
+                }
+
                 auto const dist =
                     static_cast<std::size_t>(detail::distance(first, last));
                 // C++20 [alg.shift]: if n is 0, do nothing and return last.
@@ -248,7 +259,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::shift_left
     HPX_CXX_CORE_EXPORT inline constexpr struct shift_left_t final
-      : hpx::functional::detail::tag_fallback<shift_left_t>
+      : hpx::detail::tag_parallel_algorithm<shift_left_t>
     {
     private:
         template <typename FwdIter, typename Size>

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/shift_left.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/shift_left.hpp
@@ -119,6 +119,7 @@ namespace hpx {
 #include <hpx/modules/executors.hpp>
 #include <hpx/modules/iterator_support.hpp>
 #include <hpx/modules/tag_invoke.hpp>
+#include <hpx/parallel/algorithms/detail/advance_and_get_distance.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/reverse.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
@@ -151,9 +152,9 @@ namespace hpx::parallel {
             // Handle the [alg.shift] edge cases inside the implementation by
             // clamping the reverse ranges, so the dispatch (parallel()) keeps a
             // single homogeneous return type and no unique_any_sender is needed.
-            auto const dist =
-                static_cast<std::size_t>(detail::distance(first, last));
-            FwdIter const fin = std::next(first, dist);
+            auto fin = first;
+            auto const dist = static_cast<std::size_t>(
+                detail::advance_and_get_distance(fin, last));
             bool const noop = static_cast<std::size_t>(n) >= dist;
             // C++20 [alg.shift]: n==0 -> do nothing, return last;
             //                    n>=dist -> do nothing, return first.

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/shift_left.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/shift_left.hpp
@@ -116,7 +116,6 @@ namespace hpx {
 #include <hpx/modules/async_local.hpp>
 #include <hpx/modules/concepts.hpp>
 #include <hpx/modules/execution.hpp>
-#include <hpx/modules/execution_base.hpp>
 #include <hpx/modules/executors.hpp>
 #include <hpx/modules/iterator_support.hpp>
 #include <hpx/modules/tag_invoke.hpp>
@@ -140,14 +139,28 @@ namespace hpx::parallel {
     namespace detail {
 
         HPX_CXX_CORE_EXPORT template <typename ExPolicy, typename FwdIter,
-            typename Sent>
+            typename Sent, typename Size>
         decltype(auto) shift_left_helper(
-            ExPolicy policy, FwdIter first, Sent last, FwdIter new_first)
+            ExPolicy policy, FwdIter first, Sent last, Size n)
         {
             constexpr bool has_scheduler_executor =
                 hpx::execution_policy_has_scheduler_executor_v<ExPolicy>;
 
             detail::reverse<FwdIter> r;
+
+            // Handle the [alg.shift] edge cases inside the implementation by
+            // clamping the reverse ranges, so the dispatch (parallel()) keeps a
+            // single homogeneous return type and no unique_any_sender is needed.
+            auto const dist =
+                static_cast<std::size_t>(detail::distance(first, last));
+            FwdIter const fin = std::next(first, dist);
+            bool const noop = static_cast<std::size_t>(n) >= dist;
+            // C++20 [alg.shift]: n==0 -> do nothing, return last;
+            //                    n>=dist -> do nothing, return first.
+            // Both degenerate cases collapse to empty-range reverses below.
+            FwdIter const rev1_begin = noop ? fin : std::next(first, n);
+            FwdIter const rev2_end = noop ? first : fin;
+            FwdIter const ret = noop ? first : std::next(first, dist - n);
 
             if constexpr (!has_scheduler_executor)
             {
@@ -162,16 +175,14 @@ namespace hpx::parallel {
                         f1.get();
 
                         hpx::future<FwdIter> f =
-                            r.call2(p, non_seq(), first, last);
+                            r.call2(p, non_seq(), first, rev2_end);
                         return f.then(
                             [=](hpx::future<FwdIter>&& fut) mutable -> FwdIter {
                                 fut.get();
-                                std::advance(
-                                    first, detail::distance(new_first, last));
-                                return first;
+                                return ret;
                             });
                     },
-                    r.call2(p, non_seq(), new_first, last));
+                    r.call2(p, non_seq(), rev1_begin, fin));
                 return result;
             }
             else
@@ -180,14 +191,17 @@ namespace hpx::parallel {
                 // primitives
                 namespace ex = hpx::execution::experimental;
 
-                return r.call(policy, new_first, last) |
+                // Both reverses use FwdIter-typed ends, so their sender types
+                // match and the pipeline stays homogeneous.
+                static_assert(
+                    std::is_same_v<decltype(r.call(policy, rev1_begin, fin)),
+                        decltype(r.call(policy, first, rev2_end))>);
+
+                return r.call(policy, rev1_begin, fin) |
                     ex::let_value([=](FwdIter /*unused*/) mutable {
-                        return r.call(policy, first, last);
+                        return r.call(policy, first, rev2_end);
                     }) |
-                    ex::then([=](FwdIter) mutable -> FwdIter {
-                        std::advance(first, detail::distance(new_first, last));
-                        return first;
-                    });
+                    ex::then([=](FwdIter) mutable -> FwdIter { return ret; });
             }
         }
 
@@ -246,45 +260,12 @@ namespace hpx::parallel {
             static decltype(auto) parallel(
                 ExPolicy&& policy, FwdIter2 first, Sent last, Size n)
             {
-                namespace ex = hpx::execution::experimental;
-                constexpr bool has_scheduler_executor =
-                    hpx::execution_policy_has_scheduler_executor_v<ExPolicy>;
-
-                auto const dist =
-                    static_cast<std::size_t>(detail::distance(first, last));
-                // C++20 [alg.shift]: if n is 0, do nothing and return last.
-                if (n == 0)
-                {
-                    auto result =
-                        parallel::util::detail::algorithm_result<ExPolicy,
-                            FwdIter2>::get(std::next(first, dist));
-                    if constexpr (has_scheduler_executor)
-                        return ex::unique_any_sender<FwdIter2>(
-                            HPX_MOVE(result));
-                    else
-                        return result;
-                }
-                // C++20 [alg.shift]: if n >= dist, do nothing and return first.
-                if (static_cast<std::size_t>(n) >= dist)
-                {
-                    auto result =
-                        parallel::util::detail::algorithm_result<ExPolicy,
-                            FwdIter2>::get(HPX_MOVE(first));
-                    if constexpr (has_scheduler_executor)
-                        return ex::unique_any_sender<FwdIter2>(
-                            HPX_MOVE(result));
-                    else
-                        return result;
-                }
-
-                auto result =
-                    util::detail::algorithm_result<ExPolicy, FwdIter2>::get(
-                        shift_left_helper(
-                            policy, first, last, std::next(first, n)));
-                if constexpr (has_scheduler_executor)
-                    return ex::unique_any_sender<FwdIter2>(HPX_MOVE(result));
-                else
-                    return result;
+                // Edge cases (n==0, n>=dist) are handled inside
+                // shift_left_helper, so this dispatch keeps a single return
+                // type and needs no type erasure.
+                return util::detail::algorithm_result<ExPolicy, FwdIter2>::get(
+                    shift_left_helper(
+                        HPX_FORWARD(ExPolicy, policy), first, last, n));
             }
         };
         /// \endcond

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/shift_left.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/shift_left.hpp
@@ -115,6 +115,7 @@ namespace hpx {
 #include <hpx/config.hpp>
 #include <hpx/modules/async_local.hpp>
 #include <hpx/modules/concepts.hpp>
+#include <hpx/modules/execution.hpp>
 #include <hpx/modules/executors.hpp>
 #include <hpx/modules/iterator_support.hpp>
 #include <hpx/modules/tag_invoke.hpp>
@@ -139,29 +140,55 @@ namespace hpx::parallel {
 
         HPX_CXX_CORE_EXPORT template <typename ExPolicy, typename FwdIter,
             typename Sent>
-        hpx::future<FwdIter> shift_left_helper(
+        decltype(auto) shift_left_helper(
             ExPolicy policy, FwdIter first, Sent last, FwdIter new_first)
         {
-            using non_seq = std::false_type;
-            auto p = hpx::execution::parallel_task_policy()
-                         .on(policy.executor())
-                         .with(policy.parameters());
+            constexpr bool has_scheduler_executor =
+                hpx::execution_policy_has_scheduler_executor_v<ExPolicy>;
 
             detail::reverse<FwdIter> r;
-            return dataflow(
-                [=](hpx::future<FwdIter>&& f1) mutable -> hpx::future<FwdIter> {
-                    f1.get();
 
-                    hpx::future<FwdIter> f = r.call2(p, non_seq(), first, last);
-                    return f.then(
-                        [=](hpx::future<FwdIter>&& fut) mutable -> FwdIter {
-                            fut.get();
-                            std::advance(
-                                first, detail::distance(new_first, last));
-                            return first;
-                        });
-                },
-                r.call2(p, non_seq(), new_first, last));
+            if constexpr (!has_scheduler_executor)
+            {
+                using non_seq = std::false_type;
+                auto p = hpx::execution::parallel_task_policy()
+                             .on(policy.executor())
+                             .with(policy.parameters());
+
+                return dataflow(
+                    [=](hpx::future<FwdIter>&& f1) mutable
+                        -> hpx::future<FwdIter> {
+                        f1.get();
+
+                        hpx::future<FwdIter> f =
+                            r.call2(p, non_seq(), first, last);
+                        return f.then(
+                            [=](hpx::future<FwdIter>&& fut) mutable
+                                -> FwdIter {
+                                fut.get();
+                                std::advance(first,
+                                    detail::distance(new_first, last));
+                                return first;
+                            });
+                    },
+                    r.call2(p, non_seq(), new_first, last));
+            }
+            else
+            {
+                // sender-based path: compose reverses using sender
+                // primitives
+                namespace ex = hpx::execution::experimental;
+
+                return r.call(policy, new_first, last) |
+                    ex::let_value([=](FwdIter) mutable {
+                        return r.call(policy, first, last);
+                    }) |
+                    ex::then([=](FwdIter) mutable -> FwdIter {
+                        std::advance(
+                            first, detail::distance(new_first, last));
+                        return first;
+                    });
+            }
         }
 
         // Sequential shift_left implementation inspired from
@@ -216,20 +243,9 @@ namespace hpx::parallel {
             }
 
             template <typename ExPolicy, typename Sent, typename Size>
-            static typename util::detail::algorithm_result<ExPolicy,
-                FwdIter2>::type
-            parallel(ExPolicy&& policy, FwdIter2 first, Sent last, Size n)
+            static decltype(auto) parallel(
+                ExPolicy&& policy, FwdIter2 first, Sent last, Size n)
             {
-                constexpr bool has_scheduler_executor =
-                    hpx::execution_policy_has_scheduler_executor_v<ExPolicy>;
-
-                if constexpr (has_scheduler_executor)
-                {
-                    return util::detail::algorithm_result<ExPolicy,
-                        FwdIter2>::get(sequential(
-                        HPX_FORWARD(ExPolicy, policy), first, last, n));
-                }
-
                 auto const dist =
                     static_cast<std::size_t>(detail::distance(first, last));
                 // C++20 [alg.shift]: if n is 0, do nothing and return last.

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/shift_left.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/shift_left.hpp
@@ -155,7 +155,7 @@ namespace hpx::parallel {
                              .on(policy.executor())
                              .with(policy.parameters());
 
-                return dataflow(
+                hpx::future<FwdIter> result = dataflow(
                     [=](hpx::future<FwdIter>&& f1) mutable
                         -> hpx::future<FwdIter> {
                         f1.get();
@@ -171,6 +171,7 @@ namespace hpx::parallel {
                             });
                     },
                     r.call2(p, non_seq(), new_first, last));
+                return result;
             }
             else
             {

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/shift_left.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/shift_left.hpp
@@ -302,8 +302,9 @@ namespace hpx {
             )
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
-            FwdIter>::type tag_fallback_invoke(shift_left_t, ExPolicy&& policy,
-            FwdIter first, FwdIter last, Size n)
+            FwdIter>::type
+        tag_fallback_invoke(shift_left_t, ExPolicy&& policy, FwdIter first,
+            FwdIter last, Size n)
         {
             static_assert(std::forward_iterator<FwdIter>,
                 "Requires at least forward iterator.");

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/shift_left.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/shift_left.hpp
@@ -163,11 +163,10 @@ namespace hpx::parallel {
                         hpx::future<FwdIter> f =
                             r.call2(p, non_seq(), first, last);
                         return f.then(
-                            [=](hpx::future<FwdIter>&& fut) mutable
-                                -> FwdIter {
+                            [=](hpx::future<FwdIter>&& fut) mutable -> FwdIter {
                                 fut.get();
-                                std::advance(first,
-                                    detail::distance(new_first, last));
+                                std::advance(
+                                    first, detail::distance(new_first, last));
                                 return first;
                             });
                     },
@@ -184,8 +183,7 @@ namespace hpx::parallel {
                         return r.call(policy, first, last);
                     }) |
                     ex::then([=](FwdIter) mutable -> FwdIter {
-                        std::advance(
-                            first, detail::distance(new_first, last));
+                        std::advance(first, detail::distance(new_first, last));
                         return first;
                     });
             }
@@ -304,9 +302,8 @@ namespace hpx {
             )
         // clang-format on
         friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
-            FwdIter>::type
-        tag_fallback_invoke(shift_left_t, ExPolicy&& policy, FwdIter first,
-            FwdIter last, Size n)
+            FwdIter>::type tag_fallback_invoke(shift_left_t, ExPolicy&& policy,
+            FwdIter first, FwdIter last, Size n)
         {
             static_assert(std::forward_iterator<FwdIter>,
                 "Requires at least forward iterator.");

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/shift_left.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/shift_left.hpp
@@ -180,7 +180,7 @@ namespace hpx::parallel {
                 namespace ex = hpx::execution::experimental;
 
                 return r.call(policy, new_first, last) |
-                    ex::let_value([=](FwdIter) mutable {
+                    ex::let_value([=](FwdIter /*unused*/) mutable {
                         return r.call(policy, first, last);
                     }) |
                     ex::then([=](FwdIter) mutable -> FwdIter {

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/shift_left.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/shift_left.hpp
@@ -116,6 +116,7 @@ namespace hpx {
 #include <hpx/modules/async_local.hpp>
 #include <hpx/modules/concepts.hpp>
 #include <hpx/modules/execution.hpp>
+#include <hpx/modules/execution_base.hpp>
 #include <hpx/modules/executors.hpp>
 #include <hpx/modules/iterator_support.hpp>
 #include <hpx/modules/tag_invoke.hpp>
@@ -245,24 +246,45 @@ namespace hpx::parallel {
             static decltype(auto) parallel(
                 ExPolicy&& policy, FwdIter2 first, Sent last, Size n)
             {
+                namespace ex = hpx::execution::experimental;
+                constexpr bool has_scheduler_executor =
+                    hpx::execution_policy_has_scheduler_executor_v<ExPolicy>;
+
                 auto const dist =
                     static_cast<std::size_t>(detail::distance(first, last));
                 // C++20 [alg.shift]: if n is 0, do nothing and return last.
                 if (n == 0)
                 {
-                    return parallel::util::detail::algorithm_result<ExPolicy,
-                        FwdIter2>::get(std::next(first, dist));
+                    auto result =
+                        parallel::util::detail::algorithm_result<ExPolicy,
+                            FwdIter2>::get(std::next(first, dist));
+                    if constexpr (has_scheduler_executor)
+                        return ex::unique_any_sender<FwdIter2>(
+                            HPX_MOVE(result));
+                    else
+                        return result;
                 }
                 // C++20 [alg.shift]: if n >= dist, do nothing and return first.
                 if (static_cast<std::size_t>(n) >= dist)
                 {
-                    return parallel::util::detail::algorithm_result<ExPolicy,
-                        FwdIter2>::get(HPX_MOVE(first));
+                    auto result =
+                        parallel::util::detail::algorithm_result<ExPolicy,
+                            FwdIter2>::get(HPX_MOVE(first));
+                    if constexpr (has_scheduler_executor)
+                        return ex::unique_any_sender<FwdIter2>(
+                            HPX_MOVE(result));
+                    else
+                        return result;
                 }
 
-                return util::detail::algorithm_result<ExPolicy, FwdIter2>::get(
-                    shift_left_helper(
-                        policy, first, last, std::next(first, n)));
+                auto result =
+                    util::detail::algorithm_result<ExPolicy, FwdIter2>::get(
+                        shift_left_helper(
+                            policy, first, last, std::next(first, n)));
+                if constexpr (has_scheduler_executor)
+                    return ex::unique_any_sender<FwdIter2>(HPX_MOVE(result));
+                else
+                    return result;
             }
         };
         /// \endcond
@@ -302,10 +324,8 @@ namespace hpx {
                 std::is_integral_v<Size>
             )
         // clang-format on
-        friend typename hpx::parallel::util::detail::algorithm_result<ExPolicy,
-            FwdIter>::type
-        tag_fallback_invoke(shift_left_t, ExPolicy&& policy, FwdIter first,
-            FwdIter last, Size n)
+        friend decltype(auto) tag_fallback_invoke(shift_left_t,
+            ExPolicy&& policy, FwdIter first, FwdIter last, Size n)
         {
             static_assert(std::forward_iterator<FwdIter>,
                 "Requires at least forward iterator.");

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/shift_right.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/shift_right.hpp
@@ -141,30 +141,55 @@ namespace hpx::parallel {
 
         HPX_CXX_CORE_EXPORT template <typename ExPolicy, typename FwdIter,
             typename Sent>
-        hpx::future<FwdIter> shift_right_helper(
+        decltype(auto) shift_right_helper(
             ExPolicy policy, FwdIter first, Sent last, FwdIter new_first)
         {
-            using non_seq = std::false_type;
-
-            auto p = hpx::execution::parallel_task_policy()
-                         .on(policy.executor())
-                         .with(policy.parameters());
+            constexpr bool has_scheduler_executor =
+                hpx::execution_policy_has_scheduler_executor_v<ExPolicy>;
 
             detail::reverse<FwdIter> r;
-            return dataflow(
-                [=](hpx::future<FwdIter>&& f1) mutable -> hpx::future<FwdIter> {
-                    f1.get();
 
-                    hpx::future<FwdIter> f = r.call2(p, non_seq(), first, last);
-                    return f.then(
-                        [=](hpx::future<FwdIter>&& f) mutable -> FwdIter {
-                            f.get();
-                            std::advance(
-                                first, detail::distance(new_first, last));
-                            return first;
-                        });
-                },
-                r.call2(p, non_seq(), first, new_first));
+            if constexpr (!has_scheduler_executor)
+            {
+                using non_seq = std::false_type;
+
+                auto p = hpx::execution::parallel_task_policy()
+                             .on(policy.executor())
+                             .with(policy.parameters());
+
+                return dataflow(
+                    [=](hpx::future<FwdIter>&& f1) mutable
+                        -> hpx::future<FwdIter> {
+                        f1.get();
+
+                        hpx::future<FwdIter> f =
+                            r.call2(p, non_seq(), first, last);
+                        return f.then(
+                            [=](hpx::future<FwdIter>&& f) mutable -> FwdIter {
+                                f.get();
+                                std::advance(first,
+                                    detail::distance(new_first, last));
+                                return first;
+                            });
+                    },
+                    r.call2(p, non_seq(), first, new_first));
+            }
+            else
+            {
+                // sender-based path: compose reverses using sender
+                // primitives
+                namespace ex = hpx::execution::experimental;
+
+                return r.call(policy, first, new_first) |
+                    ex::let_value([=](FwdIter) mutable {
+                        return r.call(policy, first, last);
+                    }) |
+                    ex::then([=](FwdIter) mutable -> FwdIter {
+                        std::advance(
+                            first, detail::distance(new_first, last));
+                        return first;
+                    });
+            }
         }
 
         // Sequential shift_right implementation borrowed from
@@ -261,20 +286,9 @@ namespace hpx::parallel {
             }
 
             template <typename ExPolicy, typename Sent, typename Size>
-            static typename util::detail::algorithm_result<ExPolicy,
-                FwdIter2>::type
-            parallel(ExPolicy&& policy, FwdIter2 first, Sent last, Size n)
+            static decltype(auto) parallel(
+                ExPolicy&& policy, FwdIter2 first, Sent last, Size n)
             {
-                constexpr bool has_scheduler_executor =
-                    hpx::execution_policy_has_scheduler_executor_v<ExPolicy>;
-
-                if constexpr (has_scheduler_executor)
-                {
-                    return util::detail::algorithm_result<ExPolicy,
-                        FwdIter2>::get(sequential(
-                        HPX_FORWARD(ExPolicy, policy), first, last, n));
-                }
-
                 auto dist =
                     static_cast<std::size_t>(detail::distance(first, last));
                 // C++20 [alg.shift]: if n is 0, do nothing and return first.

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/shift_right.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/shift_right.hpp
@@ -116,6 +116,7 @@ namespace hpx {
 #include <hpx/modules/async_local.hpp>
 #include <hpx/modules/concepts.hpp>
 #include <hpx/modules/execution.hpp>
+#include <hpx/modules/execution_base.hpp>
 #include <hpx/modules/executors.hpp>
 #include <hpx/modules/iterator_support.hpp>
 #include <hpx/modules/pack_traversal.hpp>
@@ -289,24 +290,45 @@ namespace hpx::parallel {
             static decltype(auto) parallel(
                 ExPolicy&& policy, FwdIter2 first, Sent last, Size n)
             {
+                namespace ex = hpx::execution::experimental;
+                constexpr bool has_scheduler_executor =
+                    hpx::execution_policy_has_scheduler_executor_v<ExPolicy>;
+
                 auto dist =
                     static_cast<std::size_t>(detail::distance(first, last));
                 // C++20 [alg.shift]: if n is 0, do nothing and return first.
                 if (n == 0)
                 {
-                    return parallel::util::detail::algorithm_result<ExPolicy,
-                        FwdIter2>::get(HPX_MOVE(first));
+                    auto result =
+                        parallel::util::detail::algorithm_result<ExPolicy,
+                            FwdIter2>::get(HPX_MOVE(first));
+                    if constexpr (has_scheduler_executor)
+                        return ex::unique_any_sender<FwdIter2>(
+                            HPX_MOVE(result));
+                    else
+                        return result;
                 }
                 // C++20 [alg.shift]: if n >= dist, do nothing and return last.
                 if (static_cast<std::size_t>(n) >= dist)
                 {
-                    return parallel::util::detail::algorithm_result<ExPolicy,
-                        FwdIter2>::get(std::next(first, dist));
+                    auto result =
+                        parallel::util::detail::algorithm_result<ExPolicy,
+                            FwdIter2>::get(std::next(first, dist));
+                    if constexpr (has_scheduler_executor)
+                        return ex::unique_any_sender<FwdIter2>(
+                            HPX_MOVE(result));
+                    else
+                        return result;
                 }
 
                 auto new_first = std::next(first, dist - n);
-                return util::detail::algorithm_result<ExPolicy, FwdIter2>::get(
-                    shift_right_helper(policy, first, last, new_first));
+                auto result =
+                    util::detail::algorithm_result<ExPolicy, FwdIter2>::get(
+                        shift_right_helper(policy, first, last, new_first));
+                if constexpr (has_scheduler_executor)
+                    return ex::unique_any_sender<FwdIter2>(HPX_MOVE(result));
+                else
+                    return result;
             }
         };
         /// \endcond
@@ -346,9 +368,8 @@ namespace hpx {
                 std::is_integral_v<Size>
             )
         // clang-format on
-        friend parallel::util::detail::algorithm_result_t<ExPolicy, FwdIter>
-        tag_fallback_invoke(shift_right_t, ExPolicy&& policy, FwdIter first,
-            FwdIter last, Size n)
+        friend decltype(auto) tag_fallback_invoke(shift_right_t,
+            ExPolicy&& policy, FwdIter first, FwdIter last, Size n)
         {
             static_assert(std::forward_iterator<FwdIter>,
                 "Requires at least forward iterator.");

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/shift_right.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/shift_right.hpp
@@ -120,6 +120,7 @@ namespace hpx {
 #include <hpx/modules/iterator_support.hpp>
 #include <hpx/modules/pack_traversal.hpp>
 #include <hpx/parallel/algorithms/copy.hpp>
+#include <hpx/parallel/algorithms/detail/advance_and_get_distance.hpp>
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/reverse.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
@@ -152,9 +153,9 @@ namespace hpx::parallel {
             // Handle the [alg.shift] edge cases inside the implementation by
             // clamping the reverse ranges, so the dispatch (parallel()) keeps a
             // single homogeneous return type and no unique_any_sender is needed.
-            auto const dist =
-                static_cast<std::size_t>(detail::distance(first, last));
-            FwdIter const fin = std::next(first, dist);
+            auto fin = first;
+            auto const dist = static_cast<std::size_t>(
+                detail::advance_and_get_distance(fin, last));
             bool const noop = static_cast<std::size_t>(n) >= dist;
             // C++20 [alg.shift]: n==0 -> do nothing, return first;
             //                    n>=dist -> do nothing, return last.

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/shift_right.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/shift_right.hpp
@@ -123,6 +123,7 @@ namespace hpx {
 #include <hpx/parallel/algorithms/detail/dispatch.hpp>
 #include <hpx/parallel/algorithms/reverse.hpp>
 #include <hpx/parallel/util/detail/algorithm_result.hpp>
+#include <hpx/parallel/util/detail/sender_util.hpp>
 #include <hpx/parallel/util/result_types.hpp>
 #include <hpx/parallel/util/transfer.hpp>
 
@@ -264,6 +265,16 @@ namespace hpx::parallel {
                 FwdIter2>::type
             parallel(ExPolicy&& policy, FwdIter2 first, Sent last, Size n)
             {
+                constexpr bool has_scheduler_executor =
+                    hpx::execution_policy_has_scheduler_executor_v<ExPolicy>;
+
+                if constexpr (has_scheduler_executor)
+                {
+                    return util::detail::algorithm_result<ExPolicy,
+                        FwdIter2>::get(sequential(
+                        HPX_FORWARD(ExPolicy, policy), first, last, n));
+                }
+
                 auto dist =
                     static_cast<std::size_t>(detail::distance(first, last));
                 // C++20 [alg.shift]: if n is 0, do nothing and return first.
@@ -293,7 +304,7 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     // CPO for hpx::shift_right
     HPX_CXX_CORE_EXPORT inline constexpr struct shift_right_t final
-      : hpx::functional::detail::tag_fallback<shift_right_t>
+      : hpx::detail::tag_parallel_algorithm<shift_right_t>
     {
     private:
         template <typename FwdIter, typename Size>

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/shift_right.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/shift_right.hpp
@@ -167,8 +167,8 @@ namespace hpx::parallel {
                         return f.then(
                             [=](hpx::future<FwdIter>&& f) mutable -> FwdIter {
                                 f.get();
-                                std::advance(first,
-                                    detail::distance(new_first, last));
+                                std::advance(
+                                    first, detail::distance(new_first, last));
                                 return first;
                             });
                     },
@@ -185,8 +185,7 @@ namespace hpx::parallel {
                         return r.call(policy, first, last);
                     }) |
                     ex::then([=](FwdIter) mutable -> FwdIter {
-                        std::advance(
-                            first, detail::distance(new_first, last));
+                        std::advance(first, detail::distance(new_first, last));
                         return first;
                     });
             }

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/shift_right.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/shift_right.hpp
@@ -116,7 +116,6 @@ namespace hpx {
 #include <hpx/modules/async_local.hpp>
 #include <hpx/modules/concepts.hpp>
 #include <hpx/modules/execution.hpp>
-#include <hpx/modules/execution_base.hpp>
 #include <hpx/modules/executors.hpp>
 #include <hpx/modules/iterator_support.hpp>
 #include <hpx/modules/pack_traversal.hpp>
@@ -141,14 +140,28 @@ namespace hpx::parallel {
     namespace detail {
 
         HPX_CXX_CORE_EXPORT template <typename ExPolicy, typename FwdIter,
-            typename Sent>
+            typename Sent, typename Size>
         decltype(auto) shift_right_helper(
-            ExPolicy policy, FwdIter first, Sent last, FwdIter new_first)
+            ExPolicy policy, FwdIter first, Sent last, Size n)
         {
             constexpr bool has_scheduler_executor =
                 hpx::execution_policy_has_scheduler_executor_v<ExPolicy>;
 
             detail::reverse<FwdIter> r;
+
+            // Handle the [alg.shift] edge cases inside the implementation by
+            // clamping the reverse ranges, so the dispatch (parallel()) keeps a
+            // single homogeneous return type and no unique_any_sender is needed.
+            auto const dist =
+                static_cast<std::size_t>(detail::distance(first, last));
+            FwdIter const fin = std::next(first, dist);
+            bool const noop = static_cast<std::size_t>(n) >= dist;
+            // C++20 [alg.shift]: n==0 -> do nothing, return first;
+            //                    n>=dist -> do nothing, return last.
+            // Both degenerate cases collapse to empty-range reverses below.
+            FwdIter const rev1_end = noop ? first : std::next(first, dist - n);
+            FwdIter const rev2_end = noop ? first : fin;
+            FwdIter const ret = noop ? fin : std::next(first, n);
 
             if constexpr (!has_scheduler_executor)
             {
@@ -164,16 +177,14 @@ namespace hpx::parallel {
                         f1.get();
 
                         hpx::future<FwdIter> f =
-                            r.call2(p, non_seq(), first, last);
+                            r.call2(p, non_seq(), first, rev2_end);
                         return f.then(
                             [=](hpx::future<FwdIter>&& f) mutable -> FwdIter {
                                 f.get();
-                                std::advance(
-                                    first, detail::distance(new_first, last));
-                                return first;
+                                return ret;
                             });
                     },
-                    r.call2(p, non_seq(), first, new_first));
+                    r.call2(p, non_seq(), first, rev1_end));
                 return result;
             }
             else
@@ -182,14 +193,17 @@ namespace hpx::parallel {
                 // primitives
                 namespace ex = hpx::execution::experimental;
 
-                return r.call(policy, first, new_first) |
+                // Both reverses use FwdIter-typed ends, so their sender types
+                // match and the pipeline stays homogeneous.
+                static_assert(
+                    std::is_same_v<decltype(r.call(policy, first, rev1_end)),
+                        decltype(r.call(policy, first, rev2_end))>);
+
+                return r.call(policy, first, rev1_end) |
                     ex::let_value([=](FwdIter /*unused*/) mutable {
-                        return r.call(policy, first, last);
+                        return r.call(policy, first, rev2_end);
                     }) |
-                    ex::then([=](FwdIter) mutable -> FwdIter {
-                        std::advance(first, detail::distance(new_first, last));
-                        return first;
-                    });
+                    ex::then([=](FwdIter) mutable -> FwdIter { return ret; });
             }
         }
 
@@ -290,45 +304,12 @@ namespace hpx::parallel {
             static decltype(auto) parallel(
                 ExPolicy&& policy, FwdIter2 first, Sent last, Size n)
             {
-                namespace ex = hpx::execution::experimental;
-                constexpr bool has_scheduler_executor =
-                    hpx::execution_policy_has_scheduler_executor_v<ExPolicy>;
-
-                auto dist =
-                    static_cast<std::size_t>(detail::distance(first, last));
-                // C++20 [alg.shift]: if n is 0, do nothing and return first.
-                if (n == 0)
-                {
-                    auto result =
-                        parallel::util::detail::algorithm_result<ExPolicy,
-                            FwdIter2>::get(HPX_MOVE(first));
-                    if constexpr (has_scheduler_executor)
-                        return ex::unique_any_sender<FwdIter2>(
-                            HPX_MOVE(result));
-                    else
-                        return result;
-                }
-                // C++20 [alg.shift]: if n >= dist, do nothing and return last.
-                if (static_cast<std::size_t>(n) >= dist)
-                {
-                    auto result =
-                        parallel::util::detail::algorithm_result<ExPolicy,
-                            FwdIter2>::get(std::next(first, dist));
-                    if constexpr (has_scheduler_executor)
-                        return ex::unique_any_sender<FwdIter2>(
-                            HPX_MOVE(result));
-                    else
-                        return result;
-                }
-
-                auto new_first = std::next(first, dist - n);
-                auto result =
-                    util::detail::algorithm_result<ExPolicy, FwdIter2>::get(
-                        shift_right_helper(policy, first, last, new_first));
-                if constexpr (has_scheduler_executor)
-                    return ex::unique_any_sender<FwdIter2>(HPX_MOVE(result));
-                else
-                    return result;
+                // Edge cases (n==0, n>=dist) are handled inside
+                // shift_right_helper, so this dispatch keeps a single return
+                // type and needs no type erasure.
+                return util::detail::algorithm_result<ExPolicy, FwdIter2>::get(
+                    shift_right_helper(
+                        HPX_FORWARD(ExPolicy, policy), first, last, n));
             }
         };
         /// \endcond

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/shift_right.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/shift_right.hpp
@@ -157,7 +157,7 @@ namespace hpx::parallel {
                              .on(policy.executor())
                              .with(policy.parameters());
 
-                return dataflow(
+                hpx::future<FwdIter> result = dataflow(
                     [=](hpx::future<FwdIter>&& f1) mutable
                         -> hpx::future<FwdIter> {
                         f1.get();
@@ -173,6 +173,7 @@ namespace hpx::parallel {
                             });
                     },
                     r.call2(p, non_seq(), first, new_first));
+                return result;
             }
             else
             {

--- a/libs/core/algorithms/include/hpx/parallel/algorithms/shift_right.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/shift_right.hpp
@@ -182,7 +182,7 @@ namespace hpx::parallel {
                 namespace ex = hpx::execution::experimental;
 
                 return r.call(policy, first, new_first) |
-                    ex::let_value([=](FwdIter) mutable {
+                    ex::let_value([=](FwdIter /*unused*/) mutable {
                         return r.call(policy, first, last);
                     }) |
                     ex::then([=](FwdIter) mutable -> FwdIter {

--- a/libs/core/algorithms/tests/unit/algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/tests/unit/algorithms/CMakeLists.txt
@@ -214,6 +214,8 @@ set(tests
     rotate_sender
     rotate_copy_sender
     search_sender
+    shift_left_sender
+    shift_right_sender
     starts_with_sender
     swapranges_sender
     transform_sender

--- a/libs/core/algorithms/tests/unit/algorithms/shift_left_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/shift_left_sender.cpp
@@ -19,6 +19,7 @@
 #include <iterator>
 #include <numeric>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "test_utils.hpp"
@@ -51,7 +52,7 @@ void test_shift_left_sender(
                           std::size_t(0)) |
             hpx::shift_left(ex_policy.on(exec)));
     HPX_TEST(std::equal(std::begin(c), std::end(c), std::begin(d)));
-    HPX_TEST(hpx::get<0>(result_zero) == iterator(std::end(c)));
+    HPX_TEST(hpx::get<0>(result_zero.value()) == iterator(std::end(c)));
 
     std::size_t n =
         (static_cast<std::size_t>(std::rand()) % (arr_size - 1)) + 1;
@@ -61,7 +62,7 @@ void test_shift_left_sender(
         hpx::shift_left(ex_policy.on(exec)));
 
     // assert returned iterator equals end - n
-    HPX_TEST(hpx::get<0>(result_n) ==
+    HPX_TEST(hpx::get<0>(result_n.value()) ==
         iterator(std::begin(c) + static_cast<std::ptrdiff_t>(arr_size - n)));
 
     std::move(std::begin(d) + static_cast<std::ptrdiff_t>(n), std::end(d),
@@ -79,7 +80,7 @@ void test_shift_left_sender(
         tt::sync_wait(ex::just(iterator(std::begin(c)), iterator(std::end(c)),
                           static_cast<std::size_t>(arr_size + 1)) |
             hpx::shift_left(ex_policy.on(exec)));
-    HPX_TEST(hpx::get<0>(result_over) == iterator(std::begin(c)));
+    HPX_TEST(hpx::get<0>(result_over.value()) == iterator(std::begin(c)));
     HPX_TEST(std::equal(std::begin(c), std::end(c), std::begin(c_snapshot)));
 }
 
@@ -103,7 +104,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
     std::cout << "using seed: " << seed << std::endl;
     std::srand(seed);
 
-    shift_left_sender_test<std::forward_iterator_tag>();
+    shift_left_sender_test<std::bidirectional_iterator_tag>();
     shift_left_sender_test<std::random_access_iterator_tag>();
 
     return hpx::local::finalize();

--- a/libs/core/algorithms/tests/unit/algorithms/shift_left_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/shift_left_sender.cpp
@@ -11,6 +11,7 @@
 #include <hpx/init.hpp>
 #include <hpx/modules/testing.hpp>
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdlib>
 #include <ctime>
@@ -44,13 +45,16 @@ void test_shift_left_sender(
 
     auto exec = ex::explicit_scheduler_executor(scheduler_t(ln_policy));
 
-    // verify shift by 0 is a no-op
-    tt::sync_wait(ex::just(iterator(std::begin(c)), iterator(std::end(c)),
-                      std::size_t(0)) |
+    // verify shift by 0 is a no-op and returns last
+    auto result_zero = tt::sync_wait(
+        ex::just(iterator(std::begin(c)), iterator(std::end(c)),
+            std::size_t(0)) |
         hpx::shift_left(ex_policy.on(exec)));
     HPX_TEST(std::equal(std::begin(c), std::end(c), std::begin(d)));
+    HPX_TEST(hpx::get<0>(result_zero) == iterator(std::end(c)));
 
-    std::size_t n = (static_cast<std::size_t>(std::rand()) % ARR_SIZE) + 1;
+    std::size_t n =
+        (static_cast<std::size_t>(std::rand()) % (ARR_SIZE - 1)) + 1;
 
     tt::sync_wait(ex::just(iterator(std::begin(c)), iterator(std::end(c)), n) |
         hpx::shift_left(ex_policy.on(exec)));
@@ -63,11 +67,12 @@ void test_shift_left_sender(
         std::begin(c) + static_cast<std::ptrdiff_t>(ARR_SIZE - n),
         std::begin(d)));
 
-    // ensure shift by more than the range length does not crash
-    tt::sync_wait(
+    // ensure shift by more than the range length returns first
+    auto result_over = tt::sync_wait(
         ex::just(iterator(std::begin(c)), iterator(std::end(c)),
             static_cast<std::size_t>(ARR_SIZE + 1)) |
         hpx::shift_left(ex_policy.on(exec)));
+    HPX_TEST(hpx::get<0>(result_over) == iterator(std::begin(c)));
 }
 
 template <typename IteratorTag>

--- a/libs/core/algorithms/tests/unit/algorithms/shift_left_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/shift_left_sender.cpp
@@ -1,0 +1,112 @@
+//  Copyright (c) 2007-2024 Hartmut Kaiser
+//  Copyright (c) 2024 Tobias Wukovitsch
+//  Copyright (c) 2026 Siddharth
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/algorithm.hpp>
+#include <hpx/execution.hpp>
+#include <hpx/init.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <cstddef>
+#include <iostream>
+#include <iterator>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include "test_utils.hpp"
+
+#define ARR_SIZE 10007
+
+template <typename LnPolicy, typename ExPolicy, typename IteratorTag>
+void test_shift_left_sender(
+    LnPolicy ln_policy, ExPolicy&& ex_policy, IteratorTag)
+{
+    static_assert(hpx::is_async_execution_policy_v<ExPolicy>,
+        "hpx::is_async_execution_policy_v<ExPolicy>");
+
+    using base_iterator = std::vector<std::size_t>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
+
+    namespace ex = hpx::execution::experimental;
+    namespace tt = hpx::this_thread::experimental;
+    using scheduler_t = ex::thread_pool_policy_scheduler<LnPolicy>;
+
+    std::vector<std::size_t> c(ARR_SIZE);
+    std::iota(std::begin(c), std::end(c), std::rand());
+    std::vector<std::size_t> d = c;
+
+    std::size_t n = (std::rand() % (std::size_t) ARR_SIZE) + 1;
+
+    auto exec = ex::explicit_scheduler_executor(scheduler_t(ln_policy));
+
+    tt::sync_wait(ex::just(iterator(std::begin(c)), iterator(std::end(c)), n) |
+        hpx::shift_left(ex_policy.on(exec)));
+
+    std::move(std::begin(d) + static_cast<std::ptrdiff_t>(n), std::end(d),
+        std::begin(d));
+
+    // verify values
+    HPX_TEST(std::equal(std::begin(c),
+        std::begin(c) + ((std::size_t) ARR_SIZE - n), std::begin(d)));
+
+    // ensure shift by more than n does not crash
+    tt::sync_wait(
+        ex::just(iterator(std::begin(c)), iterator(std::end(c)),
+            (std::size_t)(ARR_SIZE + 1)) |
+        hpx::shift_left(ex_policy.on(exec)));
+}
+
+template <typename IteratorTag>
+void shift_left_sender_test()
+{
+    using namespace hpx::execution;
+    test_shift_left_sender(hpx::launch::sync, seq(task), IteratorTag());
+    test_shift_left_sender(hpx::launch::sync, unseq(task), IteratorTag());
+
+    test_shift_left_sender(hpx::launch::async, par(task), IteratorTag());
+    test_shift_left_sender(hpx::launch::async, par_unseq(task), IteratorTag());
+}
+
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    shift_left_sender_test<std::forward_iterator_tag>();
+    shift_left_sender_test<std::random_access_iterator_tag>();
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/algorithms/tests/unit/algorithms/shift_left_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/shift_left_sender.cpp
@@ -12,6 +12,8 @@
 #include <hpx/modules/testing.hpp>
 
 #include <cstddef>
+#include <cstdlib>
+#include <ctime>
 #include <iostream>
 #include <iterator>
 #include <numeric>
@@ -40,9 +42,15 @@ void test_shift_left_sender(
     std::iota(std::begin(c), std::end(c), std::rand());
     std::vector<std::size_t> d = c;
 
-    std::size_t n = (std::rand() % (std::size_t) ARR_SIZE) + 1;
-
     auto exec = ex::explicit_scheduler_executor(scheduler_t(ln_policy));
+
+    // verify shift by 0 is a no-op
+    tt::sync_wait(ex::just(iterator(std::begin(c)), iterator(std::end(c)),
+                      std::size_t(0)) |
+        hpx::shift_left(ex_policy.on(exec)));
+    HPX_TEST(std::equal(std::begin(c), std::end(c), std::begin(d)));
+
+    std::size_t n = (static_cast<std::size_t>(std::rand()) % ARR_SIZE) + 1;
 
     tt::sync_wait(ex::just(iterator(std::begin(c)), iterator(std::end(c)), n) |
         hpx::shift_left(ex_policy.on(exec)));
@@ -52,12 +60,13 @@ void test_shift_left_sender(
 
     // verify values
     HPX_TEST(std::equal(std::begin(c),
-        std::begin(c) + ((std::size_t) ARR_SIZE - n), std::begin(d)));
+        std::begin(c) + static_cast<std::ptrdiff_t>(ARR_SIZE - n),
+        std::begin(d)));
 
-    // ensure shift by more than n does not crash
+    // ensure shift by more than the range length does not crash
     tt::sync_wait(
         ex::just(iterator(std::begin(c)), iterator(std::end(c)),
-            (std::size_t)(ARR_SIZE + 1)) |
+            static_cast<std::size_t>(ARR_SIZE + 1)) |
         hpx::shift_left(ex_policy.on(exec)));
 }
 

--- a/libs/core/algorithms/tests/unit/algorithms/shift_left_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/shift_left_sender.cpp
@@ -56,8 +56,13 @@ void test_shift_left_sender(
     std::size_t n =
         (static_cast<std::size_t>(std::rand()) % (arr_size - 1)) + 1;
 
-    tt::sync_wait(ex::just(iterator(std::begin(c)), iterator(std::end(c)), n) |
+    auto result_n = tt::sync_wait(
+        ex::just(iterator(std::begin(c)), iterator(std::end(c)), n) |
         hpx::shift_left(ex_policy.on(exec)));
+
+    // assert returned iterator equals end - n
+    HPX_TEST(hpx::get<0>(result_n) ==
+        iterator(std::begin(c) + static_cast<std::ptrdiff_t>(arr_size - n)));
 
     std::move(std::begin(d) + static_cast<std::ptrdiff_t>(n), std::end(d),
         std::begin(d));
@@ -68,11 +73,14 @@ void test_shift_left_sender(
         std::begin(d)));
 
     // ensure shift by more than the range length returns first
+    // and that the range contents are unchanged
+    std::vector<std::size_t> c_snapshot = c;
     auto result_over =
         tt::sync_wait(ex::just(iterator(std::begin(c)), iterator(std::end(c)),
                           static_cast<std::size_t>(arr_size + 1)) |
             hpx::shift_left(ex_policy.on(exec)));
     HPX_TEST(hpx::get<0>(result_over) == iterator(std::begin(c)));
+    HPX_TEST(std::equal(std::begin(c), std::end(c), std::begin(c_snapshot)));
 }
 
 template <typename IteratorTag>

--- a/libs/core/algorithms/tests/unit/algorithms/shift_left_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/shift_left_sender.cpp
@@ -96,7 +96,7 @@ void shift_left_sender_test()
 
 int hpx_main(hpx::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int) std::time(nullptr);
+    unsigned int seed = static_cast<unsigned int>(std::time(nullptr));
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/libs/core/algorithms/tests/unit/algorithms/shift_left_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/shift_left_sender.cpp
@@ -23,7 +23,7 @@
 
 #include "test_utils.hpp"
 
-#define ARR_SIZE 10007
+constexpr std::size_t arr_size = 10007;
 
 template <typename LnPolicy, typename ExPolicy, typename IteratorTag>
 void test_shift_left_sender(
@@ -39,22 +39,22 @@ void test_shift_left_sender(
     namespace tt = hpx::this_thread::experimental;
     using scheduler_t = ex::thread_pool_policy_scheduler<LnPolicy>;
 
-    std::vector<std::size_t> c(ARR_SIZE);
+    std::vector<std::size_t> c(arr_size);
     std::iota(std::begin(c), std::end(c), std::rand());
     std::vector<std::size_t> d = c;
 
     auto exec = ex::explicit_scheduler_executor(scheduler_t(ln_policy));
 
     // verify shift by 0 is a no-op and returns last
-    auto result_zero = tt::sync_wait(
-        ex::just(iterator(std::begin(c)), iterator(std::end(c)),
-            std::size_t(0)) |
-        hpx::shift_left(ex_policy.on(exec)));
+    auto result_zero =
+        tt::sync_wait(ex::just(iterator(std::begin(c)), iterator(std::end(c)),
+                          std::size_t(0)) |
+            hpx::shift_left(ex_policy.on(exec)));
     HPX_TEST(std::equal(std::begin(c), std::end(c), std::begin(d)));
     HPX_TEST(hpx::get<0>(result_zero) == iterator(std::end(c)));
 
     std::size_t n =
-        (static_cast<std::size_t>(std::rand()) % (ARR_SIZE - 1)) + 1;
+        (static_cast<std::size_t>(std::rand()) % (arr_size - 1)) + 1;
 
     tt::sync_wait(ex::just(iterator(std::begin(c)), iterator(std::end(c)), n) |
         hpx::shift_left(ex_policy.on(exec)));
@@ -64,14 +64,14 @@ void test_shift_left_sender(
 
     // verify values
     HPX_TEST(std::equal(std::begin(c),
-        std::begin(c) + static_cast<std::ptrdiff_t>(ARR_SIZE - n),
+        std::begin(c) + static_cast<std::ptrdiff_t>(arr_size - n),
         std::begin(d)));
 
     // ensure shift by more than the range length returns first
-    auto result_over = tt::sync_wait(
-        ex::just(iterator(std::begin(c)), iterator(std::end(c)),
-            static_cast<std::size_t>(ARR_SIZE + 1)) |
-        hpx::shift_left(ex_policy.on(exec)));
+    auto result_over =
+        tt::sync_wait(ex::just(iterator(std::begin(c)), iterator(std::end(c)),
+                          static_cast<std::size_t>(arr_size + 1)) |
+            hpx::shift_left(ex_policy.on(exec)));
     HPX_TEST(hpx::get<0>(result_over) == iterator(std::begin(c)));
 }
 

--- a/libs/core/algorithms/tests/unit/algorithms/shift_right_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/shift_right_sender.cpp
@@ -1,0 +1,112 @@
+//  Copyright (c) 2007-2024 Hartmut Kaiser
+//  Copyright (c) 2024 Tobias Wukovitsch
+//  Copyright (c) 2026 Siddharth
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/algorithm.hpp>
+#include <hpx/execution.hpp>
+#include <hpx/init.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <cstddef>
+#include <iostream>
+#include <iterator>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include "test_utils.hpp"
+
+#define ARR_SIZE 10007
+
+template <typename LnPolicy, typename ExPolicy, typename IteratorTag>
+void test_shift_right_sender(
+    LnPolicy ln_policy, ExPolicy&& ex_policy, IteratorTag)
+{
+    static_assert(hpx::is_async_execution_policy_v<ExPolicy>,
+        "hpx::is_async_execution_policy_v<ExPolicy>");
+
+    using base_iterator = std::vector<std::size_t>::iterator;
+    using iterator = test::test_iterator<base_iterator, IteratorTag>;
+
+    namespace ex = hpx::execution::experimental;
+    namespace tt = hpx::this_thread::experimental;
+    using scheduler_t = ex::thread_pool_policy_scheduler<LnPolicy>;
+
+    std::vector<std::size_t> c(ARR_SIZE);
+    std::iota(std::begin(c), std::end(c), std::rand());
+    std::vector<std::size_t> d = c;
+
+    std::size_t n = (std::rand() % (std::size_t) ARR_SIZE) + 1;
+
+    auto exec = ex::explicit_scheduler_executor(scheduler_t(ln_policy));
+
+    tt::sync_wait(ex::just(iterator(std::begin(c)), iterator(std::end(c)), n) |
+        hpx::shift_right(ex_policy.on(exec)));
+
+    std::move_backward(std::begin(d),
+        std::end(d) - static_cast<std::ptrdiff_t>(n), std::end(d));
+
+    // verify values
+    HPX_TEST(std::equal(std::begin(c) + static_cast<std::ptrdiff_t>(n),
+        std::end(c), std::begin(d) + static_cast<std::ptrdiff_t>(n)));
+
+    // ensure shift by more than n does not crash
+    tt::sync_wait(
+        ex::just(iterator(std::begin(c)), iterator(std::end(c)),
+            (std::size_t)(ARR_SIZE + 1)) |
+        hpx::shift_right(ex_policy.on(exec)));
+}
+
+template <typename IteratorTag>
+void shift_right_sender_test()
+{
+    using namespace hpx::execution;
+    test_shift_right_sender(hpx::launch::sync, seq(task), IteratorTag());
+    test_shift_right_sender(hpx::launch::sync, unseq(task), IteratorTag());
+
+    test_shift_right_sender(hpx::launch::async, par(task), IteratorTag());
+    test_shift_right_sender(hpx::launch::async, par_unseq(task), IteratorTag());
+}
+
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    unsigned int seed = (unsigned int) std::time(nullptr);
+    if (vm.count("seed"))
+        seed = vm["seed"].as<unsigned int>();
+
+    std::cout << "using seed: " << seed << std::endl;
+    std::srand(seed);
+
+    shift_right_sender_test<std::forward_iterator_tag>();
+    shift_right_sender_test<std::random_access_iterator_tag>();
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // add command line option which controls the random number generator seed
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "Usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("seed,s", value<unsigned int>(),
+        "the random number generator seed to use for this run");
+
+    // By default this test should run on all available cores
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    // Initialize and run HPX
+    hpx::local::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/algorithms/tests/unit/algorithms/shift_right_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/shift_right_sender.cpp
@@ -12,6 +12,8 @@
 #include <hpx/modules/testing.hpp>
 
 #include <cstddef>
+#include <cstdlib>
+#include <ctime>
 #include <iostream>
 #include <iterator>
 #include <numeric>
@@ -40,9 +42,15 @@ void test_shift_right_sender(
     std::iota(std::begin(c), std::end(c), std::rand());
     std::vector<std::size_t> d = c;
 
-    std::size_t n = (std::rand() % (std::size_t) ARR_SIZE) + 1;
-
     auto exec = ex::explicit_scheduler_executor(scheduler_t(ln_policy));
+
+    // verify shift by 0 is a no-op
+    tt::sync_wait(ex::just(iterator(std::begin(c)), iterator(std::end(c)),
+                      std::size_t(0)) |
+        hpx::shift_right(ex_policy.on(exec)));
+    HPX_TEST(std::equal(std::begin(c), std::end(c), std::begin(d)));
+
+    std::size_t n = (static_cast<std::size_t>(std::rand()) % ARR_SIZE) + 1;
 
     tt::sync_wait(ex::just(iterator(std::begin(c)), iterator(std::end(c)), n) |
         hpx::shift_right(ex_policy.on(exec)));
@@ -54,10 +62,10 @@ void test_shift_right_sender(
     HPX_TEST(std::equal(std::begin(c) + static_cast<std::ptrdiff_t>(n),
         std::end(c), std::begin(d) + static_cast<std::ptrdiff_t>(n)));
 
-    // ensure shift by more than n does not crash
+    // ensure shift by more than the range length does not crash
     tt::sync_wait(
         ex::just(iterator(std::begin(c)), iterator(std::end(c)),
-            (std::size_t)(ARR_SIZE + 1)) |
+            static_cast<std::size_t>(ARR_SIZE + 1)) |
         hpx::shift_right(ex_policy.on(exec)));
 }
 

--- a/libs/core/algorithms/tests/unit/algorithms/shift_right_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/shift_right_sender.cpp
@@ -95,7 +95,7 @@ void shift_right_sender_test()
 
 int hpx_main(hpx::program_options::variables_map& vm)
 {
-    unsigned int seed = (unsigned int) std::time(nullptr);
+    unsigned int seed = static_cast<unsigned int>(std::time(nullptr));
     if (vm.count("seed"))
         seed = vm["seed"].as<unsigned int>();
 

--- a/libs/core/algorithms/tests/unit/algorithms/shift_right_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/shift_right_sender.cpp
@@ -56,8 +56,13 @@ void test_shift_right_sender(
     std::size_t n =
         (static_cast<std::size_t>(std::rand()) % (arr_size - 1)) + 1;
 
-    tt::sync_wait(ex::just(iterator(std::begin(c)), iterator(std::end(c)), n) |
+    auto result_n = tt::sync_wait(
+        ex::just(iterator(std::begin(c)), iterator(std::end(c)), n) |
         hpx::shift_right(ex_policy.on(exec)));
+
+    // assert returned iterator equals begin + n
+    HPX_TEST(hpx::get<0>(result_n) ==
+        iterator(std::begin(c) + static_cast<std::ptrdiff_t>(n)));
 
     std::move_backward(std::begin(d),
         std::end(d) - static_cast<std::ptrdiff_t>(n), std::end(d));
@@ -67,11 +72,14 @@ void test_shift_right_sender(
         std::end(c), std::begin(d) + static_cast<std::ptrdiff_t>(n)));
 
     // ensure shift by more than the range length returns last
+    // and that the range contents are unchanged
+    std::vector<std::size_t> c_snapshot = c;
     auto result_over =
         tt::sync_wait(ex::just(iterator(std::begin(c)), iterator(std::end(c)),
                           static_cast<std::size_t>(arr_size + 1)) |
             hpx::shift_right(ex_policy.on(exec)));
     HPX_TEST(hpx::get<0>(result_over) == iterator(std::end(c)));
+    HPX_TEST(std::equal(std::begin(c), std::end(c), std::begin(c_snapshot)));
 }
 
 template <typename IteratorTag>

--- a/libs/core/algorithms/tests/unit/algorithms/shift_right_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/shift_right_sender.cpp
@@ -23,7 +23,7 @@
 
 #include "test_utils.hpp"
 
-#define ARR_SIZE 10007
+constexpr std::size_t arr_size = 10007;
 
 template <typename LnPolicy, typename ExPolicy, typename IteratorTag>
 void test_shift_right_sender(
@@ -39,22 +39,22 @@ void test_shift_right_sender(
     namespace tt = hpx::this_thread::experimental;
     using scheduler_t = ex::thread_pool_policy_scheduler<LnPolicy>;
 
-    std::vector<std::size_t> c(ARR_SIZE);
+    std::vector<std::size_t> c(arr_size);
     std::iota(std::begin(c), std::end(c), std::rand());
     std::vector<std::size_t> d = c;
 
     auto exec = ex::explicit_scheduler_executor(scheduler_t(ln_policy));
 
     // verify shift by 0 is a no-op and returns first
-    auto result_zero = tt::sync_wait(
-        ex::just(iterator(std::begin(c)), iterator(std::end(c)),
-            std::size_t(0)) |
-        hpx::shift_right(ex_policy.on(exec)));
+    auto result_zero =
+        tt::sync_wait(ex::just(iterator(std::begin(c)), iterator(std::end(c)),
+                          std::size_t(0)) |
+            hpx::shift_right(ex_policy.on(exec)));
     HPX_TEST(std::equal(std::begin(c), std::end(c), std::begin(d)));
     HPX_TEST(hpx::get<0>(result_zero) == iterator(std::begin(c)));
 
     std::size_t n =
-        (static_cast<std::size_t>(std::rand()) % (ARR_SIZE - 1)) + 1;
+        (static_cast<std::size_t>(std::rand()) % (arr_size - 1)) + 1;
 
     tt::sync_wait(ex::just(iterator(std::begin(c)), iterator(std::end(c)), n) |
         hpx::shift_right(ex_policy.on(exec)));
@@ -67,10 +67,10 @@ void test_shift_right_sender(
         std::end(c), std::begin(d) + static_cast<std::ptrdiff_t>(n)));
 
     // ensure shift by more than the range length returns last
-    auto result_over = tt::sync_wait(
-        ex::just(iterator(std::begin(c)), iterator(std::end(c)),
-            static_cast<std::size_t>(ARR_SIZE + 1)) |
-        hpx::shift_right(ex_policy.on(exec)));
+    auto result_over =
+        tt::sync_wait(ex::just(iterator(std::begin(c)), iterator(std::end(c)),
+                          static_cast<std::size_t>(arr_size + 1)) |
+            hpx::shift_right(ex_policy.on(exec)));
     HPX_TEST(hpx::get<0>(result_over) == iterator(std::end(c)));
 }
 

--- a/libs/core/algorithms/tests/unit/algorithms/shift_right_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/shift_right_sender.cpp
@@ -51,7 +51,7 @@ void test_shift_right_sender(
                           std::size_t(0)) |
             hpx::shift_right(ex_policy.on(exec)));
     HPX_TEST(std::equal(std::begin(c), std::end(c), std::begin(d)));
-    HPX_TEST(hpx::get<0>(result_zero) == iterator(std::begin(c)));
+    HPX_TEST(hpx::get<0>(result_zero.value()) == iterator(std::begin(c)));
 
     std::size_t n =
         (static_cast<std::size_t>(std::rand()) % (arr_size - 1)) + 1;
@@ -61,7 +61,7 @@ void test_shift_right_sender(
         hpx::shift_right(ex_policy.on(exec)));
 
     // assert returned iterator equals begin + n
-    HPX_TEST(hpx::get<0>(result_n) ==
+    HPX_TEST(hpx::get<0>(result_n.value()) ==
         iterator(std::begin(c) + static_cast<std::ptrdiff_t>(n)));
 
     std::move_backward(std::begin(d),
@@ -78,7 +78,7 @@ void test_shift_right_sender(
         tt::sync_wait(ex::just(iterator(std::begin(c)), iterator(std::end(c)),
                           static_cast<std::size_t>(arr_size + 1)) |
             hpx::shift_right(ex_policy.on(exec)));
-    HPX_TEST(hpx::get<0>(result_over) == iterator(std::end(c)));
+    HPX_TEST(hpx::get<0>(result_over.value()) == iterator(std::end(c)));
     HPX_TEST(std::equal(std::begin(c), std::end(c), std::begin(c_snapshot)));
 }
 
@@ -102,7 +102,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
     std::cout << "using seed: " << seed << std::endl;
     std::srand(seed);
 
-    shift_right_sender_test<std::forward_iterator_tag>();
+    shift_right_sender_test<std::bidirectional_iterator_tag>();
     shift_right_sender_test<std::random_access_iterator_tag>();
 
     return hpx::local::finalize();

--- a/libs/core/algorithms/tests/unit/algorithms/shift_right_sender.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/shift_right_sender.cpp
@@ -11,6 +11,7 @@
 #include <hpx/init.hpp>
 #include <hpx/modules/testing.hpp>
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdlib>
 #include <ctime>
@@ -44,13 +45,16 @@ void test_shift_right_sender(
 
     auto exec = ex::explicit_scheduler_executor(scheduler_t(ln_policy));
 
-    // verify shift by 0 is a no-op
-    tt::sync_wait(ex::just(iterator(std::begin(c)), iterator(std::end(c)),
-                      std::size_t(0)) |
+    // verify shift by 0 is a no-op and returns first
+    auto result_zero = tt::sync_wait(
+        ex::just(iterator(std::begin(c)), iterator(std::end(c)),
+            std::size_t(0)) |
         hpx::shift_right(ex_policy.on(exec)));
     HPX_TEST(std::equal(std::begin(c), std::end(c), std::begin(d)));
+    HPX_TEST(hpx::get<0>(result_zero) == iterator(std::begin(c)));
 
-    std::size_t n = (static_cast<std::size_t>(std::rand()) % ARR_SIZE) + 1;
+    std::size_t n =
+        (static_cast<std::size_t>(std::rand()) % (ARR_SIZE - 1)) + 1;
 
     tt::sync_wait(ex::just(iterator(std::begin(c)), iterator(std::end(c)), n) |
         hpx::shift_right(ex_policy.on(exec)));
@@ -62,11 +66,12 @@ void test_shift_right_sender(
     HPX_TEST(std::equal(std::begin(c) + static_cast<std::ptrdiff_t>(n),
         std::end(c), std::begin(d) + static_cast<std::ptrdiff_t>(n)));
 
-    // ensure shift by more than the range length does not crash
-    tt::sync_wait(
+    // ensure shift by more than the range length returns last
+    auto result_over = tt::sync_wait(
         ex::just(iterator(std::begin(c)), iterator(std::end(c)),
             static_cast<std::size_t>(ARR_SIZE + 1)) |
         hpx::shift_right(ex_policy.on(exec)));
+    HPX_TEST(hpx::get<0>(result_over) == iterator(std::end(c)));
 }
 
 template <typename IteratorTag>


### PR DESCRIPTION
Contributing to closing: #6535 for shift_left and shift_right:

Adds S/R support for shift_left and shift_right:
- tag_parallel_algorithm CPO base + has_scheduler_executor guard in parallel()
- New sender tests + CMakeLists.txt registration