### PR TITLE
actions_base: add auto-registration to reflect_action

### DIFF
--- a/libs/full/actions_base/include/hpx/actions_base/reflect_action.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/reflect_action.hpp
@@ -89,7 +89,7 @@ namespace hpx::actions {
             return func_ptr(HPX_FORWARD(Ts, vs)...);
         }
 
-        /// Automatic invocation count registration — eliminates the need
+        /// Automatic invocation count registration -- eliminates the need
         /// for HPX_REGISTER_ACTION for reflection-based plain actions.
         static detail::register_action_invocation_count<reflect_action<F>>
             invocation_count_registrar_;

--- a/libs/full/actions_base/include/hpx/actions_base/reflect_action.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/reflect_action.hpp
@@ -93,8 +93,9 @@ namespace hpx::actions {
 
         /// Automatic invocation count registration -- eliminates the need
         /// for HPX_REGISTER_ACTION for reflection-based plain actions.
-        static detail::register_action_invocation_count reflect_action < F,
-            Derived >> invocation_count_registrar_;
+        static detail::register_action_invocation_count<
+            reflect_action<F, Derived>>
+            invocation_count_registrar_;
     };
 
     /// \cond NOINTERNAL

--- a/libs/full/actions_base/include/hpx/actions_base/reflect_action.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/reflect_action.hpp
@@ -84,17 +84,15 @@ namespace hpx::actions {
         static auto invoke(naming::address::address_type /*lva*/,
             naming::address::component_type /*comptype*/, Ts&&... vs)
         {
-            using base_t =
-                basic_action<hpx::actions::detail::plain_function, func_type,
-                    detail::action_type_t<reflect_action<F, Derived>, Derived>>;
+            using base_t = basic_action<hpx::actions::detail::plain_function,
+                func_type, detail::action_type_t<reflect_action, Derived>>;
             base_t::increment_invocation_count();
             return func_ptr(HPX_FORWARD(Ts, vs)...);
         }
 
         /// Automatic invocation count registration -- eliminates the need
         /// for HPX_REGISTER_ACTION for reflection-based plain actions.
-        static detail::register_action_invocation_count<
-            reflect_action<F, Derived>>
+        static detail::register_action_invocation_count<reflect_action>
             invocation_count_registrar_;
     };
 

--- a/libs/full/actions_base/include/hpx/actions_base/reflect_action.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/reflect_action.hpp
@@ -51,6 +51,7 @@ namespace hpx::actions {
     /// no HPX_REGISTER_ACTION call is needed for reflection-based actions.
     ///
     /// \tparam F  A std::meta::info reflection of a free function.
+    /// \tparam Derived  Derived type for CRTP extensibility (default: void).
     template <std::meta::info F, typename Derived = void>
     struct reflect_action
       : basic_action<hpx::actions::detail::plain_function,
@@ -83,16 +84,17 @@ namespace hpx::actions {
         static auto invoke(naming::address::address_type /*lva*/,
             naming::address::component_type /*comptype*/, Ts&&... vs)
         {
-            using base_t = basic_action<hpx::actions::detail::plain_function,
-                func_type, reflect_action<F>>;
+            using base_t =
+                basic_action<hpx::actions::detail::plain_function, func_type,
+                    detail::action_type_t<reflect_action<F, Derived>, Derived>>;
             base_t::increment_invocation_count();
             return func_ptr(HPX_FORWARD(Ts, vs)...);
         }
 
         /// Automatic invocation count registration -- eliminates the need
         /// for HPX_REGISTER_ACTION for reflection-based plain actions.
-        static detail::register_action_invocation_count<reflect_action<F>>
-            invocation_count_registrar_;
+        static detail::register_action_invocation_count reflect_action < F,
+            Derived >> invocation_count_registrar_;
     };
 
     /// \cond NOINTERNAL

--- a/libs/full/actions_base/include/hpx/actions_base/reflect_action.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/reflect_action.hpp
@@ -6,6 +6,7 @@
 
 /// \file reflect_action.hpp
 /// \brief Reflection-based action definition for HPX remote operations.
+
 #pragma once
 
 #include <hpx/config.hpp>
@@ -13,6 +14,7 @@
 #if defined(HPX_HAVE_CXX26_REFLECTION)
 
 #include <hpx/actions_base/basic_action.hpp>
+#include <hpx/actions_base/detail/invocation_count_registry.hpp>
 #include <hpx/actions_base/plain_action.hpp>
 #include <hpx/modules/serialization.hpp>
 
@@ -45,6 +47,8 @@ namespace hpx::actions {
     /// reflect_action<F> integrates with HPX's action system by inheriting
     /// from basic_action<detail::plain_function, R(Ps...), reflect_action<F>>.
     /// All properties are derived automatically from the reflected function F.
+    /// Invocation count registration is automatic via a static member —
+    /// no HPX_REGISTER_ACTION call is needed for reflection-based actions.
     ///
     /// \tparam F  A std::meta::info reflection of a free function.
     template <std::meta::info F>
@@ -84,7 +88,18 @@ namespace hpx::actions {
             base_t::increment_invocation_count();
             return func_ptr(HPX_FORWARD(Ts, vs)...);
         }
+
+        /// Automatic invocation count registration — eliminates the need
+        /// for HPX_REGISTER_ACTION for reflection-based plain actions.
+        static detail::register_action_invocation_count<reflect_action<F>>
+            invocation_count_registrar_;
     };
+
+    /// \cond NOINTERNAL
+    template <std::meta::info F>
+    detail::register_action_invocation_count<reflect_action<F>>
+        reflect_action<F>::invocation_count_registrar_;
+    /// \endcond
 
 }    // namespace hpx::actions
 

--- a/libs/full/actions_base/include/hpx/actions_base/reflect_action.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/reflect_action.hpp
@@ -51,11 +51,11 @@ namespace hpx::actions {
     /// no HPX_REGISTER_ACTION call is needed for reflection-based actions.
     ///
     /// \tparam F  A std::meta::info reflection of a free function.
-    template <std::meta::info F>
+    template <std::meta::info F, typename Derived = void>
     struct reflect_action
       : basic_action<hpx::actions::detail::plain_function,
             typename detail::reflect_action_base<F>::func_type,
-            reflect_action<F>>
+            detail::action_type_t<reflect_action<F, Derived>, Derived>>
     {
         /// The function type (e.g. int(double, double))
         using func_type = [:std::meta::type_of(F):];
@@ -96,9 +96,9 @@ namespace hpx::actions {
     };
 
     /// \cond NOINTERNAL
-    template <std::meta::info F>
-    detail::register_action_invocation_count<reflect_action<F>>
-        reflect_action<F>::invocation_count_registrar_;
+    template <std::meta::info F, typename Derived>
+    detail::register_action_invocation_count<reflect_action<F, Derived>>
+        reflect_action<F, Derived>::invocation_count_registrar_;
     /// \endcond
 
 }    // namespace hpx::actions

--- a/libs/full/actions_base/include/hpx/actions_base/reflect_action.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/reflect_action.hpp
@@ -47,7 +47,7 @@ namespace hpx::actions {
     /// reflect_action<F> integrates with HPX's action system by inheriting
     /// from basic_action<detail::plain_function, R(Ps...), reflect_action<F>>.
     /// All properties are derived automatically from the reflected function F.
-    /// Invocation count registration is automatic via a static member —
+    /// Invocation count registration is automatic via a static member --
     /// no HPX_REGISTER_ACTION call is needed for reflection-based actions.
     ///
     /// \tparam F  A std::meta::info reflection of a free function.

--- a/libs/full/actions_base/tests/unit/reflect_action_test.cpp
+++ b/libs/full/actions_base/tests/unit/reflect_action_test.cpp
@@ -89,5 +89,15 @@ int main()
         HPX_TEST_EQ(compute_action::func_ptr(3.0, 4.0), 7);
     }
 
+    // Test: auto-registration static member exists (compile-time check)
+    // This verifies that reflect_action has the invocation_count_registrar_
+    // static member which enables automatic registration without HPX_REGISTER_ACTION
+    {
+        HPX_ACTION(app::compute, compute_action);
+        using registrar_type =
+            decltype(compute_action::invocation_count_registrar_);
+        static_assert(!std::is_void_v<registrar_type>,
+            "invocation_count_registrar_ must exist");
+    }
     return hpx::util::report_errors();
 }

--- a/libs/full/actions_base/tests/unit/reflect_action_test.cpp
+++ b/libs/full/actions_base/tests/unit/reflect_action_test.cpp
@@ -13,6 +13,7 @@
 
 #include <cstddef>
 #include <string>
+#include <type_traits>
 
 namespace app {
 


### PR DESCRIPTION
## Summary

`reflect_action` now automatically registers its invocation counter
via a static `register_action_invocation_count` member — eliminating
the need for `HPX_REGISTER_ACTION` for reflection-based plain actions.

## Design

Follows HPX's existing auto-registration pattern already used by
`register_action<Action>` in `register_action.hpp`:

```cpp
template <std::meta::info F>
struct reflect_action : basic_action<...> {
    // Auto-registers during static initialization
    static detail::register_action_invocation_count<reflect_action<F>>
        invocation_count_registrar_;
};
```

## What's still needed

The explicit `transfer_action<reflect_action<F>>` instantiation
(for shared library export) still requires `HPX_REGISTER_ACTION`
in non-reflection builds. For reflection builds, users can omit
`HPX_REGISTER_ACTION` entirely.

## Depends on

- PR #7266 (merged) — `reflect_action` core
- PR #7281 (merged) — `basic_action` integration

## Checklist
- [x] I have added a new feature and have added tests to go along with it.