### PR TITLE
Remove `tag_invoke` and use member functions

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -16,6 +16,7 @@ Checks: >
     -bugprone-reserved-identifier,
     -bugprone-lambda-function-name,
     -bugprone-unchecked-optional-access,
+    -bugprone-crtp-constructor-accessibility,
     modernize-use-nullptr,
     misc-assert-side-effect
     misc-dangling-handle

--- a/libs/core/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
@@ -25,6 +25,51 @@
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx::parallel::util::detail {
 
+    HPX_CXX_CORE_EXPORT template <typename ExPolicy>
+    void update_policy_processing_units_count(
+        ExPolicy& policy, std::size_t cores)
+    {
+        using exec_type = typename std::decay_t<ExPolicy>::executor_type;
+
+        if constexpr (std::derived_from<exec_type,
+                          hpx::execution::parallel_executor>)
+        {
+            exec_type exec = policy.executor();
+            auto& base_exec =
+                static_cast<hpx::execution::parallel_executor&>(exec);
+            if (cores == 0)
+            {
+                auto* pool = base_exec.pool_ ?
+                    base_exec.pool_ :
+                    hpx::threads::detail::get_self_or_default_pool();
+                cores = pool->get_active_os_thread_count();
+            }
+            base_exec.num_cores_ = cores;
+            policy = hpx::execution::experimental::create_rebound_policy(
+                policy, HPX_MOVE(exec), policy.parameters());
+        }
+        else if constexpr (requires {
+                               policy.query(hpx::execution::experimental::
+                                                with_processing_units_count_t{},
+                                   cores);
+                           })
+        {
+            policy = policy.query(
+                hpx::execution::experimental::with_processing_units_count_t{},
+                cores);
+        }
+        else if constexpr (hpx::functional::is_tag_invocable_v<
+                               hpx::execution::experimental::
+                                   with_processing_units_count_t,
+                               exec_type, std::size_t>)
+        {
+            policy = hpx::execution::experimental::create_rebound_policy(policy,
+                hpx::execution::experimental::with_processing_units_count(
+                    policy.executor(), cores),
+                policy.parameters());
+        }
+    }
+
     ///////////////////////////////////////////////////////////////////////////
     HPX_CXX_CORE_EXPORT template <typename F, typename Future, typename FwdIter>
     // requires traits::is_future<Future>
@@ -177,9 +222,7 @@ namespace hpx::parallel::util::detail {
             chunk_size);
 
         // update executor with new values
-        policy = hpx::experimental::prefer(
-            hpx::execution::experimental::with_processing_units_count, policy,
-            cores);
+        update_policy_processing_units_count(policy, cores);
 
         auto shape_begin = chunk_size_iterator(it_or_r, chunk_size, count);
         auto shape_end = chunk_size_iterator(last, chunk_size, count, count);
@@ -258,9 +301,7 @@ namespace hpx::parallel::util::detail {
             chunk_size);
 
         // update executor with new values
-        policy = hpx::experimental::prefer(
-            hpx::execution::experimental::with_processing_units_count, policy,
-            cores);
+        update_policy_processing_units_count(policy, cores);
 
         auto shape_begin = chunk_size_iterator(it_or_r, chunk_size, count);
         auto shape_end = chunk_size_iterator(last, chunk_size, count, count);
@@ -334,9 +375,7 @@ namespace hpx::parallel::util::detail {
             static_cast<std::size_t>(-1));
 
         // update executor with new values
-        policy = hpx::experimental::prefer(
-            hpx::execution::experimental::with_processing_units_count, policy,
-            cores);
+        update_policy_processing_units_count(policy, cores);
 
         return shape;
     }
@@ -435,9 +474,7 @@ namespace hpx::parallel::util::detail {
             chunk_size);
 
         // update executor with new values
-        policy = hpx::experimental::prefer(
-            hpx::execution::experimental::with_processing_units_count, policy,
-            cores);
+        update_policy_processing_units_count(policy, cores);
 
         using iterator =
             parallel::util::detail::chunk_size_idx_iterator<FwdIter>;
@@ -525,9 +562,7 @@ namespace hpx::parallel::util::detail {
             chunk_size);
 
         // update executor with new values
-        policy = hpx::experimental::prefer(
-            hpx::execution::experimental::with_processing_units_count, policy,
-            cores);
+        update_policy_processing_units_count(policy, cores);
 
         using iterator =
             parallel::util::detail::chunk_size_idx_iterator<FwdIter>;
@@ -606,9 +641,7 @@ namespace hpx::parallel::util::detail {
             static_cast<std::size_t>(-1));
 
         // update executor with new values
-        policy = hpx::experimental::prefer(
-            hpx::execution::experimental::with_processing_units_count, policy,
-            cores);
+        update_policy_processing_units_count(policy, cores);
 
         return shape;
     }

--- a/libs/core/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
@@ -11,12 +11,14 @@
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/datastructures.hpp>
 #include <hpx/modules/execution.hpp>
+#include <hpx/modules/executors.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/iterator_support.hpp>
 #include <hpx/modules/properties.hpp>
 #include <hpx/parallel/util/detail/chunk_size_iterator.hpp>
 
 #include <algorithm>
+#include <concepts>
 #include <cstddef>
 #include <type_traits>
 #include <utility>

--- a/libs/core/async_base/CMakeLists.txt
+++ b/libs/core/async_base/CMakeLists.txt
@@ -9,6 +9,9 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 set(async_base_headers
     hpx/async_base/async.hpp
     hpx/async_base/dataflow.hpp
+    hpx/async_base/detail/policy_holder_query.hpp
+    hpx/async_base/detail/query_dispatch.hpp
+    hpx/async_base/detail/query_first_fallback.hpp
     hpx/async_base/launch_policy.hpp
     hpx/async_base/post.hpp
     hpx/async_base/sync.hpp

--- a/libs/core/async_base/CMakeLists.txt
+++ b/libs/core/async_base/CMakeLists.txt
@@ -10,13 +10,13 @@ set(async_base_headers
     hpx/async_base/async.hpp
     hpx/async_base/dataflow.hpp
     hpx/async_base/detail/policy_holder_query.hpp
-    hpx/async_base/detail/query_dispatch.hpp
     hpx/async_base/detail/query_first_fallback.hpp
     hpx/async_base/launch_policy.hpp
     hpx/async_base/post.hpp
+    hpx/async_base/query_dispatch.hpp
+    hpx/async_base/scheduling_properties.hpp
     hpx/async_base/sync.hpp
     hpx/async_base/traits/is_launch_policy.hpp
-    hpx/async_base/scheduling_properties.hpp
 )
 
 set(async_base_sources launch_policy.cpp)

--- a/libs/core/async_base/include/hpx/async_base/dataflow.hpp
+++ b/libs/core/async_base/include/hpx/async_base/dataflow.hpp
@@ -60,8 +60,8 @@ namespace hpx {
             friend constexpr auto tag_invoke(
                 dataflow_t, Target&& target, Args&&... args)
             {
-                return HPX_FORWARD(Target, target).dataflow(
-                    HPX_FORWARD(Args, args)...);
+                return HPX_FORWARD(Target, target)
+                    .dataflow(HPX_FORWARD(Args, args)...);
             }
 
             template <typename F, typename... Ts,

--- a/libs/core/async_base/include/hpx/async_base/dataflow.hpp
+++ b/libs/core/async_base/include/hpx/async_base/dataflow.hpp
@@ -53,6 +53,17 @@ namespace hpx {
           : hpx::functional::detail::tag_fallback<dataflow_t>
         {
         private:
+            template <typename Target, typename... Args>
+                requires requires(Target&& t, Args&&... args) {
+                    HPX_FORWARD(Target, t).dataflow(HPX_FORWARD(Args, args)...);
+                }
+            friend constexpr auto tag_invoke(
+                dataflow_t, Target&& target, Args&&... args)
+            {
+                return HPX_FORWARD(Target, target).dataflow(
+                    HPX_FORWARD(Args, args)...);
+            }
+
             template <typename F, typename... Ts,
                 HPX_CONCEPT_REQUIRES_(
                     !hpx::traits::is_allocator_v<std::decay_t<F>>)>

--- a/libs/core/async_base/include/hpx/async_base/detail/policy_holder_query.hpp
+++ b/libs/core/async_base/include/hpx/async_base/detail/policy_holder_query.hpp
@@ -11,7 +11,9 @@
 
 namespace hpx::detail {
 
-    // NOLINTBEGIN(bugprone-crtp-constructor-accessibility)
+    template <typename Derived>
+    struct policy_holder;
+
     template <typename Policy>
     struct policy_holder_query
     {
@@ -59,7 +61,12 @@ namespace hpx::detail {
         {
             return static_cast<Policy const&>(*this).get_hint();
         }
+
+    private:
+        friend Policy;
+        template <typename T>
+        friend struct policy_holder;
+        constexpr policy_holder_query() = default;
     };
-    // NOLINTEND(bugprone-crtp-constructor-accessibility)
 
 }    // namespace hpx::detail

--- a/libs/core/async_base/include/hpx/async_base/detail/policy_holder_query.hpp
+++ b/libs/core/async_base/include/hpx/async_base/detail/policy_holder_query.hpp
@@ -1,0 +1,63 @@
+//  Copyright (c) 2026 The STE||AR-Group
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/async_base/scheduling_properties.hpp>
+#include <hpx/modules/coroutines.hpp>
+
+namespace hpx::detail {
+
+    template <typename Policy>
+    struct policy_holder_query
+    {
+        [[nodiscard]] constexpr Policy query(
+            execution::experimental::with_priority_t,
+            threads::thread_priority priority) const noexcept
+        {
+            Policy policy = static_cast<Policy const&>(*this);
+            policy.set_priority(priority);
+            return policy;
+        }
+
+        [[nodiscard]] constexpr threads::thread_priority query(
+            execution::experimental::get_priority_t) const noexcept
+        {
+            return static_cast<Policy const&>(*this).get_priority();
+        }
+
+        [[nodiscard]] constexpr Policy query(
+            execution::experimental::with_stacksize_t,
+            threads::thread_stacksize stacksize) const noexcept
+        {
+            Policy policy = static_cast<Policy const&>(*this);
+            policy.set_stacksize(stacksize);
+            return policy;
+        }
+
+        [[nodiscard]] constexpr threads::thread_stacksize query(
+            execution::experimental::get_stacksize_t) const noexcept
+        {
+            return static_cast<Policy const&>(*this).get_stacksize();
+        }
+
+        [[nodiscard]] constexpr Policy query(
+            execution::experimental::with_hint_t,
+            threads::thread_schedule_hint hint) const noexcept
+        {
+            Policy policy = static_cast<Policy const&>(*this);
+            policy.set_hint(hint);
+            return policy;
+        }
+
+        [[nodiscard]] constexpr threads::thread_schedule_hint query(
+            execution::experimental::get_hint_t) const noexcept
+        {
+            return static_cast<Policy const&>(*this).get_hint();
+        }
+    };
+
+}    // namespace hpx::detail

--- a/libs/core/async_base/include/hpx/async_base/detail/policy_holder_query.hpp
+++ b/libs/core/async_base/include/hpx/async_base/detail/policy_holder_query.hpp
@@ -11,6 +11,7 @@
 
 namespace hpx::detail {
 
+    // NOLINTBEGIN(bugprone-crtp-constructor-accessibility)
     template <typename Policy>
     struct policy_holder_query
     {
@@ -59,5 +60,6 @@ namespace hpx::detail {
             return static_cast<Policy const&>(*this).get_hint();
         }
     };
+    // NOLINTEND(bugprone-crtp-constructor-accessibility)
 
 }    // namespace hpx::detail

--- a/libs/core/async_base/include/hpx/async_base/detail/query_dispatch.hpp
+++ b/libs/core/async_base/include/hpx/async_base/detail/query_dispatch.hpp
@@ -14,10 +14,10 @@
 namespace hpx::execution::experimental::detail {
 
     template <typename Target, typename Tag, typename... Args>
-    inline constexpr bool has_query_v = requires(
-        Target&& target, Tag tag, Args&&... args) {
-        HPX_FORWARD(Target, target).query(tag, HPX_FORWARD(Args, args)...);
-    };
+    inline constexpr bool has_query_v =
+        requires(Target&& target, Tag tag, Args&&... args) {
+            HPX_FORWARD(Target, target).query(tag, HPX_FORWARD(Args, args)...);
+        };
 
     template <typename Target, typename Tag, typename... Args>
     using query_result_t = decltype(std::declval<Target>().query(

--- a/libs/core/async_base/include/hpx/async_base/detail/query_dispatch.hpp
+++ b/libs/core/async_base/include/hpx/async_base/detail/query_dispatch.hpp
@@ -1,0 +1,26 @@
+//  Copyright (c) 2026 The STE||AR-Group
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#include <type_traits>
+#include <utility>
+
+namespace hpx::execution::experimental::detail {
+
+    template <typename Target, typename Tag, typename... Args>
+    inline constexpr bool has_query_v = requires(
+        Target&& target, Tag tag, Args&&... args) {
+        HPX_FORWARD(Target, target).query(tag, HPX_FORWARD(Args, args)...);
+    };
+
+    template <typename Target, typename Tag, typename... Args>
+    using query_result_t = decltype(std::declval<Target>().query(
+        std::declval<Tag>(), std::declval<Args>()...));
+
+}    // namespace hpx::execution::experimental::detail

--- a/libs/core/async_base/include/hpx/async_base/detail/query_first_fallback.hpp
+++ b/libs/core/async_base/include/hpx/async_base/detail/query_first_fallback.hpp
@@ -6,7 +6,7 @@
 
 #pragma once
 
-#include <hpx/async_base/detail/query_dispatch.hpp>
+#include <hpx/async_base/query_dispatch.hpp>
 #include <hpx/modules/tag_invoke.hpp>
 
 #include <utility>
@@ -18,14 +18,14 @@ namespace hpx::execution::experimental::detail {
     template <typename Tag, typename Fallback>
     struct query_first_tag_fallback : hpx::functional::detail::tag_fallback<Tag>
     {
-    private:
-        friend Tag;
+    protected:
         constexpr query_first_tag_fallback() = default;
 
         template <typename Target, typename... Args>
         friend constexpr auto tag_invoke(
             Tag tag, Target&& target, Args&&... args)
-            requires(has_query_v<Target, Tag, Args...>)
+            requires(
+                hpx::execution::experimental::has_query_v<Target, Tag, Args...>)
         {
             return HPX_FORWARD(Target, target)
                 .query(tag, HPX_FORWARD(Args, args)...);

--- a/libs/core/async_base/include/hpx/async_base/detail/query_first_fallback.hpp
+++ b/libs/core/async_base/include/hpx/async_base/detail/query_first_fallback.hpp
@@ -1,0 +1,45 @@
+//  Copyright (c) 2026 The STE||AR-Group
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/async_base/detail/query_dispatch.hpp>
+#include <hpx/modules/tag_invoke.hpp>
+
+#include <utility>
+
+namespace hpx::execution::experimental::detail {
+
+    // CPO tag that prefers target.query(tag, args...) and otherwise invokes
+    // Fallback{}(target, args...).
+    template <typename Tag, typename Fallback>
+    struct query_first_tag_fallback
+      : hpx::functional::detail::tag_fallback<Tag>
+    {
+    private:
+        template <typename Target, typename... Args>
+        friend constexpr auto tag_invoke(Tag tag, Target&& target,
+            Args&&... args)
+            requires(has_query_v<Target, Tag, Args...>)
+        {
+            return HPX_FORWARD(Target, target).query(
+                tag, HPX_FORWARD(Args, args)...);
+        }
+
+        template <typename Target, typename... Args>
+        friend constexpr auto tag_fallback_invoke(
+            Tag, Target&& target, Args&&... args)
+            noexcept(noexcept(Fallback{}(
+                HPX_FORWARD(Target, target), HPX_FORWARD(Args, args)...)))
+                -> decltype(Fallback{}(HPX_FORWARD(Target, target),
+                    HPX_FORWARD(Args, args)...))
+        {
+            return Fallback{}(
+                HPX_FORWARD(Target, target), HPX_FORWARD(Args, args)...);
+        }
+    };
+
+}    // namespace hpx::execution::experimental::detail

--- a/libs/core/async_base/include/hpx/async_base/detail/query_first_fallback.hpp
+++ b/libs/core/async_base/include/hpx/async_base/detail/query_first_fallback.hpp
@@ -15,31 +15,32 @@ namespace hpx::execution::experimental::detail {
 
     // CPO tag that prefers target.query(tag, args...) and otherwise invokes
     // Fallback{}(target, args...).
+    // NOLINTBEGIN(bugprone-crtp-constructor-accessibility)
     template <typename Tag, typename Fallback>
-    struct query_first_tag_fallback
-      : hpx::functional::detail::tag_fallback<Tag>
+    struct query_first_tag_fallback : hpx::functional::detail::tag_fallback<Tag>
     {
     private:
         template <typename Target, typename... Args>
-        friend constexpr auto tag_invoke(Tag tag, Target&& target,
-            Args&&... args)
+        friend constexpr auto tag_invoke(
+            Tag tag, Target&& target, Args&&... args)
             requires(has_query_v<Target, Tag, Args...>)
         {
-            return HPX_FORWARD(Target, target).query(
-                tag, HPX_FORWARD(Args, args)...);
+            return HPX_FORWARD(Target, target)
+                .query(tag, HPX_FORWARD(Args, args)...);
         }
 
         template <typename Target, typename... Args>
-        friend constexpr auto tag_fallback_invoke(
-            Tag, Target&& target, Args&&... args)
-            noexcept(noexcept(Fallback{}(
-                HPX_FORWARD(Target, target), HPX_FORWARD(Args, args)...)))
-                -> decltype(Fallback{}(HPX_FORWARD(Target, target),
-                    HPX_FORWARD(Args, args)...))
+        friend constexpr auto tag_fallback_invoke(Tag, Target&& target,
+            Args&&... args) noexcept(noexcept(Fallback{}(HPX_FORWARD(Target,
+                                                             target),
+            HPX_FORWARD(Args, args)...)))
+            -> decltype(Fallback{}(
+                HPX_FORWARD(Target, target), HPX_FORWARD(Args, args)...))
         {
             return Fallback{}(
                 HPX_FORWARD(Target, target), HPX_FORWARD(Args, args)...);
         }
     };
+    // NOLINTEND(bugprone-crtp-constructor-accessibility)
 
 }    // namespace hpx::execution::experimental::detail

--- a/libs/core/async_base/include/hpx/async_base/detail/query_first_fallback.hpp
+++ b/libs/core/async_base/include/hpx/async_base/detail/query_first_fallback.hpp
@@ -15,11 +15,13 @@ namespace hpx::execution::experimental::detail {
 
     // CPO tag that prefers target.query(tag, args...) and otherwise invokes
     // Fallback{}(target, args...).
-    // NOLINTBEGIN(bugprone-crtp-constructor-accessibility)
     template <typename Tag, typename Fallback>
     struct query_first_tag_fallback : hpx::functional::detail::tag_fallback<Tag>
     {
     private:
+        friend Tag;
+        constexpr query_first_tag_fallback() = default;
+
         template <typename Target, typename... Args>
         friend constexpr auto tag_invoke(
             Tag tag, Target&& target, Args&&... args)
@@ -41,6 +43,5 @@ namespace hpx::execution::experimental::detail {
                 HPX_FORWARD(Target, target), HPX_FORWARD(Args, args)...);
         }
     };
-    // NOLINTEND(bugprone-crtp-constructor-accessibility)
 
 }    // namespace hpx::execution::experimental::detail

--- a/libs/core/async_base/include/hpx/async_base/launch_policy.hpp
+++ b/libs/core/async_base/include/hpx/async_base/launch_policy.hpp
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/async_base/detail/policy_holder_query.hpp>
 #include <hpx/async_base/scheduling_properties.hpp>
 #include <hpx/async_base/traits/is_launch_policy.hpp>
 #include <hpx/modules/coroutines.hpp>
@@ -122,7 +123,9 @@ namespace hpx {
 
         ///////////////////////////////////////////////////////////////////////
         template <typename Derived = void>
-        struct policy_holder : policy_holder_base
+        struct policy_holder
+          : policy_holder_base
+          , hpx::detail::policy_holder_query<Derived>
         {
             // NOLINTNEXTLINE(bugprone-crtp-constructor-accessibility)
             constexpr explicit policy_holder(launch_policy const p,
@@ -174,7 +177,9 @@ namespace hpx {
         };
 
         template <>
-        struct policy_holder<void> : policy_holder_base
+        struct policy_holder<void>
+          : policy_holder_base
+          , hpx::detail::policy_holder_query<policy_holder<void>>
         {
             // NOLINTNEXTLINE(bugprone-crtp-constructor-accessibility)
             constexpr explicit policy_holder(launch_policy const p,
@@ -238,57 +243,6 @@ namespace hpx {
                     launch_policy::async, priority, stacksize, hint)
             {
             }
-
-            friend async_policy tag_invoke(
-                hpx::execution::experimental::with_priority_t,
-                async_policy const policy,
-                threads::thread_priority const priority) noexcept
-            {
-                auto policy_with_priority = policy;
-                policy_with_priority.set_priority(priority);
-                return policy_with_priority;
-            }
-
-            friend constexpr hpx::threads::thread_priority tag_invoke(
-                hpx::execution::experimental::get_priority_t,
-                async_policy const policy) noexcept
-            {
-                return policy.priority();
-            }
-
-            friend async_policy tag_invoke(
-                hpx::execution::experimental::with_stacksize_t,
-                async_policy const policy,
-                threads::thread_stacksize const stacksize) noexcept
-            {
-                auto policy_with_stacksize = policy;
-                policy_with_stacksize.set_stacksize(stacksize);
-                return policy_with_stacksize;
-            }
-
-            friend constexpr hpx::threads::thread_stacksize tag_invoke(
-                hpx::execution::experimental::get_stacksize_t,
-                async_policy const policy) noexcept
-            {
-                return policy.stacksize();
-            }
-
-            friend async_policy tag_invoke(
-                hpx::execution::experimental::with_hint_t,
-                async_policy const policy,
-                threads::thread_schedule_hint const hint) noexcept
-            {
-                auto policy_with_hint = policy;
-                policy_with_hint.set_hint(hint);
-                return policy_with_hint;
-            }
-
-            friend constexpr hpx::threads::thread_schedule_hint tag_invoke(
-                hpx::execution::experimental::get_hint_t,
-                async_policy const policy) noexcept
-            {
-                return policy.hint();
-            }
         };
 
         struct fork_policy : policy_holder<fork_policy>
@@ -304,56 +258,11 @@ namespace hpx {
             {
             }
 
-            friend fork_policy tag_invoke(
-                hpx::execution::experimental::with_priority_t,
-                fork_policy const policy,
-                threads::thread_priority const priority) noexcept
-            {
-                auto policy_with_priority = policy;
-                policy_with_priority.set_priority(priority);
-                return policy_with_priority;
-            }
 
-            friend constexpr hpx::threads::thread_priority tag_invoke(
-                hpx::execution::experimental::get_priority_t,
-                fork_policy const policy) noexcept
-            {
-                return policy.priority();
-            }
 
-            friend fork_policy tag_invoke(
-                hpx::execution::experimental::with_stacksize_t,
-                fork_policy const policy,
-                threads::thread_stacksize const stacksize) noexcept
-            {
-                auto policy_with_stacksize = policy;
-                policy_with_stacksize.set_stacksize(stacksize);
-                return policy_with_stacksize;
-            }
 
-            friend constexpr hpx::threads::thread_stacksize tag_invoke(
-                hpx::execution::experimental::get_stacksize_t,
-                fork_policy const policy) noexcept
-            {
-                return policy.stacksize();
-            }
 
-            friend fork_policy tag_invoke(
-                hpx::execution::experimental::with_hint_t,
-                fork_policy const policy,
-                threads::thread_schedule_hint const hint) noexcept
-            {
-                auto policy_with_hint = policy;
-                policy_with_hint.set_hint(hint);
-                return policy_with_hint;
-            }
 
-            friend constexpr hpx::threads::thread_schedule_hint tag_invoke(
-                hpx::execution::experimental::get_hint_t,
-                fork_policy const policy) noexcept
-            {
-                return policy.hint();
-            }
         };
 
         struct sync_policy : policy_holder<sync_policy>
@@ -369,56 +278,11 @@ namespace hpx {
             {
             }
 
-            friend sync_policy tag_invoke(
-                hpx::execution::experimental::with_priority_t,
-                sync_policy const policy,
-                threads::thread_priority const priority) noexcept
-            {
-                auto policy_with_priority = policy;
-                policy_with_priority.set_priority(priority);
-                return policy_with_priority;
-            }
 
-            friend constexpr hpx::threads::thread_priority tag_invoke(
-                hpx::execution::experimental::get_priority_t,
-                sync_policy const policy) noexcept
-            {
-                return policy.priority();
-            }
 
-            friend sync_policy tag_invoke(
-                hpx::execution::experimental::with_stacksize_t,
-                sync_policy const policy,
-                threads::thread_stacksize const stacksize) noexcept
-            {
-                auto policy_with_stacksize = policy;
-                policy_with_stacksize.set_stacksize(stacksize);
-                return policy_with_stacksize;
-            }
 
-            friend constexpr hpx::threads::thread_stacksize tag_invoke(
-                hpx::execution::experimental::get_stacksize_t,
-                sync_policy const policy) noexcept
-            {
-                return policy.stacksize();
-            }
 
-            friend sync_policy tag_invoke(
-                hpx::execution::experimental::with_hint_t,
-                sync_policy const policy,
-                threads::thread_schedule_hint const hint) noexcept
-            {
-                auto policy_with_hint = policy;
-                policy_with_hint.set_hint(hint);
-                return policy_with_hint;
-            }
 
-            friend constexpr hpx::threads::thread_schedule_hint tag_invoke(
-                hpx::execution::experimental::get_hint_t,
-                sync_policy const policy) noexcept
-            {
-                return policy.hint();
-            }
         };
 
         struct deferred_policy : policy_holder<deferred_policy>
@@ -434,56 +298,11 @@ namespace hpx {
             {
             }
 
-            friend deferred_policy tag_invoke(
-                hpx::execution::experimental::with_priority_t,
-                deferred_policy const policy,
-                threads::thread_priority const priority) noexcept
-            {
-                auto policy_with_priority = policy;
-                policy_with_priority.set_priority(priority);
-                return policy_with_priority;
-            }
 
-            friend constexpr hpx::threads::thread_priority tag_invoke(
-                hpx::execution::experimental::get_priority_t,
-                deferred_policy const policy) noexcept
-            {
-                return policy.priority();
-            }
 
-            friend deferred_policy tag_invoke(
-                hpx::execution::experimental::with_stacksize_t,
-                deferred_policy const policy,
-                threads::thread_stacksize const stacksize) noexcept
-            {
-                auto policy_with_stacksize = policy;
-                policy_with_stacksize.set_stacksize(stacksize);
-                return policy_with_stacksize;
-            }
 
-            friend constexpr hpx::threads::thread_stacksize tag_invoke(
-                hpx::execution::experimental::get_stacksize_t,
-                deferred_policy const policy) noexcept
-            {
-                return policy.stacksize();
-            }
 
-            friend deferred_policy tag_invoke(
-                hpx::execution::experimental::with_hint_t,
-                deferred_policy const policy,
-                threads::thread_schedule_hint const hint) noexcept
-            {
-                auto policy_with_hint = policy;
-                policy_with_hint.set_hint(hint);
-                return policy_with_hint;
-            }
 
-            friend constexpr hpx::threads::thread_schedule_hint tag_invoke(
-                hpx::execution::experimental::get_hint_t,
-                deferred_policy const policy) noexcept
-            {
-                return policy.hint();
-            }
         };
 
         struct apply_policy : policy_holder<apply_policy>
@@ -499,56 +318,11 @@ namespace hpx {
             {
             }
 
-            friend apply_policy tag_invoke(
-                hpx::execution::experimental::with_priority_t,
-                apply_policy const policy,
-                threads::thread_priority const priority) noexcept
-            {
-                auto policy_with_priority = policy;
-                policy_with_priority.set_priority(priority);
-                return policy_with_priority;
-            }
 
-            friend constexpr hpx::threads::thread_priority tag_invoke(
-                hpx::execution::experimental::get_priority_t,
-                apply_policy const policy) noexcept
-            {
-                return policy.priority();
-            }
 
-            friend apply_policy tag_invoke(
-                hpx::execution::experimental::with_stacksize_t,
-                apply_policy const policy,
-                threads::thread_stacksize const stacksize) noexcept
-            {
-                auto policy_with_stacksize = policy;
-                policy_with_stacksize.set_stacksize(stacksize);
-                return policy_with_stacksize;
-            }
 
-            friend constexpr hpx::threads::thread_stacksize tag_invoke(
-                hpx::execution::experimental::get_stacksize_t,
-                apply_policy const policy) noexcept
-            {
-                return policy.stacksize();
-            }
 
-            friend apply_policy tag_invoke(
-                hpx::execution::experimental::with_hint_t,
-                apply_policy const policy,
-                threads::thread_schedule_hint const hint) noexcept
-            {
-                auto policy_with_hint = policy;
-                policy_with_hint.set_hint(hint);
-                return policy_with_hint;
-            }
 
-            friend constexpr hpx::threads::thread_schedule_hint tag_invoke(
-                hpx::execution::experimental::get_hint_t,
-                apply_policy const policy) noexcept
-            {
-                return policy.hint();
-            }
         };
 
         template <typename Pred>
@@ -580,56 +354,11 @@ namespace hpx {
                 return true;
             }
 
-            friend select_policy tag_invoke(
-                hpx::execution::experimental::with_priority_t,
-                select_policy const& policy,
-                threads::thread_priority priority) noexcept
-            {
-                auto policy_with_priority = policy;
-                policy_with_priority.set_priority(priority);
-                return policy_with_priority;
-            }
 
-            friend constexpr hpx::threads::thread_priority tag_invoke(
-                hpx::execution::experimental::get_priority_t,
-                select_policy const& policy) noexcept
-            {
-                return policy.priority();
-            }
 
-            friend select_policy tag_invoke(
-                hpx::execution::experimental::with_stacksize_t,
-                select_policy const& policy,
-                threads::thread_stacksize stacksize) noexcept
-            {
-                auto policy_with_stacksize = policy;
-                policy_with_stacksize.set_stacksize(stacksize);
-                return policy_with_stacksize;
-            }
 
-            friend constexpr hpx::threads::thread_stacksize tag_invoke(
-                hpx::execution::experimental::get_stacksize_t,
-                select_policy const& policy) noexcept
-            {
-                return policy.stacksize();
-            }
 
-            friend select_policy tag_invoke(
-                hpx::execution::experimental::with_hint_t,
-                select_policy const& policy,
-                threads::thread_schedule_hint hint) noexcept
-            {
-                auto policy_with_hint = policy;
-                policy_with_hint.set_hint(hint);
-                return policy_with_hint;
-            }
 
-            friend constexpr hpx::threads::thread_schedule_hint tag_invoke(
-                hpx::execution::experimental::get_hint_t,
-                select_policy const& policy) noexcept
-            {
-                return policy.hint();
-            }
 
         private:
             Pred pred_;
@@ -820,55 +549,6 @@ namespace hpx {
             threads::thread_schedule_hint const hint) noexcept
           : detail::policy_holder<>(l.policy(), priority, stacksize, hint)
         {
-        }
-
-        ///////////////////////////////////////////////////////////////////////
-        friend launch tag_invoke(hpx::execution::experimental::with_priority_t,
-            launch const& policy,
-            threads::thread_priority const priority) noexcept
-        {
-            auto policy_with_priority = policy;
-            policy_with_priority.set_priority(priority);
-            return policy_with_priority;
-        }
-
-        friend constexpr hpx::threads::thread_priority tag_invoke(
-            hpx::execution::experimental::get_priority_t,
-            launch const& policy) noexcept
-        {
-            return policy.priority();
-        }
-
-        friend launch tag_invoke(hpx::execution::experimental::with_stacksize_t,
-            launch const& policy,
-            threads::thread_stacksize const stacksize) noexcept
-        {
-            auto policy_with_stacksize = policy;
-            policy_with_stacksize.set_stacksize(stacksize);
-            return policy_with_stacksize;
-        }
-
-        friend constexpr hpx::threads::thread_stacksize tag_invoke(
-            hpx::execution::experimental::get_stacksize_t,
-            launch const& policy) noexcept
-        {
-            return policy.stacksize();
-        }
-
-        friend launch tag_invoke(hpx::execution::experimental::with_hint_t,
-            launch const& policy,
-            threads::thread_schedule_hint const hint) noexcept
-        {
-            auto policy_with_hint = policy;
-            policy_with_hint.set_hint(hint);
-            return policy_with_hint;
-        }
-
-        friend constexpr hpx::threads::thread_schedule_hint tag_invoke(
-            hpx::execution::experimental::get_hint_t,
-            launch const& policy) noexcept
-        {
-            return policy.hint();
         }
 
         ///////////////////////////////////////////////////////////////////////

--- a/libs/core/async_base/include/hpx/async_base/launch_policy.hpp
+++ b/libs/core/async_base/include/hpx/async_base/launch_policy.hpp
@@ -127,7 +127,7 @@ namespace hpx {
           : policy_holder_base
           , hpx::detail::policy_holder_query<Derived>
         {
-        protected:
+        private:
             constexpr explicit policy_holder(launch_policy const p,
                 threads::thread_priority const priority =
                     threads::thread_priority::default_,
@@ -143,6 +143,24 @@ namespace hpx {
               : policy_holder_base(p)
             {
             }
+
+            friend Derived;
+
+            template <typename D>
+            friend constexpr policy_holder<D> operator~(
+                policy_holder<D> const& p) noexcept;
+
+            template <typename Left, typename Right>
+            friend policy_holder<Left> operator&=(policy_holder<Left>& lhs,
+                policy_holder<Right> const& rhs) noexcept;
+
+            template <typename Left, typename Right>
+            friend policy_holder<Left> operator|=(policy_holder<Left>& lhs,
+                policy_holder<Right> const& rhs) noexcept;
+
+            template <typename Left, typename Right>
+            friend policy_holder<Left> operator^=(policy_holder<Left>& lhs,
+                policy_holder<Right> const& rhs) noexcept;
 
         public:
             constexpr operator launch_policy() const noexcept

--- a/libs/core/async_base/include/hpx/async_base/launch_policy.hpp
+++ b/libs/core/async_base/include/hpx/async_base/launch_policy.hpp
@@ -257,12 +257,6 @@ namespace hpx {
                     launch_policy::fork, priority, stacksize, hint)
             {
             }
-
-
-
-
-
-
         };
 
         struct sync_policy : policy_holder<sync_policy>
@@ -277,12 +271,6 @@ namespace hpx {
                     launch_policy::sync, priority, stacksize, hint)
             {
             }
-
-
-
-
-
-
         };
 
         struct deferred_policy : policy_holder<deferred_policy>
@@ -297,12 +285,6 @@ namespace hpx {
                     launch_policy::deferred, priority, stacksize, hint)
             {
             }
-
-
-
-
-
-
         };
 
         struct apply_policy : policy_holder<apply_policy>
@@ -317,12 +299,6 @@ namespace hpx {
                     launch_policy::apply, priority, stacksize, hint)
             {
             }
-
-
-
-
-
-
         };
 
         template <typename Pred>
@@ -353,12 +329,6 @@ namespace hpx {
             {
                 return true;
             }
-
-
-
-
-
-
 
         private:
             Pred pred_;

--- a/libs/core/async_base/include/hpx/async_base/launch_policy.hpp
+++ b/libs/core/async_base/include/hpx/async_base/launch_policy.hpp
@@ -127,7 +127,7 @@ namespace hpx {
           : policy_holder_base
           , hpx::detail::policy_holder_query<Derived>
         {
-            // NOLINTNEXTLINE(bugprone-crtp-constructor-accessibility)
+        protected:
             constexpr explicit policy_holder(launch_policy const p,
                 threads::thread_priority const priority =
                     threads::thread_priority::default_,
@@ -138,13 +138,13 @@ namespace hpx {
             {
             }
 
-            // NOLINTNEXTLINE(bugprone-crtp-constructor-accessibility)
             constexpr explicit policy_holder(
                 policy_holder_base const p) noexcept
               : policy_holder_base(p)
             {
             }
 
+        public:
             constexpr operator launch_policy() const noexcept
             {
                 return static_cast<Derived const*>(this)->get_policy();
@@ -181,7 +181,7 @@ namespace hpx {
           : policy_holder_base
           , hpx::detail::policy_holder_query<policy_holder<void>>
         {
-            // NOLINTNEXTLINE(bugprone-crtp-constructor-accessibility)
+        public:
             constexpr explicit policy_holder(launch_policy const p,
                 threads::thread_priority const priority =
                     threads::thread_priority::default_,
@@ -192,7 +192,6 @@ namespace hpx {
             {
             }
 
-            // NOLINTNEXTLINE(bugprone-crtp-constructor-accessibility)
             constexpr explicit policy_holder(
                 policy_holder_base const p) noexcept
               : policy_holder_base(p)

--- a/libs/core/async_base/include/hpx/async_base/query_dispatch.hpp
+++ b/libs/core/async_base/include/hpx/async_base/query_dispatch.hpp
@@ -11,7 +11,7 @@
 #include <type_traits>
 #include <utility>
 
-namespace hpx::execution::experimental::detail {
+namespace hpx::execution::experimental {
 
     template <typename Target, typename Tag, typename... Args>
     inline constexpr bool has_query_v =
@@ -23,4 +23,4 @@ namespace hpx::execution::experimental::detail {
     using query_result_t = decltype(std::declval<Target>().query(
         std::declval<Tag>(), std::declval<Args>()...));
 
-}    // namespace hpx::execution::experimental::detail
+}    // namespace hpx::execution::experimental

--- a/libs/core/async_base/include/hpx/async_base/scheduling_properties.hpp
+++ b/libs/core/async_base/include/hpx/async_base/scheduling_properties.hpp
@@ -46,12 +46,12 @@ namespace hpx::execution::experimental {
         {
         private:
             template <typename Target, typename... Args>
-            friend constexpr auto tag_invoke(Tag tag, Target&& target,
-                Args&&... args)
+            friend constexpr auto tag_invoke(
+                Tag tag, Target&& target, Args&&... args)
                 requires(has_query_v<Target, Tag, Args...>)
             {
-                return HPX_FORWARD(Target, target).query(
-                    tag, HPX_FORWARD(Args, args)...);
+                return HPX_FORWARD(Target, target)
+                    .query(tag, HPX_FORWARD(Args, args)...);
             }
 
             // attempt to improve error messages if property is not supported

--- a/libs/core/async_base/include/hpx/async_base/scheduling_properties.hpp
+++ b/libs/core/async_base/include/hpx/async_base/scheduling_properties.hpp
@@ -136,6 +136,7 @@ namespace hpx::execution::experimental {
       : detail::query_first_tag_fallback<get_priority_t,
             detail::get_priority_fallback>
     {
+        constexpr get_priority_t() = default;
     } get_priority{};
 
     template <>
@@ -158,6 +159,7 @@ namespace hpx::execution::experimental {
       : detail::query_first_tag_fallback<get_stacksize_t,
             detail::get_stacksize_fallback>
     {
+        constexpr get_stacksize_t() = default;
     } get_stacksize{};
 
     template <>
@@ -179,6 +181,7 @@ namespace hpx::execution::experimental {
     HPX_CXX_CORE_EXPORT inline constexpr struct get_hint_t final
       : detail::query_first_tag_fallback<get_hint_t, detail::get_hint_fallback>
     {
+        constexpr get_hint_t() = default;
     } get_hint{};
 
     template <>
@@ -201,6 +204,7 @@ namespace hpx::execution::experimental {
       : detail::query_first_tag_fallback<get_annotation_t,
             detail::get_annotation_fallback>
     {
+        constexpr get_annotation_t() = default;
     } get_annotation{};
 
     template <>
@@ -218,6 +222,7 @@ namespace hpx::execution::experimental {
       : detail::query_first_tag_fallback<get_first_core_t,
             detail::get_first_core_fallback>
     {
+        constexpr get_first_core_t() = default;
     } get_first_core{};
 
     template <>

--- a/libs/core/async_base/include/hpx/async_base/scheduling_properties.hpp
+++ b/libs/core/async_base/include/hpx/async_base/scheduling_properties.hpp
@@ -8,8 +8,8 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/async_base/detail/query_dispatch.hpp>
 #include <hpx/async_base/detail/query_first_fallback.hpp>
+#include <hpx/async_base/query_dispatch.hpp>
 #include <hpx/modules/coroutines.hpp>
 #include <hpx/modules/tag_invoke.hpp>
 

--- a/libs/core/async_base/include/hpx/async_base/scheduling_properties.hpp
+++ b/libs/core/async_base/include/hpx/async_base/scheduling_properties.hpp
@@ -8,6 +8,8 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/async_base/detail/query_dispatch.hpp>
+#include <hpx/async_base/detail/query_first_fallback.hpp>
 #include <hpx/modules/coroutines.hpp>
 #include <hpx/modules/tag_invoke.hpp>
 
@@ -43,11 +45,70 @@ namespace hpx::execution::experimental {
         struct property_base : hpx::functional::detail::tag_fallback<Tag>
         {
         private:
+            template <typename Target, typename... Args>
+            friend constexpr auto tag_invoke(Tag tag, Target&& target,
+                Args&&... args)
+                requires(has_query_v<Target, Tag, Args...>)
+            {
+                return HPX_FORWARD(Target, target).query(
+                    tag, HPX_FORWARD(Args, args)...);
+            }
+
             // attempt to improve error messages if property is not supported
             template <typename... Ts>
             friend constexpr auto tag_fallback_invoke(Tag, Ts&&...) noexcept
                 -> decltype(property_not_supported<Tag, Ts...>());
         };
+        struct get_priority_fallback
+        {
+            template <typename Target, typename... Args>
+            HPX_FORCEINLINE constexpr auto operator()(
+                Target&&, Args&&...) const noexcept
+            {
+                return hpx::threads::thread_priority::default_;
+            }
+        };
+
+        struct get_stacksize_fallback
+        {
+            template <typename Target, typename... Args>
+            HPX_FORCEINLINE constexpr auto operator()(
+                Target&&, Args&&...) const noexcept
+            {
+                return hpx::threads::thread_stacksize::default_;
+            }
+        };
+
+        struct get_hint_fallback
+        {
+            template <typename Target, typename... Args>
+            HPX_FORCEINLINE constexpr auto operator()(
+                Target&&, Args&&...) const noexcept
+            {
+                return hpx::threads::thread_schedule_hint{};
+            }
+        };
+
+        struct get_annotation_fallback
+        {
+            template <typename Target, typename... Args>
+            HPX_FORCEINLINE constexpr auto operator()(
+                Target&&, Args&&...) const noexcept
+            {
+                return static_cast<char const*>(nullptr);
+            }
+        };
+
+        struct get_first_core_fallback
+        {
+            template <typename Target, typename... Args>
+            HPX_FORCEINLINE constexpr std::size_t operator()(
+                Target&&, Args&&...) const noexcept
+            {
+                return 0;
+            }
+        };
+
         // NOLINTEND(bugprone-crtp-constructor-accessibility)
     }    // namespace detail
 
@@ -72,16 +133,9 @@ namespace hpx::execution::experimental {
     };
 
     HPX_CXX_CORE_EXPORT inline constexpr struct get_priority_t final
-      : hpx::functional::detail::tag_fallback<get_priority_t>
+      : detail::query_first_tag_fallback<get_priority_t,
+            detail::get_priority_fallback>
     {
-    private:
-        // simply return default_ if get_priority is not supported
-        template <typename Target>
-        friend HPX_FORCEINLINE constexpr hpx::threads::thread_priority
-        tag_fallback_invoke(get_priority_t, Target&&) noexcept
-        {
-            return hpx::threads::thread_priority::default_;
-        }
     } get_priority{};
 
     template <>
@@ -101,16 +155,9 @@ namespace hpx::execution::experimental {
     };
 
     HPX_CXX_CORE_EXPORT inline constexpr struct get_stacksize_t final
-      : hpx::functional::detail::tag_fallback<get_stacksize_t>
+      : detail::query_first_tag_fallback<get_stacksize_t,
+            detail::get_stacksize_fallback>
     {
-    private:
-        // simply return default_ if get_stacksize is not supported
-        template <typename Target>
-        friend HPX_FORCEINLINE constexpr hpx::threads::thread_stacksize
-        tag_fallback_invoke(get_stacksize_t, Target&&) noexcept
-        {
-            return hpx::threads::thread_stacksize::default_;
-        }
     } get_stacksize{};
 
     template <>
@@ -130,16 +177,8 @@ namespace hpx::execution::experimental {
     };
 
     HPX_CXX_CORE_EXPORT inline constexpr struct get_hint_t final
-      : hpx::functional::detail::tag_fallback<get_hint_t>
+      : detail::query_first_tag_fallback<get_hint_t, detail::get_hint_fallback>
     {
-    private:
-        // simply return default constructed hint if get_hint is not supported
-        template <typename Target>
-        friend HPX_FORCEINLINE constexpr hpx::threads::thread_schedule_hint
-        tag_fallback_invoke(get_hint_t, Target&&) noexcept
-        {
-            return {};
-        }
     } get_hint{};
 
     template <>
@@ -159,16 +198,9 @@ namespace hpx::execution::experimental {
     };
 
     HPX_CXX_CORE_EXPORT inline constexpr struct get_annotation_t final
-      : hpx::functional::detail::tag_fallback<get_annotation_t>
+      : detail::query_first_tag_fallback<get_annotation_t,
+            detail::get_annotation_fallback>
     {
-    private:
-        // simply return nullptr if get_annotation is not supported
-        template <typename Target>
-        friend HPX_FORCEINLINE constexpr char const* tag_fallback_invoke(
-            get_annotation_t, Target&&) noexcept
-        {
-            return nullptr;
-        }
     } get_annotation{};
 
     template <>
@@ -183,16 +215,9 @@ namespace hpx::execution::experimental {
     } with_first_core{};
 
     HPX_CXX_CORE_EXPORT inline constexpr struct get_first_core_t final
-      : hpx::functional::detail::tag_fallback<get_first_core_t>
+      : detail::query_first_tag_fallback<get_first_core_t,
+            detail::get_first_core_fallback>
     {
-    private:
-        // simply return nullptr if get_annotation is not supported
-        template <typename Target>
-        friend HPX_FORCEINLINE constexpr std::size_t tag_fallback_invoke(
-            get_first_core_t, Target&&) noexcept
-        {
-            return 0;
-        }
     } get_first_core{};
 
     template <>

--- a/libs/core/execution/include/hpx/execution/algorithms/bulk.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/bulk.hpp
@@ -9,6 +9,7 @@
 
 #include <hpx/config.hpp>
 
+#include <hpx/async_base/detail/query_dispatch.hpp>
 #include <hpx/execution/algorithms/detail/partial_algorithm.hpp>
 #include <hpx/functional/detail/tag_priority_invoke.hpp>
 #include <hpx/modules/concepts.hpp>
@@ -144,21 +145,19 @@ namespace hpx::execution::experimental {
             };
 
             template <typename Receiver>
-            friend auto tag_invoke(
-                connect_t, bulk_sender&& s, Receiver&& receiver)
+            auto connect(Receiver&& receiver) &&
             {
-                return hpx::execution::experimental::connect(HPX_MOVE(s.sender),
+                return hpx::execution::experimental::connect(HPX_MOVE(sender),
                     bulk_receiver<Receiver>(HPX_FORWARD(Receiver, receiver),
-                        HPX_MOVE(s.shape), HPX_MOVE(s.f)));
+                        HPX_MOVE(shape), HPX_MOVE(f)));
             }
 
             template <typename Receiver>
-            friend auto tag_invoke(
-                connect_t, bulk_sender& s, Receiver&& receiver)
+            auto connect(Receiver&& receiver) &
             {
-                return hpx::execution::experimental::connect(s.sender,
+                return hpx::execution::experimental::connect(sender,
                     bulk_receiver<Receiver>(
-                        HPX_FORWARD(Receiver, receiver), s.shape, s.f));
+                        HPX_FORWARD(Receiver, receiver), shape, f));
             }
         };
     }    // namespace detail
@@ -193,6 +192,17 @@ namespace hpx::execution::experimental {
       : hpx::functional::detail::tag_priority<bulk_t>
     {
     private:
+        template <typename Scheduler, typename Sender, typename Shape,
+            typename F>
+        friend constexpr auto tag_invoke(bulk_t tag, Scheduler&& sched,
+            Sender&& sender, Shape const& shape, F&& f)
+            requires detail::has_query_v<Scheduler, bulk_t, Sender, Shape const&,
+                F&&>
+        {
+            return HPX_FORWARD(Scheduler, sched).query(tag,
+                HPX_FORWARD(Sender, sender), shape, HPX_FORWARD(F, f));
+        }
+
         // clang-format off
         template <typename Sender, typename Shape, typename F,
             HPX_CONCEPT_REQUIRES_(
@@ -211,7 +221,7 @@ namespace hpx::execution::experimental {
                     hpx::execution::experimental::set_value_t>(
                     hpx::execution::experimental::get_env(sender));
 
-            return hpx::functional::tag_invoke(bulk_t{}, HPX_MOVE(scheduler),
+            return HPX_FORWARD(decltype(scheduler), scheduler).query(bulk_t{},
                 HPX_FORWARD(Sender, sender), shape, HPX_FORWARD(F, f));
         }
 

--- a/libs/core/execution/include/hpx/execution/algorithms/bulk.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/bulk.hpp
@@ -9,7 +9,7 @@
 
 #include <hpx/config.hpp>
 
-#include <hpx/async_base/detail/query_dispatch.hpp>
+#include <hpx/async_base/query_dispatch.hpp>
 #include <hpx/execution/algorithms/detail/partial_algorithm.hpp>
 #include <hpx/functional/detail/tag_priority_invoke.hpp>
 #include <hpx/modules/concepts.hpp>
@@ -196,7 +196,7 @@ namespace hpx::execution::experimental {
             typename F>
         friend constexpr auto tag_invoke(bulk_t tag, Scheduler&& sched,
             Sender&& sender, Shape const& shape, F&& f)
-            requires detail::has_query_v<Scheduler, bulk_t, Sender,
+            requires has_query_v<Scheduler, bulk_t, Sender,
                 Shape const&, F&&>
         {
             return HPX_FORWARD(Scheduler, sched)

--- a/libs/core/execution/include/hpx/execution/algorithms/bulk.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/bulk.hpp
@@ -196,8 +196,7 @@ namespace hpx::execution::experimental {
             typename F>
         friend constexpr auto tag_invoke(bulk_t tag, Scheduler&& sched,
             Sender&& sender, Shape const& shape, F&& f)
-            requires has_query_v<Scheduler, bulk_t, Sender,
-                Shape const&, F&&>
+            requires has_query_v<Scheduler, bulk_t, Sender, Shape const&, F&&>
         {
             return HPX_FORWARD(Scheduler, sched)
                 .query(

--- a/libs/core/execution/include/hpx/execution/algorithms/bulk.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/bulk.hpp
@@ -196,11 +196,12 @@ namespace hpx::execution::experimental {
             typename F>
         friend constexpr auto tag_invoke(bulk_t tag, Scheduler&& sched,
             Sender&& sender, Shape const& shape, F&& f)
-            requires detail::has_query_v<Scheduler, bulk_t, Sender, Shape const&,
-                F&&>
+            requires detail::has_query_v<Scheduler, bulk_t, Sender,
+                Shape const&, F&&>
         {
-            return HPX_FORWARD(Scheduler, sched).query(tag,
-                HPX_FORWARD(Sender, sender), shape, HPX_FORWARD(F, f));
+            return HPX_FORWARD(Scheduler, sched)
+                .query(
+                    tag, HPX_FORWARD(Sender, sender), shape, HPX_FORWARD(F, f));
         }
 
         // clang-format off
@@ -221,8 +222,9 @@ namespace hpx::execution::experimental {
                     hpx::execution::experimental::set_value_t>(
                     hpx::execution::experimental::get_env(sender));
 
-            return HPX_FORWARD(decltype(scheduler), scheduler).query(bulk_t{},
-                HPX_FORWARD(Sender, sender), shape, HPX_FORWARD(F, f));
+            return HPX_FORWARD(decltype(scheduler), scheduler)
+                .query(bulk_t{}, HPX_FORWARD(Sender, sender), shape,
+                    HPX_FORWARD(F, f));
         }
 
         // clang-format off

--- a/libs/core/execution/include/hpx/execution/algorithms/make_future.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/make_future.hpp
@@ -8,10 +8,10 @@
 #pragma once
 
 #include <hpx/assert.hpp>
+#include <hpx/async_base/detail/query_dispatch.hpp>
 #include <hpx/execution/algorithms/detail/inject_scheduler.hpp>
 #include <hpx/execution/algorithms/detail/partial_algorithm.hpp>
 #include <hpx/execution/algorithms/detail/single_result.hpp>
-#include <hpx/async_base/detail/query_dispatch.hpp>
 #include <hpx/execution/algorithms/run_loop.hpp>
 #include <hpx/execution_base/stdexec_forward.hpp>
 #include <hpx/modules/allocator_support.hpp>
@@ -399,14 +399,13 @@ namespace hpx::execution::experimental {
     private:
         template <typename Scheduler, typename Sender,
             typename Allocator = hpx::util::internal_allocator<>>
-        friend constexpr auto tag_invoke(make_future_t tag,
-            Scheduler&& sched, Sender&& sender,
-            Allocator const& allocator = Allocator{})
+        friend constexpr auto tag_invoke(make_future_t tag, Scheduler&& sched,
+            Sender&& sender, Allocator const& allocator = Allocator{})
             requires(detail::has_query_v<Scheduler, make_future_t, Sender,
                 Allocator const&>)
         {
-            return HPX_FORWARD(Scheduler, sched).query(tag,
-                HPX_FORWARD(Sender, sender), allocator);
+            return HPX_FORWARD(Scheduler, sched)
+                .query(tag, HPX_FORWARD(Sender, sender), allocator);
         }
 
         // clang-format off
@@ -478,8 +477,8 @@ namespace hpx::execution::experimental {
     } make_future{};
 
     template <typename Sender, typename Allocator>
-    auto run_loop::run_loop_scheduler::query(make_future_t, Sender&& sender,
-        Allocator const& allocator) const
+    auto run_loop::run_loop_scheduler::query(
+        make_future_t, Sender&& sender, Allocator const& allocator) const
     {
         return detail::make_future_with_run_loop(
             *this, HPX_FORWARD(Sender, sender), allocator);

--- a/libs/core/execution/include/hpx/execution/algorithms/make_future.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/make_future.hpp
@@ -11,6 +11,7 @@
 #include <hpx/execution/algorithms/detail/inject_scheduler.hpp>
 #include <hpx/execution/algorithms/detail/partial_algorithm.hpp>
 #include <hpx/execution/algorithms/detail/single_result.hpp>
+#include <hpx/async_base/detail/query_dispatch.hpp>
 #include <hpx/execution/algorithms/run_loop.hpp>
 #include <hpx/execution_base/stdexec_forward.hpp>
 #include <hpx/modules/allocator_support.hpp>
@@ -396,6 +397,18 @@ namespace hpx::execution::experimental {
       : hpx::functional::detail::tag_priority<make_future_t>
     {
     private:
+        template <typename Scheduler, typename Sender,
+            typename Allocator = hpx::util::internal_allocator<>>
+        friend constexpr auto tag_invoke(make_future_t tag,
+            Scheduler&& sched, Sender&& sender,
+            Allocator const& allocator = Allocator{})
+            requires(detail::has_query_v<Scheduler, make_future_t, Sender,
+                Allocator const&>)
+        {
+            return HPX_FORWARD(Scheduler, sched).query(tag,
+                HPX_FORWARD(Sender, sender), allocator);
+        }
+
         // clang-format off
         template <typename Sender,
             typename Allocator = hpx::util::internal_allocator<>,
@@ -418,22 +431,6 @@ namespace hpx::execution::experimental {
 
             return hpx::functional::tag_invoke(make_future_t{},
                 HPX_MOVE(scheduler), HPX_FORWARD(Sender, sender), allocator);
-        }
-
-        // clang-format off
-        template <typename Sender,
-            typename Allocator = hpx::util::internal_allocator<>,
-            HPX_CONCEPT_REQUIRES_(
-                hpx::execution::experimental::is_sender_v<Sender>
-            )>
-        // clang-format on
-        friend auto tag_invoke(make_future_t,
-            decltype(std::declval<hpx::execution::experimental::run_loop>()
-                    .get_scheduler()) const& sched,
-            Sender&& sender, Allocator const& allocator = Allocator{})
-        {
-            return detail::make_future_with_run_loop(
-                sched, HPX_FORWARD(Sender, sender), allocator);
         }
 
         // clang-format off
@@ -479,4 +476,12 @@ namespace hpx::execution::experimental {
                 allocator};
         }
     } make_future{};
+
+    template <typename Sender, typename Allocator>
+    auto run_loop::run_loop_scheduler::query(make_future_t, Sender&& sender,
+        Allocator const& allocator) const
+    {
+        return detail::make_future_with_run_loop(
+            *this, HPX_FORWARD(Sender, sender), allocator);
+    }
 }    // namespace hpx::execution::experimental

--- a/libs/core/execution/include/hpx/execution/algorithms/make_future.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/make_future.hpp
@@ -8,7 +8,7 @@
 #pragma once
 
 #include <hpx/assert.hpp>
-#include <hpx/async_base/detail/query_dispatch.hpp>
+#include <hpx/async_base/query_dispatch.hpp>
 #include <hpx/execution/algorithms/detail/inject_scheduler.hpp>
 #include <hpx/execution/algorithms/detail/partial_algorithm.hpp>
 #include <hpx/execution/algorithms/detail/single_result.hpp>
@@ -401,7 +401,7 @@ namespace hpx::execution::experimental {
             typename Allocator = hpx::util::internal_allocator<>>
         friend constexpr auto tag_invoke(make_future_t tag, Scheduler&& sched,
             Sender&& sender, Allocator const& allocator = Allocator{})
-            requires(detail::has_query_v<Scheduler, make_future_t, Sender,
+            requires(has_query_v<Scheduler, make_future_t, Sender,
                 Allocator const&>)
         {
             return HPX_FORWARD(Scheduler, sched)

--- a/libs/core/execution/include/hpx/execution/algorithms/make_future.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/make_future.hpp
@@ -401,8 +401,8 @@ namespace hpx::execution::experimental {
             typename Allocator = hpx::util::internal_allocator<>>
         friend constexpr auto tag_invoke(make_future_t tag, Scheduler&& sched,
             Sender&& sender, Allocator const& allocator = Allocator{})
-            requires(has_query_v<Scheduler, make_future_t, Sender,
-                Allocator const&>)
+            requires(
+                has_query_v<Scheduler, make_future_t, Sender, Allocator const&>)
         {
             return HPX_FORWARD(Scheduler, sched)
                 .query(tag, HPX_FORWARD(Sender, sender), allocator);

--- a/libs/core/execution/include/hpx/execution/algorithms/run_loop.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/run_loop.hpp
@@ -22,6 +22,8 @@
 
 namespace hpx::execution::experimental {
 
+    struct make_future_t;
+
     namespace detail {
 
         HPX_CXX_CORE_EXPORT struct sync_wait_domain;
@@ -161,12 +163,6 @@ namespace hpx::execution::experimental {
             {
             }
 
-            friend void tag_invoke(hpx::execution::experimental::start_t,
-                run_loop_opstate& os) noexcept
-            {
-                os.start();
-            }
-
             void start() & noexcept;
         };
 
@@ -258,6 +254,11 @@ namespace hpx::execution::experimental {
             {
                 return forward_progress_guarantee::parallel;
             }
+
+            template <typename Sender,
+                typename Allocator = hpx::util::internal_allocator<>>
+            [[nodiscard]] auto query(make_future_t, Sender&& sender,
+                Allocator const& allocator = Allocator{}) const;
 
             [[nodiscard]] friend constexpr bool operator==(
                 run_loop_scheduler const& lhs,

--- a/libs/core/execution/include/hpx/execution/algorithms/run_loop.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/run_loop.hpp
@@ -22,7 +22,7 @@
 
 namespace hpx::execution::experimental {
 
-    struct make_future_t;
+    HPX_CXX_CORE_EXPORT struct make_future_t;
 
     namespace detail {
 

--- a/libs/core/execution/include/hpx/execution/algorithms/when_all_vector.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/when_all_vector.hpp
@@ -456,18 +456,16 @@ namespace hpx::when_all_vector_detail {
         };
 
         template <typename Receiver>
-        friend auto tag_invoke(hpx::execution::experimental::connect_t,
-            when_all_vector_sender_type&& s, Receiver&& receiver)
+        operation_state<Receiver> connect(Receiver&& receiver) &&
         {
             return operation_state<Receiver>(
-                HPX_FORWARD(Receiver, receiver), HPX_MOVE(s.senders));
+                HPX_FORWARD(Receiver, receiver), HPX_MOVE(senders));
         }
 
         template <typename Receiver>
-        friend auto tag_invoke(hpx::execution::experimental::connect_t,
-            when_all_vector_sender_type& s, Receiver&& receiver)
+        operation_state<Receiver> connect(Receiver&& receiver) &
         {
-            return operation_state<Receiver>(receiver, s.senders);
+            return operation_state<Receiver>(receiver, senders);
         }
     };    // namespace hpx::when_all_vector_detail
 }    // namespace hpx::when_all_vector_detail

--- a/libs/core/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/async_base/detail/query_dispatch.hpp>
 #include <hpx/execution/traits/executor_traits.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/execution_base.hpp>
@@ -249,6 +250,54 @@ namespace hpx::execution::experimental {
     {
     private:
         template <typename Parameters, typename Executor>
+        friend HPX_FORCEINLINE decltype(auto) tag_invoke(
+            processing_units_count_t tag, Parameters&& params, Executor&& exec,
+            hpx::chrono::steady_duration const& iteration_duration,
+            std::size_t num_tasks) requires(hpx::executor_parameters<Parameters> &&
+            detail::has_query_v<Executor, processing_units_count_t, Parameters,
+                hpx::chrono::steady_duration const&, std::size_t>)
+        {
+            return HPX_FORWARD(Executor, exec).query(tag,
+                HPX_FORWARD(Parameters, params), iteration_duration, num_tasks);
+        }
+
+        template <typename Parameters, typename Executor>
+        friend HPX_FORCEINLINE decltype(auto) tag_invoke(
+            processing_units_count_t tag, Parameters&& params, Executor&& exec,
+            std::size_t num_tasks) requires(hpx::executor_parameters<Parameters> &&
+            detail::has_query_v<Executor, processing_units_count_t, Parameters,
+                hpx::chrono::steady_duration const&, std::size_t>)
+        {
+            return HPX_FORWARD(Executor, exec).query(tag,
+                HPX_FORWARD(Parameters, params), hpx::chrono::null_duration,
+                num_tasks);
+        }
+
+        template <typename Executor>
+        friend HPX_FORCEINLINE decltype(auto) tag_invoke(
+            processing_units_count_t tag, Executor&& exec,
+            hpx::chrono::steady_duration const& iteration_duration,
+            std::size_t num_tasks)
+            requires(detail::has_query_v<Executor, processing_units_count_t,
+                null_parameters_t, hpx::chrono::steady_duration const&,
+                std::size_t>)
+        {
+            return HPX_FORWARD(Executor, exec).query(tag, null_parameters,
+                iteration_duration, num_tasks);
+        }
+
+        template <typename Executor>
+        friend HPX_FORCEINLINE decltype(auto) tag_invoke(
+            processing_units_count_t tag, Executor&& exec, std::size_t num_tasks)
+            requires(detail::has_query_v<Executor, processing_units_count_t,
+                null_parameters_t, hpx::chrono::steady_duration const&,
+                std::size_t>)
+        {
+            return HPX_FORWARD(Executor, exec).query(tag, null_parameters,
+                hpx::chrono::null_duration, num_tasks);
+        }
+
+        template <typename Parameters, typename Executor>
             requires(hpx::executor_parameters<Parameters> &&
                 hpx::executor_any<Executor>)
         friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
@@ -303,6 +352,15 @@ namespace hpx::execution::experimental {
         final
       : hpx::functional::detail::tag_priority<with_processing_units_count_t>
     {
+    private:
+        template <typename Executor>
+        friend decltype(auto) tag_invoke(with_processing_units_count_t tag,
+            Executor&& exec, std::size_t num_cores)
+            requires(detail::has_query_v<Executor,
+                with_processing_units_count_t, std::size_t>)
+        {
+            return HPX_FORWARD(Executor, exec).query(tag, num_cores);
+        }
     } with_processing_units_count{};
 
     /// Mark the begin of a parallel algorithm execution

--- a/libs/core/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
@@ -253,24 +253,29 @@ namespace hpx::execution::experimental {
         friend HPX_FORCEINLINE decltype(auto) tag_invoke(
             processing_units_count_t tag, Parameters&& params, Executor&& exec,
             hpx::chrono::steady_duration const& iteration_duration,
-            std::size_t num_tasks) requires(hpx::executor_parameters<Parameters> &&
-            detail::has_query_v<Executor, processing_units_count_t, Parameters,
-                hpx::chrono::steady_duration const&, std::size_t>)
+            std::size_t num_tasks)
+            requires(hpx::executor_parameters<Parameters> &&
+                detail::has_query_v<Executor, processing_units_count_t,
+                    Parameters, hpx::chrono::steady_duration const&,
+                    std::size_t>)
         {
-            return HPX_FORWARD(Executor, exec).query(tag,
-                HPX_FORWARD(Parameters, params), iteration_duration, num_tasks);
+            return HPX_FORWARD(Executor, exec)
+                .query(tag, HPX_FORWARD(Parameters, params), iteration_duration,
+                    num_tasks);
         }
 
         template <typename Parameters, typename Executor>
         friend HPX_FORCEINLINE decltype(auto) tag_invoke(
             processing_units_count_t tag, Parameters&& params, Executor&& exec,
-            std::size_t num_tasks) requires(hpx::executor_parameters<Parameters> &&
-            detail::has_query_v<Executor, processing_units_count_t, Parameters,
-                hpx::chrono::steady_duration const&, std::size_t>)
+            std::size_t num_tasks)
+            requires(hpx::executor_parameters<Parameters> &&
+                detail::has_query_v<Executor, processing_units_count_t,
+                    Parameters, hpx::chrono::steady_duration const&,
+                    std::size_t>)
         {
-            return HPX_FORWARD(Executor, exec).query(tag,
-                HPX_FORWARD(Parameters, params), hpx::chrono::null_duration,
-                num_tasks);
+            return HPX_FORWARD(Executor, exec)
+                .query(tag, HPX_FORWARD(Parameters, params),
+                    hpx::chrono::null_duration, num_tasks);
         }
 
         template <typename Executor>
@@ -282,19 +287,21 @@ namespace hpx::execution::experimental {
                 null_parameters_t, hpx::chrono::steady_duration const&,
                 std::size_t>)
         {
-            return HPX_FORWARD(Executor, exec).query(tag, null_parameters,
-                iteration_duration, num_tasks);
+            return HPX_FORWARD(Executor, exec)
+                .query(tag, null_parameters, iteration_duration, num_tasks);
         }
 
         template <typename Executor>
         friend HPX_FORCEINLINE decltype(auto) tag_invoke(
-            processing_units_count_t tag, Executor&& exec, std::size_t num_tasks)
+            processing_units_count_t tag, Executor&& exec,
+            std::size_t num_tasks)
             requires(detail::has_query_v<Executor, processing_units_count_t,
                 null_parameters_t, hpx::chrono::steady_duration const&,
                 std::size_t>)
         {
-            return HPX_FORWARD(Executor, exec).query(tag, null_parameters,
-                hpx::chrono::null_duration, num_tasks);
+            return HPX_FORWARD(Executor, exec)
+                .query(tag, null_parameters, hpx::chrono::null_duration,
+                    num_tasks);
         }
 
         template <typename Parameters, typename Executor>

--- a/libs/core/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
@@ -255,9 +255,8 @@ namespace hpx::execution::experimental {
             hpx::chrono::steady_duration const& iteration_duration,
             std::size_t num_tasks)
             requires(hpx::executor_parameters<Parameters> &&
-                has_query_v<Executor, processing_units_count_t,
-                    Parameters, hpx::chrono::steady_duration const&,
-                    std::size_t>)
+                has_query_v<Executor, processing_units_count_t, Parameters,
+                    hpx::chrono::steady_duration const&, std::size_t>)
         {
             return HPX_FORWARD(Executor, exec)
                 .query(tag, HPX_FORWARD(Parameters, params), iteration_duration,
@@ -269,9 +268,8 @@ namespace hpx::execution::experimental {
             processing_units_count_t tag, Parameters&& params, Executor&& exec,
             std::size_t num_tasks)
             requires(hpx::executor_parameters<Parameters> &&
-                has_query_v<Executor, processing_units_count_t,
-                    Parameters, hpx::chrono::steady_duration const&,
-                    std::size_t>)
+                has_query_v<Executor, processing_units_count_t, Parameters,
+                    hpx::chrono::steady_duration const&, std::size_t>)
         {
             return HPX_FORWARD(Executor, exec)
                 .query(tag, HPX_FORWARD(Parameters, params),
@@ -363,8 +361,8 @@ namespace hpx::execution::experimental {
         template <typename Executor>
         friend decltype(auto) tag_invoke(with_processing_units_count_t tag,
             Executor&& exec, std::size_t num_cores)
-            requires(has_query_v<Executor,
-                with_processing_units_count_t, std::size_t>)
+            requires(has_query_v<Executor, with_processing_units_count_t,
+                std::size_t>)
         {
             return HPX_FORWARD(Executor, exec).query(tag, num_cores);
         }
@@ -373,8 +371,7 @@ namespace hpx::execution::experimental {
         friend decltype(auto) tag_invoke(with_processing_units_count_t tag,
             Policy&& policy, Property&& property)
             requires(hpx::is_execution_policy_v<std::decay_t<Policy>> &&
-                has_query_v<Policy, with_processing_units_count_t,
-                    Property>)
+                has_query_v<Policy, with_processing_units_count_t, Property>)
         {
             return HPX_FORWARD(Policy, policy)
                 .query(tag, HPX_FORWARD(Property, property));

--- a/libs/core/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
@@ -7,7 +7,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/async_base/detail/query_dispatch.hpp>
+#include <hpx/async_base/query_dispatch.hpp>
 #include <hpx/execution/traits/executor_traits.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/execution_base.hpp>
@@ -255,7 +255,7 @@ namespace hpx::execution::experimental {
             hpx::chrono::steady_duration const& iteration_duration,
             std::size_t num_tasks)
             requires(hpx::executor_parameters<Parameters> &&
-                detail::has_query_v<Executor, processing_units_count_t,
+                has_query_v<Executor, processing_units_count_t,
                     Parameters, hpx::chrono::steady_duration const&,
                     std::size_t>)
         {
@@ -269,7 +269,7 @@ namespace hpx::execution::experimental {
             processing_units_count_t tag, Parameters&& params, Executor&& exec,
             std::size_t num_tasks)
             requires(hpx::executor_parameters<Parameters> &&
-                detail::has_query_v<Executor, processing_units_count_t,
+                has_query_v<Executor, processing_units_count_t,
                     Parameters, hpx::chrono::steady_duration const&,
                     std::size_t>)
         {
@@ -283,7 +283,7 @@ namespace hpx::execution::experimental {
             processing_units_count_t tag, Executor&& exec,
             hpx::chrono::steady_duration const& iteration_duration,
             std::size_t num_tasks)
-            requires(detail::has_query_v<Executor, processing_units_count_t,
+            requires(has_query_v<Executor, processing_units_count_t,
                 null_parameters_t, hpx::chrono::steady_duration const&,
                 std::size_t>)
         {
@@ -295,7 +295,7 @@ namespace hpx::execution::experimental {
         friend HPX_FORCEINLINE decltype(auto) tag_invoke(
             processing_units_count_t tag, Executor&& exec,
             std::size_t num_tasks)
-            requires(detail::has_query_v<Executor, processing_units_count_t,
+            requires(has_query_v<Executor, processing_units_count_t,
                 null_parameters_t, hpx::chrono::steady_duration const&,
                 std::size_t>)
         {
@@ -363,7 +363,7 @@ namespace hpx::execution::experimental {
         template <typename Executor>
         friend decltype(auto) tag_invoke(with_processing_units_count_t tag,
             Executor&& exec, std::size_t num_cores)
-            requires(detail::has_query_v<Executor,
+            requires(has_query_v<Executor,
                 with_processing_units_count_t, std::size_t>)
         {
             return HPX_FORWARD(Executor, exec).query(tag, num_cores);
@@ -373,7 +373,7 @@ namespace hpx::execution::experimental {
         friend decltype(auto) tag_invoke(with_processing_units_count_t tag,
             Policy&& policy, Property&& property)
             requires(hpx::is_execution_policy_v<std::decay_t<Policy>> &&
-                detail::has_query_v<Policy, with_processing_units_count_t,
+                has_query_v<Policy, with_processing_units_count_t,
                     Property>)
         {
             return HPX_FORWARD(Policy, policy)

--- a/libs/core/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
@@ -368,6 +368,17 @@ namespace hpx::execution::experimental {
         {
             return HPX_FORWARD(Executor, exec).query(tag, num_cores);
         }
+
+        template <typename Policy, typename Property>
+        friend decltype(auto) tag_invoke(with_processing_units_count_t tag,
+            Policy&& policy, Property&& property)
+            requires(hpx::is_execution_policy_v<std::decay_t<Policy>> &&
+                detail::has_query_v<Policy, with_processing_units_count_t,
+                    Property>)
+        {
+            return HPX_FORWARD(Policy, policy)
+                .query(tag, HPX_FORWARD(Property, property));
+        }
     } with_processing_units_count{};
 
     /// Mark the begin of a parallel algorithm execution

--- a/libs/core/execution_base/CMakeLists.txt
+++ b/libs/core/execution_base/CMakeLists.txt
@@ -14,6 +14,7 @@ set(execution_base_headers
     hpx/execution_base/completion_signatures.hpp
     hpx/execution_base/context_base.hpp
     hpx/execution_base/coroutine_utils.hpp
+    hpx/execution_base/detail/execution_member_detect.hpp
     hpx/execution_base/detail/spinlock_deadlock_detection.hpp
     hpx/execution_base/execution.hpp
     hpx/execution_base/get_env.hpp

--- a/libs/core/execution_base/include/hpx/execution_base/detail/execution_member_detect.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/detail/execution_member_detect.hpp
@@ -20,55 +20,72 @@ namespace hpx::parallel::execution::detail {
     template <typename Executor, typename F, typename... Ts>
     concept has_sync_execute_member =
         requires(Executor&& exec, F&& f, Ts&&... ts) {
-            HPX_FORWARD(Executor, exec).sync_execute(
-                HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+            HPX_FORWARD(Executor, exec)
+                .sync_execute(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         };
 
     template <typename Executor, typename F, typename... Ts>
     concept has_async_execute_member =
         requires(Executor&& exec, F&& f, Ts&&... ts) {
-            HPX_FORWARD(Executor, exec).async_execute(
-                HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+            HPX_FORWARD(Executor, exec)
+                .async_execute(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         };
 
     template <typename Executor, typename F, typename Future, typename... Ts>
     concept has_then_execute_member =
         requires(Executor&& exec, F&& f, Future&& pred, Ts&&... ts) {
-            HPX_FORWARD(Executor, exec).then_execute(HPX_FORWARD(F, f),
-                HPX_FORWARD(Future, pred), HPX_FORWARD(Ts, ts)...);
+            HPX_FORWARD(Executor, exec)
+                .then_execute(HPX_FORWARD(F, f), HPX_FORWARD(Future, pred),
+                    HPX_FORWARD(Ts, ts)...);
         };
 
     template <typename Executor, typename F, typename... Ts>
     concept has_post_member = requires(Executor&& exec, F&& f, Ts&&... ts) {
-        HPX_FORWARD(Executor, exec).post(
-            HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+        HPX_FORWARD(Executor, exec)
+            .post(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
     };
 
     template <typename Executor, typename F, typename Shape, typename... Ts>
     concept has_bulk_sync_execute_member =
         requires(Executor&& exec, F&& f, Shape const& shape, Ts&&... ts) {
-            HPX_FORWARD(Executor, exec).bulk_sync_execute(
-                HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...);
+            HPX_FORWARD(Executor, exec)
+                .bulk_sync_execute(
+                    HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...);
         };
 
     template <typename Executor, typename F, typename Shape, typename... Ts>
     concept has_bulk_async_execute_member =
         requires(Executor&& exec, F&& f, Shape const& shape, Ts&&... ts) {
-            HPX_FORWARD(Executor, exec).bulk_async_execute(
-                HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...);
+            HPX_FORWARD(Executor, exec)
+                .bulk_async_execute(
+                    HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...);
         };
 
     template <typename Executor, typename F, typename Shape, typename Future,
         typename... Ts>
     concept has_bulk_then_execute_member = requires(
         Executor&& exec, F&& f, Shape const& shape, Future&& pred, Ts&&... ts) {
-        HPX_FORWARD(Executor, exec).bulk_then_execute(HPX_FORWARD(F, f), shape,
-            HPX_FORWARD(Future, pred), HPX_FORWARD(Ts, ts)...);
+        HPX_FORWARD(Executor, exec)
+            .bulk_then_execute(HPX_FORWARD(F, f), shape,
+                HPX_FORWARD(Future, pred), HPX_FORWARD(Ts, ts)...);
     };
 
     template <typename Executor>
-    concept has_to_non_par_member = requires(Executor const& exec) {
-        exec.to_non_par();
-    };
+    concept has_to_non_par_member =
+        requires(Executor const& exec) { exec.to_non_par(); };
+
+    template <typename Executor, typename F, typename... Fs>
+    concept has_async_invoke_member =
+        requires(Executor&& exec, F&& f, Fs&&... fs) {
+            HPX_FORWARD(Executor, exec)
+                .async_invoke(HPX_FORWARD(F, f), HPX_FORWARD(Fs, fs)...);
+        };
+
+    template <typename Executor, typename F, typename... Fs>
+    concept has_sync_invoke_member =
+        requires(Executor&& exec, F&& f, Fs&&... fs) {
+            HPX_FORWARD(Executor, exec)
+                .sync_invoke(HPX_FORWARD(F, f), HPX_FORWARD(Fs, fs)...);
+        };
 
 }    // namespace hpx::parallel::execution::detail

--- a/libs/core/execution_base/include/hpx/execution_base/detail/execution_member_detect.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/detail/execution_member_detect.hpp
@@ -1,0 +1,74 @@
+//  Copyright (c) 2026 The STE||AR-Group
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#include <type_traits>
+#include <utility>
+
+namespace hpx::parallel::execution::detail {
+
+    // Detection concepts for executor member functions.
+    // These enable the CPO bridges in execution.hpp to forward
+    // to member functions instead of requiring friend tag_invoke.
+
+    template <typename Executor, typename F, typename... Ts>
+    concept has_sync_execute_member =
+        requires(Executor&& exec, F&& f, Ts&&... ts) {
+            HPX_FORWARD(Executor, exec).sync_execute(
+                HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+        };
+
+    template <typename Executor, typename F, typename... Ts>
+    concept has_async_execute_member =
+        requires(Executor&& exec, F&& f, Ts&&... ts) {
+            HPX_FORWARD(Executor, exec).async_execute(
+                HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+        };
+
+    template <typename Executor, typename F, typename Future, typename... Ts>
+    concept has_then_execute_member =
+        requires(Executor&& exec, F&& f, Future&& pred, Ts&&... ts) {
+            HPX_FORWARD(Executor, exec).then_execute(HPX_FORWARD(F, f),
+                HPX_FORWARD(Future, pred), HPX_FORWARD(Ts, ts)...);
+        };
+
+    template <typename Executor, typename F, typename... Ts>
+    concept has_post_member = requires(Executor&& exec, F&& f, Ts&&... ts) {
+        HPX_FORWARD(Executor, exec).post(
+            HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+    };
+
+    template <typename Executor, typename F, typename Shape, typename... Ts>
+    concept has_bulk_sync_execute_member =
+        requires(Executor&& exec, F&& f, Shape const& shape, Ts&&... ts) {
+            HPX_FORWARD(Executor, exec).bulk_sync_execute(
+                HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...);
+        };
+
+    template <typename Executor, typename F, typename Shape, typename... Ts>
+    concept has_bulk_async_execute_member =
+        requires(Executor&& exec, F&& f, Shape const& shape, Ts&&... ts) {
+            HPX_FORWARD(Executor, exec).bulk_async_execute(
+                HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...);
+        };
+
+    template <typename Executor, typename F, typename Shape, typename Future,
+        typename... Ts>
+    concept has_bulk_then_execute_member = requires(
+        Executor&& exec, F&& f, Shape const& shape, Future&& pred, Ts&&... ts) {
+        HPX_FORWARD(Executor, exec).bulk_then_execute(HPX_FORWARD(F, f), shape,
+            HPX_FORWARD(Future, pred), HPX_FORWARD(Ts, ts)...);
+    };
+
+    template <typename Executor>
+    concept has_to_non_par_member = requires(Executor const& exec) {
+        exec.to_non_par();
+    };
+
+}    // namespace hpx::parallel::execution::detail

--- a/libs/core/execution_base/include/hpx/execution_base/execution.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/execution.hpp
@@ -117,8 +117,8 @@ namespace hpx::parallel::execution {
         friend HPX_FORCEINLINE decltype(auto) tag_invoke(
             sync_execute_t, Executor&& exec, F&& f, Ts&&... ts)
         {
-            return HPX_FORWARD(Executor, exec).sync_execute(
-                HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+            return HPX_FORWARD(Executor, exec)
+                .sync_execute(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
 
         template <executor_any Executor, typename F, typename... Ts>
@@ -170,8 +170,8 @@ namespace hpx::parallel::execution {
         friend HPX_FORCEINLINE decltype(auto) tag_invoke(
             async_execute_t, Executor&& exec, F&& f, Ts&&... ts)
         {
-            return HPX_FORWARD(Executor, exec).async_execute(
-                HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+            return HPX_FORWARD(Executor, exec)
+                .async_execute(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
 
         template <executor_any Executor, typename F, typename... Ts>
@@ -214,13 +214,12 @@ namespace hpx::parallel::execution {
             typename... Ts>
             requires(
                 detail::has_then_execute_member<Executor, F, Future, Ts...>)
-        friend HPX_FORCEINLINE decltype(auto) tag_invoke(
-            then_execute_t, Executor&& exec, F&& f, Future&& predecessor,
-            Ts&&... ts)
+        friend HPX_FORCEINLINE decltype(auto) tag_invoke(then_execute_t,
+            Executor&& exec, F&& f, Future&& predecessor, Ts&&... ts)
         {
-            return HPX_FORWARD(Executor, exec).then_execute(
-                HPX_FORWARD(F, f), HPX_FORWARD(Future, predecessor),
-                HPX_FORWARD(Ts, ts)...);
+            return HPX_FORWARD(Executor, exec)
+                .then_execute(HPX_FORWARD(F, f),
+                    HPX_FORWARD(Future, predecessor), HPX_FORWARD(Ts, ts)...);
         }
 
         template <executor_any Executor, typename F, typename Future,
@@ -267,8 +266,8 @@ namespace hpx::parallel::execution {
         friend HPX_FORCEINLINE decltype(auto) tag_invoke(
             post_t, Executor&& exec, F&& f, Ts&&... ts)
         {
-            return HPX_FORWARD(Executor, exec).post(
-                HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+            return HPX_FORWARD(Executor, exec)
+                .post(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
 
         template <executor_any Executor, typename F, typename... Ts>
@@ -326,17 +325,15 @@ namespace hpx::parallel::execution {
     {
     private:
         // Bridge: forward to member function if available
-        template <typename Executor, typename F, typename Shape,
-            typename... Ts>
+        template <typename Executor, typename F, typename Shape, typename... Ts>
             requires(!std::integral<Shape> &&
-                detail::has_bulk_sync_execute_member<Executor, F, Shape,
-                    Ts...>)
-        friend HPX_FORCEINLINE decltype(auto) tag_invoke(
-            bulk_sync_execute_t, Executor&& exec, F&& f, Shape const& shape,
-            Ts&&... ts)
+                detail::has_bulk_sync_execute_member<Executor, F, Shape, Ts...>)
+        friend HPX_FORCEINLINE decltype(auto) tag_invoke(bulk_sync_execute_t,
+            Executor&& exec, F&& f, Shape const& shape, Ts&&... ts)
         {
-            return HPX_FORWARD(Executor, exec).bulk_sync_execute(
-                HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...);
+            return HPX_FORWARD(Executor, exec)
+                .bulk_sync_execute(
+                    HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...);
         }
 
         template <executor_any Executor, typename F, typename Shape,
@@ -401,17 +398,16 @@ namespace hpx::parallel::execution {
     {
     private:
         // Bridge: forward to member function if available
-        template <typename Executor, typename F, typename Shape,
-            typename... Ts>
+        template <typename Executor, typename F, typename Shape, typename... Ts>
             requires(!std::integral<Shape> &&
                 detail::has_bulk_async_execute_member<Executor, F, Shape,
                     Ts...>)
-        friend HPX_FORCEINLINE decltype(auto) tag_invoke(
-            bulk_async_execute_t, Executor&& exec, F&& f, Shape const& shape,
-            Ts&&... ts)
+        friend HPX_FORCEINLINE decltype(auto) tag_invoke(bulk_async_execute_t,
+            Executor&& exec, F&& f, Shape const& shape, Ts&&... ts)
         {
-            return HPX_FORWARD(Executor, exec).bulk_async_execute(
-                HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...);
+            return HPX_FORWARD(Executor, exec)
+                .bulk_async_execute(
+                    HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...);
         }
 
         template <executor_any Executor, typename F, typename Shape,
@@ -483,15 +479,15 @@ namespace hpx::parallel::execution {
         template <typename Executor, typename F, typename Shape,
             typename Future, typename... Ts>
             requires(!std::integral<Shape> &&
-                detail::has_bulk_then_execute_member<Executor, F, Shape,
-                    Future, Ts...>)
-        friend HPX_FORCEINLINE decltype(auto) tag_invoke(
-            bulk_then_execute_t, Executor&& exec, F&& f, Shape const& shape,
-            Future&& predecessor, Ts&&... ts)
+                detail::has_bulk_then_execute_member<Executor, F, Shape, Future,
+                    Ts...>)
+        friend HPX_FORCEINLINE decltype(auto) tag_invoke(bulk_then_execute_t,
+            Executor&& exec, F&& f, Shape const& shape, Future&& predecessor,
+            Ts&&... ts)
         {
-            return HPX_FORWARD(Executor, exec).bulk_then_execute(
-                HPX_FORWARD(F, f), shape, HPX_FORWARD(Future, predecessor),
-                HPX_FORWARD(Ts, ts)...);
+            return HPX_FORWARD(Executor, exec)
+                .bulk_then_execute(HPX_FORWARD(F, f), shape,
+                    HPX_FORWARD(Future, predecessor), HPX_FORWARD(Ts, ts)...);
         }
 
         template <executor_any Executor, typename F, typename Shape,
@@ -546,6 +542,16 @@ namespace hpx::parallel::execution {
       : hpx::functional::detail::tag_fallback<async_invoke_t>
     {
     private:
+        // Bridge: forward to member function if available
+        template <typename Executor, typename F, typename... Fs>
+            requires(detail::has_async_invoke_member<Executor, F, Fs...>)
+        friend HPX_FORCEINLINE decltype(auto) tag_invoke(
+            async_invoke_t, Executor&& exec, F&& f, Fs&&... fs)
+        {
+            return HPX_FORWARD(Executor, exec)
+                .async_invoke(HPX_FORWARD(F, f), HPX_FORWARD(Fs, fs)...);
+        }
+
         template <executor_any Executor, typename F, typename... Fs>
             requires(std::invocable<F> && (std::invocable<Fs> && ...))
         friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
@@ -582,6 +588,16 @@ namespace hpx::parallel::execution {
       : hpx::functional::detail::tag_fallback<sync_invoke_t>
     {
     private:
+        // Bridge: forward to member function if available
+        template <typename Executor, typename F, typename... Fs>
+            requires(detail::has_sync_invoke_member<Executor, F, Fs...>)
+        friend HPX_FORCEINLINE decltype(auto) tag_invoke(
+            sync_invoke_t, Executor&& exec, F&& f, Fs&&... fs)
+        {
+            return HPX_FORWARD(Executor, exec)
+                .sync_invoke(HPX_FORWARD(F, f), HPX_FORWARD(Fs, fs)...);
+        }
+
         template <executor_any Executor, typename F, typename... Fs>
             requires(std::invocable<F> && (std::invocable<Fs> && ...))
         friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(

--- a/libs/core/execution_base/include/hpx/execution_base/execution.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/execution.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/execution_base/detail/execution_member_detect.hpp>
 #include <hpx/execution_base/traits/is_executor.hpp>
 #include <hpx/modules/iterator_support.hpp>
 #include <hpx/modules/tag_invoke.hpp>
@@ -110,6 +111,16 @@ namespace hpx::parallel::execution {
       : hpx::functional::detail::tag_fallback<sync_execute_t>
     {
     private:
+        // Bridge: forward to member function if available
+        template <typename Executor, typename F, typename... Ts>
+            requires(detail::has_sync_execute_member<Executor, F, Ts...>)
+        friend HPX_FORCEINLINE decltype(auto) tag_invoke(
+            sync_execute_t, Executor&& exec, F&& f, Ts&&... ts)
+        {
+            return HPX_FORWARD(Executor, exec).sync_execute(
+                HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+        }
+
         template <executor_any Executor, typename F, typename... Ts>
             requires(std::invocable<F &&, Ts && ...>)
         friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
@@ -153,6 +164,16 @@ namespace hpx::parallel::execution {
       : hpx::functional::detail::tag_fallback<async_execute_t>
     {
     private:
+        // Bridge: forward to member function if available
+        template <typename Executor, typename F, typename... Ts>
+            requires(detail::has_async_execute_member<Executor, F, Ts...>)
+        friend HPX_FORCEINLINE decltype(auto) tag_invoke(
+            async_execute_t, Executor&& exec, F&& f, Ts&&... ts)
+        {
+            return HPX_FORWARD(Executor, exec).async_execute(
+                HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+        }
+
         template <executor_any Executor, typename F, typename... Ts>
             requires(std::invocable<F &&, Ts && ...>)
         friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
@@ -188,6 +209,20 @@ namespace hpx::parallel::execution {
       : hpx::functional::detail::tag_fallback<then_execute_t>
     {
     private:
+        // Bridge: forward to member function if available
+        template <typename Executor, typename F, typename Future,
+            typename... Ts>
+            requires(
+                detail::has_then_execute_member<Executor, F, Future, Ts...>)
+        friend HPX_FORCEINLINE decltype(auto) tag_invoke(
+            then_execute_t, Executor&& exec, F&& f, Future&& predecessor,
+            Ts&&... ts)
+        {
+            return HPX_FORWARD(Executor, exec).then_execute(
+                HPX_FORWARD(F, f), HPX_FORWARD(Future, predecessor),
+                HPX_FORWARD(Ts, ts)...);
+        }
+
         template <executor_any Executor, typename F, typename Future,
             typename... Ts>
             requires(std::invocable<F &&, Future &&, Ts && ...>)
@@ -226,6 +261,16 @@ namespace hpx::parallel::execution {
       : hpx::functional::detail::tag_fallback<post_t>
     {
     private:
+        // Bridge: forward to member function if available
+        template <typename Executor, typename F, typename... Ts>
+            requires(detail::has_post_member<Executor, F, Ts...>)
+        friend HPX_FORCEINLINE decltype(auto) tag_invoke(
+            post_t, Executor&& exec, F&& f, Ts&&... ts)
+        {
+            return HPX_FORWARD(Executor, exec).post(
+                HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+        }
+
         template <executor_any Executor, typename F, typename... Ts>
             requires(std::invocable<F &&, Ts && ...>)
         friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
@@ -280,6 +325,20 @@ namespace hpx::parallel::execution {
       : hpx::functional::detail::tag_fallback<bulk_sync_execute_t>
     {
     private:
+        // Bridge: forward to member function if available
+        template <typename Executor, typename F, typename Shape,
+            typename... Ts>
+            requires(!std::integral<Shape> &&
+                detail::has_bulk_sync_execute_member<Executor, F, Shape,
+                    Ts...>)
+        friend HPX_FORCEINLINE decltype(auto) tag_invoke(
+            bulk_sync_execute_t, Executor&& exec, F&& f, Shape const& shape,
+            Ts&&... ts)
+        {
+            return HPX_FORWARD(Executor, exec).bulk_sync_execute(
+                HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...);
+        }
+
         template <executor_any Executor, typename F, typename Shape,
             typename... Ts>
             requires(!std::integral<Shape>)
@@ -341,6 +400,20 @@ namespace hpx::parallel::execution {
       : hpx::functional::detail::tag_fallback<bulk_async_execute_t>
     {
     private:
+        // Bridge: forward to member function if available
+        template <typename Executor, typename F, typename Shape,
+            typename... Ts>
+            requires(!std::integral<Shape> &&
+                detail::has_bulk_async_execute_member<Executor, F, Shape,
+                    Ts...>)
+        friend HPX_FORCEINLINE decltype(auto) tag_invoke(
+            bulk_async_execute_t, Executor&& exec, F&& f, Shape const& shape,
+            Ts&&... ts)
+        {
+            return HPX_FORWARD(Executor, exec).bulk_async_execute(
+                HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...);
+        }
+
         template <executor_any Executor, typename F, typename Shape,
             typename... Ts>
             requires(!std::integral<Shape>)
@@ -406,6 +479,21 @@ namespace hpx::parallel::execution {
       : hpx::functional::detail::tag_fallback<bulk_then_execute_t>
     {
     private:
+        // Bridge: forward to member function if available
+        template <typename Executor, typename F, typename Shape,
+            typename Future, typename... Ts>
+            requires(!std::integral<Shape> &&
+                detail::has_bulk_then_execute_member<Executor, F, Shape,
+                    Future, Ts...>)
+        friend HPX_FORCEINLINE decltype(auto) tag_invoke(
+            bulk_then_execute_t, Executor&& exec, F&& f, Shape const& shape,
+            Future&& predecessor, Ts&&... ts)
+        {
+            return HPX_FORWARD(Executor, exec).bulk_then_execute(
+                HPX_FORWARD(F, f), shape, HPX_FORWARD(Future, predecessor),
+                HPX_FORWARD(Ts, ts)...);
+        }
+
         template <executor_any Executor, typename F, typename Shape,
             typename Future, typename... Ts>
             requires(!std::integral<Shape>)

--- a/libs/core/executors/CMakeLists.txt
+++ b/libs/core/executors/CMakeLists.txt
@@ -51,7 +51,10 @@ set(executors_macro_headers hpx/executors/macros.hpp)
 
 if(HPX_WITH_DATAPAR)
   set(executors_headers
-      ${executors_headers} hpx/executors/datapar/execution_policy_fwd.hpp
+      ${executors_headers}
+      hpx/executors/datapar/detail/execution_policy_mapping_members.hpp
+      hpx/executors/datapar/detail/execution_policy_mapping_members_impl.hpp
+      hpx/executors/datapar/execution_policy_fwd.hpp
       hpx/executors/datapar/execution_policy_mappings.hpp
       hpx/executors/datapar/execution_policy.hpp
   )

--- a/libs/core/executors/include/hpx/executors/annotating_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/annotating_executor.hpp
@@ -114,85 +114,72 @@ namespace hpx::execution::experimental {
             return exec_.query(tag);
         }
 
-    private:
         // NonBlockingOneWayExecutor interface
         template <typename F, typename... Ts>
             requires(std::invocable<F, Ts...>)
-        friend decltype(auto) tag_invoke(hpx::parallel::execution::post_t,
-            annotating_executor const& exec, F&& f, Ts&&... ts)
+        decltype(auto) post(F&& f, Ts&&... ts) const
         {
-            return parallel::execution::post(exec.exec_,
-                hpx::annotated_function(HPX_FORWARD(F, f), exec.annotation_),
+            return parallel::execution::post(exec_,
+                hpx::annotated_function(HPX_FORWARD(F, f), annotation_),
                 HPX_FORWARD(Ts, ts)...);
         }
 
         // OneWayExecutor interface
         template <typename F, typename... Ts>
             requires(std::invocable<F, Ts...>)
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::sync_execute_t,
-            annotating_executor const& exec, F&& f, Ts&&... ts)
+        decltype(auto) sync_execute(F&& f, Ts&&... ts) const
         {
-            return parallel::execution::sync_execute(exec.exec_,
-                hpx::annotated_function(HPX_FORWARD(F, f), exec.annotation_),
+            return parallel::execution::sync_execute(exec_,
+                hpx::annotated_function(HPX_FORWARD(F, f), annotation_),
                 HPX_FORWARD(Ts, ts)...);
         }
 
         // TwoWayExecutor interface
         template <typename F, typename... Ts>
             requires(std::invocable<F, Ts...>)
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::async_execute_t,
-            annotating_executor const& exec, F&& f, Ts&&... ts)
+        decltype(auto) async_execute(F&& f, Ts&&... ts) const
         {
-            return parallel::execution::async_execute(exec.exec_,
-                hpx::annotated_function(HPX_FORWARD(F, f), exec.annotation_),
+            return parallel::execution::async_execute(exec_,
+                hpx::annotated_function(HPX_FORWARD(F, f), annotation_),
                 HPX_FORWARD(Ts, ts)...);
         }
 
         template <typename F, typename Future, typename... Ts>
             requires(std::invocable<F, Ts...>)
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::then_execute_t,
-            annotating_executor const& exec, F&& f, Future&& predecessor,
-            Ts&&... ts)
+        decltype(auto) then_execute(
+            F&& f, Future&& predecessor, Ts&&... ts) const
         {
-            return parallel::execution::then_execute(exec.exec_,
-                hpx::annotated_function(HPX_FORWARD(F, f), exec.annotation_),
+            return parallel::execution::then_execute(exec_,
+                hpx::annotated_function(HPX_FORWARD(F, f), annotation_),
                 HPX_FORWARD(Future, predecessor), HPX_FORWARD(Ts, ts)...);
         }
 
         // BulkTwoWayExecutor interface
         template <typename F, typename S, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::bulk_async_execute_t,
-            annotating_executor const& exec, F&& f, S const& shape, Ts&&... ts)
+        decltype(auto) bulk_async_execute(
+            F&& f, S const& shape, Ts&&... ts) const
         {
-            return parallel::execution::bulk_async_execute(exec.exec_,
-                hpx::annotated_function(HPX_FORWARD(F, f), exec.annotation_),
-                shape, HPX_FORWARD(Ts, ts)...);
+            return parallel::execution::bulk_async_execute(exec_,
+                hpx::annotated_function(HPX_FORWARD(F, f), annotation_), shape,
+                HPX_FORWARD(Ts, ts)...);
         }
 
         template <typename F, typename S, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::bulk_sync_execute_t,
-            annotating_executor const& exec, F&& f, S const& shape, Ts&&... ts)
+        decltype(auto) bulk_sync_execute(
+            F&& f, S const& shape, Ts&&... ts) const
         {
-            return parallel::execution::bulk_sync_execute(exec.exec_,
-                hpx::annotated_function(HPX_FORWARD(F, f), exec.annotation_),
-                shape, HPX_FORWARD(Ts, ts)...);
+            return parallel::execution::bulk_sync_execute(exec_,
+                hpx::annotated_function(HPX_FORWARD(F, f), annotation_), shape,
+                HPX_FORWARD(Ts, ts)...);
         }
 
         template <typename F, typename S, typename Future, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::bulk_then_execute_t,
-            annotating_executor const& exec, F&& f, S const& shape,
-            Future&& predecessor, Ts&&... ts)
+        decltype(auto) bulk_then_execute(
+            F&& f, S const& shape, Future&& predecessor, Ts&&... ts) const
         {
-            return parallel::execution::bulk_then_execute(exec.exec_,
-                hpx::annotated_function(HPX_FORWARD(F, f), exec.annotation_),
-                shape, HPX_FORWARD(Future, predecessor),
-                HPX_FORWARD(Ts, ts)...);
+            return parallel::execution::bulk_then_execute(exec_,
+                hpx::annotated_function(HPX_FORWARD(F, f), annotation_), shape,
+                HPX_FORWARD(Future, predecessor), HPX_FORWARD(Ts, ts)...);
         }
 
     private:
@@ -211,22 +198,9 @@ namespace hpx::execution::experimental {
         /// \endcond
     };
 
-    // support all properties exposed by the wrapped executor
-    HPX_CXX_CORE_EXPORT template <typename Tag, executor_any BaseExecutor,
-        typename Property>
-        requires(hpx::execution::experimental::is_scheduling_property_v<Tag>)
-    auto tag_invoke(
-        Tag tag, annotating_executor<BaseExecutor> const& exec, Property&& prop)
-    {
-        return exec.query(tag, HPX_FORWARD(Property, prop));
-    }
-
-    HPX_CXX_CORE_EXPORT template <typename Tag, typename BaseExecutor>
-        requires(hpx::execution::experimental::is_scheduling_property_v<Tag>)
-    auto tag_invoke(Tag tag, annotating_executor<BaseExecutor> const& exec)
-    {
-        return exec.query(tag);
-    }
+    // All properties exposed by the wrapped executor are supported through the
+    // public query() member functions above, which the scheduling property
+    // CPOs detect directly (via property_base). No tag_invoke bridge needed.
 
     ///////////////////////////////////////////////////////////////////////////
 #if !defined(DOXYGEN)    // doxygen gets confused by the deduction guides

--- a/libs/core/executors/include/hpx/executors/annotating_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/annotating_executor.hpp
@@ -76,6 +76,44 @@ namespace hpx::execution::experimental {
         using future_type =
             hpx::traits::executor_future_t<BaseExecutor, T, Ts...>;
 
+        [[nodiscard]] constexpr annotating_executor query(
+            with_annotation_t, char const* annotation) const
+        {
+            auto exec_with_annotation = *this;
+            exec_with_annotation.annotation_ = annotation;
+            return exec_with_annotation;
+        }
+
+        [[nodiscard]] annotating_executor query(
+            with_annotation_t, std::string annotation) const
+        {
+            auto exec_with_annotation = *this;
+            exec_with_annotation.annotation_ =
+                hpx::detail::store_function_annotation(HPX_MOVE(annotation));
+            return exec_with_annotation;
+        }
+
+        [[nodiscard]] constexpr char const* query(
+            get_annotation_t) const noexcept
+        {
+            return annotation_;
+        }
+
+        template <typename Tag, typename Property>
+            requires(is_scheduling_property_v<Tag>)
+        [[nodiscard]] auto query(Tag tag, Property&& prop) const
+        {
+            return annotating_executor(
+                exec_.query(tag, HPX_FORWARD(Property, prop)), annotation_);
+        }
+
+        template <typename Tag>
+            requires(is_scheduling_property_v<Tag>)
+        [[nodiscard]] auto query(Tag tag) const
+        {
+            return exec_.query(tag);
+        }
+
     private:
         // NonBlockingOneWayExecutor interface
         template <typename F, typename... Ts>
@@ -157,34 +195,6 @@ namespace hpx::execution::experimental {
                 HPX_FORWARD(Ts, ts)...);
         }
 
-        // support with_annotation property
-        friend constexpr annotating_executor tag_invoke(
-            hpx::execution::experimental::with_annotation_t,
-            annotating_executor const& exec, char const* annotation)
-        {
-            auto exec_with_annotation = exec;
-            exec_with_annotation.annotation_ = annotation;
-            return exec_with_annotation;
-        }
-
-        friend annotating_executor tag_invoke(
-            hpx::execution::experimental::with_annotation_t,
-            annotating_executor const& exec, std::string annotation)
-        {
-            auto exec_with_annotation = exec;
-            exec_with_annotation.annotation_ =
-                hpx::detail::store_function_annotation(HPX_MOVE(annotation));
-            return exec_with_annotation;
-        }
-
-        // support get_annotation property
-        friend constexpr char const* tag_invoke(
-            hpx::execution::experimental::get_annotation_t,
-            annotating_executor const& exec) noexcept
-        {
-            return exec.annotation_;
-        }
-
     private:
         friend class hpx::serialization::access;
 
@@ -207,19 +217,15 @@ namespace hpx::execution::experimental {
         requires(hpx::execution::experimental::is_scheduling_property_v<Tag>)
     auto tag_invoke(
         Tag tag, annotating_executor<BaseExecutor> const& exec, Property&& prop)
-        -> decltype(annotating_executor<BaseExecutor>(std::declval<Tag>()(
-            std::declval<BaseExecutor>(), std::declval<Property>())))
     {
-        return annotating_executor<BaseExecutor>(
-            tag(exec.get_executor(), HPX_FORWARD(Property, prop)));
+        return exec.query(tag, HPX_FORWARD(Property, prop));
     }
 
     HPX_CXX_CORE_EXPORT template <typename Tag, typename BaseExecutor>
         requires(hpx::execution::experimental::is_scheduling_property_v<Tag>)
     auto tag_invoke(Tag tag, annotating_executor<BaseExecutor> const& exec)
-        -> decltype(std::declval<Tag>()(std::declval<BaseExecutor>()))
     {
-        return tag(exec.get_executor());
+        return exec.query(tag);
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/libs/core/executors/include/hpx/executors/dataflow.hpp
+++ b/libs/core/executors/include/hpx/executors/dataflow.hpp
@@ -460,6 +460,10 @@ namespace hpx::lcos::detail {
 
 namespace hpx::detail {
 
+    // Dataflow CPO customizations (see hpx/async_base/dataflow.hpp). The CPO
+    // detects .dataflow() member functions directly; these overloads handle
+    // allocator + launch policy / executor / function dispatch.
+
     // clang-format off
     HPX_CXX_CORE_EXPORT template <typename Allocator, typename Policy, typename F,
         typename... Ts,
@@ -473,7 +477,6 @@ namespace hpx::detail {
         Ts&&... ts) -> decltype(hpx::lcos::detail::dataflow_dispatch_impl<false,
         std::decay_t<Policy>>::call(alloc, HPX_FORWARD(Policy, policy),
         HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...))
-    // clang-format on
     {
         return hpx::lcos::detail::dataflow_dispatch_impl<false,
             std::decay_t<Policy>>::call(alloc, HPX_FORWARD(Policy, policy),
@@ -481,7 +484,7 @@ namespace hpx::detail {
     }
 
     // clang-format off
-   HPX_CXX_CORE_EXPORT  template <typename Allocator, typename Policy, typename F,
+    HPX_CXX_CORE_EXPORT template <typename Allocator, typename Policy, typename F,
         typename... Ts,
         HPX_CONCEPT_REQUIRES_(
             hpx::traits::is_allocator_v<Allocator> &&
@@ -490,23 +493,18 @@ namespace hpx::detail {
         )>
     auto tag_invoke(dataflow_t, Allocator const& alloc, Policy&& policy, F&& f,
         Ts&&... ts)
-        -> decltype(
-                hpx::lcos::detail::dataflow_dispatch_impl<
-                    true, std::decay_t<Policy>
-                >::call(alloc, HPX_FORWARD(Policy, policy),
-                    HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...))
+        -> decltype(hpx::lcos::detail::dataflow_dispatch_impl<true,
+            std::decay_t<Policy>>::call(alloc, HPX_FORWARD(Policy, policy),
+            HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...))
     {
         return hpx::lcos::detail::dataflow_dispatch_impl<true,
             std::decay_t<Policy>>::call(alloc, HPX_FORWARD(Policy, policy),
             HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
     }
-    // clang-format on
 
-    // executors
-    //
     // clang-format off
-   HPX_CXX_CORE_EXPORT  template <typename Allocator, typename Executor, typename F,
-        typename... Ts,
+    HPX_CXX_CORE_EXPORT template <typename Allocator, typename Executor,
+        typename F, typename... Ts,
         HPX_CONCEPT_REQUIRES_(
             hpx::traits::is_allocator_v<Allocator> &&
            (hpx::traits::is_one_way_executor_v<Executor> ||
@@ -521,10 +519,8 @@ namespace hpx::detail {
             traits::acquire_future_disp()(HPX_FORWARD(Ts, ts))...);
     }
 
-    // any action, plain function, or function object
-    //
     // clang-format off
-   HPX_CXX_CORE_EXPORT  template <typename Allocator, typename F, typename... Ts,
+    HPX_CXX_CORE_EXPORT template <typename Allocator, typename F, typename... Ts,
         HPX_CONCEPT_REQUIRES_(
              hpx::traits::is_allocator_v<Allocator> &&
             !hpx::traits::is_launch_policy_v<F> &&
@@ -533,15 +529,13 @@ namespace hpx::detail {
         )>
     HPX_FORCEINLINE auto tag_invoke(
         dataflow_t, Allocator const& alloc, F&& f, Ts&&... ts)
-        -> decltype(
-                hpx::lcos::detail::dataflow_dispatch_impl<
-                    traits::is_action_v<std::decay_t<F>>, launch
-                >::call(alloc, launch::async, HPX_FORWARD(F, f),
-                    HPX_FORWARD(Ts, ts)...))
+        -> decltype(hpx::lcos::detail::dataflow_dispatch_impl<
+            traits::is_action_v<std::decay_t<F>>, launch>::call(alloc,
+            launch::async, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...))
     {
         return hpx::lcos::detail::dataflow_dispatch_impl<
             traits::is_action_v<std::decay_t<F>>, launch>::call(alloc,
             launch::async, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
     }
-    // clang-format on
+
 }    // namespace hpx::detail

--- a/libs/core/executors/include/hpx/executors/datapar/detail/execution_policy_mapping_members.hpp
+++ b/libs/core/executors/include/hpx/executors/datapar/detail/execution_policy_mapping_members.hpp
@@ -28,6 +28,10 @@ namespace hpx::execution::detail {
         constexpr auto to_task() const;
         constexpr auto to_par() const;
         constexpr auto to_non_simd() const;
+
+    private:
+        friend Derived;
+        constexpr simd_sync_policy_mappings() = default;
     };
 
     template <typename Derived>
@@ -36,6 +40,10 @@ namespace hpx::execution::detail {
         constexpr auto to_non_task() const;
         constexpr auto to_par() const;
         constexpr auto to_non_simd() const;
+
+    private:
+        friend Derived;
+        constexpr simd_async_policy_mappings() = default;
     };
 
     template <typename Derived>
@@ -44,6 +52,10 @@ namespace hpx::execution::detail {
         constexpr auto to_task() const;
         constexpr auto to_non_par() const;
         constexpr auto to_non_simd() const;
+
+    private:
+        friend Derived;
+        constexpr par_simd_sync_policy_mappings() = default;
     };
 
     template <typename Derived>
@@ -52,6 +64,10 @@ namespace hpx::execution::detail {
         constexpr auto to_non_task() const;
         constexpr auto to_non_par() const;
         constexpr auto to_non_simd() const;
+
+    private:
+        friend Derived;
+        constexpr par_simd_async_policy_mappings() = default;
     };
 
 }    // namespace hpx::execution::detail

--- a/libs/core/executors/include/hpx/executors/datapar/detail/execution_policy_mapping_members.hpp
+++ b/libs/core/executors/include/hpx/executors/datapar/detail/execution_policy_mapping_members.hpp
@@ -1,0 +1,59 @@
+//  Copyright (c) 2026 The STE||AR-Group
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_DATAPAR)
+
+#include <hpx/modules/properties.hpp>
+
+namespace hpx::execution::detail {
+
+    template <typename ResultPolicy, typename Derived, typename MappingTag>
+    constexpr auto map_execution_policy(Derived const& self, MappingTag tag)
+    {
+        return ResultPolicy()
+            .on(hpx::experimental::prefer(tag, self.executor()))
+            .with(self.parameters());
+    }
+
+    template <typename Derived>
+    struct simd_sync_policy_mappings
+    {
+        constexpr auto to_task() const;
+        constexpr auto to_par() const;
+        constexpr auto to_non_simd() const;
+    };
+
+    template <typename Derived>
+    struct simd_async_policy_mappings
+    {
+        constexpr auto to_non_task() const;
+        constexpr auto to_par() const;
+        constexpr auto to_non_simd() const;
+    };
+
+    template <typename Derived>
+    struct par_simd_sync_policy_mappings
+    {
+        constexpr auto to_task() const;
+        constexpr auto to_non_par() const;
+        constexpr auto to_non_simd() const;
+    };
+
+    template <typename Derived>
+    struct par_simd_async_policy_mappings
+    {
+        constexpr auto to_non_task() const;
+        constexpr auto to_non_par() const;
+        constexpr auto to_non_simd() const;
+    };
+
+}    // namespace hpx::execution::detail
+
+#endif

--- a/libs/core/executors/include/hpx/executors/datapar/detail/execution_policy_mapping_members_impl.hpp
+++ b/libs/core/executors/include/hpx/executors/datapar/detail/execution_policy_mapping_members_impl.hpp
@@ -1,0 +1,115 @@
+//  Copyright (c) 2026 The STE||AR-Group
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_DATAPAR)
+
+#include <hpx/executors/datapar/detail/execution_policy_mapping_members.hpp>
+
+namespace hpx::execution::detail {
+
+    template <typename Derived>
+    constexpr auto simd_sync_policy_mappings<Derived>::to_task() const
+    {
+        return map_execution_policy<simd_task_policy>(
+            static_cast<Derived const&>(*this),
+            hpx::execution::experimental::to_task);
+    }
+
+    template <typename Derived>
+    constexpr auto simd_sync_policy_mappings<Derived>::to_par() const
+    {
+        return map_execution_policy<par_simd_policy>(
+            static_cast<Derived const&>(*this),
+            hpx::execution::experimental::to_par);
+    }
+
+    template <typename Derived>
+    constexpr auto simd_sync_policy_mappings<Derived>::to_non_simd() const
+    {
+        return map_execution_policy<sequenced_policy>(
+            static_cast<Derived const&>(*this),
+            hpx::execution::experimental::to_non_simd);
+    }
+
+    template <typename Derived>
+    constexpr auto simd_async_policy_mappings<Derived>::to_non_task() const
+    {
+        return map_execution_policy<simd_policy>(
+            static_cast<Derived const&>(*this),
+            hpx::execution::experimental::to_non_task);
+    }
+
+    template <typename Derived>
+    constexpr auto simd_async_policy_mappings<Derived>::to_par() const
+    {
+        return map_execution_policy<par_simd_task_policy>(
+            static_cast<Derived const&>(*this),
+            hpx::execution::experimental::to_par);
+    }
+
+    template <typename Derived>
+    constexpr auto simd_async_policy_mappings<Derived>::to_non_simd() const
+    {
+        return map_execution_policy<sequenced_task_policy>(
+            static_cast<Derived const&>(*this),
+            hpx::execution::experimental::to_non_simd);
+    }
+
+    template <typename Derived>
+    constexpr auto par_simd_sync_policy_mappings<Derived>::to_task() const
+    {
+        return map_execution_policy<par_simd_task_policy>(
+            static_cast<Derived const&>(*this),
+            hpx::execution::experimental::to_task);
+    }
+
+    template <typename Derived>
+    constexpr auto par_simd_sync_policy_mappings<Derived>::to_non_par() const
+    {
+        return map_execution_policy<simd_policy>(
+            static_cast<Derived const&>(*this),
+            hpx::execution::experimental::to_non_par);
+    }
+
+    template <typename Derived>
+    constexpr auto par_simd_sync_policy_mappings<Derived>::to_non_simd() const
+    {
+        return map_execution_policy<parallel_policy>(
+            static_cast<Derived const&>(*this),
+            hpx::execution::experimental::to_non_simd);
+    }
+
+    template <typename Derived>
+    constexpr auto par_simd_async_policy_mappings<Derived>::to_non_task() const
+    {
+        return map_execution_policy<par_simd_policy>(
+            static_cast<Derived const&>(*this),
+            hpx::execution::experimental::to_non_task);
+    }
+
+    template <typename Derived>
+    constexpr auto par_simd_async_policy_mappings<Derived>::to_non_par() const
+    {
+        return map_execution_policy<simd_task_policy>(
+            static_cast<Derived const&>(*this),
+            hpx::execution::experimental::to_non_par);
+    }
+
+    template <typename Derived>
+    constexpr auto par_simd_async_policy_mappings<Derived>::to_non_simd() const
+    {
+        return map_execution_policy<parallel_task_policy>(
+            static_cast<Derived const&>(*this),
+            hpx::execution::experimental::to_non_simd);
+    }
+
+}    // namespace hpx::execution::detail
+
+#endif

--- a/libs/core/executors/include/hpx/executors/datapar/execution_policy.hpp
+++ b/libs/core/executors/include/hpx/executors/datapar/execution_policy.hpp
@@ -40,7 +40,8 @@ namespace hpx::execution {
         struct simd_task_policy_shim
           : execution_policy<simd_task_policy_shim, Executor, Parameters,
                 unsequenced_execution_tag>
-          , simd_async_policy_mappings<simd_task_policy_shim>
+          , simd_async_policy_mappings<
+                simd_task_policy_shim<Executor, Parameters>>
         {
         private:
             using base_type = execution_policy<simd_task_policy_shim, Executor,
@@ -111,7 +112,7 @@ namespace hpx::execution {
         struct simd_policy_shim
           : execution_policy<simd_policy_shim, Executor, Parameters,
                 unsequenced_execution_tag>
-          , simd_sync_policy_mappings<simd_policy_shim>
+          , simd_sync_policy_mappings<simd_policy_shim<Executor, Parameters>>
         {
         private:
             using base_type = execution_policy<simd_policy_shim, Executor,
@@ -179,7 +180,8 @@ namespace hpx::execution {
         struct par_simd_task_policy_shim
           : execution_policy<par_simd_task_policy_shim, Executor, Parameters,
                 unsequenced_execution_tag>
-          , par_simd_async_policy_mappings<par_simd_task_policy_shim>
+          , par_simd_async_policy_mappings<
+                par_simd_task_policy_shim<Executor, Parameters>>
         {
         private:
             using base_type = execution_policy<par_simd_task_policy_shim,
@@ -249,7 +251,8 @@ namespace hpx::execution {
         struct par_simd_policy_shim
           : execution_policy<par_simd_policy_shim, Executor, Parameters,
                 unsequenced_execution_tag>
-          , par_simd_sync_policy_mappings<par_simd_policy_shim>
+          , par_simd_sync_policy_mappings<
+                par_simd_policy_shim<Executor, Parameters>>
         {
         private:
             using base_type = execution_policy<par_simd_policy_shim, Executor,

--- a/libs/core/executors/include/hpx/executors/datapar/execution_policy.hpp
+++ b/libs/core/executors/include/hpx/executors/datapar/execution_policy.hpp
@@ -9,6 +9,7 @@
 #include <hpx/config.hpp>
 
 #if defined(HPX_HAVE_DATAPAR)
+#include <hpx/executors/datapar/detail/execution_policy_mapping_members.hpp>
 #include <hpx/executors/datapar/execution_policy_fwd.hpp>
 #include <hpx/executors/datapar/execution_policy_mappings.hpp>
 #include <hpx/executors/execution_policy.hpp>
@@ -39,6 +40,7 @@ namespace hpx::execution {
         struct simd_task_policy_shim
           : execution_policy<simd_task_policy_shim, Executor, Parameters,
                 unsequenced_execution_tag>
+          , simd_async_policy_mappings<simd_task_policy_shim>
         {
         private:
             using base_type = execution_policy<simd_task_policy_shim, Executor,
@@ -109,6 +111,7 @@ namespace hpx::execution {
         struct simd_policy_shim
           : execution_policy<simd_policy_shim, Executor, Parameters,
                 unsequenced_execution_tag>
+          , simd_sync_policy_mappings<simd_policy_shim>
         {
         private:
             using base_type = execution_policy<simd_policy_shim, Executor,
@@ -176,6 +179,7 @@ namespace hpx::execution {
         struct par_simd_task_policy_shim
           : execution_policy<par_simd_task_policy_shim, Executor, Parameters,
                 unsequenced_execution_tag>
+          , par_simd_async_policy_mappings<par_simd_task_policy_shim>
         {
         private:
             using base_type = execution_policy<par_simd_task_policy_shim,
@@ -245,6 +249,7 @@ namespace hpx::execution {
         struct par_simd_policy_shim
           : execution_policy<par_simd_policy_shim, Executor, Parameters,
                 unsequenced_execution_tag>
+          , par_simd_sync_policy_mappings<par_simd_policy_shim>
         {
         private:
             using base_type = execution_policy<par_simd_policy_shim, Executor,
@@ -295,12 +300,9 @@ namespace hpx::execution {
     }    // namespace detail
 
     ///////////////////////////////////////////////////////////////////////////
-    /// Extension: The class par_simd_task_policy is an execution policy type
+    /// Extension: The class par_simd_policy is an execution policy type
     /// used as a unique type to disambiguate parallel algorithm overloading and
     /// indicate that a parallel algorithm's execution may be parallelized.
-    ///
-    /// The algorithm returns a future representing the result of the
-    /// corresponding algorithm when invoked with the parallel_policy.
     HPX_CXX_CORE_EXPORT using par_simd_policy =
         detail::par_simd_policy_shim<parallel_executor,
             hpx::traits::executor_parameters_type_t<parallel_executor>>;
@@ -310,172 +312,44 @@ namespace hpx::execution {
 
     namespace detail {
 
-        /// \cond NOINTERN
-        HPX_CXX_CORE_EXPORT template <typename Executor, typename Parameters>
-        constexpr decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_task_t tag,
-            simd_policy_shim<Executor, Parameters> const& policy)
-        {
-            return simd_task_policy()
-                .on(hpx::experimental::prefer(tag, policy.executor()))
-                .with(policy.parameters());
-        }
-
-        HPX_CXX_CORE_EXPORT template <typename Executor, typename Parameters>
-        constexpr decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_par_t tag,
-            simd_policy_shim<Executor, Parameters> const& policy)
-        {
-            return par_simd_policy()
-                .on(hpx::experimental::prefer(tag, policy.executor()))
-                .with(policy.parameters());
-        }
-
-        HPX_CXX_CORE_EXPORT template <typename Executor, typename Parameters>
-        constexpr decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_non_simd_t tag,
-            simd_policy_shim<Executor, Parameters> const& policy)
-        {
-            return sequenced_policy()
-                .on(hpx::experimental::prefer(tag, policy.executor()))
-                .with(policy.parameters());
-        }
-
-        HPX_CXX_CORE_EXPORT template <typename Executor, typename Parameters>
-        constexpr decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_simd_t tag,
-            sequenced_policy_shim<Executor, Parameters> const& policy)
-        {
-            return simd_policy()
-                .on(hpx::experimental::prefer(tag, policy.executor()))
-                .with(policy.parameters());
-        }
-
         ///////////////////////////////////////////////////////////////////////
-        HPX_CXX_CORE_EXPORT template <typename Executor, typename Parameters>
-        constexpr decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_non_task_t tag,
-            simd_task_policy_shim<Executor, Parameters> const& policy)
-        {
-            return simd_policy()
-                .on(hpx::experimental::prefer(tag, policy.executor()))
-                .with(policy.parameters());
-        }
-
-        HPX_CXX_CORE_EXPORT template <typename Executor, typename Parameters>
-        constexpr decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_par_t tag,
-            simd_task_policy_shim<Executor, Parameters> const& policy)
-        {
-            return par_simd_task_policy()
-                .on(hpx::experimental::prefer(tag, policy.executor()))
-                .with(policy.parameters());
-        }
-
-        HPX_CXX_CORE_EXPORT template <typename Executor, typename Parameters>
-        constexpr decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_non_simd_t tag,
-            simd_task_policy_shim<Executor, Parameters> const& policy)
-        {
-            return sequenced_task_policy()
-                .on(hpx::experimental::prefer(tag, policy.executor()))
-                .with(policy.parameters());
-        }
-
-        HPX_CXX_CORE_EXPORT template <typename Executor, typename Parameters>
-        constexpr decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_simd_t tag,
-            sequenced_task_policy_shim<Executor, Parameters> const& policy)
-        {
-            return simd_task_policy()
-                .on(hpx::experimental::prefer(tag, policy.executor()))
-                .with(policy.parameters());
-        }
-
+        // to_simd() on non-datapar policy shims
         ///////////////////////////////////////////////////////////////////////
-        HPX_CXX_CORE_EXPORT template <typename Executor, typename Parameters>
-        constexpr decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_task_t tag,
-            par_simd_policy_shim<Executor, Parameters> const& policy)
+        template <typename Executor, typename Parameters>
+        constexpr auto sequenced_policy_shim<Executor, Parameters>::to_simd()
+            const
         {
-            return par_simd_task_policy()
-                .on(hpx::experimental::prefer(tag, policy.executor()))
-                .with(policy.parameters());
+            return map_execution_policy<simd_policy>(
+                *this, hpx::execution::experimental::to_simd);
         }
 
-        HPX_CXX_CORE_EXPORT template <typename Executor, typename Parameters>
-        constexpr decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_non_par_t tag,
-            par_simd_policy_shim<Executor, Parameters> const& policy)
+        template <typename Executor, typename Parameters>
+        constexpr auto
+        sequenced_task_policy_shim<Executor, Parameters>::to_simd() const
         {
-            return simd_policy()
-                .on(hpx::experimental::prefer(tag, policy.executor()))
-                .with(policy.parameters());
+            return map_execution_policy<simd_task_policy>(
+                *this, hpx::execution::experimental::to_simd);
         }
 
-        HPX_CXX_CORE_EXPORT template <typename Executor, typename Parameters>
-        constexpr decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_non_simd_t tag,
-            par_simd_policy_shim<Executor, Parameters> const& policy)
+        template <typename Executor, typename Parameters>
+        constexpr auto parallel_policy_shim<Executor, Parameters>::to_simd()
+            const
         {
-            return parallel_policy()
-                .on(hpx::experimental::prefer(tag, policy.executor()))
-                .with(policy.parameters());
+            return map_execution_policy<par_simd_policy>(
+                *this, hpx::execution::experimental::to_simd);
         }
 
-        HPX_CXX_CORE_EXPORT template <typename Executor, typename Parameters>
-        constexpr decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_simd_t tag,
-            parallel_policy_shim<Executor, Parameters> const& policy)
+        template <typename Executor, typename Parameters>
+        constexpr auto
+        parallel_task_policy_shim<Executor, Parameters>::to_simd() const
         {
-            return par_simd_policy()
-                .on(hpx::experimental::prefer(tag, policy.executor()))
-                .with(policy.parameters());
+            return map_execution_policy<par_simd_task_policy>(
+                *this, hpx::execution::experimental::to_simd);
         }
-
-        ///////////////////////////////////////////////////////////////////////
-        HPX_CXX_CORE_EXPORT template <typename Executor, typename Parameters>
-        constexpr decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_non_task_t tag,
-            par_simd_task_policy_shim<Executor, Parameters> const& policy)
-        {
-            return par_simd_policy()
-                .on(hpx::experimental::prefer(tag, policy.executor()))
-                .with(policy.parameters());
-        }
-
-        HPX_CXX_CORE_EXPORT template <typename Executor, typename Parameters>
-        constexpr decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_non_par_t tag,
-            par_simd_task_policy_shim<Executor, Parameters> const& policy)
-        {
-            return simd_task_policy()
-                .on(hpx::experimental::prefer(tag, policy.executor()))
-                .with(policy.parameters());
-        }
-
-        HPX_CXX_CORE_EXPORT template <typename Executor, typename Parameters>
-        constexpr decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_non_simd_t tag,
-            par_simd_task_policy_shim<Executor, Parameters> const& policy)
-        {
-            return parallel_task_policy()
-                .on(hpx::experimental::prefer(tag, policy.executor()))
-                .with(policy.parameters());
-        }
-
-        HPX_CXX_CORE_EXPORT template <typename Executor, typename Parameters>
-        constexpr decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_simd_t tag,
-            parallel_task_policy_shim<Executor, Parameters> const& policy)
-        {
-            return par_simd_task_policy()
-                .on(hpx::experimental::prefer(tag, policy.executor()))
-                .with(policy.parameters());
-        }
-        /// \endcond
     }    // namespace detail
 }    // namespace hpx::execution
+
+#include <hpx/executors/datapar/detail/execution_policy_mapping_members_impl.hpp>
 
 namespace hpx::detail {
 

--- a/libs/core/executors/include/hpx/executors/datapar/execution_policy_mappings.hpp
+++ b/libs/core/executors/include/hpx/executors/datapar/execution_policy_mappings.hpp
@@ -23,10 +23,19 @@ namespace hpx::execution::experimental {
 
     ///////////////////////////////////////////////////////////////////////////
     // Return the matching non-simd (vectorpack) execution policy
-    HPX_CXX_CORE_EXPORT inline constexpr struct to_non_simd_t final
+    HPX_CXX_CORE_EXPORT inline constexpr struct to_non_simd_t
       : hpx::functional::detail::tag_fallback<to_non_simd_t>
     {
     private:
+        // Bridge: forward to member function if available
+        template <typename Target>
+            requires requires(Target const& t) { t.to_non_simd(); }
+        friend constexpr decltype(auto) tag_invoke(
+            to_non_simd_t, Target const& target)
+        {
+            return target.to_non_simd();
+        }
+
         // any non-simd policy just returns itself
         template <execution_policy ExPolicy>
         friend constexpr decltype(auto) tag_fallback_invoke(
@@ -44,12 +53,20 @@ namespace hpx::execution::experimental {
     };
 
     // Return the matching simd (vectorpack) execution policy
-    HPX_CXX_CORE_EXPORT inline constexpr struct to_simd_t final
+    HPX_CXX_CORE_EXPORT inline constexpr struct to_simd_t
       : hpx::functional::detail::tag_fallback<to_simd_t>
     {
     private:
-        // any simd policy just returns itself
+        // Bridge: forward to member function if available
+        template <typename Target>
+            requires requires(Target const& t) { t.to_simd(); }
+        friend constexpr decltype(auto) tag_invoke(
+            to_simd_t, Target const& target)
+        {
+            return target.to_simd();
+        }
 
+        // any simd policy just returns itself
         template <execution_policy ExPolicy>
         friend constexpr decltype(auto) tag_fallback_invoke(
             to_simd_t, ExPolicy&& policy) noexcept

--- a/libs/core/executors/include/hpx/executors/detail/bulk_invoke_helper.hpp
+++ b/libs/core/executors/include/hpx/executors/detail/bulk_invoke_helper.hpp
@@ -10,7 +10,6 @@
 
 #include <hpx/config.hpp>
 #include <hpx/modules/datastructures.hpp>
-#include <hpx/modules/tag_invoke.hpp>
 #include <hpx/modules/type_support.hpp>
 
 #include <cstddef>

--- a/libs/core/executors/include/hpx/executors/detail/index_queue_spawning_result.hpp
+++ b/libs/core/executors/include/hpx/executors/detail/index_queue_spawning_result.hpp
@@ -21,7 +21,6 @@
 #include <hpx/modules/itt_notify.hpp>
 #include <hpx/modules/memory.hpp>
 #include <hpx/modules/resource_partitioner.hpp>
-#include <hpx/modules/tag_invoke.hpp>
 #include <hpx/modules/threading.hpp>
 #include <hpx/modules/threading_base.hpp>
 #include <hpx/modules/topology.hpp>

--- a/libs/core/executors/include/hpx/executors/detail/index_queue_spawning_void.hpp
+++ b/libs/core/executors/include/hpx/executors/detail/index_queue_spawning_void.hpp
@@ -21,7 +21,6 @@
 #include <hpx/modules/itt_notify.hpp>
 #include <hpx/modules/memory.hpp>
 #include <hpx/modules/resource_partitioner.hpp>
-#include <hpx/modules/tag_invoke.hpp>
 #include <hpx/modules/threading.hpp>
 #include <hpx/modules/threading_base.hpp>
 #include <hpx/modules/topology.hpp>

--- a/libs/core/executors/include/hpx/executors/execute_on.hpp
+++ b/libs/core/executors/include/hpx/executors/execute_on.hpp
@@ -89,7 +89,8 @@ namespace hpx::execution::experimental {
         policy_type policy;
 
         template <typename Tag, typename Property>
-            requires(hpx::execution::experimental::is_scheduling_property_v<Tag>)
+            requires(
+                hpx::execution::experimental::is_scheduling_property_v<Tag>)
         [[nodiscard]] auto query(Tag tag, Property&& prop) const
         {
             return scheduler_and_policy{
@@ -98,7 +99,8 @@ namespace hpx::execution::experimental {
         }
 
         template <typename Tag>
-            requires(hpx::execution::experimental::is_scheduling_property_v<Tag>)
+            requires(
+                hpx::execution::experimental::is_scheduling_property_v<Tag>)
         [[nodiscard]] auto query(Tag tag) const
         {
             return get_scheduler().query(tag);
@@ -112,24 +114,9 @@ namespace hpx::execution::experimental {
 
     ////////////////////////////////////////////////////////////////////////////
 
-    HPX_CXX_CORE_EXPORT template <typename Tag, typename Scheduler,
-        typename ExPolicy, typename Property>
-        requires(hpx::execution::experimental::is_scheduling_property_v<Tag>)
-    auto tag_invoke(Tag tag,
-        scheduler_and_policy<Scheduler, ExPolicy> const& scheduler,
-        Property&& prop)
-    {
-        return scheduler.query(tag, HPX_FORWARD(Property, prop));
-    }
-
-    HPX_CXX_CORE_EXPORT template <typename Tag, typename Scheduler,
-        typename ExPolicy>
-        requires(hpx::execution::experimental::is_scheduling_property_v<Tag>)
-    auto tag_invoke(
-        Tag tag, scheduler_and_policy<Scheduler, ExPolicy> const& scheduler)
-    {
-        return scheduler.query(tag);
-    }
+    // The scheduling property CPOs detect the public query() member functions
+    // of scheduler_and_policy directly (via property_base), so no tag_invoke
+    // bridge is needed here.
 
     // Experimental support for facilities from p2500 (wg21.link/p2500)
     inline namespace p2500 {

--- a/libs/core/executors/include/hpx/executors/execute_on.hpp
+++ b/libs/core/executors/include/hpx/executors/execute_on.hpp
@@ -105,6 +105,28 @@ namespace hpx::execution::experimental {
         {
             return get_scheduler().query(tag);
         }
+
+        template <typename Tag, typename... Args>
+            requires(
+                !hpx::execution::experimental::is_scheduling_property_v<Tag> &&
+                requires(base_scheduler_type const& sched, Tag t, Args... a) {
+                    sched.query(t, HPX_FORWARD(Args, a)...);
+                })
+        [[nodiscard]] auto query(Tag tag, Args&&... args) const
+        {
+            return get_scheduler().query(tag, HPX_FORWARD(Args, args)...);
+        }
+
+        template <typename Tag>
+            requires(
+                !hpx::execution::experimental::is_scheduling_property_v<Tag> &&
+                requires(base_scheduler_type const& sched, Tag t) {
+                    sched.query(t);
+                })
+        [[nodiscard]] auto query(Tag tag) const
+        {
+            return get_scheduler().query(tag);
+        }
     };
 
     HPX_CXX_CORE_EXPORT template <typename Scheduler, typename ExPolicy>

--- a/libs/core/executors/include/hpx/executors/execute_on.hpp
+++ b/libs/core/executors/include/hpx/executors/execute_on.hpp
@@ -10,7 +10,6 @@
 #include <hpx/executors/explicit_scheduler_executor.hpp>
 #include <hpx/modules/concepts.hpp>
 #include <hpx/modules/execution_base.hpp>
-#include <hpx/modules/tag_invoke.hpp>
 
 #include <type_traits>
 #include <utility>
@@ -88,6 +87,22 @@ namespace hpx::execution::experimental {
         }
 
         policy_type policy;
+
+        template <typename Tag, typename Property>
+            requires(hpx::execution::experimental::is_scheduling_property_v<Tag>)
+        [[nodiscard]] auto query(Tag tag, Property&& prop) const
+        {
+            return scheduler_and_policy{
+                get_scheduler().query(tag, HPX_FORWARD(Property, prop)),
+                get_policy()};
+        }
+
+        template <typename Tag>
+            requires(hpx::execution::experimental::is_scheduling_property_v<Tag>)
+        [[nodiscard]] auto query(Tag tag) const
+        {
+            return get_scheduler().query(tag);
+        }
     };
 
     HPX_CXX_CORE_EXPORT template <typename Scheduler, typename ExPolicy>
@@ -96,39 +111,24 @@ namespace hpx::execution::experimental {
             std::decay_t<ExPolicy>>;
 
     ////////////////////////////////////////////////////////////////////////////
-    // support all scheduling properties exposed by the embedded scheduler
 
-    // clang-format off
-    HPX_CXX_CORE_EXPORT template <typename Tag, typename Scheduler, typename ExPolicy,
-        typename Property,
-        HPX_CONCEPT_REQUIRES_(
-            hpx::execution::experimental::is_scheduling_property_v<Tag>
-        )>
+    HPX_CXX_CORE_EXPORT template <typename Tag, typename Scheduler,
+        typename ExPolicy, typename Property>
+        requires(hpx::execution::experimental::is_scheduling_property_v<Tag>)
     auto tag_invoke(Tag tag,
         scheduler_and_policy<Scheduler, ExPolicy> const& scheduler,
         Property&& prop)
-        -> decltype(scheduler_and_policy<Scheduler, ExPolicy>(
-                std::declval<Tag>()(
-                    std::declval<Scheduler>(), std::declval<Property>()),
-                std::declval<ExPolicy>()))
-    // clang-format on
     {
-        return scheduler_and_policy<Scheduler, ExPolicy>(
-            tag(scheduler.get_scheduler(), HPX_FORWARD(Property, prop)),
-            scheduler.get_policy());
+        return scheduler.query(tag, HPX_FORWARD(Property, prop));
     }
 
-    // clang-format off
-    HPX_CXX_CORE_EXPORT template <typename Tag, typename Scheduler, typename ExPolicy,
-        HPX_CONCEPT_REQUIRES_(
-            hpx::execution::experimental::is_scheduling_property_v<Tag>
-        )>
-    // clang-format on
+    HPX_CXX_CORE_EXPORT template <typename Tag, typename Scheduler,
+        typename ExPolicy>
+        requires(hpx::execution::experimental::is_scheduling_property_v<Tag>)
     auto tag_invoke(
         Tag tag, scheduler_and_policy<Scheduler, ExPolicy> const& scheduler)
-        -> decltype(std::declval<Tag>()(std::declval<Scheduler>()))
     {
-        return tag(scheduler.get_scheduler());
+        return scheduler.query(tag);
     }
 
     // Experimental support for facilities from p2500 (wg21.link/p2500)

--- a/libs/core/executors/include/hpx/executors/execution_policy.hpp
+++ b/libs/core/executors/include/hpx/executors/execution_policy.hpp
@@ -22,9 +22,13 @@
 #include <hpx/modules/properties.hpp>
 #include <hpx/modules/serialization.hpp>
 
+#include <cstddef>
 #include <memory>
+#include <string>
 #include <type_traits>
 #include <utility>
+
+#include <concepts>
 
 namespace hpx::execution {
 
@@ -241,8 +245,11 @@ namespace hpx::execution {
             // Scheduling property query implementations forward to the
             // embedded executor and rebound through create_rebound_policy.
             template <scheduling_property Tag, typename Property>
-                requires(hpx::functional::is_tag_invocable_v<Tag, executor_type,
-                    Property>)
+                requires(!std::is_same_v<Tag,
+                             hpx::execution::experimental::
+                                 with_processing_units_count_t> &&
+                    hpx::functional::is_tag_invocable_v<Tag, executor_type,
+                        Property>)
             [[nodiscard]] auto query(Tag tag, Property&& prop) const
             {
                 return hpx::execution::experimental::create_rebound_policy(
@@ -300,21 +307,52 @@ namespace hpx::execution {
             [[nodiscard]] auto query(
                 hpx::execution::experimental::with_processing_units_count_t,
                 std::size_t num_cores) const
-                requires(std::invocable<
+                requires(hpx::functional::is_tag_invocable_v<
                     hpx::execution::experimental::with_processing_units_count_t,
                     executor_type, std::size_t>)
             {
-                auto exec =
-                    hpx::execution::experimental::with_processing_units_count(
-                        executor(), num_cores);
+                using exec_type = executor_type;
+                using updated_exec_type = std::decay_t<decltype(hpx::execution::
+                        experimental::with_processing_units_count(
+                            std::declval<exec_type const&>(), num_cores))>;
 
-                return hpx::execution::experimental::create_rebound_policy(
-                    derived(), HPX_MOVE(exec), parameters());
+                if constexpr (std::is_same_v<updated_exec_type, exec_type>)
+                {
+                    auto exec = hpx::execution::experimental::
+                        with_processing_units_count(executor(), num_cores);
+
+                    return hpx::execution::experimental::create_rebound_policy(
+                        derived(), HPX_MOVE(exec), parameters());
+                }
+                else if constexpr (requires(exec_type e) {
+                                       e.num_cores_;
+                                       e.pool();
+                                   })
+                {
+                    exec_type exec = executor();
+                    if (num_cores == 0)
+                    {
+                        num_cores = exec.pool()->get_active_os_thread_count();
+                    }
+                    exec.num_cores_ = num_cores;
+
+                    return hpx::execution::experimental::create_rebound_policy(
+                        derived(), HPX_MOVE(exec), parameters());
+                }
+                else
+                {
+                    auto exec = hpx::execution::experimental::
+                        with_processing_units_count(executor(), num_cores);
+
+                    return hpx::execution::experimental::create_rebound_policy(
+                        derived(), HPX_MOVE(exec), parameters());
+                }
             }
 
             template <executor_parameters Params>
-                requires(std::invocable<hpx::execution::experimental::
-                                            with_processing_units_count_t,
+                requires(hpx::functional::is_tag_invocable_v<
+                             hpx::execution::experimental::
+                                 with_processing_units_count_t,
                              executor_type, std::size_t> &&
                     std::invocable<
                         hpx::execution::experimental::processing_units_count_t,

--- a/libs/core/executors/include/hpx/executors/execution_policy.hpp
+++ b/libs/core/executors/include/hpx/executors/execution_policy.hpp
@@ -238,6 +238,103 @@ namespace hpx::execution {
                 return params_;
             }
 
+            // Scheduling property query implementations forward to the
+            // embedded executor and rebound through create_rebound_policy.
+            template <scheduling_property Tag, typename Property>
+                requires(hpx::functional::is_tag_invocable_v<Tag, executor_type,
+                    Property>)
+            [[nodiscard]] auto query(Tag tag, Property&& prop) const
+            {
+                return hpx::execution::experimental::create_rebound_policy(
+                    derived(), tag(executor(), HPX_FORWARD(Property, prop)),
+                    parameters());
+            }
+
+            template <scheduling_property Tag>
+                requires(
+                    hpx::functional::is_tag_invocable_v<Tag, executor_type>)
+            [[nodiscard]] auto query(Tag tag) const
+            {
+                return tag(executor());
+            }
+
+#if defined(HPX_HAVE_THREAD_DESCRIPTION)
+            [[nodiscard]] auto query(
+                hpx::execution::experimental::with_annotation_t,
+                char const* annotation) const
+                requires(std::invocable<
+                    hpx::execution::experimental::with_annotation_t,
+                    executor_type, char const*>)
+            {
+                auto exec = hpx::execution::experimental::with_annotation(
+                    executor(), annotation);
+
+                return hpx::execution::experimental::create_rebound_policy(
+                    derived(), HPX_MOVE(exec), parameters());
+            }
+
+            [[nodiscard]] auto query(
+                hpx::execution::experimental::with_annotation_t,
+                std::string annotation) const
+                requires(std::invocable<
+                    hpx::execution::experimental::with_annotation_t,
+                    executor_type, std::string>)
+            {
+                auto exec = hpx::execution::experimental::with_annotation(
+                    executor(), HPX_MOVE(annotation));
+
+                return hpx::execution::experimental::create_rebound_policy(
+                    derived(), HPX_MOVE(exec), parameters());
+            }
+
+            [[nodiscard]] decltype(auto) query(
+                hpx::execution::experimental::get_annotation_t) const
+                requires(std::invocable<
+                    hpx::execution::experimental::get_annotation_t,
+                    executor_type>)
+            {
+                return hpx::execution::experimental::get_annotation(executor());
+            }
+#endif
+
+            [[nodiscard]] auto query(
+                hpx::execution::experimental::with_processing_units_count_t,
+                std::size_t num_cores) const
+                requires(std::invocable<
+                    hpx::execution::experimental::with_processing_units_count_t,
+                    executor_type, std::size_t>)
+            {
+                auto exec =
+                    hpx::execution::experimental::with_processing_units_count(
+                        executor(), num_cores);
+
+                return hpx::execution::experimental::create_rebound_policy(
+                    derived(), HPX_MOVE(exec), parameters());
+            }
+
+            template <executor_parameters Params>
+                requires(std::invocable<hpx::execution::experimental::
+                                            with_processing_units_count_t,
+                             executor_type, std::size_t> &&
+                    std::invocable<
+                        hpx::execution::experimental::processing_units_count_t,
+                        std::decay_t<Params>, executor_type,
+                        hpx::chrono::steady_duration const&, std::size_t>)
+            [[nodiscard]] auto query(
+                hpx::execution::experimental::with_processing_units_count_t,
+                Params&& params) const
+            {
+                auto exec =
+                    hpx::execution::experimental::with_processing_units_count(
+                        executor(),
+                        hpx::execution::experimental::processing_units_count(
+                            HPX_FORWARD(Params, params), executor(),
+                            hpx::chrono::null_duration, 0));
+
+                return hpx::execution::experimental::create_rebound_policy(
+                    derived(), HPX_MOVE(exec), parameters());
+            }
+
         private:
             friend struct hpx::execution::experimental::create_rebound_policy_t;
             friend class hpx::serialization::access;
@@ -313,6 +410,14 @@ namespace hpx::execution {
                 return *this;
             }
             /// \endcond
+
+            // Policy mapping member functions
+            constexpr auto to_non_task() const;
+            constexpr auto to_par() const;
+            constexpr auto to_unseq() const;
+#if defined(HPX_HAVE_DATAPAR)
+            constexpr auto to_simd() const;
+#endif
         };
     }    // namespace detail
 
@@ -383,6 +488,14 @@ namespace hpx::execution {
                 return *this;
             }
             /// \endcond
+
+            // Policy mapping member functions
+            constexpr auto to_task() const;
+            constexpr auto to_par() const;
+            constexpr auto to_unseq() const;
+#if defined(HPX_HAVE_DATAPAR)
+            constexpr auto to_simd() const;
+#endif
         };
     }    // namespace detail
 
@@ -454,6 +567,14 @@ namespace hpx::execution {
                 return *this;
             }
             /// \endcond
+
+            // Policy mapping member functions
+            constexpr auto to_non_task() const;
+            constexpr auto to_non_par() const;
+            constexpr auto to_unseq() const;
+#if defined(HPX_HAVE_DATAPAR)
+            constexpr auto to_simd() const;
+#endif
         };
     }    // namespace detail
 
@@ -522,6 +643,14 @@ namespace hpx::execution {
                 return *this;
             }
             /// \endcond
+
+            // Policy mapping member functions
+            constexpr auto to_task() const;
+            constexpr auto to_non_par() const;
+            constexpr auto to_unseq() const;
+#if defined(HPX_HAVE_DATAPAR)
+            constexpr auto to_simd() const;
+#endif
         };
     }    // namespace detail
 
@@ -596,6 +725,11 @@ namespace hpx::execution {
                 return *this;
             }
             /// \endcond
+
+            // Policy mapping member functions
+            constexpr auto to_non_task() const;
+            constexpr auto to_non_par() const;
+            constexpr auto to_non_unseq() const;
         };
     }    // namespace detail
 
@@ -660,11 +794,17 @@ namespace hpx::execution {
                 parallel_unsequenced_policy_shim<Executor_, Parameters_> const&
                     rhs)
             {
-                base_type::operator=(
-                    parallel_policy_shim(rhs.executor(), rhs.parameters()));
+                base_type::operator=(parallel_unsequenced_policy_shim(
+                    rhs.executor(), rhs.parameters()));
                 return *this;
             }
             /// \endcond
+
+            // Policy mapping member functions
+            constexpr auto to_task() const;
+            constexpr auto to_non_task() const;
+            constexpr auto to_non_par() const;
+            constexpr auto to_non_unseq() const;
         };
     }    // namespace detail
 
@@ -740,6 +880,11 @@ namespace hpx::execution {
                 return *this;
             }
             /// \endcond
+
+            // Policy mapping member functions
+            constexpr auto to_non_task() const;
+            constexpr auto to_par() const;
+            constexpr auto to_non_unseq() const;
         };
     }    // namespace detail
 
@@ -805,6 +950,11 @@ namespace hpx::execution {
                 return *this;
             }
             /// \endcond
+
+            // Policy mapping member functions
+            constexpr auto to_task() const;
+            constexpr auto to_par() const;
+            constexpr auto to_non_unseq() const;
         };
     }    // namespace detail
 
@@ -822,257 +972,265 @@ namespace hpx::execution {
     namespace detail {
 
         ///////////////////////////////////////////////////////////////////////
-        HPX_CXX_CORE_EXPORT template <typename Executor, typename Parameters>
-        constexpr decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_task_t tag,
-            sequenced_policy_shim<Executor, Parameters> const& policy)
+        // Policy mapping member function implementations
+        ///////////////////////////////////////////////////////////////////////
+        template <typename Executor, typename Parameters>
+        constexpr auto sequenced_policy_shim<Executor, Parameters>::to_task()
+            const
         {
             return sequenced_task_policy()
-                .on(hpx::experimental::prefer(tag, policy.executor()))
-                .with(policy.parameters());
+                .on(hpx::experimental::prefer(
+                    hpx::execution::experimental::to_task, this->executor()))
+                .with(this->parameters());
         }
 
-        HPX_CXX_CORE_EXPORT template <typename Executor, typename Parameters>
-        constexpr decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_par_t tag,
-            sequenced_policy_shim<Executor, Parameters> const& policy)
+        template <typename Executor, typename Parameters>
+        constexpr auto sequenced_policy_shim<Executor, Parameters>::to_par()
+            const
         {
             return parallel_policy()
-                .on(hpx::experimental::prefer(tag, policy.executor()))
-                .with(policy.parameters());
+                .on(hpx::experimental::prefer(
+                    hpx::execution::experimental::to_par, this->executor()))
+                .with(this->parameters());
         }
 
-        HPX_CXX_CORE_EXPORT template <typename Executor, typename Parameters>
-        constexpr decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_unseq_t tag,
-            sequenced_policy_shim<Executor, Parameters> const& policy)
+        template <typename Executor, typename Parameters>
+        constexpr auto sequenced_policy_shim<Executor, Parameters>::to_unseq()
+            const
         {
             return unsequenced_policy()
-                .on(hpx::experimental::prefer(tag, policy.executor()))
-                .with(policy.parameters());
+                .on(hpx::experimental::prefer(
+                    hpx::execution::experimental::to_unseq, this->executor()))
+                .with(this->parameters());
         }
 
-        ///////////////////////////////////////////////////////////////////////
-        HPX_CXX_CORE_EXPORT template <typename Executor, typename Parameters>
-        constexpr decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_non_task_t tag,
-            sequenced_task_policy_shim<Executor, Parameters> const& policy)
+        template <typename Executor, typename Parameters>
+        constexpr auto
+        sequenced_task_policy_shim<Executor, Parameters>::to_non_task() const
         {
             return sequenced_policy()
-                .on(hpx::experimental::prefer(tag, policy.executor()))
-                .with(policy.parameters());
+                .on(hpx::experimental::prefer(
+                    hpx::execution::experimental::to_non_task,
+                    this->executor()))
+                .with(this->parameters());
         }
 
-        HPX_CXX_CORE_EXPORT template <typename Executor, typename Parameters>
-        constexpr decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_par_t tag,
-            sequenced_task_policy_shim<Executor, Parameters> const& policy)
+        template <typename Executor, typename Parameters>
+        constexpr auto
+        sequenced_task_policy_shim<Executor, Parameters>::to_par() const
         {
             return parallel_task_policy()
-                .on(hpx::experimental::prefer(tag, policy.executor()))
-                .with(policy.parameters());
+                .on(hpx::experimental::prefer(
+                    hpx::execution::experimental::to_par, this->executor()))
+                .with(this->parameters());
         }
 
-        HPX_CXX_CORE_EXPORT template <typename Executor, typename Parameters>
-        constexpr decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_unseq_t tag,
-            sequenced_task_policy_shim<Executor, Parameters> const& policy)
+        template <typename Executor, typename Parameters>
+        constexpr auto
+        sequenced_task_policy_shim<Executor, Parameters>::to_unseq() const
         {
             return unsequenced_task_policy()
-                .on(hpx::experimental::prefer(tag, policy.executor()))
-                .with(policy.parameters());
+                .on(hpx::experimental::prefer(
+                    hpx::execution::experimental::to_unseq, this->executor()))
+                .with(this->parameters());
         }
 
-        ///////////////////////////////////////////////////////////////////////
-        HPX_CXX_CORE_EXPORT template <typename Executor, typename Parameters>
-        constexpr decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_non_task_t tag,
-            parallel_task_policy_shim<Executor, Parameters> const& policy)
+        template <typename Executor, typename Parameters>
+        constexpr auto
+        parallel_task_policy_shim<Executor, Parameters>::to_non_task() const
         {
             return parallel_policy()
-                .on(hpx::experimental::prefer(tag, policy.executor()))
-                .with(policy.parameters());
+                .on(hpx::experimental::prefer(
+                    hpx::execution::experimental::to_non_task,
+                    this->executor()))
+                .with(this->parameters());
         }
 
-        HPX_CXX_CORE_EXPORT template <typename Executor, typename Parameters>
-        constexpr decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_non_par_t tag,
-            parallel_task_policy_shim<Executor, Parameters> const& policy)
+        template <typename Executor, typename Parameters>
+        constexpr auto
+        parallel_task_policy_shim<Executor, Parameters>::to_non_par() const
         {
             return sequenced_task_policy()
-                .on(hpx::experimental::prefer(tag, policy.executor()))
-                .with(policy.parameters());
+                .on(hpx::experimental::prefer(
+                    hpx::execution::experimental::to_non_par, this->executor()))
+                .with(this->parameters());
         }
 
-        HPX_CXX_CORE_EXPORT template <typename Executor, typename Parameters>
-        constexpr decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_unseq_t tag,
-            parallel_task_policy_shim<Executor, Parameters> const& policy)
+        template <typename Executor, typename Parameters>
+        constexpr auto
+        parallel_task_policy_shim<Executor, Parameters>::to_unseq() const
         {
             return parallel_unsequenced_task_policy()
-                .on(hpx::experimental::prefer(tag, policy.executor()))
-                .with(policy.parameters());
+                .on(hpx::experimental::prefer(
+                    hpx::execution::experimental::to_unseq, this->executor()))
+                .with(this->parameters());
         }
 
-        ///////////////////////////////////////////////////////////////////////
-        HPX_CXX_CORE_EXPORT template <typename Executor, typename Parameters>
-        constexpr decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_task_t tag,
-            parallel_policy_shim<Executor, Parameters> const& policy)
+        template <typename Executor, typename Parameters>
+        constexpr auto parallel_policy_shim<Executor, Parameters>::to_task()
+            const
         {
             return parallel_task_policy()
-                .on(hpx::experimental::prefer(tag, policy.executor()))
-                .with(policy.parameters());
+                .on(hpx::experimental::prefer(
+                    hpx::execution::experimental::to_task, this->executor()))
+                .with(this->parameters());
         }
 
-        HPX_CXX_CORE_EXPORT template <typename Executor, typename Parameters>
-        constexpr decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_non_par_t tag,
-            parallel_policy_shim<Executor, Parameters> const& policy)
+        template <typename Executor, typename Parameters>
+        constexpr auto parallel_policy_shim<Executor, Parameters>::to_non_par()
+            const
         {
             return sequenced_policy()
-                .on(hpx::experimental::prefer(tag, policy.executor()))
-                .with(policy.parameters());
+                .on(hpx::experimental::prefer(
+                    hpx::execution::experimental::to_non_par, this->executor()))
+                .with(this->parameters());
         }
 
-        HPX_CXX_CORE_EXPORT template <typename Executor, typename Parameters>
-        constexpr decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_unseq_t tag,
-            parallel_policy_shim<Executor, Parameters> const& policy)
+        template <typename Executor, typename Parameters>
+        constexpr auto parallel_policy_shim<Executor, Parameters>::to_unseq()
+            const
         {
             return parallel_unsequenced_policy()
-                .on(hpx::experimental::prefer(tag, policy.executor()))
-                .with(policy.parameters());
+                .on(hpx::experimental::prefer(
+                    hpx::execution::experimental::to_unseq, this->executor()))
+                .with(this->parameters());
         }
 
-        ///////////////////////////////////////////////////////////////////////
-        HPX_CXX_CORE_EXPORT template <typename Executor, typename Parameters>
-        constexpr decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_non_task_t tag,
-            parallel_unsequenced_task_policy_shim<Executor, Parameters> const&
-                policy)
+        template <typename Executor, typename Parameters>
+        constexpr auto parallel_unsequenced_task_policy_shim<Executor,
+            Parameters>::to_non_task() const
         {
             return parallel_unsequenced_policy()
-                .on(hpx::experimental::prefer(tag, policy.executor()))
-                .with(policy.parameters());
+                .on(hpx::experimental::prefer(
+                    hpx::execution::experimental::to_non_task,
+                    this->executor()))
+                .with(this->parameters());
         }
 
-        HPX_CXX_CORE_EXPORT template <typename Executor, typename Parameters>
-        constexpr decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_non_par_t tag,
-            parallel_unsequenced_task_policy_shim<Executor, Parameters> const&
-                policy)
+        template <typename Executor, typename Parameters>
+        constexpr auto parallel_unsequenced_task_policy_shim<Executor,
+            Parameters>::to_non_par() const
         {
             return unsequenced_task_policy()
-                .on(hpx::experimental::prefer(tag, policy.executor()))
-                .with(policy.parameters());
+                .on(hpx::experimental::prefer(
+                    hpx::execution::experimental::to_non_par, this->executor()))
+                .with(this->parameters());
         }
 
-        HPX_CXX_CORE_EXPORT template <typename Executor, typename Parameters>
-        constexpr decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_non_unseq_t tag,
-            parallel_unsequenced_task_policy_shim<Executor, Parameters> const&
-                policy)
+        template <typename Executor, typename Parameters>
+        constexpr auto parallel_unsequenced_task_policy_shim<Executor,
+            Parameters>::to_non_unseq() const
         {
             return parallel_task_policy()
-                .on(hpx::experimental::prefer(tag, policy.executor()))
-                .with(policy.parameters());
+                .on(hpx::experimental::prefer(
+                    hpx::execution::experimental::to_non_unseq,
+                    this->executor()))
+                .with(this->parameters());
         }
 
-        ///////////////////////////////////////////////////////////////////////
-        HPX_CXX_CORE_EXPORT template <typename Executor, typename Parameters>
-        constexpr decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_task_t tag,
-            parallel_unsequenced_policy_shim<Executor, Parameters> const&
-                policy)
+        template <typename Executor, typename Parameters>
+        constexpr auto
+        parallel_unsequenced_policy_shim<Executor, Parameters>::to_task() const
         {
             return parallel_unsequenced_task_policy()
-                .on(hpx::experimental::prefer(tag, policy.executor()))
-                .with(policy.parameters());
+                .on(hpx::experimental::prefer(
+                    hpx::execution::experimental::to_task, this->executor()))
+                .with(this->parameters());
         }
 
-        HPX_CXX_CORE_EXPORT template <typename Executor, typename Parameters>
-        constexpr decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_non_par_t tag,
-            parallel_unsequenced_policy_shim<Executor, Parameters> const&
-                policy)
+        template <typename Executor, typename Parameters>
+        constexpr auto parallel_unsequenced_policy_shim<Executor,
+            Parameters>::to_non_task() const
+        {
+            return parallel_unsequenced_policy()
+                .on(hpx::experimental::prefer(
+                    hpx::execution::experimental::to_non_task,
+                    this->executor()))
+                .with(this->parameters());
+        }
+
+        template <typename Executor, typename Parameters>
+        constexpr auto parallel_unsequenced_policy_shim<Executor,
+            Parameters>::to_non_par() const
         {
             return unsequenced_policy()
-                .on(hpx::experimental::prefer(tag, policy.executor()))
-                .with(policy.parameters());
+                .on(hpx::experimental::prefer(
+                    hpx::execution::experimental::to_non_par, this->executor()))
+                .with(this->parameters());
         }
 
-        HPX_CXX_CORE_EXPORT template <typename Executor, typename Parameters>
-        constexpr decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_non_unseq_t tag,
-            parallel_unsequenced_policy_shim<Executor, Parameters> const&
-                policy)
+        template <typename Executor, typename Parameters>
+        constexpr auto parallel_unsequenced_policy_shim<Executor,
+            Parameters>::to_non_unseq() const
         {
             return parallel_policy()
-                .on(hpx::experimental::prefer(tag, policy.executor()))
-                .with(policy.parameters());
+                .on(hpx::experimental::prefer(
+                    hpx::execution::experimental::to_non_unseq,
+                    this->executor()))
+                .with(this->parameters());
         }
 
-        ///////////////////////////////////////////////////////////////////////
-        HPX_CXX_CORE_EXPORT template <typename Executor, typename Parameters>
-        constexpr decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_non_task_t tag,
-            unsequenced_task_policy_shim<Executor, Parameters> const& policy)
+        template <typename Executor, typename Parameters>
+        constexpr auto
+        unsequenced_task_policy_shim<Executor, Parameters>::to_non_task() const
         {
             return unsequenced_policy()
-                .on(hpx::experimental::prefer(tag, policy.executor()))
-                .with(policy.parameters());
+                .on(hpx::experimental::prefer(
+                    hpx::execution::experimental::to_non_task,
+                    this->executor()))
+                .with(this->parameters());
         }
 
-        HPX_CXX_CORE_EXPORT template <typename Executor, typename Parameters>
-        constexpr decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_par_t tag,
-            unsequenced_task_policy_shim<Executor, Parameters> const& policy)
+        template <typename Executor, typename Parameters>
+        constexpr auto
+        unsequenced_task_policy_shim<Executor, Parameters>::to_par() const
         {
             return parallel_unsequenced_task_policy()
-                .on(hpx::experimental::prefer(tag, policy.executor()))
-                .with(policy.parameters());
+                .on(hpx::experimental::prefer(
+                    hpx::execution::experimental::to_par, this->executor()))
+                .with(this->parameters());
         }
 
-        HPX_CXX_CORE_EXPORT template <typename Executor, typename Parameters>
-        constexpr decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_non_unseq_t tag,
-            unsequenced_task_policy_shim<Executor, Parameters> const& policy)
+        template <typename Executor, typename Parameters>
+        constexpr auto
+        unsequenced_task_policy_shim<Executor, Parameters>::to_non_unseq() const
         {
             return sequenced_task_policy()
-                .on(hpx::experimental::prefer(tag, policy.executor()))
-                .with(policy.parameters());
+                .on(hpx::experimental::prefer(
+                    hpx::execution::experimental::to_non_unseq,
+                    this->executor()))
+                .with(this->parameters());
         }
 
-        ///////////////////////////////////////////////////////////////////////
-        HPX_CXX_CORE_EXPORT template <typename Executor, typename Parameters>
-        constexpr decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_task_t tag,
-            unsequenced_policy_shim<Executor, Parameters> const& policy)
+        template <typename Executor, typename Parameters>
+        constexpr auto unsequenced_policy_shim<Executor, Parameters>::to_task()
+            const
         {
             return unsequenced_task_policy()
-                .on(hpx::experimental::prefer(tag, policy.executor()))
-                .with(policy.parameters());
+                .on(hpx::experimental::prefer(
+                    hpx::execution::experimental::to_task, this->executor()))
+                .with(this->parameters());
         }
 
-        HPX_CXX_CORE_EXPORT template <typename Executor, typename Parameters>
-        constexpr decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_par_t tag,
-            unsequenced_policy_shim<Executor, Parameters> const& policy)
+        template <typename Executor, typename Parameters>
+        constexpr auto unsequenced_policy_shim<Executor, Parameters>::to_par()
+            const
         {
             return parallel_unsequenced_policy()
-                .on(hpx::experimental::prefer(tag, policy.executor()))
-                .with(policy.parameters());
+                .on(hpx::experimental::prefer(
+                    hpx::execution::experimental::to_par, this->executor()))
+                .with(this->parameters());
         }
 
-        HPX_CXX_CORE_EXPORT template <typename Executor, typename Parameters>
-        constexpr decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_non_unseq_t tag,
-            unsequenced_policy_shim<Executor, Parameters> const& policy)
+        template <typename Executor, typename Parameters>
+        constexpr auto
+        unsequenced_policy_shim<Executor, Parameters>::to_non_unseq() const
         {
             return sequenced_policy()
-                .on(hpx::experimental::prefer(tag, policy.executor()))
-                .with(policy.parameters());
+                .on(hpx::experimental::prefer(
+                    hpx::execution::experimental::to_non_unseq,
+                    this->executor()))
+                .with(this->parameters());
         }
 
         ///////////////////////////////////////////////////////////////////////

--- a/libs/core/executors/include/hpx/executors/execution_policy_annotation.hpp
+++ b/libs/core/executors/include/hpx/executors/execution_policy_annotation.hpp
@@ -22,43 +22,9 @@
 
 namespace hpx::execution::experimental {
 
-    // with_annotation property implementation for execution policies
-    // that simply forwards to the embedded executor
-    template <execution_policy ExPolicy>
-        requires(std::invocable<hpx::execution::experimental::with_annotation_t,
-            typename std::decay_t<ExPolicy>::executor_type, char const*>)
-    constexpr decltype(auto) tag_invoke(
-        hpx::execution::experimental::with_annotation_t, ExPolicy&& policy,
-        char const* annotation)
-    {
-        auto exec = hpx::execution::experimental::with_annotation(
-            policy.executor(), annotation);
-
-        return hpx::execution::experimental::create_rebound_policy(
-            policy, HPX_MOVE(exec), policy.parameters());
-    }
-
-    template <execution_policy ExPolicy>
-        requires(std::invocable<hpx::execution::experimental::with_annotation_t,
-            typename std::decay_t<ExPolicy>::executor_type, std::string>)
-    decltype(auto) tag_invoke(hpx::execution::experimental::with_annotation_t,
-        ExPolicy&& policy, std::string annotation)
-    {
-        auto exec = hpx::execution::experimental::with_annotation(
-            policy.executor(), HPX_MOVE(annotation));
-
-        return hpx::execution::experimental::create_rebound_policy(
-            policy, HPX_MOVE(exec), policy.parameters());
-    }
-
-    // get_annotation property implementation for execution policies
-    // that simply forwards to the embedded executor
-    template <execution_policy ExPolicy>
-        requires(std::invocable<hpx::execution::experimental::get_annotation_t,
-            typename std::decay_t<ExPolicy>::executor_type>)
-    constexpr decltype(auto) tag_invoke(
-        hpx::execution::experimental::get_annotation_t, ExPolicy&& policy)
-    {
-        return hpx::execution::experimental::get_annotation(policy.executor());
-    }
+    // with_annotation/get_annotation property implementations for execution
+    // policies are provided through the public query() member functions on
+    // execution_policy (see hpx/executors/execution_policy.hpp). The property
+    // CPOs detect those members directly (via property_base), so no tag_invoke
+    // bridge is needed here.
 }    // namespace hpx::execution::experimental

--- a/libs/core/executors/include/hpx/executors/execution_policy_mappings.hpp
+++ b/libs/core/executors/include/hpx/executors/execution_policy_mappings.hpp
@@ -30,7 +30,7 @@ namespace hpx::execution::experimental {
 
     ///////////////////////////////////////////////////////////////////////////
     // Return the matching non-parallel (sequenced) execution policy
-    HPX_CXX_CORE_EXPORT inline constexpr struct to_non_par_t final
+    HPX_CXX_CORE_EXPORT inline constexpr struct to_non_par_t
       : hpx::functional::detail::tag_fallback<to_non_par_t>
     {
     private:
@@ -60,10 +60,19 @@ namespace hpx::execution::experimental {
     };
 
     // Return the matching parallel execution policy
-    HPX_CXX_CORE_EXPORT inline constexpr struct to_par_t final
+    HPX_CXX_CORE_EXPORT inline constexpr struct to_par_t
       : hpx::functional::detail::tag_fallback<to_par_t>
     {
     private:
+        // Bridge: forward to member function if available
+        template <typename Target>
+            requires requires(Target const& t) { t.to_par(); }
+        friend constexpr decltype(auto) tag_invoke(
+            to_par_t, Target const& target)
+        {
+            return target.to_par();
+        }
+
         // any parallel policy just returns itself
         template <execution_policy ExPolicy>
         friend constexpr decltype(auto) tag_fallback_invoke(
@@ -86,6 +95,15 @@ namespace hpx::execution::experimental {
       : hpx::functional::detail::tag_fallback<to_non_task_t>
     {
     private:
+        // Bridge: forward to member function if available
+        template <typename Target>
+            requires requires(Target const& t) { t.to_non_task(); }
+        friend constexpr decltype(auto) tag_invoke(
+            to_non_task_t, Target const& target)
+        {
+            return target.to_non_task();
+        }
+
         // any non-task policy just returns itself
         template <execution_policy ExPolicy>
         friend constexpr decltype(auto) tag_fallback_invoke(
@@ -107,6 +125,15 @@ namespace hpx::execution::experimental {
       : hpx::functional::detail::tag_fallback<to_task_t>
     {
     private:
+        // Bridge: forward to member function if available
+        template <typename Target>
+            requires requires(Target const& t) { t.to_task(); }
+        friend constexpr decltype(auto) tag_invoke(
+            to_task_t, Target const& target)
+        {
+            return target.to_task();
+        }
+
         // any task policy just returns itself
         template <execution_policy ExPolicy>
         friend constexpr decltype(auto) tag_fallback_invoke(
@@ -125,10 +152,19 @@ namespace hpx::execution::experimental {
 
     ///////////////////////////////////////////////////////////////////////////
     // Return the matching non-unsequenced execution policy
-    HPX_CXX_CORE_EXPORT inline constexpr struct to_non_unseq_t final
+    HPX_CXX_CORE_EXPORT inline constexpr struct to_non_unseq_t
       : hpx::functional::detail::tag_fallback<to_non_unseq_t>
     {
     private:
+        // Bridge: forward to member function if available
+        template <typename Target>
+            requires requires(Target const& t) { t.to_non_unseq(); }
+        friend constexpr decltype(auto) tag_invoke(
+            to_non_unseq_t, Target const& target)
+        {
+            return target.to_non_unseq();
+        }
+
         // any non-unsequenced policy just returns itself
         template <execution_policy ExPolicy>
         friend constexpr decltype(auto) tag_fallback_invoke(
@@ -146,10 +182,19 @@ namespace hpx::execution::experimental {
     };
 
     // Return the matching unsequenced execution policy
-    HPX_CXX_CORE_EXPORT inline constexpr struct to_unseq_t final
+    HPX_CXX_CORE_EXPORT inline constexpr struct to_unseq_t
       : hpx::functional::detail::tag_fallback<to_unseq_t>
     {
     private:
+        // Bridge: forward to member function if available
+        template <typename Target>
+            requires requires(Target const& t) { t.to_unseq(); }
+        friend constexpr decltype(auto) tag_invoke(
+            to_unseq_t, Target const& target)
+        {
+            return target.to_unseq();
+        }
+
         // any unsequenced policy just returns itself
         template <execution_policy ExPolicy>
         friend constexpr decltype(auto) tag_fallback_invoke(

--- a/libs/core/executors/include/hpx/executors/execution_policy_mappings.hpp
+++ b/libs/core/executors/include/hpx/executors/execution_policy_mappings.hpp
@@ -34,6 +34,15 @@ namespace hpx::execution::experimental {
       : hpx::functional::detail::tag_fallback<to_non_par_t>
     {
     private:
+        // Bridge: forward to member function if available
+        template <typename Target>
+            requires requires(Target const& t) { t.to_non_par(); }
+        friend constexpr decltype(auto) tag_invoke(
+            to_non_par_t, Target const& target)
+        {
+            return target.to_non_par();
+        }
+
         // any non-parallel policy just returns itself
         template <execution_policy ExPolicy>
         friend constexpr decltype(auto) tag_fallback_invoke(

--- a/libs/core/executors/include/hpx/executors/execution_policy_parameters.hpp
+++ b/libs/core/executors/include/hpx/executors/execution_policy_parameters.hpp
@@ -30,6 +30,7 @@ namespace hpx::execution::experimental {
     // the underlying executor
     HPX_CXX_CORE_EXPORT template <typename ParametersProperty,
         execution_policy ExPolicy, executor_parameters Params>
+        requires(!is_scheduling_property_v<ParametersProperty>)
     constexpr decltype(auto) tag_fallback_invoke(
         ParametersProperty, ExPolicy&& policy, Params&& params)
     {

--- a/libs/core/executors/include/hpx/executors/execution_policy_parameters.hpp
+++ b/libs/core/executors/include/hpx/executors/execution_policy_parameters.hpp
@@ -21,42 +21,10 @@
 
 namespace hpx::execution::experimental {
 
-    // with_processing_units_count property implementation for execution
-    // policies that simply forwards to the embedded executor (if that supports
-    // the parameters type)
-
-    HPX_CXX_CORE_EXPORT template <execution_policy ExPolicy>
-        requires(std::invocable<with_processing_units_count_t,
-            typename std::decay_t<ExPolicy>::executor_type, std::size_t>)
-    constexpr decltype(auto) tag_invoke(
-        with_processing_units_count_t, ExPolicy&& policy, std::size_t num_cores)
-    {
-        auto exec = with_processing_units_count(policy.executor(), num_cores);
-
-        return create_rebound_policy(
-            policy, HPX_MOVE(exec), policy.parameters());
-    }
-
-    HPX_CXX_CORE_EXPORT template <execution_policy ExPolicy,
-        executor_parameters Params>
-        requires(
-            std::invocable<with_processing_units_count_t,
-                typename std::decay_t<ExPolicy>::executor_type, std::size_t> &&
-            std::invocable<processing_units_count_t, std::decay_t<Params>,
-                typename std::decay_t<ExPolicy>::executor_type,
-                hpx::chrono::steady_duration const&, std::size_t>)
-    constexpr decltype(auto) tag_invoke(
-        with_processing_units_count_t, ExPolicy&& policy, Params&& params)
-    {
-        // explicitly extract pu count from given parameters object as otherwise
-        // the executor might take precedence
-        auto exec = with_processing_units_count(policy.executor(),
-            processing_units_count(
-                params, policy.executor(), hpx::chrono::null_duration, 0));
-
-        return create_rebound_policy(
-            policy, HPX_MOVE(exec), policy.parameters());
-    }
+    // with_processing_units_count property implementations for execution
+    // policies that support the embedded executor are provided through the
+    // public query() member functions on execution_policy (see
+    // hpx/executors/execution_policy.hpp).
 
     // general fallback for parameters types that are not directly supported by
     // the underlying executor

--- a/libs/core/executors/include/hpx/executors/execution_policy_scheduling_property.hpp
+++ b/libs/core/executors/include/hpx/executors/execution_policy_scheduling_property.hpp
@@ -17,27 +17,9 @@
 
 namespace hpx::execution::experimental {
 
-    // Scheduling property implementations for execution policies that simply
-    // forwards to the embedded executor
-
-    HPX_CXX_CORE_EXPORT template <scheduling_property Tag,
-        execution_policy ExPolicy, typename Property>
-        requires(hpx::functional::is_tag_invocable_v<Tag,
-            typename std::decay_t<ExPolicy>::executor_type, Property>)
-    constexpr decltype(auto) tag_invoke(
-        Tag tag, ExPolicy&& policy, Property&& prop)
-    {
-        return hpx::execution::experimental::create_rebound_policy(policy,
-            tag(policy.executor(), HPX_FORWARD(Property, prop)),
-            policy.parameters());
-    }
-
-    HPX_CXX_CORE_EXPORT template <scheduling_property Tag,
-        execution_policy ExPolicy>
-        requires(hpx::functional::is_tag_invocable_v<Tag,
-            typename std::decay_t<ExPolicy>::executor_type>)
-    constexpr decltype(auto) tag_invoke(Tag tag, ExPolicy&& policy)
-    {
-        return tag(policy.executor());
-    }
+    // Scheduling property implementations for execution policies are provided
+    // through the public query() member functions on execution_policy (see
+    // hpx/executors/execution_policy.hpp). The scheduling property CPOs detect
+    // those members directly (via property_base), so no tag_invoke bridge is
+    // needed here.
 }    // namespace hpx::execution::experimental

--- a/libs/core/executors/include/hpx/executors/explicit_scheduler_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/explicit_scheduler_executor.hpp
@@ -92,7 +92,10 @@ namespace hpx::execution::experimental {
 
         template <typename Tag, typename Property>
             requires(
-                hpx::execution::experimental::is_scheduling_property_v<Tag>)
+                hpx::execution::experimental::is_scheduling_property_v<Tag> &&
+                requires(BaseScheduler const& sched, Tag tag, Property prop) {
+                    sched.query(tag, HPX_FORWARD(Property, prop));
+                })
         [[nodiscard]] auto query(Tag tag, Property&& prop) const
         {
             return explicit_scheduler_executor{
@@ -101,7 +104,9 @@ namespace hpx::execution::experimental {
 
         template <typename Tag>
             requires(
-                hpx::execution::experimental::is_scheduling_property_v<Tag>)
+                hpx::execution::experimental::is_scheduling_property_v<Tag> &&
+                requires(
+                    BaseScheduler const& sched, Tag tag) { sched.query(tag); })
         [[nodiscard]] auto query(Tag tag) const
         {
             return sched_.query(tag);

--- a/libs/core/executors/include/hpx/executors/explicit_scheduler_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/explicit_scheduler_executor.hpp
@@ -80,6 +80,33 @@ namespace hpx::execution::experimental {
             return sched_;
         }
 
+        template <typename Parameters>
+            requires(hpx::traits::is_executor_parameters_v<Parameters>)
+        [[nodiscard]] auto query(processing_units_count_t,
+            Parameters&& params,
+            hpx::chrono::steady_duration const& =
+                hpx::chrono::null_duration,
+            std::size_t = 0) const
+        {
+            return sched_.query(processing_units_count_t{},
+                HPX_FORWARD(Parameters, params), hpx::chrono::null_duration, 0);
+        }
+
+        template <typename Tag, typename Property>
+            requires(hpx::execution::experimental::is_scheduling_property_v<Tag>)
+        [[nodiscard]] auto query(Tag tag, Property&& prop) const
+        {
+            return explicit_scheduler_executor{
+                sched_.query(tag, HPX_FORWARD(Property, prop))};
+        }
+
+        template <typename Tag>
+            requires(hpx::execution::experimental::is_scheduling_property_v<Tag>)
+        [[nodiscard]] auto query(Tag tag) const
+        {
+            return sched_.query(tag);
+        }
+
         // clang-format off
         template <typename Parameters,
             HPX_CONCEPT_REQUIRES_(
@@ -87,16 +114,14 @@ namespace hpx::execution::experimental {
             )>
         // clang-format on
         friend auto tag_invoke(
-            hpx::execution::experimental::processing_units_count_t tag,
+            hpx::execution::experimental::processing_units_count_t,
             Parameters&& params, explicit_scheduler_executor const& exec,
-            hpx::chrono::steady_duration const& = hpx::chrono::null_duration,
-            std::size_t = 0)
-            -> decltype(std::declval<
-                hpx::execution::experimental::processing_units_count_t>()(
-                std::declval<Parameters>(), std::declval<BaseScheduler>(),
-                std::declval<hpx::chrono::steady_duration>(), 0))
+            hpx::chrono::steady_duration const& duration =
+                hpx::chrono::null_duration,
+            std::size_t num_cores = 0)
         {
-            return tag(HPX_FORWARD(Parameters, params), exec.sched_);
+            return exec.query(processing_units_count_t{},
+                HPX_FORWARD(Parameters, params), duration, num_cores);
         }
 
         // Associate the parallel_execution_tag executor tag type as a default
@@ -317,35 +342,22 @@ namespace hpx::execution::experimental {
     explicit explicit_scheduler_executor(BaseScheduler&& sched)
         -> explicit_scheduler_executor<std::decay_t<BaseScheduler>>;
 
-    // support all properties exposed by the wrapped scheduler
-    // clang-format off
+    // HPX scheduling CPOs still dispatch via tag_invoke; forward to query().
     HPX_CXX_CORE_EXPORT template <typename Tag, typename BaseScheduler,
-        typename Property,
-        HPX_CONCEPT_REQUIRES_(
-            hpx::execution::experimental::is_scheduling_property_v<Tag>
-        )>
-    // clang-format on
+        typename Property>
+        requires(hpx::execution::experimental::is_scheduling_property_v<Tag>)
     auto tag_invoke(Tag tag,
         explicit_scheduler_executor<BaseScheduler> const& exec, Property&& prop)
-        -> decltype(explicit_scheduler_executor<BaseScheduler>(
-            std::declval<Tag>()(
-                std::declval<BaseScheduler>(), std::declval<Property>())))
     {
-        return explicit_scheduler_executor<BaseScheduler>(
-            tag(exec.sched(), HPX_FORWARD(Property, prop)));
+        return exec.query(tag, HPX_FORWARD(Property, prop));
     }
 
-    // clang-format off
-    HPX_CXX_CORE_EXPORT template <typename Tag, typename BaseScheduler,
-        HPX_CONCEPT_REQUIRES_(
-            hpx::execution::experimental::is_scheduling_property_v<Tag>
-        )>
-    // clang-format on
+    HPX_CXX_CORE_EXPORT template <typename Tag, typename BaseScheduler>
+        requires(hpx::execution::experimental::is_scheduling_property_v<Tag>)
     auto tag_invoke(
         Tag tag, explicit_scheduler_executor<BaseScheduler> const& exec)
-        -> decltype(std::declval<Tag>()(std::declval<BaseScheduler>()))
     {
-        return tag(exec.sched());
+        return exec.query(tag);
     }
 }    // namespace hpx::execution::experimental
 

--- a/libs/core/executors/include/hpx/executors/explicit_scheduler_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/explicit_scheduler_executor.hpp
@@ -82,10 +82,8 @@ namespace hpx::execution::experimental {
 
         template <typename Parameters>
             requires(hpx::traits::is_executor_parameters_v<Parameters>)
-        [[nodiscard]] auto query(processing_units_count_t,
-            Parameters&& params,
-            hpx::chrono::steady_duration const& =
-                hpx::chrono::null_duration,
+        [[nodiscard]] auto query(processing_units_count_t, Parameters&& params,
+            hpx::chrono::steady_duration const& = hpx::chrono::null_duration,
             std::size_t = 0) const
         {
             return sched_.query(processing_units_count_t{},
@@ -93,7 +91,8 @@ namespace hpx::execution::experimental {
         }
 
         template <typename Tag, typename Property>
-            requires(hpx::execution::experimental::is_scheduling_property_v<Tag>)
+            requires(
+                hpx::execution::experimental::is_scheduling_property_v<Tag>)
         [[nodiscard]] auto query(Tag tag, Property&& prop) const
         {
             return explicit_scheduler_executor{
@@ -101,27 +100,11 @@ namespace hpx::execution::experimental {
         }
 
         template <typename Tag>
-            requires(hpx::execution::experimental::is_scheduling_property_v<Tag>)
+            requires(
+                hpx::execution::experimental::is_scheduling_property_v<Tag>)
         [[nodiscard]] auto query(Tag tag) const
         {
             return sched_.query(tag);
-        }
-
-        // clang-format off
-        template <typename Parameters,
-            HPX_CONCEPT_REQUIRES_(
-                hpx::traits::is_executor_parameters_v<Parameters>
-            )>
-        // clang-format on
-        friend auto tag_invoke(
-            hpx::execution::experimental::processing_units_count_t,
-            Parameters&& params, explicit_scheduler_executor const& exec,
-            hpx::chrono::steady_duration const& duration =
-                hpx::chrono::null_duration,
-            std::size_t num_cores = 0)
-        {
-            return exec.query(processing_units_count_t{},
-                HPX_FORWARD(Parameters, params), duration, num_cores);
         }
 
         // Associate the parallel_execution_tag executor tag type as a default
@@ -135,22 +118,19 @@ namespace hpx::execution::experimental {
 
         // NonBlockingOneWayExecutor interface
         template <typename F, typename... Ts>
-        friend void tag_invoke(hpx::parallel::execution::post_t,
-            explicit_scheduler_executor const& exec, F&& f, Ts&&... ts)
+        void post(F&& f, Ts&&... ts) const
         {
-            start_detached(then(schedule(exec.sched_),
+            start_detached(then(schedule(sched_),
                 hpx::util::deferred_call(
                     HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...)));
         }
 
         // OneWayExecutor interface
         template <typename F, typename... Ts>
-        friend auto tag_invoke(hpx::parallel::execution::sync_execute_t,
-            explicit_scheduler_executor const& exec, F&& f, Ts&&... ts)
+        auto sync_execute(F&& f, Ts&&... ts) const
         {
             auto result = hpx::this_thread::experimental::sync_wait(
-                hpx::parallel::execution::async_execute(
-                    exec, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...));
+                async_execute(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...));
             constexpr std::size_t size =
                 hpx::tuple_size<std::decay_t<decltype(*result)>>::value;
             if constexpr (size == 0)
@@ -166,21 +146,18 @@ namespace hpx::execution::experimental {
 
         // TwoWayExecutor interface
         template <typename F, typename... Ts>
-        friend auto tag_invoke(hpx::parallel::execution::async_execute_t,
-            explicit_scheduler_executor const& exec, F&& f, Ts&&... ts)
+        auto async_execute(F&& f, Ts&&... ts) const
         {
-            return then(schedule(exec.sched_),
+            return then(schedule(sched_),
                 hpx::util::deferred_call(
                     HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...));
         }
 
         template <typename F, typename Future, typename... Ts>
-        friend auto tag_invoke(hpx::parallel::execution::then_execute_t,
-            explicit_scheduler_executor const& exec, F&& f,
-            Future&& predecessor, Ts&&... ts)
+        auto then_execute(F&& f, Future&& predecessor, Ts&&... ts) const
         {
             auto&& predecessor_continues_on_sched = continues_on(
-                keep_future(HPX_FORWARD(Future, predecessor)), exec.sched_);
+                keep_future(HPX_FORWARD(Future, predecessor)), sched_);
 
             return then(HPX_MOVE(predecessor_continues_on_sched),
                 hpx::bind_back(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...));
@@ -190,22 +167,18 @@ namespace hpx::execution::experimental {
         // Integral shape overload - passes integral directly to bulk
         template <typename F, typename S, typename... Ts>
             requires(std::is_integral_v<S>)
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::bulk_async_execute_t,
-            explicit_scheduler_executor const& exec, F&& f, S const& shape,
-            Ts&&... ts)
+        decltype(auto) bulk_async_execute(
+            F&& f, S const& shape, Ts&&... ts) const
         {
-            return bulk(schedule(exec.sched_), shape,
+            return bulk(schedule(sched_), shape,
                 hpx::bind_back(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...));
         }
 
         // Range shape overload
         template <typename F, typename S, typename... Ts>
             requires(!std::is_integral_v<S>)
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::bulk_async_execute_t,
-            explicit_scheduler_executor const& exec, F&& f, S const& shape,
-            Ts&&... ts)
+        decltype(auto) bulk_async_execute(
+            F&& f, S const& shape, Ts&&... ts) const
         {
             using shape_element = hpx::traits::range_traits<S>::value_type;
             using result_type = hpx::util::detail::invoke_deferred_result_t<F,
@@ -216,7 +189,7 @@ namespace hpx::execution::experimental {
                 // stdexec::bulk requires integral shape and execution policy
                 using size_type = decltype(std::ranges::size(shape));
                 size_type const n = std::ranges::size(shape);
-                return bulk(schedule(exec.sched_), n,
+                return bulk(schedule(sched_), n,
                     [shape,
                         bound_f = hpx::bind_back(HPX_FORWARD(F, f),
                             HPX_FORWARD(Ts, ts)...)](size_type i) mutable {
@@ -255,7 +228,7 @@ namespace hpx::execution::experimental {
                 return continues_on(
                            just(HPX_MOVE(result_vector), shape,
                                HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...),
-                           exec.sched_) |
+                           sched_) |
                     bulk(shape_size, HPX_MOVE(f_wrapper)) |
                     then(HPX_MOVE(get_result));
             }
@@ -264,40 +237,33 @@ namespace hpx::execution::experimental {
         // Integral shape overload - passes integral directly
         template <typename F, typename S, typename... Ts>
             requires(std::is_integral_v<S>)
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::bulk_sync_execute_t,
-            explicit_scheduler_executor const& exec, F&& f, S const& shape,
-            Ts&&... ts)
+        decltype(auto) bulk_sync_execute(
+            F&& f, S const& shape, Ts&&... ts) const
         {
-            hpx::this_thread::experimental::sync_wait(
-                hpx::parallel::execution::bulk_async_execute(
-                    exec, HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...));
+            hpx::this_thread::experimental::sync_wait(bulk_async_execute(
+                HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...));
         }
 
         // Range shape overload
         template <typename F, typename S, typename... Ts>
             requires(!std::is_integral_v<S>)
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::bulk_sync_execute_t,
-            explicit_scheduler_executor const& exec, F&& f, S const& shape,
-            Ts&&... ts)
+        decltype(auto) bulk_sync_execute(
+            F&& f, S const& shape, Ts&&... ts) const
         {
-            hpx::this_thread::experimental::sync_wait(
-                hpx::parallel::execution::bulk_async_execute(
-                    exec, HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...));
+            hpx::this_thread::experimental::sync_wait(bulk_async_execute(
+                HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...));
         }
 
         // Integral shape overload - passes integral directly to bulk
         template <typename F, typename S, typename Future, typename... Ts>
             requires(std::is_integral_v<S>)
-        friend auto tag_invoke(hpx::parallel::execution::bulk_then_execute_t,
-            explicit_scheduler_executor const& exec, F&& f, S const& shape,
-            Future&& predecessor, Ts&&... ts)
+        auto bulk_then_execute(
+            F&& f, S const& shape, Future&& predecessor, Ts&&... ts) const
         {
             auto pre_req =
                 when_all(keep_future(HPX_FORWARD(Future, predecessor)));
 
-            return continues_on(HPX_MOVE(pre_req), exec.sched_) |
+            return continues_on(HPX_MOVE(pre_req), sched_) |
                 bulk(shape,
                     hpx::bind_back(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...));
         }
@@ -305,9 +271,8 @@ namespace hpx::execution::experimental {
         // Range shape overload
         template <typename F, typename S, typename Future, typename... Ts>
             requires(!std::is_integral_v<S>)
-        friend auto tag_invoke(hpx::parallel::execution::bulk_then_execute_t,
-            explicit_scheduler_executor const& exec, F&& f, S const& shape,
-            Future&& predecessor, Ts&&... ts)
+        auto bulk_then_execute(
+            F&& f, S const& shape, Future&& predecessor, Ts&&... ts) const
         {
             using result_type =
                 parallel::execution::detail::then_bulk_function_result_t<F, S,
@@ -321,7 +286,7 @@ namespace hpx::execution::experimental {
 
             using size_type = decltype(std::ranges::size(shape));
             size_type const n = std::ranges::size(shape);
-            return continues_on(HPX_MOVE(pre_req), exec.sched_) |
+            return continues_on(HPX_MOVE(pre_req), sched_) |
                 bulk(n,
                     [shape,
                         bound_f = hpx::bind_back(
@@ -342,23 +307,8 @@ namespace hpx::execution::experimental {
     explicit explicit_scheduler_executor(BaseScheduler&& sched)
         -> explicit_scheduler_executor<std::decay_t<BaseScheduler>>;
 
-    // HPX scheduling CPOs still dispatch via tag_invoke; forward to query().
-    HPX_CXX_CORE_EXPORT template <typename Tag, typename BaseScheduler,
-        typename Property>
-        requires(hpx::execution::experimental::is_scheduling_property_v<Tag>)
-    auto tag_invoke(Tag tag,
-        explicit_scheduler_executor<BaseScheduler> const& exec, Property&& prop)
-    {
-        return exec.query(tag, HPX_FORWARD(Property, prop));
-    }
-
-    HPX_CXX_CORE_EXPORT template <typename Tag, typename BaseScheduler>
-        requires(hpx::execution::experimental::is_scheduling_property_v<Tag>)
-    auto tag_invoke(
-        Tag tag, explicit_scheduler_executor<BaseScheduler> const& exec)
-    {
-        return exec.query(tag);
-    }
+    // Scheduling property CPOs (and processing_units_count) detect the public
+    // query() member functions directly, so no tag_invoke bridge is needed.
 }    // namespace hpx::execution::experimental
 
 namespace hpx::execution::experimental {

--- a/libs/core/executors/include/hpx/executors/fork_join_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/fork_join_executor.hpp
@@ -1306,61 +1306,54 @@ namespace hpx::execution::experimental {
                 priority, stacksize, sched, yield_delay, pu_mask);
         }
 
-        friend fork_join_executor tag_invoke(
-            hpx::execution::experimental::with_annotation_t,
-            fork_join_executor const& exec, char const* annotation) noexcept
+        [[nodiscard]] fork_join_executor query(
+            experimental::with_annotation_t, char const* annotation) const noexcept
         {
-            auto exec_with_annotation = exec;
+            auto exec_with_annotation = *this;
             exec_with_annotation.shared_data_->annotation_ = annotation;
             return exec_with_annotation;
         }
 
-        friend fork_join_executor tag_invoke(
-            hpx::execution::experimental::with_annotation_t,
-            fork_join_executor const& exec, std::string annotation)
+        [[nodiscard]] fork_join_executor query(
+            experimental::with_annotation_t, std::string annotation) const
         {
-            auto exec_with_annotation = exec;
+            auto exec_with_annotation = *this;
             exec_with_annotation.shared_data_->annotation_ =
                 hpx::detail::store_function_annotation(HPX_MOVE(annotation));
             return exec_with_annotation;
         }
 
-        friend char const* tag_invoke(
-            hpx::execution::experimental::get_annotation_t,
-            fork_join_executor const& exec) noexcept
+        [[nodiscard]] char const* query(
+            experimental::get_annotation_t) const noexcept
         {
-            return exec.shared_data_->annotation_;
+            return shared_data_->annotation_;
         }
 
-        friend auto tag_invoke(
-            hpx::execution::experimental::get_processing_units_mask_t,
-            fork_join_executor const& exec) noexcept
+        [[nodiscard]] auto query(
+            experimental::get_processing_units_mask_t) const noexcept
         {
-            return exec.shared_data_->pu_mask_;
+            return shared_data_->pu_mask_;
         }
 
-        friend auto tag_invoke(hpx::execution::experimental::get_cores_mask_t,
-            fork_join_executor const& exec) noexcept
+        [[nodiscard]] auto query(experimental::get_cores_mask_t) const noexcept
         {
-            return exec.shared_data_->pu_mask_;
+            return shared_data_->pu_mask_;
         }
 
-        friend std::size_t tag_invoke(
-            hpx::execution::experimental::get_first_core_t,
-            fork_join_executor const& exec) noexcept
+        [[nodiscard]] std::size_t query(
+            experimental::get_first_core_t) const noexcept
         {
-            return shared_data::get_first_core(exec.shared_data_->pu_mask_);
+            return shared_data::get_first_core(shared_data_->pu_mask_);
         }
 
         template <typename Parameters>
-            requires(hpx::traits::is_executor_parameters_v<Parameters>)
-        friend std::size_t tag_invoke(
-            hpx::execution::experimental::processing_units_count_t,
-            Parameters&&, fork_join_executor const& exec,
-            hpx::chrono::steady_duration const& = hpx::chrono::null_duration,
-            std::size_t = 0) noexcept
+            requires(hpx::executor_parameters<Parameters>)
+        [[nodiscard]] std::size_t query(experimental::processing_units_count_t,
+            Parameters&&, hpx::chrono::steady_duration const& =
+                hpx::chrono::null_duration,
+            std::size_t = 0) const noexcept
         {
-            return exec.shared_data_->num_threads_;
+            return shared_data_->num_threads_;
         }
 
         /// \cond NOINTERNAL

--- a/libs/core/executors/include/hpx/executors/fork_join_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/fork_join_executor.hpp
@@ -1207,48 +1207,43 @@ namespace hpx::execution::experimental {
             shared_data_->sync_invoke_helper(function_pack, first, size);
         }
 
+        template <typename F, typename S, typename... Ts>
+            requires(!std::is_integral_v<S>)
+        decltype(auto) bulk_sync_execute(
+            F&& f, S const& shape, Ts&&... ts) const
+        {
+            return shared_data_->bulk_sync_execute(
+                HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...);
+        }
+
+        template <typename F, typename S, typename... Ts>
+            requires(!std::is_integral_v<S>)
+        decltype(auto) bulk_async_execute(
+            F&& f, S const& shape, Ts&&... ts) const
+        {
+            return shared_data_->bulk_async_execute(
+                HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...);
+        }
+
+    public:
+        template <typename F, typename... Fs>
+            requires(std::invocable<F> && (std::invocable<Fs> && ...))
+        decltype(auto) async_invoke(F&& f, Fs&&... fs) const
+        {
+            return shared_data_->async_invoke(
+                HPX_FORWARD(F, f), HPX_FORWARD(Fs, fs)...);
+        }
+
+        template <typename F, typename... Fs>
+            requires(std::invocable<F> && (std::invocable<Fs> && ...))
+        decltype(auto) sync_invoke(F&& f, Fs&&... fs) const
+        {
+            return shared_data_->sync_invoke(
+                HPX_FORWARD(F, f), HPX_FORWARD(Fs, fs)...);
+        }
+
     private:
         std::shared_ptr<shared_data> shared_data_ = nullptr;
-
-        template <typename F, typename S, typename... Ts>
-            requires(!std::is_integral_v<S>)
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::bulk_sync_execute_t,
-            fork_join_executor const& exec, F&& f, S const& shape, Ts&&... ts)
-        {
-            return exec.shared_data_->bulk_sync_execute(
-                HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...);
-        }
-
-        template <typename F, typename S, typename... Ts>
-            requires(!std::is_integral_v<S>)
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::bulk_async_execute_t,
-            fork_join_executor const& exec, F&& f, S const& shape, Ts&&... ts)
-        {
-            return exec.shared_data_->bulk_async_execute(
-                HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...);
-        }
-
-        template <typename F, typename... Fs>
-            requires(std::invocable<F> && (std::invocable<Fs> && ...))
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::async_invoke_t,
-            fork_join_executor const& exec, F&& f, Fs&&... fs)
-        {
-            return exec.shared_data_->async_invoke(
-                HPX_FORWARD(F, f), HPX_FORWARD(Fs, fs)...);
-        }
-
-        template <typename F, typename... Fs>
-            requires(std::invocable<F> && (std::invocable<Fs> && ...))
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::sync_invoke_t,
-            fork_join_executor const& exec, F&& f, Fs&&... fs)
-        {
-            return exec.shared_data_->sync_invoke(
-                HPX_FORWARD(F, f), HPX_FORWARD(Fs, fs)...);
-        }
 
     public:
         bool operator==(fork_join_executor const& rhs) const noexcept
@@ -1306,8 +1301,8 @@ namespace hpx::execution::experimental {
                 priority, stacksize, sched, yield_delay, pu_mask);
         }
 
-        [[nodiscard]] fork_join_executor query(
-            experimental::with_annotation_t, char const* annotation) const noexcept
+        [[nodiscard]] fork_join_executor query(experimental::with_annotation_t,
+            char const* annotation) const noexcept
         {
             auto exec_with_annotation = *this;
             exec_with_annotation.shared_data_->annotation_ = annotation;
@@ -1349,8 +1344,8 @@ namespace hpx::execution::experimental {
         template <typename Parameters>
             requires(hpx::executor_parameters<Parameters>)
         [[nodiscard]] std::size_t query(experimental::processing_units_count_t,
-            Parameters&&, hpx::chrono::steady_duration const& =
-                hpx::chrono::null_duration,
+            Parameters&&,
+            hpx::chrono::steady_duration const& = hpx::chrono::null_duration,
             std::size_t = 0) const noexcept
         {
             return shared_data_->num_threads_;

--- a/libs/core/executors/include/hpx/executors/guided_pool_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/guided_pool_executor.hpp
@@ -301,14 +301,13 @@ namespace hpx::execution::experimental {
         {
         }
 
-    private:
+    public:
         // --------------------------------------------------------------------
         // async execute specialized for simple arguments typical
         // of a normal async call with arbitrary arguments
         // --------------------------------------------------------------------
         template <typename F, typename... Ts>
-        friend auto tag_invoke(hpx::parallel::execution::async_execute_t,
-            guided_pool_executor const& exec, F&& f, Ts&&... ts)
+        auto async_execute(F&& f, Ts&&... ts) const
             -> future<hpx::util::detail::invoke_deferred_result_t<F, Ts...>>
         {
             using result_type =
@@ -328,7 +327,7 @@ namespace hpx::execution::experimental {
             return dataflow(launch::sync,
                 detail::pre_execution_async_domain_schedule<
                     guided_pool_executor, pool_numa_hint<Tag>>(
-                    exec, exec.hint_, exec.hp_sync_),
+                    *this, hint_, hp_sync_),
                 HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
 
@@ -338,9 +337,7 @@ namespace hpx::execution::experimental {
         // --------------------------------------------------------------------
         template <typename F, typename Future, typename... Ts,
             typename = std::enable_if_t<hpx::traits::is_future_v<Future>>>
-        friend auto tag_invoke(hpx::parallel::execution::then_execute_t,
-            guided_pool_executor const& exec, F&& f, Future&& predecessor,
-            Ts&&... ts)
+        auto then_execute(F&& f, Future&& predecessor, Ts&&... ts) const
             -> future<
                 hpx::util::detail::invoke_deferred_result_t<F, Future, Ts...>>
         {
@@ -372,7 +369,8 @@ namespace hpx::execution::experimental {
             // the real task will be spawned on a new task with hints - as intended
             return HPX_FORWARD(Future, predecessor)
                 .then(hpx::launch::sync,
-                    [f = HPX_FORWARD(F, f), exec, ... ts = HPX_FORWARD(Ts, ts)](
+                    [f = HPX_FORWARD(F, f), exec = *this,
+                        ... ts = HPX_FORWARD(Ts, ts)](
                         std::decay_t<Future> predecessor) mutable {
                         detail::pre_execution_then_domain_schedule<
                             guided_pool_executor, pool_numa_hint<Tag>>
@@ -393,10 +391,9 @@ namespace hpx::execution::experimental {
                 OuterFuture<hpx::tuple<InnerFutures...>>>::value>,
             typename = std::enable_if_t<
                 hpx::traits::is_future_tuple_v<hpx::tuple<InnerFutures...>>>>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::then_execute_t,
-            guided_pool_executor const& exec, F&& f,
-            OuterFuture<hpx::tuple<InnerFutures...>>&& predecessor, Ts&&... ts)
+        decltype(auto) then_execute(F&& f,
+            OuterFuture<hpx::tuple<InnerFutures...>>&& predecessor,
+            Ts&&... ts) const
         {
 #ifdef GUIDED_EXECUTOR_DEBUG
             // create a tuple of the unwrapped future values
@@ -428,7 +425,8 @@ namespace hpx::execution::experimental {
             return HPX_FORWARD(
                 OuterFuture<hpx::tuple<InnerFutures...>>, predecessor)
                 .then(hpx::launch::sync,
-                    [f = HPX_FORWARD(F, f), exec, ... ts = HPX_FORWARD(Ts, ts)](
+                    [f = HPX_FORWARD(F, f), exec = *this,
+                        ... ts = HPX_FORWARD(Ts, ts)](
                         OuterFuture<hpx::tuple<InnerFutures...>>
                             predecessor) mutable {
                         detail::pre_execution_then_domain_schedule<
@@ -448,9 +446,8 @@ namespace hpx::execution::experimental {
         template <typename F, typename... InnerFutures,
             typename = std::enable_if_t<
                 hpx::traits::is_future_tuple_v<hpx::tuple<InnerFutures...>>>>
-        friend auto tag_invoke(hpx::parallel::execution::async_execute_t,
-            guided_pool_executor const& exec, F&& f,
-            hpx::tuple<InnerFutures...>&& predecessor)
+        auto async_execute(
+            F&& f, hpx::tuple<InnerFutures...>&& predecessor) const
             -> future<hpx::util::detail::invoke_deferred_result_t<F,
                 hpx::tuple<InnerFutures...>>>
         {
@@ -464,7 +461,7 @@ namespace hpx::execution::experimental {
             auto unwrapped_futures_tuple = hpx::util::map_pack(
                 detail::future_extract_value{}, predecessor);
 
-            int domain = hpx::invoke_fused(exec.hint_, unwrapped_futures_tuple);
+            int domain = hpx::invoke_fused(hint_, unwrapped_futures_tuple);
 #endif
 
 #ifndef GUIDED_EXECUTOR_DEBUG
@@ -490,20 +487,19 @@ namespace hpx::execution::experimental {
                 hpx::util::deferred_call(HPX_FORWARD(F, f),
                     std::forward<hpx::tuple<InnerFutures...>>(predecessor)));
 
-            if (exec.hp_sync_ &&
-                exec.priority_ == hpx::threads::thread_priority::high)
+            if (hp_sync_ && priority_ == hpx::threads::thread_priority::high)
             {
-                p.post(exec.pool_, "guided async",
+                p.post(pool_, "guided async",
                     hpx::launch::sync_policy(
-                        hpx::threads::thread_priority::high, exec.stacksize_,
+                        hpx::threads::thread_priority::high, stacksize_,
                         hpx::threads::thread_schedule_hint(
                             hpx::threads::thread_schedule_hint_mode::numa,
                             static_cast<std::int16_t>(domain))));
             }
             else
             {
-                p.post(exec.pool_, "guided async",
-                    hpx::launch::async_policy(exec.priority_, exec.stacksize_,
+                p.post(pool_, "guided async",
+                    hpx::launch::async_policy(priority_, stacksize_,
                         hpx::threads::thread_schedule_hint(
                             hpx::threads::thread_schedule_hint_mode::numa,
                             static_cast<std::int16_t>(domain))));
@@ -551,16 +547,14 @@ namespace hpx::execution::experimental {
         {
         }
 
-    private:
+    public:
         // --------------------------------------------------------------------
         // async
         // --------------------------------------------------------------------
         template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::async_execute_t,
-            guided_pool_executor_shim const& exec, F&& f, Ts&&... ts)
+        decltype(auto) async_execute(F&& f, Ts&&... ts) const
         {
-            return exec.async_execute_helper(
+            return async_execute_helper(
                 HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
 
@@ -594,15 +588,13 @@ namespace hpx::execution::experimental {
         // --------------------------------------------------------------------
         template <typename F, typename Future, typename... Ts,
             typename = std::enable_if_t<hpx::traits::is_future_v<Future>>>
-        friend auto tag_invoke(hpx::parallel::execution::then_execute_t,
-            guided_pool_executor_shim const& exec, F&& f, Future&& predecessor,
-            Ts&&... ts)
+        auto then_execute(F&& f, Future&& predecessor, Ts&&... ts) const
             -> future<
                 hpx::util::detail::invoke_deferred_result_t<F, Future, Ts...>>
         {
-            if (exec.guided_)
+            if (guided_)
             {
-                return hpx::parallel::execution::then_execute(exec.guided_exec_,
+                return hpx::parallel::execution::then_execute(guided_exec_,
                     HPX_FORWARD(F, f), HPX_FORWARD(Future, predecessor),
                     HPX_FORWARD(Ts, ts)...);
             }
@@ -617,7 +609,8 @@ namespace hpx::execution::experimental {
 
                 hpx::traits::detail::shared_state_ptr_t<result_type> p =
                     hpx::lcos::detail::make_continuation_exec<result_type>(
-                        HPX_FORWARD(Future, predecessor), exec, HPX_MOVE(func));
+                        HPX_FORWARD(Future, predecessor), *this,
+                        HPX_MOVE(func));
 
                 return hpx::traits::future_access<
                     hpx::future<result_type>>::create(HPX_MOVE(p));

--- a/libs/core/executors/include/hpx/executors/likwid_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/likwid_executor.hpp
@@ -73,103 +73,89 @@ namespace hpx::execution::experimental {
 
         // OneWayExecutor interface
         template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::sync_execute_t,
-            likwid_executor const& exec, F&& f, Ts&&... ts)
+        decltype(auto) sync_execute(F&& f, Ts&&... ts) const
         {
-            return hpx::parallel::execution::sync_execute(exec.base_executor(),
-                hook_wrapper<F>{exec, HPX_FORWARD(F, f)},
+            return hpx::parallel::execution::sync_execute(base_executor(),
+                hook_wrapper<F>{*this, HPX_FORWARD(F, f)},
                 HPX_FORWARD(Ts, ts)...);
         }
 
         // TwoWayExecutor interface
         template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::async_execute_t,
-            likwid_executor const& exec, F&& f, Ts&&... ts)
+        decltype(auto) async_execute(F&& f, Ts&&... ts) const
         {
-            return hpx::parallel::execution::async_execute(exec.base_executor(),
-                hook_wrapper<F>{exec, HPX_FORWARD(F, f)},
+            return hpx::parallel::execution::async_execute(base_executor(),
+                hook_wrapper<F>{*this, HPX_FORWARD(F, f)},
                 HPX_FORWARD(Ts, ts)...);
         }
 
         template <typename F, typename Future, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::then_execute_t,
-            likwid_executor const& exec, F&& f, Future&& predecessor,
-            Ts&&... ts)
+        decltype(auto) then_execute(
+            F&& f, Future&& predecessor, Ts&&... ts) const
         {
-            return hpx::parallel::execution::then_execute(exec.base_executor(),
-                hook_wrapper<F>{exec, HPX_FORWARD(F, f)},
+            return hpx::parallel::execution::then_execute(base_executor(),
+                hook_wrapper<F>{*this, HPX_FORWARD(F, f)},
                 HPX_FORWARD(Future, predecessor), HPX_FORWARD(Ts, ts)...);
         }
 
         // NonBlockingOneWayExecutor (adapted) interface
         template <typename F, typename... Ts>
-        friend void tag_invoke(hpx::parallel::execution::post_t,
-            likwid_executor const& exec, F&& f, Ts&&... ts)
+        void post(F&& f, Ts&&... ts) const
         {
-            hpx::parallel::execution::post(exec.base_executor(),
-                hook_wrapper<F>{exec, HPX_FORWARD(F, f)},
+            hpx::parallel::execution::post(base_executor(),
+                hook_wrapper<F>{*this, HPX_FORWARD(F, f)},
                 HPX_FORWARD(Ts, ts)...);
         }
 
         // BulkOneWayExecutor interface
         template <typename F, typename S, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::bulk_sync_execute_t,
-            likwid_executor const& exec, F&& f, S const& shape, Ts&&... ts)
+        decltype(auto) bulk_sync_execute(
+            F&& f, S const& shape, Ts&&... ts) const
         {
-            return hpx::parallel::execution::bulk_sync_execute(
-                exec.base_executor(), hook_wrapper<F>{exec, HPX_FORWARD(F, f)},
-                shape, HPX_FORWARD(Ts, ts)...);
+            return hpx::parallel::execution::bulk_sync_execute(base_executor(),
+                hook_wrapper<F>{*this, HPX_FORWARD(F, f)}, shape,
+                HPX_FORWARD(Ts, ts)...);
         }
 
         // BulkTwoWayExecutor interface
         template <typename F, typename S, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::bulk_async_execute_t,
-            likwid_executor const& exec, F&& f, S const& shape, Ts&&... ts)
+        decltype(auto) bulk_async_execute(
+            F&& f, S const& shape, Ts&&... ts) const
         {
-            return hpx::parallel::execution::bulk_async_execute(
-                exec.base_executor(), hook_wrapper<F>{exec, HPX_FORWARD(F, f)},
-                shape, HPX_FORWARD(Ts, ts)...);
-        }
-
-        template <typename F, typename S, typename Future, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::bulk_then_execute_t,
-            likwid_executor const& exec, F&& f, S const& shape,
-            Future&& predecessor, Ts&&... ts)
-        {
-            return hpx::parallel::execution::bulk_then_execute(
-                exec.base_executor(), hook_wrapper<F>{exec, HPX_FORWARD(F, f)},
-                shape, HPX_FORWARD(Future, predecessor),
+            return hpx::parallel::execution::bulk_async_execute(base_executor(),
+                hook_wrapper<F>{*this, HPX_FORWARD(F, f)}, shape,
                 HPX_FORWARD(Ts, ts)...);
         }
 
-        friend constexpr auto tag_invoke(
-            hpx::execution::experimental::with_annotation_t,
-            likwid_executor const& exec, char const* name)
+        template <typename F, typename S, typename Future, typename... Ts>
+        decltype(auto) bulk_then_execute(
+            F&& f, S const& shape, Future&& predecessor, Ts&&... ts) const
         {
-            auto exec_with_annotation = exec;
+            return hpx::parallel::execution::bulk_then_execute(base_executor(),
+                hook_wrapper<F>{*this, HPX_FORWARD(F, f)}, shape,
+                HPX_FORWARD(Future, predecessor), HPX_FORWARD(Ts, ts)...);
+        }
+
+        constexpr auto query(hpx::execution::experimental::with_annotation_t,
+            char const* name) const
+        {
+            auto exec_with_annotation = *this;
             exec_with_annotation.name_ = name;
             return exec_with_annotation;
         }
 
-        friend auto tag_invoke(hpx::execution::experimental::with_annotation_t,
-            likwid_executor const& exec, std::string name)
+        auto query(hpx::execution::experimental::with_annotation_t,
+            std::string name) const
         {
-            auto exec_with_annotation = exec;
+            auto exec_with_annotation = *this;
             exec_with_annotation.name_ = HPX_MOVE(name);
             return exec_with_annotation;
         }
 
-        friend constexpr char const* tag_invoke(
-            hpx::execution::experimental::get_annotation_t,
-            likwid_executor const& exec) noexcept
+        constexpr char const* query(
+            hpx::execution::experimental::get_annotation_t) const noexcept
         {
-            return exec.name_.c_str();
+            return name_.c_str();
         }
 
     private:

--- a/libs/core/executors/include/hpx/executors/limiting_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/limiting_executor.hpp
@@ -203,38 +203,32 @@ namespace hpx::execution::experimental {
             return *this;
         }
 
-    private:
+    public:
         // --------------------------------------------------------------------
         // OneWayExecutor interface
         template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::sync_execute_t,
-            limiting_executor const& exec, F&& f, Ts&&... ts)
+        decltype(auto) sync_execute(F&& f, Ts&&... ts) const
         {
-            return hpx::parallel::execution::sync_execute(exec.executor_,
-                throttling_wrapper<F>(exec, exec.executor_, HPX_FORWARD(F, f)),
+            return hpx::parallel::execution::sync_execute(executor_,
+                throttling_wrapper<F>(*this, executor_, HPX_FORWARD(F, f)),
                 HPX_FORWARD(Ts, ts)...);
         }
 
         // --------------------------------------------------------------------
         // TwoWayExecutor interface
         template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::async_execute_t, limiting_executor& exec,
-            F&& f, Ts&&... ts)
+        decltype(auto) async_execute(F&& f, Ts&&... ts)
         {
-            return hpx::parallel::execution::async_execute(exec.executor_,
-                throttling_wrapper<F>(exec, exec.executor_, HPX_FORWARD(F, f)),
+            return hpx::parallel::execution::async_execute(executor_,
+                throttling_wrapper<F>(*this, executor_, HPX_FORWARD(F, f)),
                 HPX_FORWARD(Ts, ts)...);
         }
 
         template <typename F, typename Future, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::then_execute_t, limiting_executor& exec,
-            F&& f, Future&& predecessor, Ts&&... ts)
+        decltype(auto) then_execute(F&& f, Future&& predecessor, Ts&&... ts)
         {
-            return hpx::parallel::execution::then_execute(exec.executor_,
-                throttling_wrapper<F>(exec, exec.executor_, HPX_FORWARD(F, f)),
+            return hpx::parallel::execution::then_execute(executor_,
+                throttling_wrapper<F>(*this, executor_, HPX_FORWARD(F, f)),
                 HPX_FORWARD(Future, predecessor), HPX_FORWARD(Ts, ts)...);
         }
 
@@ -243,11 +237,10 @@ namespace hpx::execution::experimental {
         // NonBlockingOneWayExecutor (adapted) interface
         // --------------------------------------------------------------------
         template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(hpx::parallel::execution::post_t,
-            limiting_executor& exec, F&& f, Ts&&... ts)
+        void post(F&& f, Ts&&... ts)
         {
-            hpx::parallel::execution::post(exec.executor_,
-                throttling_wrapper<F>(exec, exec.executor_, HPX_FORWARD(F, f)),
+            hpx::parallel::execution::post(executor_,
+                throttling_wrapper<F>(*this, executor_, HPX_FORWARD(F, f)),
                 HPX_FORWARD(Ts, ts)...);
         }
 
@@ -255,27 +248,22 @@ namespace hpx::execution::experimental {
         // BulkTwoWayExecutor interface
         template <typename F, typename S, typename... Ts>
             requires(!std::is_integral_v<S>)
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::bulk_async_execute_t,
-            limiting_executor& exec, F&& f, S const& shape, Ts&&... ts)
+        decltype(auto) bulk_async_execute(F&& f, S const& shape, Ts&&... ts)
         {
-            return hpx::parallel::execution::bulk_async_execute(exec.executor_,
+            return hpx::parallel::execution::bulk_async_execute(executor_,
                 shape,
-                throttling_wrapper<F>(exec, exec.executor_, HPX_FORWARD(F, f)),
+                throttling_wrapper<F>(*this, executor_, HPX_FORWARD(F, f)),
                 HPX_FORWARD(Ts, ts)...);
         }
 
         // --------------------------------------------------------------------
         template <typename F, typename S, typename Future, typename... Ts>
             requires(!std::is_integral_v<S>)
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::bulk_then_execute_t,
-            limiting_executor& exec, F&& f, S const& shape,
-            Future&& predecessor, Ts&&... ts)
+        decltype(auto) bulk_then_execute(
+            F&& f, S const& shape, Future&& predecessor, Ts&&... ts)
         {
-            return hpx::parallel::execution::bulk_then_execute(exec.executor_,
-                shape,
-                throttling_wrapper<F>(exec, exec.executor_, HPX_FORWARD(F, f)),
+            return hpx::parallel::execution::bulk_then_execute(executor_, shape,
+                throttling_wrapper<F>(*this, executor_, HPX_FORWARD(F, f)),
                 HPX_FORWARD(Future, predecessor), HPX_FORWARD(Ts, ts)...);
         }
 

--- a/libs/core/executors/include/hpx/executors/parallel_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/parallel_executor.hpp
@@ -506,8 +506,8 @@ namespace hpx::execution {
         constexpr ~parallel_policy_executor() {}
 #endif
 
-        [[nodiscard]] auto query(
-            experimental::with_processing_units_count_t, std::size_t num_cores) const
+        [[nodiscard]] auto query(experimental::with_processing_units_count_t,
+            std::size_t num_cores) const
         {
             return base_type::with_num_cores(*this, num_cores);
         }
@@ -515,8 +515,8 @@ namespace hpx::execution {
         template <typename Parameters>
             requires(hpx::executor_parameters<Parameters>)
         [[nodiscard]] std::size_t query(experimental::processing_units_count_t,
-            Parameters&&, hpx::chrono::steady_duration const& =
-                hpx::chrono::null_duration,
+            Parameters&&,
+            hpx::chrono::steady_duration const& = hpx::chrono::null_duration,
             std::size_t = 0) const
         {
             return this->get_num_cores();
@@ -553,8 +553,8 @@ namespace hpx::execution {
             return base_type::with_annotation(*this, annotation);
         }
 
-        [[nodiscard]] auto query(experimental::with_annotation_t,
-            std::string annotation) const
+        [[nodiscard]] auto query(
+            experimental::with_annotation_t, std::string annotation) const
         {
             return base_type::with_annotation(*this, HPX_MOVE(annotation));
         }
@@ -569,7 +569,10 @@ namespace hpx::execution {
         // Generic scheduling property forwarding via embedded policy
         template <typename Tag, typename Property>
             requires(
-                hpx::execution::experimental::is_scheduling_property_v<Tag>)
+                hpx::execution::experimental::is_scheduling_property_v<Tag> &&
+                requires(Tag t, Policy const& pol, Property&& p) {
+                    t(pol, HPX_FORWARD(Property, p));
+                })
         [[nodiscard]] auto query(Tag tag, Property&& prop) const
         {
             auto exec_with_prop = *this;
@@ -580,7 +583,8 @@ namespace hpx::execution {
 
         template <typename Tag>
             requires(
-                hpx::execution::experimental::is_scheduling_property_v<Tag>)
+                hpx::execution::experimental::is_scheduling_property_v<Tag> &&
+                requires(Tag t, Policy const& pol) { t(pol); })
         [[nodiscard]] auto query(Tag tag) const
         {
             return tag(this->policy());
@@ -625,7 +629,8 @@ namespace hpx::execution {
 
         template <typename F, typename S, typename... Ts>
             requires(!std::is_integral_v<S>)
-        decltype(auto) bulk_sync_execute(F&& f, S const& shape, Ts&&... ts) const
+        decltype(auto) bulk_sync_execute(
+            F&& f, S const& shape, Ts&&... ts) const
         {
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)
             hpx::threads::thread_description desc(f, this->annotation_);
@@ -813,8 +818,8 @@ namespace hpx::execution {
 
         ~parallel_policy_executor() = default;
 
-        [[nodiscard]] auto query(
-            experimental::with_processing_units_count_t, std::size_t num_cores) const
+        [[nodiscard]] auto query(experimental::with_processing_units_count_t,
+            std::size_t num_cores) const
         {
             return base_type::with_num_cores(*this, num_cores);
         }
@@ -822,8 +827,8 @@ namespace hpx::execution {
         template <typename Parameters>
             requires(hpx::executor_parameters<Parameters>)
         [[nodiscard]] std::size_t query(experimental::processing_units_count_t,
-            Parameters&&, hpx::chrono::steady_duration const& =
-                hpx::chrono::null_duration,
+            Parameters&&,
+            hpx::chrono::steady_duration const& = hpx::chrono::null_duration,
             std::size_t = 0) const
         {
             return this->get_num_cores();
@@ -860,8 +865,8 @@ namespace hpx::execution {
             return base_type::with_annotation(*this, annotation);
         }
 
-        [[nodiscard]] auto query(experimental::with_annotation_t,
-            std::string annotation) const
+        [[nodiscard]] auto query(
+            experimental::with_annotation_t, std::string annotation) const
         {
             return base_type::with_annotation(*this, HPX_MOVE(annotation));
         }
@@ -876,7 +881,10 @@ namespace hpx::execution {
         // Generic scheduling property forwarding via embedded policy
         template <typename Tag, typename Property>
             requires(
-                hpx::execution::experimental::is_scheduling_property_v<Tag>)
+                hpx::execution::experimental::is_scheduling_property_v<Tag> &&
+                requires(Tag t, Policy const& pol, Property&& p) {
+                    t(pol, HPX_FORWARD(Property, p));
+                })
         [[nodiscard]] auto query(Tag tag, Property&& prop) const
         {
             auto exec_with_prop = *this;
@@ -887,7 +895,8 @@ namespace hpx::execution {
 
         template <typename Tag>
             requires(
-                hpx::execution::experimental::is_scheduling_property_v<Tag>)
+                hpx::execution::experimental::is_scheduling_property_v<Tag> &&
+                requires(Tag t, Policy const& pol) { t(pol); })
         [[nodiscard]] auto query(Tag tag) const
         {
             return tag(this->policy());
@@ -932,7 +941,8 @@ namespace hpx::execution {
 
         template <typename F, typename S, typename... Ts>
             requires(!std::is_integral_v<S>)
-        decltype(auto) bulk_sync_execute(F&& f, S const& shape, Ts&&... ts) const
+        decltype(auto) bulk_sync_execute(
+            F&& f, S const& shape, Ts&&... ts) const
         {
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)
             hpx::threads::thread_description desc(f, this->annotation_);

--- a/libs/core/executors/include/hpx/executors/parallel_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/parallel_executor.hpp
@@ -207,6 +207,41 @@ namespace hpx::execution {
             return get_num_cores();
         }
 
+        template <typename Self>
+        static Self with_num_cores(Self self, std::size_t num_cores)
+        {
+            if (num_cores == 0)
+            {
+                num_cores = self.pool()->get_active_os_thread_count();
+            }
+            self.num_cores_ = num_cores;
+            return self;
+        }
+
+        template <typename Self>
+        static Self with_first_core(Self self, std::size_t first_core) noexcept
+        {
+            self.first_core_ = first_core;
+            return self;
+        }
+
+#if defined(HPX_HAVE_THREAD_DESCRIPTION)
+        template <typename Self>
+        static Self with_annotation(Self self, char const* annotation)
+        {
+            self.annotation_ = annotation;
+            return self;
+        }
+
+        template <typename Self>
+        static Self with_annotation(Self self, std::string annotation)
+        {
+            self.annotation_ =
+                hpx::detail::store_function_annotation(HPX_MOVE(annotation));
+            return self;
+        }
+#endif
+
     public:
         /// \cond NOINTERNAL
         void policy(Policy policy) noexcept
@@ -471,210 +506,178 @@ namespace hpx::execution {
         constexpr ~parallel_policy_executor() {}
 #endif
 
-    private:
-        // property implementations
-#if defined(HPX_HAVE_THREAD_DESCRIPTION)
-        template <typename Executor_>
-            requires(std::is_convertible_v<Executor_, parallel_policy_executor>)
-        friend constexpr auto tag_invoke(
-            hpx::execution::experimental::with_annotation_t,
-            Executor_ const& exec, char const* annotation)
+        [[nodiscard]] auto query(
+            experimental::with_processing_units_count_t, std::size_t num_cores) const
         {
-            auto exec_with_annotation = exec;
-            exec_with_annotation.annotation_ = annotation;
-            return exec_with_annotation;
-        }
-
-        template <typename Executor_>
-            requires(std::is_convertible_v<Executor_, parallel_policy_executor>)
-        friend auto tag_invoke(hpx::execution::experimental::with_annotation_t,
-            Executor_ const& exec, std::string annotation)
-        {
-            auto exec_with_annotation = exec;
-            exec_with_annotation.annotation_ =
-                hpx::detail::store_function_annotation(HPX_MOVE(annotation));
-            return exec_with_annotation;
-        }
-
-        friend constexpr char const* tag_invoke(
-            hpx::execution::experimental::get_annotation_t,
-            parallel_policy_executor const& exec) noexcept
-        {
-            return exec.annotation_;
-        }
-#endif
-
-        template <typename Executor_>
-            requires(std::is_convertible_v<Executor_, parallel_policy_executor>)
-        friend auto tag_invoke(
-            hpx::execution::experimental::with_processing_units_count_t,
-            Executor_ const& exec, std::size_t num_cores)
-        {
-            if (num_cores == 0)
-            {
-                num_cores = exec.pool()->get_active_os_thread_count();
-            }
-
-            auto exec_with_num_cores = exec;
-            exec_with_num_cores.num_cores_ = num_cores;
-            return exec_with_num_cores;
+            return base_type::with_num_cores(*this, num_cores);
         }
 
         template <typename Parameters>
-            requires(hpx::traits::is_executor_parameters_v<Parameters>)
-        friend constexpr std::size_t tag_invoke(
-            hpx::execution::experimental::processing_units_count_t,
-            Parameters&&, parallel_policy_executor const& exec,
-            hpx::chrono::steady_duration const& = hpx::chrono::null_duration,
-            std::size_t = 0)
+            requires(hpx::executor_parameters<Parameters>)
+        [[nodiscard]] std::size_t query(experimental::processing_units_count_t,
+            Parameters&&, hpx::chrono::steady_duration const& =
+                hpx::chrono::null_duration,
+            std::size_t = 0) const
         {
-            return exec.get_num_cores();
+            return this->get_num_cores();
         }
 
-        template <typename Executor_>
-            requires(std::is_convertible_v<Executor_, parallel_policy_executor>)
-        friend constexpr auto tag_invoke(
-            hpx::execution::experimental::with_first_core_t,
-            Executor_ const& exec, std::size_t first_core) noexcept
+        [[nodiscard]] auto query(experimental::with_first_core_t,
+            std::size_t first_core) const noexcept
         {
-            auto exec_with_first_core = exec;
-            exec_with_first_core.first_core_ = first_core;
-            return exec_with_first_core;
+            return base_type::with_first_core(*this, first_core);
         }
 
-        friend constexpr std::size_t tag_invoke(
-            hpx::execution::experimental::get_first_core_t,
-            parallel_policy_executor const& exec) noexcept
+        [[nodiscard]] constexpr std::size_t query(
+            experimental::get_first_core_t) const noexcept
         {
-            return exec.get_first_core();
+            return this->get_first_core();
         }
 
-        friend auto tag_invoke(
-            hpx::execution::experimental::get_processing_units_mask_t,
-            parallel_policy_executor const& exec)
+        [[nodiscard]] auto query(
+            experimental::get_processing_units_mask_t) const
         {
-            return exec.pu_mask();
+            return this->pu_mask();
         }
 
-        friend auto tag_invoke(hpx::execution::experimental::get_cores_mask_t,
-            parallel_policy_executor const& exec)
+        [[nodiscard]] auto query(experimental::get_cores_mask_t) const
         {
-            return exec.pool()->get_used_processing_units(
-                exec.get_num_cores(), true);
+            return this->pool()->get_used_processing_units(
+                this->get_num_cores(), true);
+        }
+
+#if defined(HPX_HAVE_THREAD_DESCRIPTION)
+        [[nodiscard]] auto query(
+            experimental::with_annotation_t, char const* annotation) const
+        {
+            return base_type::with_annotation(*this, annotation);
+        }
+
+        [[nodiscard]] auto query(experimental::with_annotation_t,
+            std::string annotation) const
+        {
+            return base_type::with_annotation(*this, HPX_MOVE(annotation));
+        }
+
+        [[nodiscard]] constexpr char const* query(
+            experimental::get_annotation_t) const noexcept
+        {
+            return this->annotation_;
+        }
+#endif
+
+        // Generic scheduling property forwarding via embedded policy
+        template <typename Tag, typename Property>
+            requires(
+                hpx::execution::experimental::is_scheduling_property_v<Tag>)
+        [[nodiscard]] auto query(Tag tag, Property&& prop) const
+        {
+            auto exec_with_prop = *this;
+            exec_with_prop.policy(
+                tag(exec_with_prop.policy(), HPX_FORWARD(Property, prop)));
+            return exec_with_prop;
+        }
+
+        template <typename Tag>
+            requires(
+                hpx::execution::experimental::is_scheduling_property_v<Tag>)
+        [[nodiscard]] auto query(Tag tag) const
+        {
+            return tag(this->policy());
+        }
+
+    public:
+        // Execution interface as member functions
+        template <typename F, typename... Ts>
+        decltype(auto) sync_execute(F&& f, Ts&&... ts) const
+        {
+            return this->sync_impl(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
 
         template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::sync_execute_t,
-            parallel_policy_executor const& exec, F&& f, Ts&&... ts)
+        decltype(auto) async_execute(F&& f, Ts&&... ts) const
         {
-            return exec.sync_impl(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
-        }
-
-        template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::async_execute_t,
-            parallel_policy_executor const& exec, F&& f, Ts&&... ts)
-        {
-            return exec.async_impl(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+            return this->async_impl(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
 
         template <typename F, typename Future, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::then_execute_t,
-            parallel_policy_executor const& exec, F&& f, Future&& predecessor,
-            Ts&&... ts)
+        decltype(auto) then_execute(
+            F&& f, Future&& predecessor, Ts&&... ts) const
         {
-            return exec.then_impl(HPX_FORWARD(F, f),
+            return this->then_impl(HPX_FORWARD(F, f),
                 HPX_FORWARD(Future, predecessor), HPX_FORWARD(Ts, ts)...);
         }
 
         template <typename F, typename... Ts>
-        friend void tag_invoke(hpx::parallel::execution::post_t,
-            parallel_policy_executor const& exec, F&& f, Ts&&... ts)
+        void post(F&& f, Ts&&... ts) const
         {
-            exec.post_impl(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+            this->post_impl(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
 
         template <typename F, typename S, typename Future, typename... Ts>
             requires(!std::is_integral_v<S>)
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::bulk_then_execute_t,
-            parallel_policy_executor const& exec, F&& f, S const& shape,
-            Future&& predecessor, Ts&&... ts)
+        decltype(auto) bulk_then_execute(
+            F&& f, S const& shape, Future&& predecessor, Ts&&... ts) const
         {
-            return base_type::bulk_then_impl(exec, HPX_FORWARD(F, f), shape,
+            return base_type::bulk_then_impl(*this, HPX_FORWARD(F, f), shape,
                 HPX_FORWARD(Future, predecessor), HPX_FORWARD(Ts, ts)...);
         }
 
-        // BulkTwoWayExecutor interface
         template <typename F, typename S, typename... Ts>
             requires(!std::is_integral_v<S>)
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::bulk_sync_execute_t,
-            parallel_policy_executor const& exec, F&& f, S const& shape,
-            Ts&&... ts)
+        decltype(auto) bulk_sync_execute(F&& f, S const& shape, Ts&&... ts) const
         {
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)
-            hpx::threads::thread_description desc(f, exec.annotation_);
+            hpx::threads::thread_description desc(f, this->annotation_);
 #else
             hpx::threads::thread_description desc(f);
 #endif
 
-            // use scheduling based on index_queue if no hierarchical threshold
-            // is given
             HPX_ASSERT(!hpx::threads::do_not_combine_tasks(
-                exec.policy().get_hint().sharing_mode()));
+                this->policy().get_hint().sharing_mode()));
 
             return parallel::execution::detail::index_queue_bulk_sync_execute(
-                desc, exec.pool(), exec.get_first_core(), exec.get_num_cores(),
-                exec.policy_, HPX_FORWARD(F, f), shape, exec.pu_mask(),
-                HPX_FORWARD(Ts, ts)...);
+                desc, this->pool(), this->get_first_core(),
+                this->get_num_cores(), this->policy_, HPX_FORWARD(F, f), shape,
+                this->pu_mask(), HPX_FORWARD(Ts, ts)...);
         }
 
         template <typename F, typename S, typename... Ts>
             requires(!std::is_integral_v<S>)
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::bulk_async_execute_t,
-            parallel_policy_executor const& exec, F&& f, S const& shape,
-            Ts&&... ts)
+        decltype(auto) bulk_async_execute(
+            F&& f, S const& shape, Ts&&... ts) const
         {
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)
-            hpx::threads::thread_description desc(f, exec.annotation_);
+            hpx::threads::thread_description desc(f, this->annotation_);
 #else
             hpx::threads::thread_description desc(f);
 #endif
 
-            // use scheduling based on index_queue only if no hierarchical
-            // threshold is given
             HPX_ASSERT(!hpx::threads::do_not_combine_tasks(
-                exec.policy().get_hint().sharing_mode()));
+                this->policy().get_hint().sharing_mode()));
 
             return parallel::execution::detail::index_queue_bulk_async_execute(
-                desc, exec.pool(), exec.get_first_core(), exec.get_num_cores(),
-                exec.policy_, HPX_FORWARD(F, f), shape, exec.pu_mask(),
-                HPX_FORWARD(Ts, ts)...);
+                desc, this->pool(), this->get_first_core(),
+                this->get_num_cores(), this->policy_, HPX_FORWARD(F, f), shape,
+                this->pu_mask(), HPX_FORWARD(Ts, ts)...);
         }
 
-        // map execution policy categories to proper executor
-        friend decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_non_par_t,
-            parallel_policy_executor const& exec)
+        decltype(auto) to_non_par() const
         {
             if constexpr (std::is_same_v<Policy, launch::sync_policy>)
             {
-                return exec;
+                return *this;
             }
             else
             {
                 auto non_par_exec =
-                    parallel_policy_executor<launch::sync_policy>(exec.pool_,
-                        launch::sync_policy(exec.policy_.priority(),
-                            exec.policy_.stacksize(), exec.policy_.hint()));
+                    parallel_policy_executor<launch::sync_policy>(this->pool_,
+                        launch::sync_policy(this->policy_.priority(),
+                            this->policy_.stacksize(), this->policy_.hint()));
 
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)
                 return hpx::execution::experimental::with_annotation(
-                    HPX_MOVE(non_par_exec), exec.annotation_);
+                    HPX_MOVE(non_par_exec), this->annotation_);
 #else
                 return non_par_exec;
 #endif
@@ -810,203 +813,174 @@ namespace hpx::execution {
 
         ~parallel_policy_executor() = default;
 
-    private:
-        // property implementations
-
-#if defined(HPX_HAVE_THREAD_DESCRIPTION)
-        template <typename Executor_>
-            requires(std::is_convertible_v<Executor_, parallel_policy_executor>)
-        friend constexpr auto tag_invoke(
-            hpx::execution::experimental::with_annotation_t,
-            Executor_ const& exec, char const* annotation)
+        [[nodiscard]] auto query(
+            experimental::with_processing_units_count_t, std::size_t num_cores) const
         {
-            auto exec_with_annotation = exec;
-            exec_with_annotation.annotation_ = annotation;
-            return exec_with_annotation;
-        }
-
-        template <typename Executor_>
-            requires(std::is_convertible_v<Executor_, parallel_policy_executor>)
-        friend auto tag_invoke(hpx::execution::experimental::with_annotation_t,
-            Executor_ const& exec, std::string annotation)
-        {
-            auto exec_with_annotation = exec;
-            exec_with_annotation.annotation_ =
-                hpx::detail::store_function_annotation(HPX_MOVE(annotation));
-            return exec_with_annotation;
-        }
-
-        friend constexpr char const* tag_invoke(
-            hpx::execution::experimental::get_annotation_t,
-            parallel_policy_executor const& exec) noexcept
-        {
-            return exec.annotation_;
-        }
-#endif
-
-        template <typename Executor_>
-            requires(std::is_convertible_v<Executor_, parallel_policy_executor>)
-        friend auto tag_invoke(
-            hpx::execution::experimental::with_processing_units_count_t,
-            Executor_ const& exec, std::size_t num_cores)
-        {
-            if (num_cores == 0)
-            {
-                num_cores = exec.pool()->get_active_os_thread_count();
-            }
-
-            auto exec_with_num_cores = exec;
-            exec_with_num_cores.num_cores_ = num_cores;
-            return exec_with_num_cores;
+            return base_type::with_num_cores(*this, num_cores);
         }
 
         template <typename Parameters>
-            requires(hpx::traits::is_executor_parameters_v<Parameters>)
-        friend constexpr std::size_t tag_invoke(
-            hpx::execution::experimental::processing_units_count_t,
-            Parameters&&, parallel_policy_executor const& exec,
-            hpx::chrono::steady_duration const& = hpx::chrono::null_duration,
-            std::size_t = 0)
+            requires(hpx::executor_parameters<Parameters>)
+        [[nodiscard]] std::size_t query(experimental::processing_units_count_t,
+            Parameters&&, hpx::chrono::steady_duration const& =
+                hpx::chrono::null_duration,
+            std::size_t = 0) const
         {
-            return exec.get_num_cores();
+            return this->get_num_cores();
         }
 
-        template <typename Executor_>
-            requires(std::is_convertible_v<Executor_, parallel_policy_executor>)
-        friend constexpr auto tag_invoke(
-            hpx::execution::experimental::with_first_core_t,
-            Executor_ const& exec, std::size_t first_core) noexcept
+        [[nodiscard]] auto query(experimental::with_first_core_t,
+            std::size_t first_core) const noexcept
         {
-            auto exec_with_first_core = exec;
-            exec_with_first_core.first_core_ = first_core;
-            return exec_with_first_core;
+            return base_type::with_first_core(*this, first_core);
         }
 
-        friend constexpr std::size_t tag_invoke(
-            hpx::execution::experimental::get_first_core_t,
-            parallel_policy_executor const& exec) noexcept
+        [[nodiscard]] constexpr std::size_t query(
+            experimental::get_first_core_t) const noexcept
         {
-            return exec.get_first_core();
+            return this->get_first_core();
         }
 
-        friend auto tag_invoke(
-            hpx::execution::experimental::get_processing_units_mask_t,
-            parallel_policy_executor const& exec)
+        [[nodiscard]] auto query(
+            experimental::get_processing_units_mask_t) const
         {
-            return exec.pu_mask();
+            return this->pu_mask();
         }
 
-        friend auto tag_invoke(hpx::execution::experimental::get_cores_mask_t,
-            parallel_policy_executor const& exec)
+        [[nodiscard]] auto query(experimental::get_cores_mask_t) const
         {
-            return exec.pool()->get_used_processing_units(
-                exec.get_num_cores(), true);
+            return this->pool()->get_used_processing_units(
+                this->get_num_cores(), true);
+        }
+
+#if defined(HPX_HAVE_THREAD_DESCRIPTION)
+        [[nodiscard]] auto query(
+            experimental::with_annotation_t, char const* annotation) const
+        {
+            return base_type::with_annotation(*this, annotation);
+        }
+
+        [[nodiscard]] auto query(experimental::with_annotation_t,
+            std::string annotation) const
+        {
+            return base_type::with_annotation(*this, HPX_MOVE(annotation));
+        }
+
+        [[nodiscard]] constexpr char const* query(
+            experimental::get_annotation_t) const noexcept
+        {
+            return this->annotation_;
+        }
+#endif
+
+        // Generic scheduling property forwarding via embedded policy
+        template <typename Tag, typename Property>
+            requires(
+                hpx::execution::experimental::is_scheduling_property_v<Tag>)
+        [[nodiscard]] auto query(Tag tag, Property&& prop) const
+        {
+            auto exec_with_prop = *this;
+            exec_with_prop.policy(
+                tag(exec_with_prop.policy(), HPX_FORWARD(Property, prop)));
+            return exec_with_prop;
+        }
+
+        template <typename Tag>
+            requires(
+                hpx::execution::experimental::is_scheduling_property_v<Tag>)
+        [[nodiscard]] auto query(Tag tag) const
+        {
+            return tag(this->policy());
+        }
+
+    public:
+        // Execution interface as member functions
+        template <typename F, typename... Ts>
+        decltype(auto) sync_execute(F&& f, Ts&&... ts) const
+        {
+            return this->sync_impl(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
 
         template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::sync_execute_t,
-            parallel_policy_executor const& exec, F&& f, Ts&&... ts)
+        decltype(auto) async_execute(F&& f, Ts&&... ts) const
         {
-            return exec.sync_impl(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
-        }
-
-        template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::async_execute_t,
-            parallel_policy_executor const& exec, F&& f, Ts&&... ts)
-        {
-            return exec.async_impl(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+            return this->async_impl(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
 
         template <typename F, typename Future, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::then_execute_t,
-            parallel_policy_executor const& exec, F&& f, Future&& predecessor,
-            Ts&&... ts)
+        decltype(auto) then_execute(
+            F&& f, Future&& predecessor, Ts&&... ts) const
         {
-            return exec.then_impl(HPX_FORWARD(F, f),
+            return this->then_impl(HPX_FORWARD(F, f),
                 HPX_FORWARD(Future, predecessor), HPX_FORWARD(Ts, ts)...);
         }
 
         template <typename F, typename... Ts>
-        friend void tag_invoke(hpx::parallel::execution::post_t,
-            parallel_policy_executor const& exec, F&& f, Ts&&... ts)
+        void post(F&& f, Ts&&... ts) const
         {
-            exec.post_impl(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+            this->post_impl(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
 
         template <typename F, typename S, typename Future, typename... Ts>
             requires(!std::is_integral_v<S>)
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::bulk_then_execute_t,
-            parallel_policy_executor const& exec, F&& f, S const& shape,
-            Future&& predecessor, Ts&&... ts)
+        decltype(auto) bulk_then_execute(
+            F&& f, S const& shape, Future&& predecessor, Ts&&... ts) const
         {
-            return base_type::bulk_then_impl(exec, HPX_FORWARD(F, f), shape,
+            return base_type::bulk_then_impl(*this, HPX_FORWARD(F, f), shape,
                 HPX_FORWARD(Future, predecessor), HPX_FORWARD(Ts, ts)...);
         }
 
-        // BulkTwoWayExecutor interface
         template <typename F, typename S, typename... Ts>
             requires(!std::is_integral_v<S>)
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::bulk_sync_execute_t,
-            parallel_policy_executor const& exec, F&& f, S const& shape,
-            Ts&&... ts)
+        decltype(auto) bulk_sync_execute(F&& f, S const& shape, Ts&&... ts) const
         {
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)
-            hpx::threads::thread_description desc(f, exec.annotation_);
+            hpx::threads::thread_description desc(f, this->annotation_);
 #else
             hpx::threads::thread_description desc(f);
 #endif
 
             return parallel::execution::detail::hierarchical_bulk_sync_execute(
-                desc, exec.pool(), exec.get_first_core(), exec.get_num_cores(),
-                exec.hierarchical_threshold_, exec.policy_, HPX_FORWARD(F, f),
-                shape, HPX_FORWARD(Ts, ts)...);
+                desc, this->pool(), this->get_first_core(),
+                this->get_num_cores(), hierarchical_threshold_, this->policy_,
+                HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...);
         }
 
         template <typename F, typename S, typename... Ts>
             requires(!std::is_integral_v<S>)
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::bulk_async_execute_t,
-            parallel_policy_executor const& exec, F&& f, S const& shape,
-            Ts&&... ts)
+        decltype(auto) bulk_async_execute(
+            F&& f, S const& shape, Ts&&... ts) const
         {
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)
-            hpx::threads::thread_description desc(f, exec.annotation_);
+            hpx::threads::thread_description desc(f, this->annotation_);
 #else
             hpx::threads::thread_description desc(f);
 #endif
 
             return parallel::execution::detail::hierarchical_bulk_async_execute(
-                desc, exec.pool(), exec.get_first_core(), exec.get_num_cores(),
-                exec.hierarchical_threshold_, exec.policy_, HPX_FORWARD(F, f),
-                shape, HPX_FORWARD(Ts, ts)...);
+                desc, this->pool(), this->get_first_core(),
+                this->get_num_cores(), hierarchical_threshold_, this->policy_,
+                HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...);
         }
 
-        // map execution policy categories to proper executor
-        friend decltype(auto) tag_invoke(
-            hpx::execution::experimental::to_non_par_t,
-            parallel_policy_executor const& exec)
+        decltype(auto) to_non_par() const
         {
             if constexpr (std::is_same_v<Policy, launch::sync_policy>)
             {
-                return exec;
+                return *this;
             }
             else
             {
                 auto non_par_exec =
                     parallel_policy_executor<launch::sync_policy, true>(
-                        exec.pool_,
-                        launch::sync_policy(exec.policy_.priority(),
-                            exec.policy_.stacksize(), exec.policy_.hint()),
-                        exec.hierarchical_threshold_);
+                        this->pool_,
+                        launch::sync_policy(this->policy_.priority(),
+                            this->policy_.stacksize(), this->policy_.hint()),
+                        hierarchical_threshold_);
 
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)
                 return hpx::execution::experimental::with_annotation(
-                    HPX_MOVE(non_par_exec), exec.annotation_);
+                    HPX_MOVE(non_par_exec), this->annotation_);
 #else
                 return non_par_exec;
 #endif
@@ -1132,37 +1106,6 @@ namespace hpx::execution {
     constexpr Executor to_non_hierarchical_spawning(Executor&& exec) noexcept
     {
         return HPX_FORWARD(Executor, exec);
-    }
-
-    ////////////////////////////////////////////////////////////////////////////
-    // support all properties exposed by the embedded policy
-    HPX_CXX_CORE_EXPORT template <typename Tag, typename Policy,
-        bool HierarchicalSpawning, typename Property,
-        HPX_CONCEPT_REQUIRES_(
-            hpx::execution::experimental::is_scheduling_property_v<Tag>)>
-    auto tag_invoke(Tag tag,
-        parallel_policy_executor<Policy, HierarchicalSpawning> const& exec,
-        Property&& prop)
-        -> decltype(std::declval<parallel_policy_executor<Policy,
-                        HierarchicalSpawning>>()
-                        .policy(std::declval<Tag>()(
-                            std::declval<Policy>(), std::declval<Property>())),
-            parallel_policy_executor<Policy, HierarchicalSpawning>())
-    {
-        auto exec_with_prop = exec;
-        exec_with_prop.policy(tag(exec.policy(), HPX_FORWARD(Property, prop)));
-        return exec_with_prop;
-    }
-
-    HPX_CXX_CORE_EXPORT template <typename Tag, typename Policy,
-        bool HierarchicalSpawning,
-        HPX_CONCEPT_REQUIRES_(
-            hpx::execution::experimental::is_scheduling_property_v<Tag>)>
-    auto tag_invoke(Tag tag,
-        parallel_policy_executor<Policy, HierarchicalSpawning> const& exec)
-        -> decltype(std::declval<Tag>()(std::declval<Policy>()))
-    {
-        return tag(exec.policy());
     }
 
     HPX_CXX_CORE_EXPORT using parallel_executor =

--- a/libs/core/executors/include/hpx/executors/parallel_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/parallel_executor.hpp
@@ -509,7 +509,8 @@ namespace hpx::execution {
         [[nodiscard]] auto query(experimental::with_processing_units_count_t,
             std::size_t num_cores) const
         {
-            return base_type::with_num_cores(*this, num_cores);
+            using self_type = std::decay_t<decltype(*this)>;
+            return base_type::with_num_cores(self_type(*this), num_cores);
         }
 
         template <typename Parameters>
@@ -525,7 +526,8 @@ namespace hpx::execution {
         [[nodiscard]] auto query(experimental::with_first_core_t,
             std::size_t first_core) const noexcept
         {
-            return base_type::with_first_core(*this, first_core);
+            using self_type = std::decay_t<decltype(*this)>;
+            return base_type::with_first_core(self_type(*this), first_core);
         }
 
         [[nodiscard]] constexpr std::size_t query(
@@ -821,7 +823,8 @@ namespace hpx::execution {
         [[nodiscard]] auto query(experimental::with_processing_units_count_t,
             std::size_t num_cores) const
         {
-            return base_type::with_num_cores(*this, num_cores);
+            using self_type = std::decay_t<decltype(*this)>;
+            return base_type::with_num_cores(self_type(*this), num_cores);
         }
 
         template <typename Parameters>
@@ -837,7 +840,8 @@ namespace hpx::execution {
         [[nodiscard]] auto query(experimental::with_first_core_t,
             std::size_t first_core) const noexcept
         {
-            return base_type::with_first_core(*this, first_core);
+            using self_type = std::decay_t<decltype(*this)>;
+            return base_type::with_first_core(self_type(*this), first_core);
         }
 
         [[nodiscard]] constexpr std::size_t query(

--- a/libs/core/executors/include/hpx/executors/parallel_scheduler.hpp
+++ b/libs/core/executors/include/hpx/executors/parallel_scheduler.hpp
@@ -623,9 +623,8 @@ namespace hpx::execution::experimental {
         }
 
         template <hpx::executor_parameters Parameters>
-        [[nodiscard]] std::size_t query(processing_units_count_t,
-            Parameters&&, hpx::chrono::steady_duration const& =
-                hpx::chrono::null_duration,
+        [[nodiscard]] std::size_t query(processing_units_count_t, Parameters&&,
+            hpx::chrono::steady_duration const& = hpx::chrono::null_duration,
             std::size_t = 0) const
         {
             if (auto const* u = get_underlying_scheduler())
@@ -751,23 +750,21 @@ namespace hpx::execution::experimental {
                     set_stopped_t()>;
 
             template <typename Receiver>
-            operation_state<std::decay_t<Receiver>> connect(
-                Receiver&& receiver) const& noexcept(
-                std::is_nothrow_constructible_v<std::decay_t<Receiver>,
-                    Receiver>)
+            operation_state<std::decay_t<Receiver>> connect(Receiver&& receiver)
+                const& noexcept(
+                    std::is_nothrow_constructible_v<std::decay_t<Receiver>,
+                        Receiver>)
             {
-                return {HPX_FORWARD(Receiver, receiver),
-                    sched_.get_backend()};
+                return {HPX_FORWARD(Receiver, receiver), sched_.get_backend()};
             }
 
             template <typename Receiver>
-            operation_state<std::decay_t<Receiver>> connect(
-                Receiver&& receiver) && noexcept(
+            operation_state<std::decay_t<Receiver>>
+            connect(Receiver&& receiver) && noexcept(
                 std::is_nothrow_constructible_v<std::decay_t<Receiver>,
                     Receiver>)
             {
-                return {HPX_FORWARD(Receiver, receiver),
-                    sched_.get_backend()};
+                return {HPX_FORWARD(Receiver, receiver), sched_.get_backend()};
             }
 
             struct env

--- a/libs/core/executors/include/hpx/executors/parallel_scheduler.hpp
+++ b/libs/core/executors/include/hpx/executors/parallel_scheduler.hpp
@@ -422,30 +422,24 @@ namespace hpx::execution::experimental {
                 }
             };
 
-            // connect: creates the right op state behind the
-            // type-erased pointer.
             template <typename Receiver>
-            friend dispatch_op<std::decay_t<Receiver>> tag_invoke(
-                hpx::execution::experimental::connect_t,
-                parallel_bulk_dispatch_sender&& self, Receiver&& rcvr)
+            dispatch_op<std::decay_t<Receiver>> connect(Receiver&& rcvr) &&
             {
-                if (auto* fast = std::get_if<fast_path_data>(&self.data_))
+                if (auto* fast = std::get_if<fast_path_data>(&data_))
                 {
                     return dispatch_op<std::decay_t<Receiver>>{
                         std::make_unique<fast_parallel_bulk_op<FastSender,
                             std::decay_t<Receiver>>>(HPX_MOVE(fast->sender_),
                             HPX_FORWARD(Receiver, rcvr))};
                 }
-                else
-                {
-                    auto& vp = std::get<virtual_path_data>(self.data_);
-                    return dispatch_op<std::decay_t<Receiver>>{
-                        std::make_unique<virtual_parallel_bulk_op<F, IsChunked,
-                            IsParallel, ChildSender, std::decay_t<Receiver>>>(
-                            HPX_MOVE(vp.backend_), vp.count_, vp.actual_shape_,
-                            HPX_MOVE(vp.f_), HPX_MOVE(vp.child_),
-                            HPX_FORWARD(Receiver, rcvr))};
-                }
+
+                auto& vp = std::get<virtual_path_data>(data_);
+                return dispatch_op<std::decay_t<Receiver>>{
+                    std::make_unique<virtual_parallel_bulk_op<F, IsChunked,
+                        IsParallel, ChildSender, std::decay_t<Receiver>>>(
+                        HPX_MOVE(vp.backend_), vp.count_, vp.actual_shape_,
+                        HPX_MOVE(vp.f_), HPX_MOVE(vp.child_),
+                        HPX_FORWARD(Receiver, rcvr))};
             }
         };
 
@@ -620,44 +614,39 @@ namespace hpx::execution::experimental {
         }
 
         // Scheduling properties: forward to the wrapped thread_pool_policy_scheduler
-        // when present so callers use get_processing_units_mask(sched),
-        // get_first_core(sched), processing_units_count(..., sched), etc.,
-        // consistent with thread_pool_policy_scheduler.
-        friend std::size_t tag_invoke(
-            get_first_core_t, parallel_scheduler const& sched) noexcept
+        // when present, consistent with thread_pool_policy_scheduler.
+        [[nodiscard]] std::size_t query(get_first_core_t) const noexcept
         {
-            if (auto const* u = sched.get_underlying_scheduler())
-                return get_first_core(*u);
+            if (auto const* u = get_underlying_scheduler())
+                return u->query(get_first_core_t{});
             return 0;
         }
 
         template <hpx::executor_parameters Parameters>
-        friend std::size_t tag_invoke(processing_units_count_t, Parameters&&,
-            parallel_scheduler const& sched,
-            hpx::chrono::steady_duration const& = hpx::chrono::null_duration,
-            std::size_t = 0)
+        [[nodiscard]] std::size_t query(processing_units_count_t,
+            Parameters&&, hpx::chrono::steady_duration const& =
+                hpx::chrono::null_duration,
+            std::size_t = 0) const
         {
-            if (auto const* u = sched.get_underlying_scheduler())
-                return processing_units_count(
-                    null_parameters, *u, hpx::chrono::null_duration, 0);
+            if (auto const* u = get_underlying_scheduler())
+                return u->query(processing_units_count_t{}, null_parameters,
+                    hpx::chrono::null_duration, 0);
             return 1;
         }
 
-        friend auto tag_invoke(
-            get_processing_units_mask_t, parallel_scheduler const& sched)
+        [[nodiscard]] auto query(get_processing_units_mask_t) const
         {
-            if (auto const* cached = sched.get_pu_mask())
+            if (auto const* cached = get_pu_mask())
                 return *cached;
-            if (auto const* u = sched.get_underlying_scheduler())
-                return get_processing_units_mask(*u);
+            if (auto const* u = get_underlying_scheduler())
+                return u->query(get_processing_units_mask_t{});
             return hpx::threads::create_topology().get_machine_affinity_mask();
         }
 
-        friend auto tag_invoke(
-            get_cores_mask_t, parallel_scheduler const& sched)
+        [[nodiscard]] auto query(get_cores_mask_t) const
         {
-            if (auto const* u = sched.get_underlying_scheduler())
-                return get_cores_mask(*u);
+            if (auto const* u = get_underlying_scheduler())
+                return u->query(get_cores_mask_t{});
             return hpx::threads::create_topology().get_machine_affinity_mask();
         }
 
@@ -762,23 +751,23 @@ namespace hpx::execution::experimental {
                     set_stopped_t()>;
 
             template <typename Receiver>
-            friend operation_state<std::decay_t<Receiver>> tag_invoke(
-                connect_t, sender const& s, Receiver&& receiver) noexcept(std::
-                    is_nothrow_constructible_v<std::decay_t<Receiver>,
-                        Receiver>)
-            {
-                return {
-                    HPX_FORWARD(Receiver, receiver), s.sched_.get_backend()};
-            }
-
-            template <typename Receiver>
-            friend operation_state<std::decay_t<Receiver>>
-            tag_invoke(connect_t, sender&& s, Receiver&& receiver) noexcept(
+            operation_state<std::decay_t<Receiver>> connect(
+                Receiver&& receiver) const& noexcept(
                 std::is_nothrow_constructible_v<std::decay_t<Receiver>,
                     Receiver>)
             {
-                return {
-                    HPX_FORWARD(Receiver, receiver), s.sched_.get_backend()};
+                return {HPX_FORWARD(Receiver, receiver),
+                    sched_.get_backend()};
+            }
+
+            template <typename Receiver>
+            operation_state<std::decay_t<Receiver>> connect(
+                Receiver&& receiver) && noexcept(
+                std::is_nothrow_constructible_v<std::decay_t<Receiver>,
+                    Receiver>)
+            {
+                return {HPX_FORWARD(Receiver, receiver),
+                    sched_.get_backend()};
             }
 
             struct env

--- a/libs/core/executors/include/hpx/executors/restricted_thread_pool_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/restricted_thread_pool_executor.hpp
@@ -139,113 +139,94 @@ namespace hpx::execution::experimental {
                     static_cast<std::int16_t>(thread_num)));
         }
 
-    private:
+    public:
         // property implementations
 
         // support all properties exposed by the embedded executor
         template <typename Tag, typename Property>
             requires(
-                hpx::execution::experimental::is_scheduling_property_v<Tag> &&
-                hpx::functional::is_tag_invocable_v<Tag, embedded_executor,
-                    Property>)
-        friend restricted_policy_executor tag_invoke(
-            Tag tag, restricted_policy_executor const& exec, Property&& prop)
+                hpx::execution::experimental::is_scheduling_property_v<Tag>)
+        restricted_policy_executor query(Tag tag, Property&& prop) const
         {
-            auto exec_with_prop = exec;
-            exec_with_prop.exec_ = hpx::functional::tag_invoke(tag,
-                exec.generate_executor(exec.get_current_thread_num()),
-                HPX_FORWARD(Property, prop));
+            auto exec_with_prop = *this;
+            exec_with_prop.exec_ =
+                tag(generate_executor(get_current_thread_num()),
+                    HPX_FORWARD(Property, prop));
             return exec_with_prop;
         }
 
         template <scheduling_property Tag>
-            requires(
-                hpx::functional::is_tag_invocable_v<Tag, embedded_executor>)
-        friend decltype(auto) tag_invoke(
-            Tag tag, restricted_policy_executor const& exec)
+        decltype(auto) query(Tag tag) const
         {
-            return tag(exec.generate_executor(exec.get_current_thread_num()));
+            return tag(generate_executor(get_current_thread_num()));
         }
 
         template <executor_parameters Parameters>
-        friend constexpr std::size_t tag_invoke(
+        constexpr std::size_t query(
             hpx::execution::experimental::processing_units_count_t tag,
-            Parameters&& params, restricted_policy_executor const& exec,
+            Parameters&& params,
             hpx::chrono::steady_duration const& duration =
                 hpx::chrono::null_duration,
-            std::size_t num_tasks = 0)
+            std::size_t num_tasks = 0) const
         {
             return tag(HPX_FORWARD(Parameters, params),
-                exec.generate_executor(exec.get_current_thread_num()), duration,
+                generate_executor(get_current_thread_num()), duration,
                 num_tasks);
         }
 
         // executor API
         template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::sync_execute_t,
-            restricted_policy_executor const& exec, F&& f, Ts&&... ts)
+        decltype(auto) sync_execute(F&& f, Ts&&... ts) const
         {
             return hpx::parallel::execution::sync_execute(
-                exec.generate_executor(exec.get_next_thread_num()),
-                HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+                generate_executor(get_next_thread_num()), HPX_FORWARD(F, f),
+                HPX_FORWARD(Ts, ts)...);
         }
 
         template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::async_execute_t,
-            restricted_policy_executor const& exec, F&& f, Ts&&... ts)
+        decltype(auto) async_execute(F&& f, Ts&&... ts) const
         {
             return hpx::parallel::execution::async_execute(
-                exec.generate_executor(exec.get_next_thread_num()),
-                HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+                generate_executor(get_next_thread_num()), HPX_FORWARD(F, f),
+                HPX_FORWARD(Ts, ts)...);
         }
 
         template <typename F, typename Future, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::then_execute_t,
-            restricted_policy_executor const& exec, F&& f, Future&& predecessor,
-            Ts&&... ts)
+        decltype(auto) then_execute(
+            F&& f, Future&& predecessor, Ts&&... ts) const
         {
             return hpx::parallel::execution::then_execute(
-                exec.generate_executor(exec.get_next_thread_num()),
-                HPX_FORWARD(F, f), HPX_FORWARD(Future, predecessor),
-                HPX_FORWARD(Ts, ts)...);
+                generate_executor(get_next_thread_num()), HPX_FORWARD(F, f),
+                HPX_FORWARD(Future, predecessor), HPX_FORWARD(Ts, ts)...);
         }
 
         // NonBlockingOneWayExecutor (adapted) interface
         template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(hpx::parallel::execution::post_t,
-            restricted_policy_executor const& exec, F&& f, Ts&&... ts)
+        decltype(auto) post(F&& f, Ts&&... ts) const
         {
             return hpx::parallel::execution::post(
-                exec.generate_executor(exec.get_next_thread_num()),
-                HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+                generate_executor(get_next_thread_num()), HPX_FORWARD(F, f),
+                HPX_FORWARD(Ts, ts)...);
         }
 
         template <typename F, typename S, typename... Ts>
             requires(!std::is_integral_v<S>)
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::bulk_async_execute_t,
-            restricted_policy_executor const& exec, F&& f, S const& shape,
-            Ts&&... ts)
+        decltype(auto) bulk_async_execute(
+            F&& f, S const& shape, Ts&&... ts) const
         {
             return hpx::parallel::execution::bulk_async_execute(
-                exec.generate_executor(exec.first_thread_), HPX_FORWARD(F, f),
-                shape, HPX_FORWARD(Ts, ts)...);
+                generate_executor(first_thread_), HPX_FORWARD(F, f), shape,
+                HPX_FORWARD(Ts, ts)...);
         }
 
         template <typename F, typename S, typename Future, typename... Ts>
             requires(!std::is_integral_v<S>)
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::bulk_then_execute_t,
-            restricted_policy_executor const& exec, F&& f, S const& shape,
-            Future&& predecessor, Ts&&... ts)
+        decltype(auto) bulk_then_execute(
+            F&& f, S const& shape, Future&& predecessor, Ts&&... ts) const
         {
             return hpx::parallel::execution::bulk_then_execute(
-                exec.generate_executor(exec.first_thread_), HPX_FORWARD(F, f),
-                shape, HPX_FORWARD(Future, predecessor),
-                HPX_FORWARD(Ts, ts)...);
+                generate_executor(first_thread_), HPX_FORWARD(F, f), shape,
+                HPX_FORWARD(Future, predecessor), HPX_FORWARD(Ts, ts)...);
         }
         /// \endcond
 

--- a/libs/core/executors/include/hpx/executors/scheduler_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/scheduler_executor.hpp
@@ -243,7 +243,7 @@ namespace hpx::execution::experimental {
         template <typename Tag, typename Property>
             requires(
                 hpx::execution::experimental::is_scheduling_property_v<Tag> &&
-                hpx::execution::experimental::detail::has_query_v<
+                hpx::execution::experimental::has_query_v<
                     std::decay_t<BaseScheduler>, Tag, Property>)
         [[nodiscard]] auto query(Tag tag, Property&& prop) const
         {
@@ -254,7 +254,7 @@ namespace hpx::execution::experimental {
         template <typename Tag>
             requires(
                 hpx::execution::experimental::is_scheduling_property_v<Tag> &&
-                hpx::execution::experimental::detail::has_query_v<
+                hpx::execution::experimental::has_query_v<
                     std::decay_t<BaseScheduler>, Tag>)
         [[nodiscard]] auto query(Tag tag) const
         {

--- a/libs/core/executors/include/hpx/executors/scheduler_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/scheduler_executor.hpp
@@ -13,7 +13,6 @@
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/execution_base.hpp>
 #include <hpx/modules/functional.hpp>
-#include <hpx/modules/tag_invoke.hpp>
 #include <hpx/modules/timing.hpp>
 #include <hpx/modules/topology.hpp>
 #include <hpx/modules/type_support.hpp>
@@ -232,8 +231,7 @@ namespace hpx::execution::experimental {
         using future_type = hpx::future<T>;
 
         template <executor_parameters Parameters>
-        [[nodiscard]] auto query(processing_units_count_t,
-            Parameters&& params,
+        [[nodiscard]] auto query(processing_units_count_t, Parameters&& params,
             hpx::chrono::steady_duration const& duration =
                 hpx::chrono::null_duration,
             std::size_t num_cores = 0) const
@@ -243,7 +241,10 @@ namespace hpx::execution::experimental {
         }
 
         template <typename Tag, typename Property>
-            requires(hpx::execution::experimental::is_scheduling_property_v<Tag>)
+            requires(
+                hpx::execution::experimental::is_scheduling_property_v<Tag> &&
+                hpx::execution::experimental::detail::has_query_v<
+                    std::decay_t<BaseScheduler>, Tag, Property>)
         [[nodiscard]] auto query(Tag tag, Property&& prop) const
         {
             return scheduler_executor{
@@ -251,27 +252,27 @@ namespace hpx::execution::experimental {
         }
 
         template <typename Tag>
-            requires(hpx::execution::experimental::is_scheduling_property_v<Tag>)
+            requires(
+                hpx::execution::experimental::is_scheduling_property_v<Tag> &&
+                hpx::execution::experimental::detail::has_query_v<
+                    std::decay_t<BaseScheduler>, Tag>)
         [[nodiscard]] auto query(Tag tag) const
         {
             return sched_.query(tag);
         }
 
-    private:
         // NonBlockingOneWayExecutor interface
         template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(hpx::parallel::execution::post_t,
-            scheduler_executor const& exec, F&& f, Ts&&... ts)
+        void post(F&& f, Ts&&... ts) const
         {
-            start_detached(then(schedule(exec.sched_),
+            start_detached(then(schedule(sched_),
                 hpx::util::deferred_call(
                     HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...)));
         }
 
         // OneWayExecutor interface
         template <typename F, typename... Ts>
-        friend auto tag_invoke(hpx::parallel::execution::sync_execute_t,
-            scheduler_executor const& exec, F&& f, Ts&&... ts)
+        auto sync_execute(F&& f, Ts&&... ts) const
         {
             using result_type =
                 hpx::util::detail::invoke_deferred_result_t<F, Ts...>;
@@ -279,30 +280,26 @@ namespace hpx::execution::experimental {
             return hpx::util::void_guard<result_type>(),
                    // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
                    *hpx::this_thread::experimental::sync_wait(
-                       then(schedule(exec.sched_),
+                       then(schedule(sched_),
                            hpx::util::deferred_call(
                                HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...)));
         }
 
         // TwoWayExecutor interface
         template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::async_execute_t,
-            scheduler_executor const& exec, F&& f, Ts&&... ts)
+        decltype(auto) async_execute(F&& f, Ts&&... ts) const
         {
-            return make_future(then(schedule(exec.sched_),
+            return make_future(then(schedule(sched_),
                 hpx::util::deferred_call(
                     HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...)));
         }
 
         template <typename F, typename Future, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::then_execute_t,
-            scheduler_executor const& exec, F&& f, Future&& predecessor,
-            Ts&&... ts)
+        decltype(auto) then_execute(
+            F&& f, Future&& predecessor, Ts&&... ts) const
         {
             auto&& predecessor_transfer_sched = continues_on(
-                keep_future(HPX_FORWARD(Future, predecessor)), exec.sched_);
+                keep_future(HPX_FORWARD(Future, predecessor)), sched_);
 
             return make_future(then(HPX_MOVE(predecessor_transfer_sched),
                 hpx::bind_back(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...)));
@@ -311,8 +308,7 @@ namespace hpx::execution::experimental {
         // BulkTwoWayExecutor interface
         template <typename F, typename S, typename... Ts>
             requires(!std::is_integral_v<S>)
-        friend auto tag_invoke(hpx::parallel::execution::bulk_async_execute_t,
-            scheduler_executor const& exec, F&& f, S const& shape, Ts&&... ts)
+        auto bulk_async_execute(F&& f, S const& shape, Ts&&... ts) const
         {
             using shape_element = hpx::traits::range_traits<S>::value_type;
             using result_type = hpx::util::detail::invoke_deferred_result_t<F,
@@ -327,28 +323,27 @@ namespace hpx::execution::experimental {
                 if constexpr (detail::has_thread_pool_backend<
                                   std::decay_t<BaseScheduler>>::value)
                 {
-                    return detail::scheduler_bulk_async_via_thread_pool(
-                        exec.sched_, HPX_FORWARD(F, f), shape,
-                        HPX_FORWARD(Ts, ts)...);
+                    return detail::scheduler_bulk_async_via_thread_pool(sched_,
+                        HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...);
                 }
                 else if constexpr (requires {
-                                       exec.sched_.get_underlying_scheduler();
+                                       sched_.get_underlying_scheduler();
                                    })
                 {
                     using underlying_type = std::decay_t<
-                        decltype(exec.sched_.get_underlying_scheduler())>;
+                        decltype(sched_.get_underlying_scheduler())>;
                     if constexpr (detail::has_thread_pool_backend<
                                       underlying_type>::value)
                     {
                         auto const& underlying =
-                            exec.sched_.get_underlying_scheduler();
+                            sched_.get_underlying_scheduler();
                         return detail::scheduler_bulk_async_via_thread_pool(
                             underlying, HPX_FORWARD(F, f), shape,
                             HPX_FORWARD(Ts, ts)...);
                     }
                     else
                     {
-                        return make_future(bulk(schedule(exec.sched_), n,
+                        return make_future(bulk(schedule(sched_), n,
                             [shape,
                                 bound_f = hpx::bind_back(
                                     HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...)](
@@ -361,7 +356,7 @@ namespace hpx::execution::experimental {
                 }
                 else
                 {
-                    return make_future(bulk(schedule(exec.sched_), n,
+                    return make_future(bulk(schedule(sched_), n,
                         [shape,
                             bound_f = hpx::bind_back(HPX_FORWARD(F, f),
                                 HPX_FORWARD(Ts, ts)...)](size_type i) mutable {
@@ -411,7 +406,7 @@ namespace hpx::execution::experimental {
                 start_detached(bulk(
                     continues_on(just(HPX_MOVE(promises), HPX_FORWARD(F, f),
                                      shape, HPX_FORWARD(Ts, ts)...),
-                        exec.sched_),
+                        sched_),
                     n, HPX_MOVE(f_helper)));
 
                 return results;
@@ -420,8 +415,7 @@ namespace hpx::execution::experimental {
 
         template <typename F, typename S, typename... Ts>
             requires(!std::is_integral_v<S>)
-        friend auto tag_invoke(hpx::parallel::execution::bulk_sync_execute_t,
-            scheduler_executor const& exec, F&& f, S const& shape, Ts&&... ts)
+        auto bulk_sync_execute(F&& f, S const& shape, Ts&&... ts) const
         {
             using shape_element = hpx::traits::range_traits<S>::value_type;
             using result_type = hpx::util::detail::invoke_deferred_result_t<F,
@@ -434,20 +428,17 @@ namespace hpx::execution::experimental {
                               std::decay_t<BaseScheduler>>::value)
             {
                 return hpx::util::void_guard<result_type>(),
-                       detail::scheduler_bulk_sync_via_thread_pool(exec.sched_,
+                       detail::scheduler_bulk_sync_via_thread_pool(sched_,
                            HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...);
             }
-            else if constexpr (requires {
-                                   exec.sched_.get_underlying_scheduler();
-                               })
+            else if constexpr (requires { sched_.get_underlying_scheduler(); })
             {
-                using underlying_type = std::decay_t<
-                    decltype(exec.sched_.get_underlying_scheduler())>;
+                using underlying_type =
+                    std::decay_t<decltype(sched_.get_underlying_scheduler())>;
                 if constexpr (detail::has_thread_pool_backend<
                                   underlying_type>::value)
                 {
-                    auto const& underlying =
-                        exec.sched_.get_underlying_scheduler();
+                    auto const& underlying = sched_.get_underlying_scheduler();
 
                     return hpx::util::void_guard<result_type>(),
                            detail::scheduler_bulk_sync_via_thread_pool(
@@ -459,7 +450,7 @@ namespace hpx::execution::experimental {
                     return hpx::util::void_guard<result_type>(),
                            // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
                            *hpx::this_thread::experimental::sync_wait(bulk(
-                               schedule(exec.sched_), n,
+                               schedule(sched_), n,
                                [shape,
                                    bound_f = hpx::bind_back(HPX_FORWARD(F, f),
                                        HPX_FORWARD(Ts, ts)...)](
@@ -475,7 +466,7 @@ namespace hpx::execution::experimental {
                 return hpx::util::void_guard<result_type>(),
                        // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
                        *hpx::this_thread::experimental::sync_wait(
-                           bulk(schedule(exec.sched_), n,
+                           bulk(schedule(sched_), n,
                                [shape,
                                    bound_f = hpx::bind_back(HPX_FORWARD(F, f),
                                        HPX_FORWARD(Ts, ts)...)](
@@ -489,10 +480,8 @@ namespace hpx::execution::experimental {
 
         template <typename F, typename S, typename Future, typename... Ts>
             requires(!std::is_integral_v<S>)
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::bulk_then_execute_t,
-            scheduler_executor const& exec, F&& f, S const& shape,
-            Future&& predecessor, Ts&&... ts)
+        decltype(auto) bulk_then_execute(
+            F&& f, S const& shape, Future&& predecessor, Ts&&... ts) const
         {
             using result_type =
                 parallel::execution::detail::then_bulk_function_result_t<F, S,
@@ -503,8 +492,7 @@ namespace hpx::execution::experimental {
                 auto pre_req =
                     when_all(keep_future(HPX_FORWARD(Future, predecessor)));
 
-                auto loop = bulk(continues_on(HPX_MOVE(pre_req), exec.sched_),
-                    shape,
+                auto loop = bulk(continues_on(HPX_MOVE(pre_req), sched_), shape,
                     hpx::bind_back(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...));
 
                 return make_future(HPX_MOVE(loop));
@@ -523,10 +511,9 @@ namespace hpx::execution::experimental {
                     keep_future(HPX_FORWARD(Future, predecessor)),
                     just(std::vector<result_type>(std::ranges::size(shape))));
 
-                auto loop =
-                    bulk(continues_on(HPX_MOVE(pre_req), exec.sched_), shape,
-                        detail::captured_args_then(
-                            HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...));
+                auto loop = bulk(continues_on(HPX_MOVE(pre_req), sched_), shape,
+                    detail::captured_args_then(
+                        HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...));
 
                 return make_future(then(
                     HPX_MOVE(loop), [](auto&&, std::vector<result_type>&& v) {
@@ -544,21 +531,8 @@ namespace hpx::execution::experimental {
     explicit scheduler_executor(BaseScheduler&& sched)
         -> scheduler_executor<std::decay_t<BaseScheduler>>;
 
-    HPX_CXX_CORE_EXPORT template <typename Tag, typename BaseScheduler,
-        typename Property>
-        requires(hpx::execution::experimental::is_scheduling_property_v<Tag>)
-    auto tag_invoke(
-        Tag tag, scheduler_executor<BaseScheduler> const& exec, Property&& prop)
-    {
-        return exec.query(tag, HPX_FORWARD(Property, prop));
-    }
-
-    HPX_CXX_CORE_EXPORT template <typename Tag, typename BaseScheduler>
-        requires(hpx::execution::experimental::is_scheduling_property_v<Tag>)
-    auto tag_invoke(Tag tag, scheduler_executor<BaseScheduler> const& exec)
-    {
-        return exec.query(tag);
-    }
+    // Scheduling property CPOs detect the public query() member functions
+    // above directly (via property_base), so no tag_invoke bridge is needed.
 
     /// \cond NOINTERNAL
     template <typename BaseScheduler>

--- a/libs/core/executors/include/hpx/executors/scheduler_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/scheduler_executor.hpp
@@ -231,23 +231,33 @@ namespace hpx::execution::experimental {
         template <typename T, typename... Ts>
         using future_type = hpx::future<T>;
 
-    private:
         template <executor_parameters Parameters>
-        friend auto tag_invoke(
-            hpx::execution::experimental::processing_units_count_t tag,
-            Parameters&& params, scheduler_executor const& exec,
+        [[nodiscard]] auto query(processing_units_count_t,
+            Parameters&& params,
             hpx::chrono::steady_duration const& duration =
                 hpx::chrono::null_duration,
-            std::size_t num_cores = 0)
-            -> decltype(std::declval<
-                hpx::execution::experimental::processing_units_count_t>()(
-                std::declval<Parameters>(), std::declval<BaseScheduler>(),
-                std::declval<hpx::chrono::steady_duration>(), 0))
+            std::size_t num_cores = 0) const
         {
-            return tag(HPX_FORWARD(Parameters, params), exec.sched_, duration,
-                num_cores);
+            return sched_.query(processing_units_count_t{},
+                HPX_FORWARD(Parameters, params), duration, num_cores);
         }
 
+        template <typename Tag, typename Property>
+            requires(hpx::execution::experimental::is_scheduling_property_v<Tag>)
+        [[nodiscard]] auto query(Tag tag, Property&& prop) const
+        {
+            return scheduler_executor{
+                sched_.query(tag, HPX_FORWARD(Property, prop))};
+        }
+
+        template <typename Tag>
+            requires(hpx::execution::experimental::is_scheduling_property_v<Tag>)
+        [[nodiscard]] auto query(Tag tag) const
+        {
+            return sched_.query(tag);
+        }
+
+    private:
         // NonBlockingOneWayExecutor interface
         template <typename F, typename... Ts>
         friend decltype(auto) tag_invoke(hpx::parallel::execution::post_t,
@@ -534,26 +544,20 @@ namespace hpx::execution::experimental {
     explicit scheduler_executor(BaseScheduler&& sched)
         -> scheduler_executor<std::decay_t<BaseScheduler>>;
 
-    // support all properties exposed by the wrapped scheduler
     HPX_CXX_CORE_EXPORT template <typename Tag, typename BaseScheduler,
-        typename Property,
-        HPX_CONCEPT_REQUIRES_(
-            hpx::execution::experimental::is_scheduling_property_v<Tag>)>
+        typename Property>
+        requires(hpx::execution::experimental::is_scheduling_property_v<Tag>)
     auto tag_invoke(
         Tag tag, scheduler_executor<BaseScheduler> const& exec, Property&& prop)
-        -> decltype(scheduler_executor<BaseScheduler>(std::declval<Tag>()(
-            std::declval<BaseScheduler>(), std::declval<Property>())))
     {
-        return scheduler_executor<BaseScheduler>(
-            tag(exec.sched(), HPX_FORWARD(Property, prop)));
+        return exec.query(tag, HPX_FORWARD(Property, prop));
     }
 
     HPX_CXX_CORE_EXPORT template <typename Tag, typename BaseScheduler>
         requires(hpx::execution::experimental::is_scheduling_property_v<Tag>)
     auto tag_invoke(Tag tag, scheduler_executor<BaseScheduler> const& exec)
-        -> decltype(std::declval<Tag>()(std::declval<BaseScheduler>()))
     {
-        return tag(exec.sched());
+        return exec.query(tag);
     }
 
     /// \cond NOINTERNAL

--- a/libs/core/executors/include/hpx/executors/sequenced_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/sequenced_executor.hpp
@@ -56,16 +56,16 @@ namespace hpx::execution {
         }
 
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)
-        [[nodiscard]] auto query(experimental::with_annotation_t,
-            char const* annotation) const
+        [[nodiscard]] auto query(
+            experimental::with_annotation_t, char const* annotation) const
         {
             auto exec_with_annotation = *this;
             exec_with_annotation.annotation_ = annotation;
             return exec_with_annotation;
         }
 
-        [[nodiscard]] auto query(experimental::with_annotation_t,
-            std::string annotation) const
+        [[nodiscard]] auto query(
+            experimental::with_annotation_t, std::string annotation) const
         {
             auto exec_with_annotation = *this;
             exec_with_annotation.annotation_ =
@@ -84,8 +84,7 @@ namespace hpx::execution {
             requires(hpx::executor_parameters<Parameters>)
         [[nodiscard]] constexpr std::size_t query(
             experimental::processing_units_count_t, Parameters&&,
-            hpx::chrono::steady_duration const& =
-                hpx::chrono::null_duration,
+            hpx::chrono::steady_duration const& = hpx::chrono::null_duration,
             std::size_t = 0) const
         {
             return 1;
@@ -109,78 +108,51 @@ namespace hpx::execution {
         /// \cond NOINTERNAL
         using execution_category = sequenced_execution_tag;
 
-    private:
         // OneWayExecutor interface
         template <typename F, typename... Ts>
-        static decltype(auto) sync_execute_impl(F&& f, Ts&&... ts)
-        {
-            return hpx::detail::sync_launch_policy_dispatch<
-                launch::sync_policy>::call(launch::sync, HPX_FORWARD(F, f),
-                HPX_FORWARD(Ts, ts)...);
-        }
-
-        template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::sync_execute_t,
-            [[maybe_unused]] sequenced_executor const& exec, F&& f, Ts&&... ts)
+        decltype(auto) sync_execute(F&& f, Ts&&... ts) const
         {
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)
-            hpx::scoped_annotation annotate(exec.annotation_ ?
-                    exec.annotation_ :
+            hpx::scoped_annotation annotate(annotation_ ?
+                    annotation_ :
                     "parallel_policy_executor::sync_execute");
 #endif
-            return sequenced_executor::sync_execute_impl(
-                HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+            return sync_execute_impl(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
 
         // TwoWayExecutor interface
         template <typename F, typename... Ts>
-        static decltype(auto) async_execute_impl(
-            hpx::threads::thread_description const& desc, F&& f, Ts&&... ts)
-        {
-            return hpx::detail::async_launch_policy_dispatch<
-                launch::deferred_policy>::call(launch::deferred, desc,
-                HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
-        }
-
-        template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::async_execute_t,
-            [[maybe_unused]] sequenced_executor const& exec, F&& f, Ts&&... ts)
+        decltype(auto) async_execute(F&& f, Ts&&... ts) const
         {
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)
-            hpx::threads::thread_description desc(f, exec.annotation_);
+            hpx::threads::thread_description desc(f, annotation_);
 #else
             hpx::threads::thread_description desc(f);
 #endif
-            return sequenced_executor::async_execute_impl(
+            return async_execute_impl(
                 desc, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
 
         // NonBlockingOneWayExecutor (adapted) interface
         template <typename F, typename... Ts>
-        friend void tag_invoke(hpx::parallel::execution::post_t,
-            [[maybe_unused]] sequenced_executor const& exec, F&& f, Ts&&... ts)
+        void post(F&& f, Ts&&... ts) const
         {
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)
-            hpx::scoped_annotation annotate(exec.annotation_ ?
-                    exec.annotation_ :
+            hpx::scoped_annotation annotate(annotation_ ?
+                    annotation_ :
                     "parallel_policy_executor::sync_execute");
 #endif
-            sequenced_executor::sync_execute_impl(
-                HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+            sync_execute_impl(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
 
         // BulkTwoWayExecutor interface
         template <typename F, typename S, typename... Ts>
             requires(!std::is_integral_v<S>)
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::bulk_async_execute_t,
-            [[maybe_unused]] sequenced_executor const& exec, F&& f,
-            S const& shape, Ts&&... ts)
+        decltype(auto) bulk_async_execute(
+            F&& f, S const& shape, Ts&&... ts) const
         {
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)
-            hpx::threads::thread_description desc(f, exec.annotation_);
+            hpx::threads::thread_description desc(f, annotation_);
 #else
             hpx::threads::thread_description desc(f);
 #endif
@@ -194,8 +166,7 @@ namespace hpx::execution {
             {
                 for (auto const& elem : shape)
                 {
-                    results.push_back(sequenced_executor::async_execute_impl(
-                        desc, f, elem, ts...));
+                    results.push_back(async_execute_impl(desc, f, elem, ts...));
                 }
             }
             catch (std::bad_alloc const&)
@@ -212,20 +183,18 @@ namespace hpx::execution {
 
         template <typename F, typename S, typename... Ts>
             requires(!std::is_integral_v<S>)
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::bulk_sync_execute_t,
-            sequenced_executor const& exec, F&& f, S const& shape, Ts&&... ts)
+        decltype(auto) bulk_sync_execute(
+            F&& f, S const& shape, Ts&&... ts) const
         {
-            return hpx::unwrap(hpx::parallel::execution::bulk_async_execute(
-                exec, HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...));
+            return hpx::unwrap(bulk_async_execute(
+                HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...));
         }
 
-        friend decltype(auto) tag_invoke(hpx::execution::experimental::to_par_t,
-            [[maybe_unused]] sequenced_executor const& exec)
+        decltype(auto) to_par() const
         {
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)
             return hpx::execution::experimental::with_annotation(
-                parallel_executor(), exec.annotation_);
+                parallel_executor(), annotation_);
 #else
             return parallel_executor();
 #endif
@@ -243,6 +212,23 @@ namespace hpx::execution {
         /// \endcond
 
     private:
+        template <typename F, typename... Ts>
+        static decltype(auto) sync_execute_impl(F&& f, Ts&&... ts)
+        {
+            return hpx::detail::sync_launch_policy_dispatch<
+                launch::sync_policy>::call(launch::sync, HPX_FORWARD(F, f),
+                HPX_FORWARD(Ts, ts)...);
+        }
+
+        template <typename F, typename... Ts>
+        static decltype(auto) async_execute_impl(
+            hpx::threads::thread_description const& desc, F&& f, Ts&&... ts)
+        {
+            return hpx::detail::async_launch_policy_dispatch<
+                launch::deferred_policy>::call(launch::deferred, desc,
+                HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+        }
+
         friend class hpx::serialization::access;
 
         template <typename Archive>

--- a/libs/core/executors/include/hpx/executors/sequenced_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/sequenced_executor.hpp
@@ -54,6 +54,56 @@ namespace hpx::execution {
         {
             return *this;
         }
+
+#if defined(HPX_HAVE_THREAD_DESCRIPTION)
+        [[nodiscard]] auto query(experimental::with_annotation_t,
+            char const* annotation) const
+        {
+            auto exec_with_annotation = *this;
+            exec_with_annotation.annotation_ = annotation;
+            return exec_with_annotation;
+        }
+
+        [[nodiscard]] auto query(experimental::with_annotation_t,
+            std::string annotation) const
+        {
+            auto exec_with_annotation = *this;
+            exec_with_annotation.annotation_ =
+                hpx::detail::store_function_annotation(HPX_MOVE(annotation));
+            return exec_with_annotation;
+        }
+
+        [[nodiscard]] constexpr char const* query(
+            experimental::get_annotation_t) const noexcept
+        {
+            return annotation_;
+        }
+#endif
+
+        template <typename Parameters>
+            requires(hpx::executor_parameters<Parameters>)
+        [[nodiscard]] constexpr std::size_t query(
+            experimental::processing_units_count_t, Parameters&&,
+            hpx::chrono::steady_duration const& =
+                hpx::chrono::null_duration,
+            std::size_t = 0) const
+        {
+            return 1;
+        }
+
+        [[nodiscard]] auto query(
+            experimental::get_processing_units_mask_t) const
+        {
+            return threads::detail::get_self_or_default_pool()
+                ->get_used_processing_unit(hpx::get_worker_thread_num(), false);
+        }
+
+        [[nodiscard]] auto query(experimental::get_cores_mask_t) const
+        {
+            return threads::detail::get_self_or_default_pool()
+                ->get_used_processing_unit(hpx::get_worker_thread_num(), true);
+        }
+
         /// \endcond
 
         /// \cond NOINTERNAL
@@ -168,62 +218,6 @@ namespace hpx::execution {
         {
             return hpx::unwrap(hpx::parallel::execution::bulk_async_execute(
                 exec, HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...));
-        }
-
-#if defined(HPX_HAVE_THREAD_DESCRIPTION)
-        template <typename Executor_>
-            requires(std::is_convertible_v<Executor_, sequenced_executor>)
-        friend constexpr auto tag_invoke(
-            hpx::execution::experimental::with_annotation_t,
-            Executor_ const& exec, char const* annotation)
-        {
-            auto exec_with_annotation = exec;
-            exec_with_annotation.annotation_ = annotation;
-            return exec_with_annotation;
-        }
-
-        template <typename Executor_>
-            requires(std::is_convertible_v<Executor_, sequenced_executor>)
-        friend auto tag_invoke(hpx::execution::experimental::with_annotation_t,
-            Executor_ const& exec, std::string annotation)
-        {
-            auto exec_with_annotation = exec;
-            exec_with_annotation.annotation_ =
-                hpx::detail::store_function_annotation(HPX_MOVE(annotation));
-            return exec_with_annotation;
-        }
-
-        friend constexpr char const* tag_invoke(
-            hpx::execution::experimental::get_annotation_t,
-            sequenced_executor const& exec) noexcept
-        {
-            return exec.annotation_;
-        }
-#endif
-
-        template <executor_parameters Parameters>
-        friend constexpr std::size_t tag_invoke(
-            hpx::execution::experimental::processing_units_count_t,
-            Parameters&&, sequenced_executor const&,
-            hpx::chrono::steady_duration const& = hpx::chrono::null_duration,
-            std::size_t = 0)
-        {
-            return 1;
-        }
-
-        friend auto tag_invoke(
-            hpx::execution::experimental::get_processing_units_mask_t,
-            sequenced_executor const&)
-        {
-            return threads::detail::get_self_or_default_pool()
-                ->get_used_processing_unit(hpx::get_worker_thread_num(), false);
-        }
-
-        friend auto tag_invoke(hpx::execution::experimental::get_cores_mask_t,
-            sequenced_executor const&)
-        {
-            return threads::detail::get_self_or_default_pool()
-                ->get_used_processing_unit(hpx::get_worker_thread_num(), true);
         }
 
         friend decltype(auto) tag_invoke(hpx::execution::experimental::to_par_t,

--- a/libs/core/executors/include/hpx/executors/service_executors.hpp
+++ b/libs/core/executors/include/hpx/executors/service_executors.hpp
@@ -50,12 +50,11 @@ namespace hpx::parallel::execution::detail {
             HPX_ASSERT(pool);
         }
 
-        HPX_CORE_EXPORT static void post(
+        HPX_CORE_EXPORT static void post_to_pool(
             hpx::util::io_service_pool* pool, hpx::function<void()>&&);
 
         template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(hpx::parallel::execution::post_t,
-            [[maybe_unused]] service_executor const& exec, F&& f, Ts&&... ts)
+        void post(F&& f, Ts&&... ts) const
         {
             using result_type =
                 hpx::util::detail::invoke_deferred_result_t<F, Ts...>;
@@ -67,7 +66,7 @@ namespace hpx::parallel::execution::detail {
                 HPX_MOVE(f_wrapper));
 
 #if defined(HPX_COMPUTE_HOST_CODE)
-            post(exec.pool_,
+            post_to_pool(pool_,
                 hpx::bind_front(
                     &post_wrapper_helper<decltype(f_wrapper)>::invoke,
                     HPX_MOVE(t)));
@@ -78,9 +77,7 @@ namespace hpx::parallel::execution::detail {
         }
 
         template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::async_execute_t,
-            [[maybe_unused]] service_executor const& exec, F&& f, Ts&&... ts)
+        decltype(auto) async_execute(F&& f, Ts&&... ts) const
         {
             using result_type =
                 hpx::util::detail::invoke_deferred_result_t<F, Ts...>;
@@ -93,7 +90,7 @@ namespace hpx::parallel::execution::detail {
                 HPX_MOVE(f_wrapper));
 
 #if defined(HPX_COMPUTE_HOST_CODE)
-            post(exec.pool_,
+            post_to_pool(pool_,
                 hpx::bind_front(
                     &async_execute_wrapper_helper<decltype(f_wrapper),
                         result_type>::invoke,
@@ -107,8 +104,7 @@ namespace hpx::parallel::execution::detail {
         }
 
         template <typename F, typename Shape, typename... Ts>
-        friend auto tag_invoke(hpx::parallel::execution::bulk_async_execute_t,
-            service_executor const& exec, F&& f, Shape const& shape, Ts&&... ts)
+        auto bulk_async_execute(F&& f, Shape const& shape, Ts&&... ts) const
         {
             std::vector<
                 hpx::future<detail::bulk_function_result_t<F, Shape, Ts...>>>
@@ -118,7 +114,7 @@ namespace hpx::parallel::execution::detail {
             for (auto const& elem : shape)
             {
                 results.push_back(hpx::parallel::execution::async_execute(
-                    exec, f, elem, ts...));
+                    *this, f, elem, ts...));
             }
 
             return results;
@@ -130,12 +126,11 @@ namespace hpx::parallel::execution::detail {
         // for the bulk continuations. Because of this the intermediate task is
         // spawned on the current thread pool, not the service pool.
         template <typename F, typename Shape, typename Future, typename... Ts>
-        friend auto tag_invoke(hpx::parallel::execution::bulk_then_execute_t,
-            service_executor const& exec, F&& f, Shape const& shape,
-            Future&& predecessor, Ts&&... ts)
+        auto bulk_then_execute(
+            F&& f, Shape const& shape, Future&& predecessor, Ts&&... ts) const
         {
             auto func = parallel::execution::detail::
-                make_fused_bulk_async_execute_helper(exec, HPX_FORWARD(F, f),
+                make_fused_bulk_async_execute_helper(*this, HPX_FORWARD(F, f),
                     shape, hpx::make_tuple(HPX_FORWARD(Ts, ts)...));
             using vector_result_type =
                 parallel::execution::detail::bulk_then_execute_result_t<F,

--- a/libs/core/executors/include/hpx/executors/thread_pool_scheduler.hpp
+++ b/libs/core/executors/include/hpx/executors/thread_pool_scheduler.hpp
@@ -196,13 +196,13 @@ namespace hpx::execution::experimental {
             return pool_;
         }
 
-        [[nodiscard]] auto query(with_processing_units_count_t,
-            std::size_t num_cores) const
+        [[nodiscard]] auto query(
+            with_processing_units_count_t, std::size_t num_cores) const
         {
             if (num_cores == 0)
             {
-                auto pool = pool_ ? pool_ :
-                                       threads::detail::get_self_or_default_pool();
+                auto pool =
+                    pool_ ? pool_ : threads::detail::get_self_or_default_pool();
                 num_cores = pool->get_active_os_thread_count();
             }
             auto scheduler_with_num_cores = *this;
@@ -211,16 +211,15 @@ namespace hpx::execution::experimental {
         }
 
         template <executor_parameters Parameters>
-        [[nodiscard]] std::size_t query(processing_units_count_t,
-            Parameters&&, hpx::chrono::steady_duration const& =
-                hpx::chrono::null_duration,
+        [[nodiscard]] std::size_t query(processing_units_count_t, Parameters&&,
+            hpx::chrono::steady_duration const& = hpx::chrono::null_duration,
             std::size_t = 0) const
         {
             return get_num_cores();
         }
 
-        [[nodiscard]] auto query(with_first_core_t,
-            std::size_t first_core) const noexcept
+        [[nodiscard]] auto query(
+            with_first_core_t, std::size_t first_core) const noexcept
         {
             auto scheduler_with_first_core = *this;
             scheduler_with_first_core.first_core_ = first_core;
@@ -234,15 +233,16 @@ namespace hpx::execution::experimental {
         }
 
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)
-        [[nodiscard]] auto query(with_annotation_t,
-            char const* annotation) const
+        [[nodiscard]] auto query(
+            with_annotation_t, char const* annotation) const
         {
             auto sched_with_annotation = *this;
             sched_with_annotation.annotation_ = annotation;
             return sched_with_annotation;
         }
 
-        [[nodiscard]] auto query(with_annotation_t, std::string annotation) const
+        [[nodiscard]] auto query(
+            with_annotation_t, std::string annotation) const
         {
             auto sched_with_annotation = *this;
             sched_with_annotation.annotation_ =
@@ -259,20 +259,21 @@ namespace hpx::execution::experimental {
 
         [[nodiscard]] auto query(get_processing_units_mask_t) const
         {
-            auto pool = pool_ ? pool_ :
-                                   threads::detail::get_self_or_default_pool();
+            auto pool =
+                pool_ ? pool_ : threads::detail::get_self_or_default_pool();
             return pool->get_used_processing_units(get_num_cores(), false);
         }
 
         [[nodiscard]] auto query(get_cores_mask_t) const
         {
-            auto pool = pool_ ? pool_ :
-                                   threads::detail::get_self_or_default_pool();
+            auto pool =
+                pool_ ? pool_ : threads::detail::get_self_or_default_pool();
             return pool->get_used_processing_units(get_num_cores(), true);
         }
 
         template <typename Tag, typename Property>
-            requires(hpx::execution::experimental::is_scheduling_property_v<Tag>)
+            requires(
+                hpx::execution::experimental::is_scheduling_property_v<Tag>)
         [[nodiscard]] auto query(Tag tag, Property&& prop) const
         {
             auto scheduler_with_prop = *this;
@@ -282,7 +283,8 @@ namespace hpx::execution::experimental {
         }
 
         template <typename Tag>
-            requires(hpx::execution::experimental::is_scheduling_property_v<Tag>)
+            requires(
+                hpx::execution::experimental::is_scheduling_property_v<Tag>)
         [[nodiscard]] auto query(Tag tag) const
         {
             return tag(policy());

--- a/libs/core/executors/include/hpx/executors/thread_pool_scheduler.hpp
+++ b/libs/core/executors/include/hpx/executors/thread_pool_scheduler.hpp
@@ -273,7 +273,8 @@ namespace hpx::execution::experimental {
 
         template <typename Tag, typename Property>
             requires(
-                hpx::execution::experimental::is_scheduling_property_v<Tag>)
+                hpx::execution::experimental::is_scheduling_property_v<Tag> &&
+                hpx::functional::is_tag_invocable_v<Tag, Policy, Property>)
         [[nodiscard]] auto query(Tag tag, Property&& prop) const
         {
             auto scheduler_with_prop = *this;
@@ -284,7 +285,8 @@ namespace hpx::execution::experimental {
 
         template <typename Tag>
             requires(
-                hpx::execution::experimental::is_scheduling_property_v<Tag>)
+                hpx::execution::experimental::is_scheduling_property_v<Tag> &&
+                hpx::functional::is_tag_invocable_v<Tag, Policy>)
         [[nodiscard]] auto query(Tag tag) const
         {
             return tag(policy());

--- a/libs/core/executors/include/hpx/executors/thread_pool_scheduler.hpp
+++ b/libs/core/executors/include/hpx/executors/thread_pool_scheduler.hpp
@@ -196,39 +196,101 @@ namespace hpx::execution::experimental {
             return pool_;
         }
 
-        template <typename Executor_>
-            requires(
-                std::is_convertible_v<Executor_, thread_pool_policy_scheduler>)
-        friend auto tag_invoke(
-            hpx::execution::experimental::with_processing_units_count_t,
-            Executor_ const& scheduler, std::size_t num_cores)
+        [[nodiscard]] auto query(with_processing_units_count_t,
+            std::size_t num_cores) const
         {
             if (num_cores == 0)
             {
-                auto pool = scheduler.pool_ ?
-                    scheduler.pool_ :
-                    threads::detail::get_self_or_default_pool();
+                auto pool = pool_ ? pool_ :
+                                       threads::detail::get_self_or_default_pool();
                 num_cores = pool->get_active_os_thread_count();
             }
-            auto scheduler_with_num_cores = scheduler;
+            auto scheduler_with_num_cores = *this;
             scheduler_with_num_cores.num_cores_ = num_cores;
             return scheduler_with_num_cores;
         }
 
         template <executor_parameters Parameters>
-        friend constexpr std::size_t tag_invoke(
-            hpx::execution::experimental::processing_units_count_t,
-            Parameters&&, thread_pool_policy_scheduler const& scheduler,
-            hpx::chrono::steady_duration const& = hpx::chrono::null_duration,
-            std::size_t = 0)
+        [[nodiscard]] std::size_t query(processing_units_count_t,
+            Parameters&&, hpx::chrono::steady_duration const& =
+                hpx::chrono::null_duration,
+            std::size_t = 0) const
         {
-            return scheduler.get_num_cores();
+            return get_num_cores();
+        }
+
+        [[nodiscard]] auto query(with_first_core_t,
+            std::size_t first_core) const noexcept
+        {
+            auto scheduler_with_first_core = *this;
+            scheduler_with_first_core.first_core_ = first_core;
+            return scheduler_with_first_core;
+        }
+
+        [[nodiscard]] constexpr std::size_t query(
+            get_first_core_t) const noexcept
+        {
+            return get_first_core();
+        }
+
+#if defined(HPX_HAVE_THREAD_DESCRIPTION)
+        [[nodiscard]] auto query(with_annotation_t,
+            char const* annotation) const
+        {
+            auto sched_with_annotation = *this;
+            sched_with_annotation.annotation_ = annotation;
+            return sched_with_annotation;
+        }
+
+        [[nodiscard]] auto query(with_annotation_t, std::string annotation) const
+        {
+            auto sched_with_annotation = *this;
+            sched_with_annotation.annotation_ =
+                hpx::detail::store_function_annotation(HPX_MOVE(annotation));
+            return sched_with_annotation;
+        }
+
+        [[nodiscard]] constexpr char const* query(
+            get_annotation_t) const noexcept
+        {
+            return annotation_;
+        }
+#endif
+
+        [[nodiscard]] auto query(get_processing_units_mask_t) const
+        {
+            auto pool = pool_ ? pool_ :
+                                   threads::detail::get_self_or_default_pool();
+            return pool->get_used_processing_units(get_num_cores(), false);
+        }
+
+        [[nodiscard]] auto query(get_cores_mask_t) const
+        {
+            auto pool = pool_ ? pool_ :
+                                   threads::detail::get_self_or_default_pool();
+            return pool->get_used_processing_units(get_num_cores(), true);
+        }
+
+        template <typename Tag, typename Property>
+            requires(hpx::execution::experimental::is_scheduling_property_v<Tag>)
+        [[nodiscard]] auto query(Tag tag, Property&& prop) const
+        {
+            auto scheduler_with_prop = *this;
+            scheduler_with_prop.policy(
+                tag(policy(), HPX_FORWARD(Property, prop)));
+            return scheduler_with_prop;
+        }
+
+        template <typename Tag>
+            requires(hpx::execution::experimental::is_scheduling_property_v<Tag>)
+        [[nodiscard]] auto query(Tag tag) const
+        {
+            return tag(policy());
         }
 
         template <typename Sender, typename Shape, typename F>
-        friend auto tag_invoke(hpx::execution::experimental::bulk_t,
-            thread_pool_policy_scheduler const& scheduler, Sender&& sender,
-            Shape const& shape, F&& f)
+        [[nodiscard]] auto query(hpx::execution::experimental::bulk_t,
+            Sender&& sender, Shape const& shape, F&& f) const
         {
             constexpr bool is_parallel =
                 !std::is_same_v<Policy, hpx::launch::sync_policy> &&
@@ -240,9 +302,6 @@ namespace hpx::execution::experimental {
             {
                 auto iota_shape = hpx::util::counting_shape(shape);
 
-                // For parallel policies, we want internal chunking for efficiency.
-                // Since bulk_t expects an unchunked function, we wrap f to
-                // handle a range of indices in a loop.
                 if constexpr (!std::is_same_v<Policy, hpx::launch::sync_policy>)
                 {
                     auto wrapped_f = [f = HPX_FORWARD(F, f)](auto start,
@@ -256,7 +315,7 @@ namespace hpx::execution::experimental {
                     return detail::thread_pool_bulk_sender<Policy,
                         std::decay_t<Sender>, decltype(iota_shape),
                         decltype(wrapped_f), true, is_parallel, is_unsequenced>{
-                        scheduler, HPX_FORWARD(Sender, sender), iota_shape,
+                        *this, HPX_FORWARD(Sender, sender), iota_shape,
                         HPX_MOVE(wrapped_f)};
                 }
                 else
@@ -264,7 +323,7 @@ namespace hpx::execution::experimental {
                     return detail::thread_pool_bulk_sender<Policy,
                         std::decay_t<Sender>, decltype(iota_shape),
                         std::decay_t<F>, false, is_parallel, is_unsequenced>{
-                        scheduler, HPX_FORWARD(Sender, sender), iota_shape,
+                        *this, HPX_FORWARD(Sender, sender), iota_shape,
                         HPX_FORWARD(F, f)};
                 }
             }
@@ -283,7 +342,7 @@ namespace hpx::execution::experimental {
                     return detail::thread_pool_bulk_sender<Policy,
                         std::decay_t<Sender>, std::decay_t<Shape>,
                         decltype(wrapped_f), true, is_parallel, is_unsequenced>{
-                        scheduler, HPX_FORWARD(Sender, sender), shape,
+                        *this, HPX_FORWARD(Sender, sender), shape,
                         HPX_MOVE(wrapped_f)};
                 }
                 else
@@ -291,83 +350,10 @@ namespace hpx::execution::experimental {
                     return detail::thread_pool_bulk_sender<Policy,
                         std::decay_t<Sender>, std::decay_t<Shape>,
                         std::decay_t<F>, false, is_parallel, is_unsequenced>{
-                        scheduler, HPX_FORWARD(Sender, sender), shape,
+                        *this, HPX_FORWARD(Sender, sender), shape,
                         HPX_FORWARD(F, f)};
                 }
             }
-        }
-
-        template <typename Executor_>
-            requires(
-                std::is_convertible_v<Executor_, thread_pool_policy_scheduler>)
-        friend constexpr auto tag_invoke(
-            hpx::execution::experimental::with_first_core_t,
-            Executor_ const& exec, std::size_t first_core) noexcept
-        {
-            auto exec_with_first_core = exec;
-            exec_with_first_core.first_core_ = first_core;
-            return exec_with_first_core;
-        }
-
-        friend constexpr std::size_t tag_invoke(
-            hpx::execution::experimental::get_first_core_t,
-            thread_pool_policy_scheduler const& exec) noexcept
-        {
-            return exec.get_first_core();
-        }
-
-#if defined(HPX_HAVE_THREAD_DESCRIPTION)
-        // support with_annotation property
-        template <typename Executor_>
-            requires(
-                std::is_convertible_v<Executor_, thread_pool_policy_scheduler>)
-        friend constexpr auto tag_invoke(
-            hpx::execution::experimental::with_annotation_t,
-            Executor_ const& scheduler, char const* annotation)
-        {
-            auto sched_with_annotation = scheduler;
-            sched_with_annotation.annotation_ = annotation;
-            return sched_with_annotation;
-        }
-
-        template <typename Executor_>
-            requires(
-                std::is_convertible_v<Executor_, thread_pool_policy_scheduler>)
-        friend auto tag_invoke(hpx::execution::experimental::with_annotation_t,
-            Executor_ const& scheduler, std::string annotation)
-        {
-            auto sched_with_annotation = scheduler;
-            sched_with_annotation.annotation_ =
-                hpx::detail::store_function_annotation(HPX_MOVE(annotation));
-            return sched_with_annotation;
-        }
-
-        // support get_annotation property
-        friend constexpr char const* tag_invoke(
-            hpx::execution::experimental::get_annotation_t,
-            thread_pool_policy_scheduler const& scheduler) noexcept
-        {
-            return scheduler.annotation_;
-        }
-#endif
-
-        friend auto tag_invoke(
-            hpx::execution::experimental::get_processing_units_mask_t,
-            thread_pool_policy_scheduler const& exec)
-        {
-            auto pool = exec.pool_ ?
-                exec.pool_ :
-                threads::detail::get_self_or_default_pool();
-            return pool->get_used_processing_units(exec.get_num_cores(), false);
-        }
-
-        friend auto tag_invoke(hpx::execution::experimental::get_cores_mask_t,
-            thread_pool_policy_scheduler const& exec)
-        {
-            auto pool = exec.pool_ ?
-                exec.pool_ :
-                threads::detail::get_self_or_default_pool();
-            return pool->get_used_processing_units(exec.get_num_cores(), true);
         }
 
         template <typename F>
@@ -615,40 +601,6 @@ namespace hpx::execution::experimental {
 #endif
         /// \endcond
     };
-
-    // support all properties exposed by the embedded policy
-    // clang-format off
-    HPX_CXX_CORE_EXPORT template <typename Tag, typename Policy,
-        typename Property,
-        HPX_CONCEPT_REQUIRES_(
-            hpx::execution::experimental::is_scheduling_property_v<Tag>
-        )>
-    // clang-format on
-    auto tag_invoke(Tag tag,
-        thread_pool_policy_scheduler<Policy> const& scheduler, Property&& prop)
-        -> decltype(std::declval<thread_pool_policy_scheduler<Policy>>().policy(
-                        std::declval<Tag>()(
-                            std::declval<Policy>(), std::declval<Property>())),
-            thread_pool_policy_scheduler<Policy>())
-    {
-        auto scheduler_with_prop = scheduler;
-        scheduler_with_prop.policy(
-            tag(scheduler.policy(), HPX_FORWARD(Property, prop)));
-        return scheduler_with_prop;
-    }
-
-    // clang-format off
-    HPX_CXX_CORE_EXPORT template <typename Tag, typename Policy,
-        HPX_CONCEPT_REQUIRES_(
-            hpx::execution::experimental::is_scheduling_property_v<Tag>
-        )>
-    // clang-format on
-    auto tag_invoke(
-        Tag tag, thread_pool_policy_scheduler<Policy> const& scheduler)
-        -> decltype(std::declval<Tag>()(std::declval<Policy>()))
-    {
-        return tag(scheduler.policy());
-    }
 
     HPX_CXX_CORE_EXPORT using thread_pool_scheduler =
         thread_pool_policy_scheduler<hpx::launch>;

--- a/libs/core/executors/include/hpx/executors/thread_pool_scheduler_bulk.hpp
+++ b/libs/core/executors/include/hpx/executors/thread_pool_scheduler_bulk.hpp
@@ -20,7 +20,6 @@
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/iterator_support.hpp>
 #include <hpx/modules/resource_partitioner.hpp>
-#include <hpx/modules/tag_invoke.hpp>
 #include <hpx/modules/threading_base.hpp>
 #include <hpx/modules/topology.hpp>
 #include <hpx/modules/type_support.hpp>
@@ -769,9 +768,11 @@ namespace hpx::execution::experimental::detail {
           , shape(HPX_FORWARD(Shape_, shape))
           , f(HPX_FORWARD(F_, f))
           , pu_mask(detail::full_mask(
-                hpx::execution::experimental::get_first_core(scheduler),
-                hpx::execution::experimental::processing_units_count(
-                    hpx::execution::experimental::null_parameters, scheduler,
+                this->scheduler.query(
+                    hpx::execution::experimental::get_first_core_t{}),
+                this->scheduler.query(
+                    hpx::execution::experimental::processing_units_count_t{},
+                    hpx::execution::experimental::null_parameters,
                     hpx::chrono::null_duration, 0)))
         {
         }
@@ -907,11 +908,12 @@ namespace hpx::execution::experimental::detail {
                     HPX_FORWARD(Sender_, sender),
                     bulk_receiver<operation_state, F, Shape>{this}))
               , first_thread(
-                    hpx::execution::experimental::get_first_core(scheduler))
-              , num_worker_threads(
-                    hpx::execution::experimental::processing_units_count(
-                        hpx::execution::experimental::null_parameters,
-                        scheduler, hpx::chrono::null_duration, 0))
+                    scheduler.query(
+                        hpx::execution::experimental::get_first_core_t{}))
+              , num_worker_threads(scheduler.query(
+                    hpx::execution::experimental::processing_units_count_t{},
+                    hpx::execution::experimental::null_parameters,
+                    hpx::chrono::null_duration, 0))
               , pu_mask(HPX_MOVE(pumask))
               , queues(num_worker_threads)
               , shape(HPX_FORWARD(Shape_, shape))
@@ -938,28 +940,23 @@ namespace hpx::execution::experimental::detail {
 
     public:
         template <typename Receiver>
-        friend auto tag_invoke(
-            connect_t, thread_pool_bulk_sender&& s, Receiver&& receiver)
+        operation_state<std::decay_t<Receiver>> connect(Receiver&& receiver) &&
         {
             return operation_state<std::decay_t<Receiver>>{
-                HPX_MOVE(s.scheduler), HPX_MOVE(s.sender), HPX_MOVE(s.shape),
-                HPX_MOVE(s.f), HPX_MOVE(s.pu_mask),
+                HPX_MOVE(scheduler), HPX_MOVE(sender), HPX_MOVE(shape),
+                HPX_MOVE(f), HPX_MOVE(pu_mask),
                 HPX_FORWARD(Receiver, receiver)};
         }
 
         template <typename Receiver>
-        friend auto tag_invoke(
-            connect_t, thread_pool_bulk_sender& s, Receiver&& receiver)
+        operation_state<std::decay_t<Receiver>> connect(Receiver&& receiver) &
         {
-            return operation_state<std::decay_t<Receiver>>{s.scheduler,
-                s.sender, s.shape, s.f, s.pu_mask,
-                HPX_FORWARD(Receiver, receiver)};
+            return operation_state<std::decay_t<Receiver>>{scheduler, sender,
+                shape, f, pu_mask, HPX_FORWARD(Receiver, receiver)};
         }
     };
 }    // namespace hpx::execution::experimental::detail
 
-// Note: With stdexec integration, bulk operations are now customized
-// through the domain system in thread_pool_scheduler.hpp rather than
-// direct tag_invoke customizations. The thread_pool_domain<Policy>
-// intercepts hpx::execution::experimental::bulk_chunked_t operations and creates
-// thread_pool_bulk_sender instances for parallel execution.
+// Bulk operations are customized through the domain system in
+// thread_pool_scheduler.hpp. thread_pool_domain<Policy> intercepts bulk
+// operations and creates thread_pool_bulk_sender instances.

--- a/libs/core/executors/include/hpx/executors/thread_pool_scheduler_bulk.hpp
+++ b/libs/core/executors/include/hpx/executors/thread_pool_scheduler_bulk.hpp
@@ -907,9 +907,8 @@ namespace hpx::execution::experimental::detail {
               , op_state(hpx::execution::experimental::connect(
                     HPX_FORWARD(Sender_, sender),
                     bulk_receiver<operation_state, F, Shape>{this}))
-              , first_thread(
-                    scheduler.query(
-                        hpx::execution::experimental::get_first_core_t{}))
+              , first_thread(scheduler.query(
+                    hpx::execution::experimental::get_first_core_t{}))
               , num_worker_threads(scheduler.query(
                     hpx::execution::experimental::processing_units_count_t{},
                     hpx::execution::experimental::null_parameters,
@@ -942,10 +941,9 @@ namespace hpx::execution::experimental::detail {
         template <typename Receiver>
         operation_state<std::decay_t<Receiver>> connect(Receiver&& receiver) &&
         {
-            return operation_state<std::decay_t<Receiver>>{
-                HPX_MOVE(scheduler), HPX_MOVE(sender), HPX_MOVE(shape),
-                HPX_MOVE(f), HPX_MOVE(pu_mask),
-                HPX_FORWARD(Receiver, receiver)};
+            return operation_state<std::decay_t<Receiver>>{HPX_MOVE(scheduler),
+                HPX_MOVE(sender), HPX_MOVE(shape), HPX_MOVE(f),
+                HPX_MOVE(pu_mask), HPX_FORWARD(Receiver, receiver)};
         }
 
         template <typename Receiver>

--- a/libs/core/executors/include/hpx/executors/thread_pool_scheduler_bulk.hpp
+++ b/libs/core/executors/include/hpx/executors/thread_pool_scheduler_bulk.hpp
@@ -900,10 +900,10 @@ namespace hpx::execution::experimental::detail {
 
             template <typename Scheduler_, typename Sender_, typename Shape_,
                 typename F_, typename Receiver_>
-            operation_state(Scheduler_&& scheduler, Sender_&& sender,
+            operation_state(Scheduler_&& scheduler_, Sender_&& sender,
                 Shape_&& shape, F_&& f, hpx::threads::mask_type pumask,
                 Receiver_&& receiver)
-              : scheduler(HPX_FORWARD(Scheduler_, scheduler))
+              : scheduler(HPX_FORWARD(Scheduler_, scheduler_))
               , op_state(hpx::execution::experimental::connect(
                     HPX_FORWARD(Sender_, sender),
                     bulk_receiver<operation_state, F, Shape>{this}))

--- a/libs/core/executors/src/service_executors.cpp
+++ b/libs/core/executors/src/service_executors.cpp
@@ -17,7 +17,7 @@
 
 namespace hpx::parallel::execution::detail {
 
-    void service_executor::post(
+    void service_executor::post_to_pool(
         hpx::util::io_service_pool* pool, hpx::function<void()>&& f)
     {
 #if ASIO_VERSION >= 103400

--- a/libs/core/executors/tests/unit/created_executor.cpp
+++ b/libs/core/executors/tests/unit/created_executor.cpp
@@ -35,26 +35,22 @@ struct void_parallel_executor : hpx::execution::parallel_executor
     using base_type = hpx::execution::parallel_executor;
 
     template <typename F, typename Shape, typename... Ts>
-    friend auto tag_invoke(hpx::parallel::execution::bulk_async_execute_t,
-        void_parallel_executor const& exec, F&& f, Shape const& shape,
-        Ts&&... ts)
+    auto bulk_async_execute(F&& f, Shape const& shape, Ts&&... ts) const
     {
         std::vector<hpx::future<void>> results;
         for (auto const& elem : shape)
         {
             results.push_back(hpx::parallel::execution::async_execute(
-                static_cast<base_type const&>(exec), f, elem, ts...));
+                static_cast<base_type const&>(*this), f, elem, ts...));
         }
         return results;
     }
 
     template <typename F, typename Shape, typename... Ts>
-    friend auto tag_invoke(hpx::parallel::execution::bulk_sync_execute_t,
-        void_parallel_executor const& exec, F&& f, Shape const& shape,
-        Ts&&... ts)
+    auto bulk_sync_execute(F&& f, Shape const& shape, Ts&&... ts) const
     {
-        return hpx::unwrap(hpx::parallel::execution::bulk_async_execute(
-            exec, std::forward<F>(f), shape, std::forward<Ts>(ts)...));
+        return hpx::unwrap(bulk_async_execute(
+            HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...));
     }
 };
 

--- a/libs/core/topology/CMakeLists.txt
+++ b/libs/core/topology/CMakeLists.txt
@@ -30,10 +30,8 @@ endif()
 
 # Default location is $HPX_ROOT/libs/topology/include
 set(topology_headers
-    hpx/topology/cpu_mask.hpp
-    hpx/topology/detail/mask_fallback.hpp
-    hpx/topology/scheduling_properties.hpp
-    hpx/topology/topology.hpp
+    hpx/topology/cpu_mask.hpp hpx/topology/detail/mask_fallback.hpp
+    hpx/topology/scheduling_properties.hpp hpx/topology/topology.hpp
 )
 
 # Default location is $HPX_ROOT/libs/topology/include_compatibility

--- a/libs/core/topology/CMakeLists.txt
+++ b/libs/core/topology/CMakeLists.txt
@@ -30,7 +30,9 @@ endif()
 
 # Default location is $HPX_ROOT/libs/topology/include
 set(topology_headers
-    hpx/topology/cpu_mask.hpp hpx/topology/scheduling_properties.hpp
+    hpx/topology/cpu_mask.hpp
+    hpx/topology/detail/mask_fallback.hpp
+    hpx/topology/scheduling_properties.hpp
     hpx/topology/topology.hpp
 )
 

--- a/libs/core/topology/include/hpx/topology/detail/mask_fallback.hpp
+++ b/libs/core/topology/include/hpx/topology/detail/mask_fallback.hpp
@@ -1,0 +1,23 @@
+//  Copyright (c) 2026 The STE||AR-Group
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/topology/topology.hpp>
+
+namespace hpx::execution::experimental::detail {
+
+    struct machine_affinity_mask_fallback
+    {
+        template <typename Target, typename... Args>
+        HPX_FORCEINLINE decltype(auto) operator()(
+            Target&&, Args&&...) const noexcept
+        {
+            return hpx::threads::create_topology().get_machine_affinity_mask();
+        }
+    };
+
+}    // namespace hpx::execution::experimental::detail

--- a/libs/core/topology/include/hpx/topology/scheduling_properties.hpp
+++ b/libs/core/topology/include/hpx/topology/scheduling_properties.hpp
@@ -22,6 +22,7 @@ namespace hpx::execution::experimental {
       : detail::query_first_tag_fallback<get_processing_units_mask_t,
             detail::machine_affinity_mask_fallback>
     {
+        constexpr get_processing_units_mask_t() = default;
     } get_processing_units_mask{};
 
     template <>
@@ -34,6 +35,7 @@ namespace hpx::execution::experimental {
       : detail::query_first_tag_fallback<get_cores_mask_t,
             detail::machine_affinity_mask_fallback>
     {
+        constexpr get_cores_mask_t() = default;
     } get_cores_mask{};
 
     template <>

--- a/libs/core/topology/include/hpx/topology/scheduling_properties.hpp
+++ b/libs/core/topology/include/hpx/topology/scheduling_properties.hpp
@@ -7,9 +7,10 @@
 #pragma once
 
 #include <hpx/config.hpp>
+#include <hpx/async_base/detail/query_first_fallback.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/tag_invoke.hpp>
-#include <hpx/topology/topology.hpp>
+#include <hpx/topology/detail/mask_fallback.hpp>
 
 #include <type_traits>
 
@@ -18,17 +19,9 @@ namespace hpx::execution::experimental {
     ///////////////////////////////////////////////////////////////////////////
     HPX_CXX_CORE_EXPORT inline constexpr struct get_processing_units_mask_t
         final
-      : hpx::functional::detail::tag_fallback<get_processing_units_mask_t>
+      : detail::query_first_tag_fallback<get_processing_units_mask_t,
+            detail::machine_affinity_mask_fallback>
     {
-    private:
-        // simply return machine affinity mask if get_processing_units_mask is
-        // not supported
-        template <typename Target>
-        friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            get_processing_units_mask_t, Target&&) noexcept
-        {
-            return hpx::threads::create_topology().get_machine_affinity_mask();
-        }
     } get_processing_units_mask{};
 
     template <>
@@ -38,17 +31,9 @@ namespace hpx::execution::experimental {
 
     ///////////////////////////////////////////////////////////////////////////
     HPX_CXX_CORE_EXPORT inline constexpr struct get_cores_mask_t final
-      : hpx::functional::detail::tag_fallback<get_cores_mask_t>
+      : detail::query_first_tag_fallback<get_cores_mask_t,
+            detail::machine_affinity_mask_fallback>
     {
-    private:
-        // simply return machine affinity mask if get_cores_mask is not
-        // supported
-        template <typename Target>
-        friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            get_cores_mask_t, Target&&) noexcept
-        {
-            return hpx::threads::create_topology().get_machine_affinity_mask();
-        }
     } get_cores_mask{};
 
     template <>


### PR DESCRIPTION
Clean up `tag_invoke`