### PR TITLE
Fix max_element returning last greatest element instead of first

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/algorithms/minmax.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/algorithms/minmax.hpp
@@ -652,7 +652,7 @@ namespace hpx::parallel {
             util::const_loop_n<std::decay_t<ExPolicy>>(
                 ++it, count - 1, [&](FwdIter const& curr) -> void {
                     if (element_type curr_value = HPX_INVOKE(proj, *curr);
-                        !HPX_INVOKE(f, curr_value, value))
+                        HPX_INVOKE(f, value, curr_value))
                     {
                         largest = curr;
                         value = HPX_MOVE(curr_value);
@@ -679,7 +679,7 @@ namespace hpx::parallel {
             util::const_loop_n<std::decay_t<ExPolicy>>(
                 ++it, count - 1, [&](FwdIter const& curr) -> void {
                     if (element_type curr_value = *curr;
-                        !HPX_INVOKE(f, curr_value, value))
+                        HPX_INVOKE(f, value, curr_value))
                     {
                         largest = curr;
                         value = HPX_MOVE(curr_value);
@@ -717,7 +717,7 @@ namespace hpx::parallel {
                 util::const_loop_n<std::decay_t<ExPolicy>>(
                     ++it, count - 1, [&](FwdIter const& curr) -> void {
                         if (element_type curr_value = HPX_INVOKE(proj, **curr);
-                            !HPX_INVOKE(f, curr_value, value))
+                            HPX_INVOKE(f, value, curr_value))
                         {
                             largest = *curr;
                             value = HPX_MOVE(curr_value);
@@ -747,7 +747,7 @@ namespace hpx::parallel {
                 util::const_loop_n<std::decay_t<ExPolicy>>(
                     ++it, count - 1, [&](FwdIter const& curr) -> void {
                         if (element_type curr_value = **curr;
-                            !HPX_INVOKE(f, curr_value, value))
+                            HPX_INVOKE(f, value, curr_value))
                         {
                             largest = *curr;
                             value = HPX_MOVE(curr_value);
@@ -780,7 +780,7 @@ namespace hpx::parallel {
                 util::const_loop(HPX_FORWARD(ExPolicy, policy), ++first, last,
                     [&](FwdIter const& curr) -> void {
                         if (element_type curr_value = HPX_INVOKE(proj, *curr);
-                            !HPX_INVOKE(f, curr_value, value))
+                            HPX_INVOKE(f, value, curr_value))
                         {
                             largest = curr;
                             value = HPX_MOVE(curr_value);
@@ -807,7 +807,7 @@ namespace hpx::parallel {
                 util::const_loop(HPX_FORWARD(ExPolicy, policy), ++first, last,
                     [&](FwdIter const& curr) -> void {
                         if (element_type curr_value = *curr;
-                            !HPX_INVOKE(f, curr_value, value))
+                            HPX_INVOKE(f, value, curr_value))
                         {
                             largest = curr;
                             value = HPX_MOVE(curr_value);

--- a/libs/core/algorithms/tests/unit/algorithms/max_element.cpp
+++ b/libs/core/algorithms/tests/unit/algorithms/max_element.cpp
@@ -36,6 +36,8 @@ void test_max_element(IteratorTag)
         std::max_element(std::begin(c), std::end(c), std::less<std::size_t>());
     HPX_TEST(ref != ref_end);
     HPX_TEST_EQ(*ref, *r);
+    HPX_TEST_EQ(std::distance(std::begin(c), ref),
+        std::distance(iterator(std::begin(c)), r));
 
     r = hpx::max_element(iterator(std::begin(c)), iterator(std::end(c)));
     HPX_TEST(r != end);
@@ -43,6 +45,8 @@ void test_max_element(IteratorTag)
     ref = std::max_element(std::begin(c), std::end(c));
     HPX_TEST(ref != ref_end);
     HPX_TEST_EQ(*ref, *r);
+    HPX_TEST_EQ(std::distance(std::begin(c), ref),
+        std::distance(iterator(std::begin(c)), r));
 }
 
 template <typename ExPolicy, typename IteratorTag>
@@ -67,6 +71,8 @@ void test_max_element(ExPolicy policy, IteratorTag)
         std::max_element(std::begin(c), std::end(c), std::less<std::size_t>());
     HPX_TEST(ref != ref_end);
     HPX_TEST_EQ(*ref, *r);
+    HPX_TEST_EQ(std::distance(std::begin(c), ref),
+        std::distance(iterator(std::begin(c)), r));
 
     r = hpx::max_element(
         policy, iterator(std::begin(c)), iterator(std::end(c)));
@@ -75,6 +81,8 @@ void test_max_element(ExPolicy policy, IteratorTag)
     ref = std::max_element(std::begin(c), std::end(c));
     HPX_TEST(ref != ref_end);
     HPX_TEST_EQ(*ref, *r);
+    HPX_TEST_EQ(std::distance(std::begin(c), ref),
+        std::distance(iterator(std::begin(c)), r));
 }
 
 template <typename ExPolicy, typename IteratorTag>
@@ -97,6 +105,8 @@ void test_max_element_async(ExPolicy p, IteratorTag)
         std::max_element(std::begin(c), std::end(c), std::less<std::size_t>());
     HPX_TEST(ref != ref_end);
     HPX_TEST_EQ(*ref, *rit);
+    HPX_TEST_EQ(std::distance(std::begin(c), ref),
+        std::distance(iterator(std::begin(c)), rit));
 
     r = hpx::max_element(p, iterator(std::begin(c)), iterator(std::end(c)));
     rit = r.get();
@@ -105,6 +115,8 @@ void test_max_element_async(ExPolicy p, IteratorTag)
     ref = std::max_element(std::begin(c), std::end(c));
     HPX_TEST(ref != ref_end);
     HPX_TEST_EQ(*ref, *rit);
+    HPX_TEST_EQ(std::distance(std::begin(c), ref),
+        std::distance(iterator(std::begin(c)), rit));
 }
 
 template <typename IteratorTag>


### PR DESCRIPTION


## Proposed Changes

  - Fixed internal loop conditions for `hpx::max_element` across all execution policies in `minmax.hpp` by changing `!HPX_INVOKE(f, curr, max)` to `HPX_INVOKE(f, max, curr)`.
  - Resolved C++ standard non-compliance where `hpx::max_element` was returning the **last** greatest element instead of the **first** greatest element when encountering duplicate max values.
  - Hardened the `max_element.cpp` unit tests by adding strict iterator distance checks (`std::distance`) alongside the existing value equality checks, preventing similar subtle regressions in the future.

## Any background context you want to provide?

According to C++23 `[alg.min.max]` p16, `std::max_element` must return the *first* iterator `i` such that no other element is strictly greater. On the other hand, `std::minmax_element` is mandated to return the *last* greatest element for its upper bound.

Previously, `hpx::max_element` was incorrectly using the comparison logic designed for `minmax_element`. By using `!HPX_INVOKE(f, curr, value)`, which evaluates to `>=` for the default `std::less` comparator, the algorithm would incorrectly replace the maximum iterator whenever it found an equal element, resulting in the *last* maximum. The existing test suite allowed this to pass unnoticed because it only asserted the equality of dereferenced values (`HPX_TEST_EQ(*std_max, *hpx_max)`). Changing the evaluation to strictly `HPX_INVOKE(f, value, curr)` ensures that the iterator only advances when a strictly larger element is encountered, satisfying the standard.

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [x] I have fixed a bug and have added a regression test.
- [x] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
