### PR TITLE
Add hierarchical all_to_all collective

### DIFF
--- a/libs/core/execution/include/hpx/execution/algorithms/run_loop.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/run_loop.hpp
@@ -172,13 +172,6 @@ namespace hpx::execution::experimental {
 
         struct env_t
         {
-            // Explicit constructor needed for Apple Clang which does not
-            // support P0960 (parenthesized aggregate initialization).
-            explicit constexpr env_t(run_loop* l) noexcept
-              : loop(l)
-            {
-            }
-
             [[nodiscard]]
             auto query(get_completion_scheduler_t<set_value_t>) const noexcept;
 

--- a/libs/core/execution/include/hpx/execution/algorithms/run_loop.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/run_loop.hpp
@@ -172,6 +172,13 @@ namespace hpx::execution::experimental {
 
         struct env_t
         {
+            // Explicit constructor needed for Apple Clang which does not
+            // support P0960 (parenthesized aggregate initialization).
+            explicit constexpr env_t(run_loop* l) noexcept
+              : loop(l)
+            {
+            }
+
             [[nodiscard]]
             auto query(get_completion_scheduler_t<set_value_t>) const noexcept;
 

--- a/libs/full/collectives/CMakeLists.txt
+++ b/libs/full/collectives/CMakeLists.txt
@@ -81,6 +81,9 @@ add_hpx_module(
   SOURCES ${collectives_sources}
   HEADERS ${collectives_headers}
   MACRO_HEADERS ${collectives_macros_headers}
+  ADD_TO_GLOBAL_HEADER
+    "hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp"
+    "hpx/collectives/detail/hierarchical_helpers.hpp"
   COMPAT_HEADERS ${collectives_compat_headers}
   DEPENDENCIES hpx_core
   MODULE_DEPENDENCIES

--- a/libs/full/collectives/CMakeLists.txt
+++ b/libs/full/collectives/CMakeLists.txt
@@ -23,6 +23,7 @@ set(collectives_headers
     hpx/collectives/create_communicator.hpp
     hpx/collectives/detail/channel_communicator.hpp
     hpx/collectives/detail/communicator.hpp
+    hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
     hpx/collectives/detail/hierarchical_helpers.hpp
     hpx/collectives/detail/latch.hpp
     hpx/collectives/exclusive_scan.hpp

--- a/libs/full/collectives/CMakeLists.txt
+++ b/libs/full/collectives/CMakeLists.txt
@@ -23,6 +23,7 @@ set(collectives_headers
     hpx/collectives/create_communicator.hpp
     hpx/collectives/detail/channel_communicator.hpp
     hpx/collectives/detail/communicator.hpp
+    hpx/collectives/detail/hierarchical_helpers.hpp
     hpx/collectives/detail/latch.hpp
     hpx/collectives/exclusive_scan.hpp
     hpx/collectives/fold.hpp

--- a/libs/full/collectives/CMakeLists.txt
+++ b/libs/full/collectives/CMakeLists.txt
@@ -31,12 +31,15 @@ set(collectives_headers
     hpx/collectives/gather.hpp
     hpx/collectives/inclusive_scan.hpp
     hpx/collectives/latch.hpp
+    hpx/collectives/macros.hpp
     hpx/collectives/reduce.hpp
     hpx/collectives/reduce_direct.hpp
     hpx/collectives/scatter.hpp
     hpx/collectives/spmd_block.hpp
     hpx/collectives/detail/latch.hpp
 )
+
+set(collectives_macros_headers hpx/collectives/macros.hpp)
 
 # Default location is $HPX_ROOT/libs/collectives/include_compatibility
 # cmake-format: off
@@ -73,8 +76,11 @@ set(collectives_sources
 include(HPX_AddModule)
 add_hpx_module(
   full collectives
+  GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_MODULE_GEN ON
   SOURCES ${collectives_sources}
   HEADERS ${collectives_headers}
+  MACRO_HEADERS ${collectives_macros_headers}
   COMPAT_HEADERS ${collectives_compat_headers}
   DEPENDENCIES hpx_core
   MODULE_DEPENDENCIES

--- a/libs/full/collectives/CMakeLists.txt
+++ b/libs/full/collectives/CMakeLists.txt
@@ -1,71 +1,92 @@
-#Copyright(c) 2019 - 2020 The STE || AR - Group
+# Copyright (c) 2019-2020 The STE||AR-Group
 #
-#SPDX - License - Identifier : BSL - 1.0
-#Distributed under the Boost Software License, Version 1.0.(See accompanying
-#file LICENSE_1_0.txt or copy at http:    //www.boost.org/LICENSE_1_0.txt)
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-if (NOT HPX_WITH_DISTRIBUTED_RUNTIME)
-return () endif()
+if(NOT HPX_WITH_DISTRIBUTED_RUNTIME)
+  return()
+endif()
 
-    list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
-#Default location is $HPX_ROOT / libs / collectives / include
-        set(collectives_headers hpx / collectives / all_gather.hpp hpx /
-            collectives / all_reduce.hpp hpx / collectives /
-            all_to_all.hpp hpx / collectives / argument_types.hpp hpx /
-            collectives / barrier.hpp hpx / collectives / broadcast.hpp hpx /
-            collectives / broadcast_direct.hpp hpx / collectives /
-            channel_communicator.hpp hpx / collectives /
-            create_communicator.hpp hpx / collectives / detail /
-            channel_communicator.hpp hpx / collectives / detail /
-            communicator.hpp hpx / collectives / detail /
-            hierarchical_all_to_all_helpers.hpp hpx / collectives / detail /
-            hierarchical_helpers.hpp hpx / collectives / detail /
-            latch.hpp hpx / collectives / exclusive_scan.hpp hpx / collectives /
-            fold.hpp hpx / collectives / gather.hpp hpx / collectives /
-            inclusive_scan.hpp hpx / collectives / latch.hpp hpx / collectives /
-            macros.hpp hpx / collectives / reduce.hpp hpx / collectives /
-            reduce_direct.hpp hpx / collectives / scatter.hpp hpx /
-            collectives / spmd_block.hpp hpx / collectives / detail / latch.hpp)
+# Default location is $HPX_ROOT/libs/collectives/include
+set(collectives_headers
+    hpx/collectives/all_gather.hpp
+    hpx/collectives/all_reduce.hpp
+    hpx/collectives/all_to_all.hpp
+    hpx/collectives/argument_types.hpp
+    hpx/collectives/barrier.hpp
+    hpx/collectives/broadcast.hpp
+    hpx/collectives/broadcast_direct.hpp
+    hpx/collectives/channel_communicator.hpp
+    hpx/collectives/create_communicator.hpp
+    hpx/collectives/detail/channel_communicator.hpp
+    hpx/collectives/detail/communicator.hpp
+    hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
+    hpx/collectives/detail/hierarchical_helpers.hpp
+    hpx/collectives/detail/latch.hpp
+    hpx/collectives/exclusive_scan.hpp
+    hpx/collectives/fold.hpp
+    hpx/collectives/gather.hpp
+    hpx/collectives/inclusive_scan.hpp
+    hpx/collectives/latch.hpp
+    hpx/collectives/reduce.hpp
+    hpx/collectives/reduce_direct.hpp
+    hpx/collectives/scatter.hpp
+    hpx/collectives/spmd_block.hpp
+    hpx/collectives/detail/latch.hpp
+)
 
-            set(collectives_macros_headers hpx / collectives / macros.hpp)
+# Default location is $HPX_ROOT/libs/collectives/include_compatibility
+# cmake-format: off
+set(collectives_compat_headers
+  hpx/lcos/barrier.hpp => hpx/barrier.hpp
+  hpx/lcos/broadcast.hpp => hpx/include/lcos.hpp
+  hpx/lcos/fold.hpp => hpx/include/lcos.hpp
+  hpx/lcos/gather.hpp => hpx/include/lcos.hpp
+  hpx/lcos/latch.hpp => hpx/latch.hpp
+  hpx/lcos/reduce.hpp => hpx/include/lcos.hpp
+  hpx/lcos/spmd_block.hpp => hpx/include/lcos.hpp
+)
 
-#Default location is $HPX_ROOT / libs / collectives / include_compatibility
-#cmake - format : off
-                set(collectives_compat_headers hpx / lcos / barrier.hpp =
-                        > hpx / barrier.hpp hpx / lcos / broadcast.hpp =
-                            > hpx / include / lcos.hpp hpx / lcos / fold.hpp =
-                                > hpx / include / lcos.hpp hpx / lcos /
-                            gather.hpp = > hpx / include / lcos.hpp hpx / lcos /
-                            latch.hpp = > hpx / latch.hpp hpx / lcos /
-                            reduce.hpp = > hpx / include / lcos.hpp hpx / lcos /
-                            spmd_block.hpp = > hpx / include / lcos.hpp)
+# cmake-format: on
 
-#cmake - format : on
+# Default location is $HPX_ROOT/libs/collectives/src
+set(collectives_sources
+    all_gather.cpp
+    all_reduce.cpp
+    all_to_all.cpp
+    barrier.cpp
+    broadcast.cpp
+    channel_communicator.cpp
+    create_communicator.cpp
+    detail/channel_communicator_server.cpp
+    exclusive_scan.cpp
+    gather.cpp
+    inclusive_scan.cpp
+    latch.cpp
+    reduce.cpp
+    scatter.cpp
+)
 
-#Default location is $HPX_ROOT / libs / collectives / src
-                    set(collectives_sources all_gather.cpp all_reduce
-                            .cpp all_to_all.cpp barrier.cpp broadcast
-                            .cpp channel_communicator.cpp create_communicator
-                            .cpp detail /
-                        channel_communicator_server.cpp exclusive_scan
-                            .cpp gather.cpp inclusive_scan.cpp latch.cpp reduce
-                            .cpp scatter.cpp)
-
-                        include(HPX_AddModule) add_hpx_module(
-                            full collectives GLOBAL_HEADER_GEN ON
-                                GLOBAL_HEADER_MODULE_GEN ON SOURCES ${
-                                    collectives_sources} HEADERS ${
-                                    collectives_headers} MACRO_HEADERS ${
-                                    collectives_macros_headers} COMPAT_HEADERS ${
-                                    collectives_compat_headers} DEPENDENCIES
-                                    hpx_core MODULE_DEPENDENCIES hpx_actions
-                                        hpx_actions_base hpx_async_colocated
-                                            hpx_async_distributed hpx_components
-                                                hpx_components_base hpx_naming_base
-                                                    hpx_performance_counters
-                                                        hpx_runtime_components
-                                                            hpx_runtime_distributed
-                                                                CMAKE_SUBDIRS
-                                                                    examples
-                                                                        tests)
+include(HPX_AddModule)
+add_hpx_module(
+  full collectives
+  SOURCES ${collectives_sources}
+  HEADERS ${collectives_headers}
+  COMPAT_HEADERS ${collectives_compat_headers}
+  DEPENDENCIES hpx_core
+  MODULE_DEPENDENCIES
+    hpx_actions
+    hpx_actions_base
+    hpx_async_colocated
+    hpx_async_distributed
+    hpx_components
+    hpx_components_base
+    hpx_naming_base
+    hpx_performance_counters
+    hpx_runtime_components
+    hpx_runtime_distributed
+  CMAKE_SUBDIRS examples tests
+)

--- a/libs/full/collectives/CMakeLists.txt
+++ b/libs/full/collectives/CMakeLists.txt
@@ -1,98 +1,71 @@
-# Copyright (c) 2019-2020 The STE||AR-Group
+#Copyright(c) 2019 - 2020 The STE || AR - Group
 #
-# SPDX-License-Identifier: BSL-1.0
-# Distributed under the Boost Software License, Version 1.0. (See accompanying
-# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#SPDX - License - Identifier : BSL - 1.0
+#Distributed under the Boost Software License, Version 1.0.(See accompanying
+#file LICENSE_1_0.txt or copy at http:    //www.boost.org/LICENSE_1_0.txt)
 
-if(NOT HPX_WITH_DISTRIBUTED_RUNTIME)
-  return()
-endif()
+if (NOT HPX_WITH_DISTRIBUTED_RUNTIME)
+return () endif()
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+    list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
-# Default location is $HPX_ROOT/libs/collectives/include
-set(collectives_headers
-    hpx/collectives/all_gather.hpp
-    hpx/collectives/all_reduce.hpp
-    hpx/collectives/all_to_all.hpp
-    hpx/collectives/argument_types.hpp
-    hpx/collectives/barrier.hpp
-    hpx/collectives/broadcast.hpp
-    hpx/collectives/broadcast_direct.hpp
-    hpx/collectives/channel_communicator.hpp
-    hpx/collectives/create_communicator.hpp
-    hpx/collectives/detail/channel_communicator.hpp
-    hpx/collectives/detail/communicator.hpp
-    hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
-    hpx/collectives/detail/hierarchical_helpers.hpp
-    hpx/collectives/detail/latch.hpp
-    hpx/collectives/exclusive_scan.hpp
-    hpx/collectives/fold.hpp
-    hpx/collectives/gather.hpp
-    hpx/collectives/inclusive_scan.hpp
-    hpx/collectives/latch.hpp
-    hpx/collectives/macros.hpp
-    hpx/collectives/reduce.hpp
-    hpx/collectives/reduce_direct.hpp
-    hpx/collectives/scatter.hpp
-    hpx/collectives/spmd_block.hpp
-    hpx/collectives/detail/latch.hpp
-)
+#Default location is $HPX_ROOT / libs / collectives / include
+        set(collectives_headers hpx / collectives / all_gather.hpp hpx /
+            collectives / all_reduce.hpp hpx / collectives /
+            all_to_all.hpp hpx / collectives / argument_types.hpp hpx /
+            collectives / barrier.hpp hpx / collectives / broadcast.hpp hpx /
+            collectives / broadcast_direct.hpp hpx / collectives /
+            channel_communicator.hpp hpx / collectives /
+            create_communicator.hpp hpx / collectives / detail /
+            channel_communicator.hpp hpx / collectives / detail /
+            communicator.hpp hpx / collectives / detail /
+            hierarchical_all_to_all_helpers.hpp hpx / collectives / detail /
+            hierarchical_helpers.hpp hpx / collectives / detail /
+            latch.hpp hpx / collectives / exclusive_scan.hpp hpx / collectives /
+            fold.hpp hpx / collectives / gather.hpp hpx / collectives /
+            inclusive_scan.hpp hpx / collectives / latch.hpp hpx / collectives /
+            macros.hpp hpx / collectives / reduce.hpp hpx / collectives /
+            reduce_direct.hpp hpx / collectives / scatter.hpp hpx /
+            collectives / spmd_block.hpp hpx / collectives / detail / latch.hpp)
 
-set(collectives_macros_headers hpx/collectives/macros.hpp)
+            set(collectives_macros_headers hpx / collectives / macros.hpp)
 
-# Default location is $HPX_ROOT/libs/collectives/include_compatibility
-# cmake-format: off
-set(collectives_compat_headers
-  hpx/lcos/barrier.hpp => hpx/barrier.hpp
-  hpx/lcos/broadcast.hpp => hpx/include/lcos.hpp
-  hpx/lcos/fold.hpp => hpx/include/lcos.hpp
-  hpx/lcos/gather.hpp => hpx/include/lcos.hpp
-  hpx/lcos/latch.hpp => hpx/latch.hpp
-  hpx/lcos/reduce.hpp => hpx/include/lcos.hpp
-  hpx/lcos/spmd_block.hpp => hpx/include/lcos.hpp
-)
+#Default location is $HPX_ROOT / libs / collectives / include_compatibility
+#cmake - format : off
+                set(collectives_compat_headers hpx / lcos / barrier.hpp =
+                        > hpx / barrier.hpp hpx / lcos / broadcast.hpp =
+                            > hpx / include / lcos.hpp hpx / lcos / fold.hpp =
+                                > hpx / include / lcos.hpp hpx / lcos /
+                            gather.hpp = > hpx / include / lcos.hpp hpx / lcos /
+                            latch.hpp = > hpx / latch.hpp hpx / lcos /
+                            reduce.hpp = > hpx / include / lcos.hpp hpx / lcos /
+                            spmd_block.hpp = > hpx / include / lcos.hpp)
 
-# cmake-format: on
+#cmake - format : on
 
-# Default location is $HPX_ROOT/libs/collectives/src
-set(collectives_sources
-    all_gather.cpp
-    all_reduce.cpp
-    all_to_all.cpp
-    barrier.cpp
-    broadcast.cpp
-    channel_communicator.cpp
-    create_communicator.cpp
-    detail/channel_communicator_server.cpp
-    exclusive_scan.cpp
-    gather.cpp
-    inclusive_scan.cpp
-    latch.cpp
-    reduce.cpp
-    scatter.cpp
-)
+#Default location is $HPX_ROOT / libs / collectives / src
+                    set(collectives_sources all_gather.cpp all_reduce
+                            .cpp all_to_all.cpp barrier.cpp broadcast
+                            .cpp channel_communicator.cpp create_communicator
+                            .cpp detail /
+                        channel_communicator_server.cpp exclusive_scan
+                            .cpp gather.cpp inclusive_scan.cpp latch.cpp reduce
+                            .cpp scatter.cpp)
 
-include(HPX_AddModule)
-add_hpx_module(
-  full collectives
-  GLOBAL_HEADER_GEN ON
-  GLOBAL_HEADER_MODULE_GEN ON
-  SOURCES ${collectives_sources}
-  HEADERS ${collectives_headers}
-  MACRO_HEADERS ${collectives_macros_headers}
-  COMPAT_HEADERS ${collectives_compat_headers}
-  DEPENDENCIES hpx_core
-  MODULE_DEPENDENCIES
-    hpx_actions
-    hpx_actions_base
-    hpx_async_colocated
-    hpx_async_distributed
-    hpx_components
-    hpx_components_base
-    hpx_naming_base
-    hpx_performance_counters
-    hpx_runtime_components
-    hpx_runtime_distributed
-  CMAKE_SUBDIRS examples tests
-)
+                        include(HPX_AddModule) add_hpx_module(
+                            full collectives GLOBAL_HEADER_GEN ON
+                                GLOBAL_HEADER_MODULE_GEN ON SOURCES ${
+                                    collectives_sources} HEADERS ${
+                                    collectives_headers} MACRO_HEADERS ${
+                                    collectives_macros_headers} COMPAT_HEADERS ${
+                                    collectives_compat_headers} DEPENDENCIES
+                                    hpx_core MODULE_DEPENDENCIES hpx_actions
+                                        hpx_actions_base hpx_async_colocated
+                                            hpx_async_distributed hpx_components
+                                                hpx_components_base hpx_naming_base
+                                                    hpx_performance_counters
+                                                        hpx_runtime_components
+                                                            hpx_runtime_distributed
+                                                                CMAKE_SUBDIRS
+                                                                    examples
+                                                                        tests)

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -477,8 +477,9 @@ namespace hpx::collectives {
 
         auto const groups =
             detail::get_top_level_groups(num_sites_val, arity_val);
+        auto const gidx = detail::classify_site(this_site, groups);
         bool const is_representative =
-            detail::is_top_level_rep(this_site, num_sites_val, arity_val);
+            gidx != -1 && this_site == groups[gidx].left;
 
         if (is_representative)
         {
@@ -487,7 +488,6 @@ namespace hpx::collectives {
                 detail::subtree_gather_at_top_rep(
                     communicators, HPX_MOVE(local_result), gather_gen);
 
-            auto const gidx = detail::classify_site(this_site, groups);
             std::size_t const my_group_size = groups[gidx].size;
             std::size_t const num_groups = groups.size();
 

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -502,11 +502,9 @@ namespace hpx::collectives {
                 exchange_blocks[group].reserve(my_group_size * dest_group_size);
                 for (std::size_t s = 0; s != my_group_size; ++s)
                 {
-                    for (std::size_t j = 0; j != dest_group_size; ++j)
-                    {
-                        exchange_blocks[group].push_back(
-                            HPX_MOVE(gathered[s][dest_left + j]));
-                    }
+                    std::move(gathered[s].begin() + dest_left,
+                        gathered[s].begin() + dest_left + dest_group_size,
+                        std::back_inserter(exchange_blocks[group]));
                 }
             }
 

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -487,7 +487,7 @@ namespace hpx::collectives {
                 detail::subtree_gather_at_top_rep(
                     communicators, HPX_MOVE(local_result), gather_gen);
 
-            std::size_t const gidx = detail::classify_site(this_site, groups);
+            auto const gidx = detail::classify_site(this_site, groups);
             std::size_t const my_group_size = groups[gidx].size;
             std::size_t const num_groups = groups.size();
 

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -480,17 +480,18 @@ namespace hpx::collectives {
             // Phase 2: Build exchange blocks — pack gathered data by
             // destination group, then perform flat all_to_all among reps.
             std::vector<std::vector<T>> exchange_blocks(num_groups);
-            for (std::size_t h = 0; h != num_groups; ++h)
+            for (std::size_t group = 0; group != num_groups; ++group)
             {
-                std::size_t const dest_group_size = groups[h].size;
-                std::size_t const dest_left = groups[h].left;
+                std::size_t const dest_group_size = groups[group].size;
+                std::size_t const dest_left = groups[group].left;
 
-                exchange_blocks[h].reserve(my_group_size * dest_group_size);
+                exchange_blocks[group].reserve(
+                    my_group_size * dest_group_size);
                 for (std::size_t s = 0; s != my_group_size; ++s)
                 {
                     for (std::size_t j = 0; j != dest_group_size; ++j)
                     {
-                        exchange_blocks[h].push_back(
+                        exchange_blocks[group].push_back(
                             HPX_MOVE(gathered[s][dest_left + j]));
                     }
                 }
@@ -506,14 +507,14 @@ namespace hpx::collectives {
             for (std::size_t j = 0; j != my_group_size; ++j)
             {
                 scatter_input[j].resize(num_sites_val);
-                for (std::size_t h = 0; h != num_groups; ++h)
+                for (std::size_t group = 0; group != num_groups; ++group)
                 {
-                    std::size_t const src_group_size = groups[h].size;
-                    std::size_t const src_left = groups[h].left;
+                    std::size_t const src_group_size = groups[group].size;
+                    std::size_t const src_left = groups[group].left;
                     for (std::size_t s = 0; s != src_group_size; ++s)
                     {
                         scatter_input[j][src_left + s] =
-                            HPX_MOVE(received[h][s * my_group_size + j]);
+                            HPX_MOVE(received[group][s * my_group_size + j]);
                     }
                 }
             }

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -463,10 +463,10 @@ namespace hpx::collectives {
 
         auto const groups =
             detail::get_top_level_groups(num_sites_val, arity_val);
-        bool const is_rep =
+        bool const is_representative =
             detail::is_top_level_rep(this_site, num_sites_val, arity_val);
 
-        if (is_rep)
+        if (is_representative)
         {
             // Phase 1: Gather all subtree sites' data at this rep.
             std::vector<std::vector<T>> gathered =

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -417,7 +417,7 @@ namespace hpx::collectives {
     // which is required by the and_gate synchronization mechanism.
 
     // Async overload
-    template <typename T>
+    HPX_CXX_EXPORT template <typename T>
     hpx::future<std::vector<T>> all_to_all(
         hierarchical_communicator const& communicators,
         std::vector<T>&& local_result,
@@ -536,7 +536,7 @@ namespace hpx::collectives {
     }
 
     // Sync overload
-    template <typename T>
+    HPX_CXX_EXPORT template <typename T>
     std::vector<T> all_to_all(hpx::launch::sync_policy,
         hierarchical_communicator const& communicators,
         std::vector<T>&& local_result,

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -532,9 +532,8 @@ namespace hpx::collectives {
                 }
             }
 
-            auto result = detail::subtree_scatter_at_top_rep(
+            return detail::subtree_scatter_at_top_rep(
                 communicators, HPX_MOVE(scatter_input), scatter_gen);
-            return hpx::make_ready_future(HPX_MOVE(result));
         }
         else
         {
@@ -543,9 +542,8 @@ namespace hpx::collectives {
             detail::subtree_send_to_top_rep(
                 communicators, HPX_MOVE(local_result), gather_gen);
 
-            auto result = detail::subtree_receive_from_top_rep<std::vector<T>>(
+            return detail::subtree_receive_from_top_rep<std::vector<T>>(
                 communicators, scatter_gen);
-            return hpx::make_ready_future(HPX_MOVE(result));
         }
     }
 }    // namespace hpx::collectives

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -477,7 +477,7 @@ namespace hpx::collectives {
             std::size_t const my_group_size = groups[gidx].size;
             std::size_t const num_groups = groups.size();
 
-            // Phase 2: Build exchange blocks — pack gathered data by
+            // Phase 2: Build exchange blocks -- pack gathered data by
             // destination group, then perform flat all_to_all among reps.
             std::vector<std::vector<T>> exchange_blocks(num_groups);
             for (std::size_t group = 0; group != num_groups; ++group)

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -365,24 +365,28 @@ namespace hpx::collectives {
     }
 
     ///////////////////////////////////////////////////////////////////////////
-    HPX_CXX_EXPORT template <typename T>
-    std::vector<T> all_to_all(hpx::launch::sync_policy, communicator fid,
+    // Generic sync overload: dispatches to the flat or hierarchical async
+    // overload based on the communicator type passed.
+    HPX_CXX_EXPORT template <typename Communicator, typename T>
+        requires(is_communicator_v<std::decay_t<Communicator>>)
+    std::vector<T> all_to_all(hpx::launch::sync_policy, Communicator&& fid,
         std::vector<T>&& local_result,
         this_site_arg const this_site = this_site_arg(),
         generation_arg const generation = generation_arg())
     {
-        return all_to_all(
-            HPX_MOVE(fid), HPX_MOVE(local_result), this_site, generation)
+        return all_to_all(HPX_FORWARD(Communicator, fid),
+            HPX_MOVE(local_result), this_site, generation)
             .get();
     }
 
-    HPX_CXX_EXPORT template <typename T>
-    std::vector<T> all_to_all(hpx::launch::sync_policy, communicator fid,
+    HPX_CXX_EXPORT template <typename Communicator, typename T>
+        requires(is_communicator_v<std::decay_t<Communicator>>)
+    std::vector<T> all_to_all(hpx::launch::sync_policy, Communicator&& fid,
         std::vector<T>&& local_result, generation_arg const generation,
         this_site_arg const this_site = this_site_arg())
     {
-        return all_to_all(
-            HPX_MOVE(fid), HPX_MOVE(local_result), this_site, generation)
+        return all_to_all(HPX_FORWARD(Communicator, fid),
+            HPX_MOVE(local_result), this_site, generation)
             .get();
     }
 
@@ -534,19 +538,6 @@ namespace hpx::collectives {
                 communicators, scatter_gen);
             return hpx::make_ready_future(HPX_MOVE(result));
         }
-    }
-
-    // Sync overload
-    HPX_CXX_EXPORT template <typename T>
-    std::vector<T> all_to_all(hpx::launch::sync_policy,
-        hierarchical_communicator const& communicators,
-        std::vector<T>&& local_result,
-        this_site_arg const this_site = this_site_arg(),
-        generation_arg const generation = generation_arg())
-    {
-        return all_to_all(
-            communicators, HPX_MOVE(local_result), this_site, generation)
-            .get();
     }
 }    // namespace hpx::collectives
 

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -364,6 +364,16 @@ namespace hpx::collectives {
             HPX_MOVE(local_result), this_site);
     }
 
+    // Forward declaration of the hierarchical overload (defined below) so the
+    // generic sync overload can resolve to it; otherwise only the flat
+    // overloads above are visible at that call site.
+    HPX_CXX_EXPORT template <typename T>
+    hpx::future<std::vector<T>> all_to_all(
+        hierarchical_communicator const& communicators,
+        std::vector<T>&& local_result,
+        this_site_arg this_site = this_site_arg(),
+        generation_arg generation = generation_arg());
+
     ///////////////////////////////////////////////////////////////////////////
     // Generic sync overload: dispatches to the flat or hierarchical async
     // overload based on the communicator type passed.
@@ -420,13 +430,13 @@ namespace hpx::collectives {
     // Each communicator sees consecutive generations starting at 1,
     // which is required by the and_gate synchronization mechanism.
 
-    // Async overload
+    // Async overload (declared above; default arguments live on that
+    // forward declaration).
     HPX_CXX_EXPORT template <typename T>
     hpx::future<std::vector<T>> all_to_all(
         hierarchical_communicator const& communicators,
-        std::vector<T>&& local_result,
-        this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg())
+        std::vector<T>&& local_result, this_site_arg this_site,
+        generation_arg const generation)
     {
         if (generation.is_default())
         {

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -221,6 +221,7 @@ namespace hpx { namespace collectives {
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/type_support.hpp>
 
+#include <algorithm>
 #include <cstddef>
 #include <type_traits>
 #include <utility>

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -442,8 +442,7 @@ namespace hpx::collectives {
             this_site = agas::get_locality_id();
         }
 
-        std::size_t const num_sites_val =
-            hpx::get<0>(communicators.get_info());
+        std::size_t const num_sites_val = hpx::get<0>(communicators.get_info());
         std::size_t const arity_val = communicators.get_arity();
 
         // Flat fallback: created by create_hierarchical_communicator when
@@ -451,9 +450,8 @@ namespace hpx::collectives {
         // spanning all N sites. Delegate to the flat overload.
         if (communicators.is_flat_fallback())
         {
-            return all_to_all(communicators.get(0),
-                HPX_MOVE(local_result), communicators.site(0),
-                generation);
+            return all_to_all(communicators.get(0), HPX_MOVE(local_result),
+                communicators.site(0), generation);
         }
 
         // Generation mapping: each communicator must see consecutive
@@ -475,11 +473,10 @@ namespace hpx::collectives {
         {
             // Phase 1: Gather all subtree sites' data at this rep.
             std::vector<std::vector<T>> gathered =
-                detail::subtree_gather_at_top_rep(communicators,
-                    HPX_MOVE(local_result), gather_gen);
+                detail::subtree_gather_at_top_rep(
+                    communicators, HPX_MOVE(local_result), gather_gen);
 
-            std::size_t const gidx =
-                detail::classify_site(this_site, groups);
+            std::size_t const gidx = detail::classify_site(this_site, groups);
             std::size_t const my_group_size = groups[gidx].size;
             std::size_t const num_groups = groups.size();
 
@@ -491,8 +488,7 @@ namespace hpx::collectives {
                 std::size_t const dest_group_size = groups[h].size;
                 std::size_t const dest_left = groups[h].left;
 
-                exchange_blocks[h].reserve(
-                    my_group_size * dest_group_size);
+                exchange_blocks[h].reserve(my_group_size * dest_group_size);
                 for (std::size_t s = 0; s != my_group_size; ++s)
                 {
                     for (std::size_t j = 0; j != dest_group_size; ++j)
@@ -503,10 +499,9 @@ namespace hpx::collectives {
                 }
             }
 
-            std::vector<std::vector<T>> received =
-                all_to_all(hpx::launch::sync, communicators.get(0),
-                    HPX_MOVE(exchange_blocks), communicators.site(0),
-                    exchange_gen);
+            std::vector<std::vector<T>> received = all_to_all(hpx::launch::sync,
+                communicators.get(0), HPX_MOVE(exchange_blocks),
+                communicators.site(0), exchange_gen);
 
             // Phase 3: Transpose received blocks back to per-site vectors,
             // then scatter down the subtree.
@@ -520,8 +515,8 @@ namespace hpx::collectives {
                     std::size_t const src_left = groups[h].left;
                     for (std::size_t s = 0; s != src_group_size; ++s)
                     {
-                        scatter_input[j][src_left + s] = HPX_MOVE(
-                            received[h][s * my_group_size + j]);
+                        scatter_input[j][src_left + s] =
+                            HPX_MOVE(received[h][s * my_group_size + j]);
                     }
                 }
             }
@@ -537,9 +532,8 @@ namespace hpx::collectives {
             detail::subtree_send_to_top_rep(
                 communicators, HPX_MOVE(local_result), gather_gen);
 
-            auto result =
-                detail::subtree_receive_from_top_rep<std::vector<T>>(
-                    communicators, scatter_gen);
+            auto result = detail::subtree_receive_from_top_rep<std::vector<T>>(
+                communicators, scatter_gen);
             return hpx::make_ready_future(HPX_MOVE(result));
         }
     }
@@ -552,8 +546,8 @@ namespace hpx::collectives {
         this_site_arg const this_site = this_site_arg(),
         generation_arg const generation = generation_arg())
     {
-        return all_to_all(communicators, HPX_MOVE(local_result),
-            this_site, generation)
+        return all_to_all(
+            communicators, HPX_MOVE(local_result), this_site, generation)
             .get();
     }
 }    // namespace hpx::collectives

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -209,6 +209,11 @@ namespace hpx { namespace collectives {
 #include <hpx/config.hpp>
 
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
+
+#include <hpx/collectives/argument_types.hpp>
+#include <hpx/collectives/create_communicator.hpp>
+#include <hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp>
+#include <hpx/collectives/detail/hierarchical_helpers.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/components_base.hpp>
@@ -395,6 +400,160 @@ namespace hpx::collectives {
         return all_to_all(create_communicator(basename, num_sites, this_site,
                               generation, root_site),
             HPX_MOVE(local_result), this_site)
+            .get();
+    }
+    ///////////////////////////////////////////////////////////////////////////
+    // hierarchical all_to_all
+    //
+    // Three-phase algorithm:
+    //  Phase 1 (gather):   subtree sites gather their local_result vectors
+    //                      at their top-level representative.
+    //  Phase 2 (exchange): representatives perform flat all_to_all at level 0,
+    //                      exchanging blocks of data between groups.
+    //  Phase 3 (scatter):  representatives scatter the transposed results
+    //                      back to their subtree sites.
+    //
+    // Generation mapping (user generation k, starting from 1):
+    //  - Subtree communicators: 2k-1 (gather) and 2k (scatter)
+    //  - Inter-group communicator: k (exchange)
+    // Each communicator sees consecutive generations starting at 1,
+    // which is required by the and_gate synchronization mechanism.
+
+    // Async overload
+    template <typename T>
+    hpx::future<std::vector<T>> all_to_all(
+        hierarchical_communicator const& communicators,
+        std::vector<T>&& local_result,
+        this_site_arg this_site = this_site_arg(),
+        generation_arg const generation = generation_arg())
+    {
+        if (generation.is_default())
+        {
+            return hpx::make_exceptional_future<std::vector<T>>(
+                HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                    "hpx::collectives::all_to_all (hierarchical)",
+                    "hierarchical all_to_all requires an explicit "
+                    "generation number for its internal generation "
+                    "mapping"));
+        }
+
+        if (this_site.is_default())
+        {
+            this_site = agas::get_locality_id();
+        }
+
+        std::size_t const num_sites_val =
+            hpx::get<0>(communicators.get_info());
+        std::size_t const arity_val = communicators.get_arity();
+
+        // Flat fallback: created by create_hierarchical_communicator when
+        // num_sites < threshold. All sites share a single flat communicator
+        // spanning all N sites. Delegate to the flat overload.
+        if (communicators.is_flat_fallback())
+        {
+            return all_to_all(communicators.get(0),
+                HPX_MOVE(local_result), communicators.site(0),
+                generation);
+        }
+
+        // Generation mapping: each communicator must see consecutive
+        // generation numbers starting from 1 (the gate blocks until all
+        // prior generations complete).  Subtree communicators participate
+        // in both gather and scatter, so they use 2k-1 / 2k.  The
+        // inter-group communicator participates only in the exchange, so
+        // it uses k directly.
+        generation_arg const gather_gen(2 * generation - 1);
+        generation_arg const exchange_gen(generation);
+        generation_arg const scatter_gen(2 * generation);
+
+        auto const groups =
+            detail::get_top_level_groups(num_sites_val, arity_val);
+        bool const is_rep =
+            detail::is_top_level_rep(this_site, num_sites_val, arity_val);
+
+        if (is_rep)
+        {
+            // Phase 1: Gather all subtree sites' data at this rep.
+            std::vector<std::vector<T>> gathered =
+                detail::subtree_gather_at_top_rep(communicators,
+                    HPX_MOVE(local_result), gather_gen);
+
+            std::size_t const gidx =
+                detail::classify_site(this_site, groups);
+            std::size_t const my_group_size = groups[gidx].size;
+            std::size_t const num_groups = groups.size();
+
+            // Phase 2: Build exchange blocks — pack gathered data by
+            // destination group, then perform flat all_to_all among reps.
+            std::vector<std::vector<T>> exchange_blocks(num_groups);
+            for (std::size_t h = 0; h != num_groups; ++h)
+            {
+                std::size_t const dest_group_size = groups[h].size;
+                std::size_t const dest_left = groups[h].left;
+
+                exchange_blocks[h].reserve(
+                    my_group_size * dest_group_size);
+                for (std::size_t s = 0; s != my_group_size; ++s)
+                {
+                    for (std::size_t j = 0; j != dest_group_size; ++j)
+                    {
+                        exchange_blocks[h].push_back(
+                            HPX_MOVE(gathered[s][dest_left + j]));
+                    }
+                }
+            }
+
+            std::vector<std::vector<T>> received =
+                all_to_all(hpx::launch::sync, communicators.get(0),
+                    HPX_MOVE(exchange_blocks), communicators.site(0),
+                    exchange_gen);
+
+            // Phase 3: Transpose received blocks back to per-site vectors,
+            // then scatter down the subtree.
+            std::vector<std::vector<T>> scatter_input(my_group_size);
+            for (std::size_t j = 0; j != my_group_size; ++j)
+            {
+                scatter_input[j].resize(num_sites_val);
+                for (std::size_t h = 0; h != num_groups; ++h)
+                {
+                    std::size_t const src_group_size = groups[h].size;
+                    std::size_t const src_left = groups[h].left;
+                    for (std::size_t s = 0; s != src_group_size; ++s)
+                    {
+                        scatter_input[j][src_left + s] = HPX_MOVE(
+                            received[h][s * my_group_size + j]);
+                    }
+                }
+            }
+
+            auto result = detail::subtree_scatter_at_top_rep(
+                communicators, HPX_MOVE(scatter_input), scatter_gen);
+            return hpx::make_ready_future(HPX_MOVE(result));
+        }
+        else
+        {
+            // Non-representative: send data to rep, then receive
+            // result from rep.
+            detail::subtree_send_to_top_rep(
+                communicators, HPX_MOVE(local_result), gather_gen);
+
+            auto result =
+                detail::subtree_receive_from_top_rep<std::vector<T>>(
+                    communicators, scatter_gen);
+            return hpx::make_ready_future(HPX_MOVE(result));
+        }
+    }
+
+    // Sync overload
+    template <typename T>
+    std::vector<T> all_to_all(hpx::launch::sync_policy,
+        hierarchical_communicator const& communicators,
+        std::vector<T>&& local_result,
+        this_site_arg const this_site = this_site_arg(),
+        generation_arg const generation = generation_arg())
+    {
+        return all_to_all(communicators, HPX_MOVE(local_result),
+            this_site, generation)
             .get();
     }
 }    // namespace hpx::collectives

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -221,9 +221,6 @@ namespace hpx { namespace collectives {
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/type_support.hpp>
 
-#include <hpx/collectives/argument_types.hpp>
-#include <hpx/collectives/create_communicator.hpp>
-
 #include <cstddef>
 #include <type_traits>
 #include <utility>

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -489,8 +489,7 @@ namespace hpx::collectives {
                 std::size_t const dest_group_size = groups[group].size;
                 std::size_t const dest_left = groups[group].left;
 
-                exchange_blocks[group].reserve(
-                    my_group_size * dest_group_size);
+                exchange_blocks[group].reserve(my_group_size * dest_group_size);
                 for (std::size_t s = 0; s != my_group_size; ++s)
                 {
                     for (std::size_t j = 0; j != dest_group_size; ++j)

--- a/libs/full/collectives/include/hpx/collectives/create_communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/create_communicator.hpp
@@ -300,12 +300,14 @@ namespace hpx::collectives {
         hierarchical_communicator(
             std::vector<hpx::tuple<communicator, this_site_arg>>&& comms,
             arity_arg arity, root_site_arg root_site, num_sites_arg num_sites,
-            this_site_arg this_site) noexcept
+            this_site_arg this_site,
+            bool flat_fallback = false) noexcept
           : communicators(HPX_MOVE(comms))
           , num_sites(num_sites)
           , this_site(this_site)
           , root_site(root_site)
           , arity(arity)
+          , flat_fallback_(flat_fallback)
         {
         }
 
@@ -360,6 +362,11 @@ namespace hpx::collectives {
             return arity;
         }
 
+        [[nodiscard]] constexpr bool is_flat_fallback() const noexcept
+        {
+            return flat_fallback_;
+        }
+
         [[nodiscard]] HPX_EXPORT
             hpx::tuple<num_sites_arg, this_site_arg, root_site_arg>
             get_info_ex() const noexcept;
@@ -373,6 +380,7 @@ namespace hpx::collectives {
         this_site_arg this_site;
         root_site_arg root_site;
         arity_arg arity;
+        bool flat_fallback_ = false;
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/libs/full/collectives/include/hpx/collectives/create_communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/create_communicator.hpp
@@ -300,8 +300,7 @@ namespace hpx::collectives {
         hierarchical_communicator(
             std::vector<hpx::tuple<communicator, this_site_arg>>&& comms,
             arity_arg arity, root_site_arg root_site, num_sites_arg num_sites,
-            this_site_arg this_site,
-            bool flat_fallback = false) noexcept
+            this_site_arg this_site, bool flat_fallback = false) noexcept
           : communicators(HPX_MOVE(comms))
           , num_sites(num_sites)
           , this_site(this_site)

--- a/libs/full/collectives/include/hpx/collectives/create_communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/create_communicator.hpp
@@ -300,7 +300,7 @@ namespace hpx::collectives {
         hierarchical_communicator(
             std::vector<hpx::tuple<communicator, this_site_arg>>&& comms,
             arity_arg arity, root_site_arg root_site, num_sites_arg num_sites,
-            this_site_arg this_site, bool flat_fallback = false) noexcept
+            this_site_arg this_site, bool flat_fallback) noexcept
           : communicators(HPX_MOVE(comms))
           , num_sites(num_sites)
           , this_site(this_site)

--- a/libs/full/collectives/include/hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
@@ -164,6 +164,8 @@ namespace hpx::collectives::detail {
     T subtree_receive_from_top_rep(
         hierarchical_communicator const& comms, generation_arg const generation)
     {
+        HPX_ASSERT(comms.size() != 0);
+
         auto [current_communicator, current_site] = comms[0];
 
         std::vector<T> data = scatter_from<std::vector<T>>(

--- a/libs/full/collectives/include/hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
@@ -144,7 +144,7 @@ namespace hpx::collectives::detail {
         }
 
         // At the leaf level (size()-1), pass data directly to scatter_to
-        // WITHOUT scatter_data — each element maps 1:1 to a leaf site.
+        // WITHOUT scatter_data -- each element maps 1:1 to a leaf site.
         // (Same pattern as scatter_to(hierarchical_communicator).)
         return scatter_to(hpx::launch::sync, comms.back(), HPX_MOVE(data),
             this_site_arg(0), generation);

--- a/libs/full/collectives/include/hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
@@ -121,8 +121,9 @@ namespace hpx::collectives::detail {
     // (and only) element of the input data.
     ///////////////////////////////////////////////////////////////////////////
     template <typename T>
-    T subtree_scatter_at_top_rep(hierarchical_communicator const& comms,
-        std::vector<T>&& data, generation_arg const generation)
+    hpx::future<T> subtree_scatter_at_top_rep(
+        hierarchical_communicator const& comms, std::vector<T>&& data,
+        generation_arg const generation)
     {
         HPX_ASSERT(comms.size() != 0);
 
@@ -130,7 +131,7 @@ namespace hpx::collectives::detail {
         // belongs to this site.
         if (comms.size() == 1)
         {
-            return HPX_MOVE(data[0]);
+            return hpx::make_ready_future(HPX_MOVE(data[0]));
         }
 
         arity_arg const arity = comms.get_arity();
@@ -145,11 +146,11 @@ namespace hpx::collectives::detail {
                 generation);
         }
 
-        // At the leaf level (size()-1), pass data directly to scatter_to
-        // WITHOUT scatter_data -- each element maps 1:1 to a leaf site.
-        // (Same pattern as scatter_to(hierarchical_communicator).)
-        return scatter_to(hpx::launch::sync, comms.back(), HPX_MOVE(data),
-            this_site_arg(0), generation);
+        // At the leaf level (size()-1), scatter asynchronously and return
+        // the future directly (no scatter_data; each element maps 1:1 to a
+        // leaf site).
+        return scatter_to(
+            comms.back(), HPX_MOVE(data), this_site_arg(0), generation);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -163,7 +164,7 @@ namespace hpx::collectives::detail {
     // level 0, then scatter down through intermediate levels to the leaf.
     ///////////////////////////////////////////////////////////////////////////
     template <typename T>
-    T subtree_receive_from_top_rep(
+    hpx::future<T> subtree_receive_from_top_rep(
         hierarchical_communicator const& comms, generation_arg const generation)
     {
         HPX_ASSERT(comms.size() != 0);
@@ -171,11 +172,11 @@ namespace hpx::collectives::detail {
         auto [current_communicator, current_site] = comms[0];
 
         // A direct leaf of the top representative receives exactly its own
-        // portion (a single T), so the scatter delivers T directly.
+        // portion (a single T) as a future, returned directly.
         if (comms.size() == 1)
         {
-            return scatter_from<T>(hpx::launch::sync, current_communicator,
-                current_site, generation);
+            return scatter_from<T>(
+                current_communicator, current_site, generation);
         }
 
         // An intermediate representative receives a vector<T> (one element
@@ -193,10 +194,10 @@ namespace hpx::collectives::detail {
                 generation);
         }
 
-        // At the leaf level, pass data directly to scatter_to WITHOUT
-        // scatter_data -- each element maps 1:1 to a leaf site.
-        return scatter_to(hpx::launch::sync, comms.back(), HPX_MOVE(data),
-            this_site_arg(0), generation);
+        // At the leaf level, scatter asynchronously and return the future
+        // directly (no scatter_data; each element maps 1:1 to a leaf site).
+        return scatter_to(
+            comms.back(), HPX_MOVE(data), this_site_arg(0), generation);
     }
 
 }    // namespace hpx::collectives::detail

--- a/libs/full/collectives/include/hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
@@ -43,7 +43,7 @@ namespace hpx::collectives::detail {
     // For the flat fallback case (comms.size() <= 1), returns the site's
     // own data wrapped in a single-element vector.
     ///////////////////////////////////////////////////////////////////////////
-    template <typename T>
+    HPX_CXX_EXPORT template <typename T>
     std::vector<std::decay_t<T>> subtree_gather_at_top_rep(
         hierarchical_communicator const& comms, T&& local_result,
         generation_arg const generation)
@@ -83,7 +83,7 @@ namespace hpx::collectives::detail {
     // walk bottom-up with gather_here at intermediate levels, then
     // gather_there at the topmost level.
     ///////////////////////////////////////////////////////////////////////////
-    template <typename T>
+    HPX_CXX_EXPORT template <typename T>
     void subtree_send_to_top_rep(hierarchical_communicator const& comms,
         T&& local_result, generation_arg const generation)
     {
@@ -120,7 +120,7 @@ namespace hpx::collectives::detail {
     // For the flat fallback case (comms.size() <= 1), returns the first
     // (and only) element of the input data.
     ///////////////////////////////////////////////////////////////////////////
-    template <typename T>
+    HPX_CXX_EXPORT template <typename T>
     hpx::future<T> subtree_scatter_at_top_rep(
         hierarchical_communicator const& comms, std::vector<T>&& data,
         generation_arg const generation)
@@ -163,7 +163,7 @@ namespace hpx::collectives::detail {
     // portion. This mirrors scatter_from(hierarchical_comm): receive at
     // level 0, then scatter down through intermediate levels to the leaf.
     ///////////////////////////////////////////////////////////////////////////
-    template <typename T>
+    HPX_CXX_EXPORT template <typename T>
     hpx::future<T> subtree_receive_from_top_rep(
         hierarchical_communicator const& comms, generation_arg const generation)
     {

--- a/libs/full/collectives/include/hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
@@ -48,22 +48,21 @@ namespace hpx::collectives::detail {
         hierarchical_communicator const& comms, T&& local_result,
         generation_arg const generation)
     {
+        HPX_ASSERT(comms.size() != 0);
+
         using value_type = std::decay_t<T>;
 
         // Wrap local value in a vector (same pattern as hierarchical
         // gather_here).
         std::vector<value_type> result(1, HPX_FORWARD(T, local_result));
 
-        // Flat fallback or single-level tree: subtree is just this site.
-        if (comms.size() <= 1)
-        {
-            return result;
-        }
-
-        // Walk bottom-up from leaf (size()-1) to level 1, skipping level 0.
-        // At every subtree level, this site is rank 0 (subtree root), so
-        // we call gather_here.
-        for (std::size_t i = comms.size() - 1; i >= 1; --i)
+        // Walk bottom-up from leaf (size()-1) to level 1, skipping level 0
+        // (the inter-group communicator). At every subtree level this site
+        // is rank 0 (subtree root), so we call gather_here. For a
+        // single-level subtree (size() == 1, e.g. the arity >= num_sites
+        // case) the loop body simply does not execute and the site's own
+        // data is returned.
+        for (std::size_t i = comms.size() - 1; i != 0; --i)
         {
             result = gather_data(gather_here(hpx::launch::sync, comms.get(i),
                 HPX_MOVE(result), this_site_arg(0), generation));

--- a/libs/full/collectives/include/hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
@@ -64,9 +64,8 @@ namespace hpx::collectives::detail {
         // we call gather_here.
         for (std::size_t i = comms.size() - 1; i >= 1; --i)
         {
-            result = gather_data(
-                gather_here(hpx::launch::sync, comms.get(i),
-                    HPX_MOVE(result), this_site_arg(0), generation));
+            result = gather_data(gather_here(hpx::launch::sync, comms.get(i),
+                HPX_MOVE(result), this_site_arg(0), generation));
         }
 
         return result;
@@ -96,9 +95,8 @@ namespace hpx::collectives::detail {
         // (each intermediate rep gathers from its children).
         for (std::size_t i = comms.size() - 1; i != 0; --i)
         {
-            data = gather_data(
-                gather_here(hpx::launch::sync, comms.get(i),
-                    HPX_MOVE(data), this_site_arg(0), generation));
+            data = gather_data(gather_here(hpx::launch::sync, comms.get(i),
+                HPX_MOVE(data), this_site_arg(0), generation));
         }
 
         // At the topmost level (level 0 in this site's vector, which is
@@ -145,8 +143,8 @@ namespace hpx::collectives::detail {
         // At the leaf level (size()-1), pass data directly to scatter_to
         // WITHOUT scatter_data — each element maps 1:1 to a leaf site.
         // (Same pattern as scatter_to(hierarchical_communicator).)
-        return scatter_to(hpx::launch::sync, comms.back(),
-            HPX_MOVE(data), this_site_arg(0), generation);
+        return scatter_to(hpx::launch::sync, comms.back(), HPX_MOVE(data),
+            this_site_arg(0), generation);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -160,16 +158,15 @@ namespace hpx::collectives::detail {
     // level 0, then scatter down through intermediate levels to the leaf.
     ///////////////////////////////////////////////////////////////////////////
     template <typename T>
-    T subtree_receive_from_top_rep(hierarchical_communicator const& comms,
-        generation_arg const generation)
+    T subtree_receive_from_top_rep(
+        hierarchical_communicator const& comms, generation_arg const generation)
     {
         auto [current_communicator, current_site] = comms[0];
 
         if (comms.size() == 1)
         {
-            return scatter_from<T>(
-                hpx::launch::sync, current_communicator, current_site,
-                generation);
+            return scatter_from<T>(hpx::launch::sync, current_communicator,
+                current_site, generation);
         }
 
         std::vector<T> data = scatter_from<std::vector<T>>(
@@ -188,8 +185,8 @@ namespace hpx::collectives::detail {
         // At the leaf level, pass data directly to scatter_to WITHOUT
         // scatter_data — each element maps 1:1 to a leaf site.
         // (Same pattern as scatter_from(hierarchical_communicator).)
-        return scatter_to(hpx::launch::sync, comms.back(),
-            HPX_MOVE(data), this_site_arg(0), generation);
+        return scatter_to(hpx::launch::sync, comms.back(), HPX_MOVE(data),
+            this_site_arg(0), generation);
     }
 
 }    // namespace hpx::collectives::detail

--- a/libs/full/collectives/include/hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
@@ -166,14 +166,13 @@ namespace hpx::collectives::detail {
     {
         auto [current_communicator, current_site] = comms[0];
 
-        if (comms.size() == 1)
-        {
-            return scatter_from<T>(hpx::launch::sync, current_communicator,
-                current_site, generation);
-        }
-
         std::vector<T> data = scatter_from<std::vector<T>>(
             hpx::launch::sync, current_communicator, current_site, generation);
+
+        if (comms.size() == 1)
+        {
+            return data;
+        }
 
         arity_arg const arity = comms.get_arity();
 
@@ -186,8 +185,7 @@ namespace hpx::collectives::detail {
         }
 
         // At the leaf level, pass data directly to scatter_to WITHOUT
-        // scatter_data — each element maps 1:1 to a leaf site.
-        // (Same pattern as scatter_from(hierarchical_communicator).)
+        // scatter_data -- each element maps 1:1 to a leaf site.
         return scatter_to(hpx::launch::sync, comms.back(), HPX_MOVE(data),
             this_site_arg(0), generation);
     }

--- a/libs/full/collectives/include/hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
@@ -124,8 +124,11 @@ namespace hpx::collectives::detail {
     T subtree_scatter_at_top_rep(hierarchical_communicator const& comms,
         std::vector<T>&& data, generation_arg const generation)
     {
-        // Flat fallback: the entire data vector belongs to this site.
-        if (comms.size() <= 1)
+        HPX_ASSERT(comms.size() != 0);
+
+        // Flat fallback or single-level subtree: the entire data vector
+        // belongs to this site.
+        if (comms.size() == 1)
         {
             return HPX_MOVE(data[0]);
         }

--- a/libs/full/collectives/include/hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
@@ -1,0 +1,197 @@
+//  Copyright (c) 2026 Anshuman Agrawal
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file detail/hierarchical_all_to_all_helpers.hpp
+/// Subtree gather/scatter primitives for the hierarchical all_to_all
+/// collective. These mirror the existing hierarchical gather_here/
+/// gather_there and scatter_to/scatter_from patterns but skip the
+/// top-level (inter-group) communicator at level 0.
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+
+#include <hpx/collectives/create_communicator.hpp>
+#include <hpx/collectives/gather.hpp>
+#include <hpx/collectives/scatter.hpp>
+#include <hpx/modules/async_base.hpp>
+#include <hpx/modules/type_support.hpp>
+
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace hpx::collectives::detail {
+
+    ///////////////////////////////////////////////////////////////////////////
+    // subtree_gather_at_top_rep
+    //
+    // Called by a top-level representative. Gathers data from all sites in
+    // its subtree using communicator levels 1..size()-1, skipping level 0
+    // (the inter-group communicator).
+    //
+    // Returns: flat vector of all subtree sites' data, ordered by subtree
+    //          site rank.
+    //
+    // For the flat fallback case (comms.size() <= 1), returns the site's
+    // own data wrapped in a single-element vector.
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    std::vector<std::decay_t<T>> subtree_gather_at_top_rep(
+        hierarchical_communicator const& comms, T&& local_result,
+        generation_arg const generation)
+    {
+        using value_type = std::decay_t<T>;
+
+        // Flat fallback or single-level tree: subtree is just this site.
+        if (comms.size() <= 1)
+        {
+            return std::vector<value_type>(1, HPX_FORWARD(T, local_result));
+        }
+
+        // Wrap local value in a vector (same pattern as hierarchical
+        // gather_here).
+        std::vector<value_type> result(1, HPX_FORWARD(T, local_result));
+
+        // Walk bottom-up from leaf (size()-1) to level 1, skipping level 0.
+        // At every subtree level, this site is rank 0 (subtree root), so
+        // we call gather_here.
+        for (std::size_t i = comms.size() - 1; i >= 1; --i)
+        {
+            result = gather_data(
+                gather_here(hpx::launch::sync, comms.get(i),
+                    HPX_MOVE(result), this_site_arg(0), generation));
+        }
+
+        return result;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // subtree_send_to_top_rep
+    //
+    // Called by a non-top-level-representative site. Sends this site's data
+    // up through the subtree to the top-level representative.
+    //
+    // For non-rep sites, the entire communicator vector IS the subtree
+    // portion (they don't have the inter-group communicator at level 0).
+    // This is structurally identical to gather_there(hierarchical_comm):
+    // walk bottom-up with gather_here at intermediate levels, then
+    // gather_there at the topmost level.
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    void subtree_send_to_top_rep(hierarchical_communicator const& comms,
+        T&& local_result, generation_arg const generation)
+    {
+        using value_type = std::decay_t<T>;
+
+        std::vector<value_type> data(1, HPX_FORWARD(T, local_result));
+
+        // Walk bottom-up from leaf to level 1, calling gather_here
+        // (each intermediate rep gathers from its children).
+        for (std::size_t i = comms.size() - 1; i != 0; --i)
+        {
+            data = gather_data(
+                gather_here(hpx::launch::sync, comms.get(i),
+                    HPX_MOVE(data), this_site_arg(0), generation));
+        }
+
+        // At the topmost level (level 0 in this site's vector, which is
+        // a subtree-internal communicator, NOT the inter-group one),
+        // send to the subtree root via gather_there.
+        gather_there(hpx::launch::sync, comms.get(0), HPX_MOVE(data),
+            comms.site(0), generation);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // subtree_scatter_at_top_rep
+    //
+    // Called by a top-level representative. Scatters data from a flat vector
+    // to all sites in its subtree using communicator levels 1..size()-1,
+    // skipping level 0 (the inter-group communicator).
+    //
+    // Returns: this site's portion (a T) after scattering down the tree.
+    //
+    // For the flat fallback case (comms.size() <= 1), returns the first
+    // (and only) element of the input data.
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    T subtree_scatter_at_top_rep(hierarchical_communicator const& comms,
+        std::vector<T>&& data, generation_arg const generation)
+    {
+        // Flat fallback: the entire data vector belongs to this site.
+        if (comms.size() <= 1)
+        {
+            return HPX_MOVE(data[0]);
+        }
+
+        arity_arg const arity = comms.get_arity();
+
+        // Walk top-down from level 1 through size()-2, partitioning and
+        // scattering at each level. At each level, this site is rank 0
+        // (subtree root).
+        for (std::size_t i = 1; i < comms.size() - 1; ++i)
+        {
+            data = scatter_to(hpx::launch::sync, comms.get(i),
+                scatter_data(HPX_MOVE(data), arity), this_site_arg(0),
+                generation);
+        }
+
+        // At the leaf level (size()-1), pass data directly to scatter_to
+        // WITHOUT scatter_data — each element maps 1:1 to a leaf site.
+        // (Same pattern as scatter_to(hierarchical_communicator).)
+        return scatter_to(hpx::launch::sync, comms.back(),
+            HPX_MOVE(data), this_site_arg(0), generation);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // subtree_receive_from_top_rep
+    //
+    // Called by a non-top-level-representative site. Receives this site's
+    // portion of the scattered data from the top-level representative.
+    //
+    // For non-rep sites, the entire communicator vector IS the subtree
+    // portion. This mirrors scatter_from(hierarchical_comm): receive at
+    // level 0, then scatter down through intermediate levels to the leaf.
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    T subtree_receive_from_top_rep(hierarchical_communicator const& comms,
+        generation_arg const generation)
+    {
+        auto [current_communicator, current_site] = comms[0];
+
+        if (comms.size() == 1)
+        {
+            return scatter_from<T>(
+                hpx::launch::sync, current_communicator, current_site,
+                generation);
+        }
+
+        std::vector<T> data = scatter_from<std::vector<T>>(
+            hpx::launch::sync, current_communicator, current_site, generation);
+
+        arity_arg const arity = comms.get_arity();
+
+        // Walk down through intermediate levels.
+        for (std::size_t i = 1; i < comms.size() - 1; ++i)
+        {
+            data = scatter_to(hpx::launch::sync, comms.get(i),
+                scatter_data(HPX_MOVE(data), arity), this_site_arg(0),
+                generation);
+        }
+
+        // At the leaf level, pass data directly to scatter_to WITHOUT
+        // scatter_data — each element maps 1:1 to a leaf site.
+        // (Same pattern as scatter_from(hierarchical_communicator).)
+        return scatter_to(hpx::launch::sync, comms.back(),
+            HPX_MOVE(data), this_site_arg(0), generation);
+    }
+
+}    // namespace hpx::collectives::detail
+
+#endif    // !HPX_COMPUTE_DEVICE_CODE

--- a/libs/full/collectives/include/hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
@@ -49,15 +49,15 @@ namespace hpx::collectives::detail {
     {
         using value_type = std::decay_t<T>;
 
-        // Flat fallback or single-level tree: subtree is just this site.
-        if (comms.size() <= 1)
-        {
-            return std::vector<value_type>(1, HPX_FORWARD(T, local_result));
-        }
-
         // Wrap local value in a vector (same pattern as hierarchical
         // gather_here).
         std::vector<value_type> result(1, HPX_FORWARD(T, local_result));
+
+        // Flat fallback or single-level tree: subtree is just this site.
+        if (comms.size() <= 1)
+        {
+            return result;
+        }
 
         // Walk bottom-up from leaf (size()-1) to level 1, skipping level 0.
         // At every subtree level, this site is rank 0 (subtree root), so

--- a/libs/full/collectives/include/hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
@@ -16,6 +16,7 @@
 
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 
+#include <hpx/assert.hpp>
 #include <hpx/collectives/create_communicator.hpp>
 #include <hpx/collectives/gather.hpp>
 #include <hpx/collectives/scatter.hpp>
@@ -87,6 +88,8 @@ namespace hpx::collectives::detail {
     void subtree_send_to_top_rep(hierarchical_communicator const& comms,
         T&& local_result, generation_arg const generation)
     {
+        HPX_ASSERT(comms.size() != 0);
+
         using value_type = std::decay_t<T>;
 
         std::vector<value_type> data(1, HPX_FORWARD(T, local_result));

--- a/libs/full/collectives/include/hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
@@ -168,13 +168,18 @@ namespace hpx::collectives::detail {
 
         auto [current_communicator, current_site] = comms[0];
 
-        std::vector<T> data = scatter_from<std::vector<T>>(
-            hpx::launch::sync, current_communicator, current_site, generation);
-
+        // A direct leaf of the top representative receives exactly its own
+        // portion (a single T), so the scatter delivers T directly.
         if (comms.size() == 1)
         {
-            return data;
+            return scatter_from<T>(hpx::launch::sync, current_communicator,
+                current_site, generation);
         }
+
+        // An intermediate representative receives a vector<T> (one element
+        // per site in its subtree) to scatter further down.
+        std::vector<T> data = scatter_from<std::vector<T>>(
+            hpx::launch::sync, current_communicator, current_site, generation);
 
         arity_arg const arity = comms.get_arity();
 

--- a/libs/full/collectives/include/hpx/collectives/detail/hierarchical_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/hierarchical_helpers.hpp
@@ -59,9 +59,11 @@ namespace hpx::collectives::detail {
         return groups;
     }
 
-    // Return the index of the top-level group that contains `this_site`.
-    // Groups are sorted by left boundary, so we use std::lower_bound.
-    inline std::size_t classify_site(
+    // Return the index of the top-level group that contains `this_site`,
+    // or -1 if there is none. Groups are sorted by left boundary, so we use
+    // std::lower_bound. The return type is signed so the -1 sentinel and the
+    // std::distance result need no casts.
+    inline std::ptrdiff_t classify_site(
         std::size_t this_site, std::vector<top_level_group> const& groups)
     {
         auto const it = std::lower_bound(groups.begin(), groups.end(),
@@ -71,10 +73,10 @@ namespace hpx::collectives::detail {
 
         if (it != groups.end() && this_site >= it->left)
         {
-            return static_cast<std::size_t>(std::distance(groups.begin(), it));
+            return std::distance(groups.begin(), it);
         }
 
-        return static_cast<std::size_t>(-1);
+        return -1;
     }
 
     // Return true if `this_site` is the leftmost site (representative)
@@ -84,8 +86,7 @@ namespace hpx::collectives::detail {
     {
         auto const groups = get_top_level_groups(num_sites, arity);
         auto const g = classify_site(this_site, groups);
-        return (g != static_cast<std::size_t>(-1)) &&
-            (this_site == groups[g].left);
+        return g != -1 && this_site == groups[g].left;
     }
 
 }    // namespace hpx::collectives::detail

--- a/libs/full/collectives/include/hpx/collectives/detail/hierarchical_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/hierarchical_helpers.hpp
@@ -1,0 +1,74 @@
+//  Copyright (c) 2026 Anshuman Agrawal
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file detail/hierarchical_helpers.hpp
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#include <cstddef>
+#include <vector>
+
+namespace hpx::collectives::detail {
+
+    struct top_level_group
+    {
+        std::size_t left;
+        std::size_t right;
+        std::size_t size;
+    };
+
+    // Compute the top-level partition of [0, num_sites) into `arity` groups.
+    // Uses the same division logic as recursively_fill_communicators:
+    // first (num_sites % arity) groups get ceil(num_sites/arity) sites,
+    // the rest get floor(num_sites/arity).
+    inline std::vector<top_level_group> get_top_level_groups(
+        std::size_t num_sites, std::size_t arity)
+    {
+        if (arity > num_sites)
+        {
+            arity = num_sites;
+        }
+
+        std::size_t const division_steps = num_sites / arity;
+        std::size_t const remainder = num_sites % arity;
+
+        std::vector<top_level_group> groups;
+        groups.reserve(arity);
+
+        std::size_t offset = 0;
+        for (std::size_t i = 0; i != arity; ++i)
+        {
+            std::size_t const group_size =
+                division_steps + (i < remainder ? 1 : 0);
+
+            std::size_t const left = offset;
+            std::size_t const right = left + group_size - 1;
+            groups.push_back(top_level_group{left, right, group_size});
+
+            offset += group_size;
+        }
+
+        return groups;
+    }
+
+    // Return the index of the top-level group that contains `this_site`.
+    inline std::size_t classify_site(
+        std::size_t this_site, std::vector<top_level_group> const& groups)
+    {
+        for (std::size_t i = 0; i != groups.size(); ++i)
+        {
+            if (this_site >= groups[i].left && this_site <= groups[i].right)
+            {
+                return i;
+            }
+        }
+
+        return static_cast<std::size_t>(-1);
+    }
+
+}    // namespace hpx::collectives::detail

--- a/libs/full/collectives/include/hpx/collectives/detail/hierarchical_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/hierarchical_helpers.hpp
@@ -71,4 +71,15 @@ namespace hpx::collectives::detail {
         return static_cast<std::size_t>(-1);
     }
 
+    // Return true if `this_site` is the leftmost site (representative)
+    // of its top-level group.
+    inline bool is_top_level_rep(
+        std::size_t this_site, std::size_t num_sites, std::size_t arity)
+    {
+        auto const groups = get_top_level_groups(num_sites, arity);
+        auto const g = classify_site(this_site, groups);
+        return (g != static_cast<std::size_t>(-1)) &&
+            (this_site == groups[g].left);
+    }
+
 }    // namespace hpx::collectives::detail

--- a/libs/full/collectives/include/hpx/collectives/detail/hierarchical_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/hierarchical_helpers.hpp
@@ -11,6 +11,7 @@
 #include <hpx/config.hpp>
 
 #include <cstddef>
+#include <cstdlib>
 #include <vector>
 
 namespace hpx::collectives::detail {
@@ -34,8 +35,9 @@ namespace hpx::collectives::detail {
             arity = num_sites;
         }
 
-        std::size_t const division_steps = num_sites / arity;
-        std::size_t const remainder = num_sites % arity;
+        auto const dv = std::lldiv(
+            static_cast<long long>(num_sites),
+            static_cast<long long>(arity));
 
         std::vector<top_level_group> groups;
         groups.reserve(arity);
@@ -44,7 +46,8 @@ namespace hpx::collectives::detail {
         for (std::size_t i = 0; i != arity; ++i)
         {
             std::size_t const group_size =
-                division_steps + (i < remainder ? 1 : 0);
+                static_cast<std::size_t>(dv.quot) +
+                (i < static_cast<std::size_t>(dv.rem) ? 1 : 0);
 
             std::size_t const left = offset;
             std::size_t const right = left + group_size - 1;

--- a/libs/full/collectives/include/hpx/collectives/detail/hierarchical_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/hierarchical_helpers.hpp
@@ -38,8 +38,7 @@ namespace hpx::collectives::detail {
         }
 
         auto const dv = std::lldiv(
-            static_cast<long long>(num_sites),
-            static_cast<long long>(arity));
+            static_cast<long long>(num_sites), static_cast<long long>(arity));
 
         std::vector<top_level_group> groups;
         groups.reserve(arity);
@@ -47,8 +46,7 @@ namespace hpx::collectives::detail {
         std::size_t offset = 0;
         for (std::size_t i = 0; i != arity; ++i)
         {
-            std::size_t const group_size =
-                static_cast<std::size_t>(dv.quot) +
+            std::size_t const group_size = static_cast<std::size_t>(dv.quot) +
                 (i < static_cast<std::size_t>(dv.rem) ? 1 : 0);
 
             std::size_t const left = offset;
@@ -67,15 +65,13 @@ namespace hpx::collectives::detail {
         std::size_t this_site, std::vector<top_level_group> const& groups)
     {
         auto const it = std::lower_bound(groups.begin(), groups.end(),
-            this_site,
-            [](top_level_group const& g, std::size_t site) {
+            this_site, [](top_level_group const& g, std::size_t site) {
                 return g.right < site;
             });
 
         if (it != groups.end() && this_site >= it->left)
         {
-            return static_cast<std::size_t>(
-                std::distance(groups.begin(), it));
+            return static_cast<std::size_t>(std::distance(groups.begin(), it));
         }
 
         return static_cast<std::size_t>(-1);

--- a/libs/full/collectives/include/hpx/collectives/detail/hierarchical_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/hierarchical_helpers.hpp
@@ -20,7 +20,7 @@
 
 namespace hpx::collectives::detail {
 
-    struct top_level_group
+    HPX_CXX_EXPORT struct top_level_group
     {
         std::size_t left;
         std::size_t right;
@@ -31,7 +31,7 @@ namespace hpx::collectives::detail {
     // Uses the same division logic as recursively_fill_communicators:
     // first (num_sites % arity) groups get ceil(num_sites/arity) sites,
     // the rest get floor(num_sites/arity).
-    inline std::vector<top_level_group> get_top_level_groups(
+    HPX_CXX_EXPORT inline std::vector<top_level_group> get_top_level_groups(
         std::size_t num_sites, std::size_t arity)
     {
         HPX_ASSERT(arity != 0);
@@ -67,7 +67,7 @@ namespace hpx::collectives::detail {
     // or -1 if there is none. Groups are sorted by left boundary, so we use
     // std::lower_bound. The return type is signed so the -1 sentinel and the
     // std::distance result need no casts.
-    inline std::ptrdiff_t classify_site(
+    HPX_CXX_EXPORT inline std::ptrdiff_t classify_site(
         std::size_t this_site, std::vector<top_level_group> const& groups)
     {
         auto const it = std::lower_bound(groups.begin(), groups.end(),
@@ -85,7 +85,7 @@ namespace hpx::collectives::detail {
 
     // Return true if `this_site` is the leftmost site (representative)
     // of its top-level group.
-    inline bool is_top_level_rep(
+    HPX_CXX_EXPORT inline bool is_top_level_rep(
         std::size_t this_site, std::size_t num_sites, std::size_t arity)
     {
         auto const groups = get_top_level_groups(num_sites, arity);

--- a/libs/full/collectives/include/hpx/collectives/detail/hierarchical_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/hierarchical_helpers.hpp
@@ -10,8 +10,10 @@
 
 #include <hpx/config.hpp>
 
+#include <algorithm>
 #include <cstddef>
 #include <cstdlib>
+#include <iterator>
 #include <vector>
 
 namespace hpx::collectives::detail {
@@ -60,15 +62,20 @@ namespace hpx::collectives::detail {
     }
 
     // Return the index of the top-level group that contains `this_site`.
+    // Groups are sorted by left boundary, so we use std::lower_bound.
     inline std::size_t classify_site(
         std::size_t this_site, std::vector<top_level_group> const& groups)
     {
-        for (std::size_t i = 0; i != groups.size(); ++i)
+        auto const it = std::lower_bound(groups.begin(), groups.end(),
+            this_site,
+            [](top_level_group const& g, std::size_t site) {
+                return g.right < site;
+            });
+
+        if (it != groups.end() && this_site >= it->left)
         {
-            if (this_site >= groups[i].left && this_site <= groups[i].right)
-            {
-                return i;
-            }
+            return static_cast<std::size_t>(
+                std::distance(groups.begin(), it));
         }
 
         return static_cast<std::size_t>(-1);

--- a/libs/full/collectives/include/hpx/collectives/detail/hierarchical_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/hierarchical_helpers.hpp
@@ -10,6 +10,8 @@
 
 #include <hpx/config.hpp>
 
+#include <hpx/assert.hpp>
+
 #include <algorithm>
 #include <cstddef>
 #include <cstdlib>
@@ -32,6 +34,8 @@ namespace hpx::collectives::detail {
     inline std::vector<top_level_group> get_top_level_groups(
         std::size_t num_sites, std::size_t arity)
     {
+        HPX_ASSERT(arity != 0);
+
         if (arity > num_sites)
         {
             arity = num_sites;

--- a/libs/full/collectives/src/create_communicator.cpp
+++ b/libs/full/collectives/src/create_communicator.cpp
@@ -9,6 +9,9 @@
 
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/assert.hpp>
+#include <hpx/collectives/argument_types.hpp>
+#include <hpx/collectives/create_communicator.hpp>
+#include <hpx/collectives/detail/hierarchical_helpers.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/components.hpp>
@@ -392,30 +395,25 @@ namespace hpx::collectives {
                 return;
             }
 
-            std::size_t division_steps = (right - left + 1) / arity;
-            std::size_t remainder = (right - left + 1) % arity;
-            std::size_t offset = 0;
+            auto const groups = detail::get_top_level_groups(
+                right - left + 1, arity);
 
-            for (std::size_t i = 0; i != arity; ++i)
+            for (std::size_t i = 0; i != groups.size(); ++i)
             {
-                std::size_t const current_group_size =
-                    division_steps + (i < remainder ? 1 : 0);
-
-                std::size_t const current_left = left + offset;
-                std::size_t const current_right =
-                    current_left + current_group_size - 1;
-                offset += current_group_size;
+                std::size_t const current_left = left + groups[i].left;
+                std::size_t const current_right = left + groups[i].right;
 
                 if (this_site == current_left)
                 {
                     auto c = create_communicator(name.c_str(),
-                        num_sites_arg(arity), this_site_arg(i),
-                        generation_arg(generation), root_site_arg(0));
+                        num_sites_arg(groups.size()),
+                        this_site_arg(i), generation_arg(generation),
+                        root_site_arg(0));
 
                     communicators.emplace_back(HPX_MOVE(c), this_site_arg(i));
                 }
 
-                if (this_site >= current_left && this_site < current_right + 1)
+                if (this_site >= current_left && this_site <= current_right)
                 {
                     recursively_fill_communicators(communicators, current_left,
                         current_right, basename, arity, this_site, num_sites,
@@ -477,7 +475,8 @@ namespace hpx::collectives {
             std::vector<hpx::tuple<communicator, this_site_arg>> communicators;
             communicators.emplace_back(HPX_MOVE(c), this_site);
             return hierarchical_communicator(HPX_MOVE(communicators), arity,
-                root_site, num_sites, this_site);
+                root_site, num_sites, this_site,
+                /*flat_fallback=*/true);
         }
 
         std::vector<hpx::tuple<communicator, this_site_arg>> communicators;

--- a/libs/full/collectives/src/create_communicator.cpp
+++ b/libs/full/collectives/src/create_communicator.cpp
@@ -481,8 +481,8 @@ namespace hpx::collectives {
         std::vector<hpx::tuple<communicator, this_site_arg>> communicators;
         recursively_fill_communicators(communicators, 0, num_sites - 1, name,
             arity, this_site, num_sites, generation);
-        return hierarchical_communicator(
-            HPX_MOVE(communicators), arity, root_site, num_sites, this_site);
+        return hierarchical_communicator(HPX_MOVE(communicators), arity,
+            root_site, num_sites, this_site, /*flat_fallback=*/false);
     }
 
     hpx::tuple<num_sites_arg, this_site_arg, root_site_arg>

--- a/libs/full/collectives/src/create_communicator.cpp
+++ b/libs/full/collectives/src/create_communicator.cpp
@@ -395,8 +395,8 @@ namespace hpx::collectives {
                 return;
             }
 
-            auto const groups = detail::get_top_level_groups(
-                right - left + 1, arity);
+            auto const groups =
+                detail::get_top_level_groups(right - left + 1, arity);
 
             for (std::size_t i = 0; i != groups.size(); ++i)
             {
@@ -406,9 +406,8 @@ namespace hpx::collectives {
                 if (this_site == current_left)
                 {
                     auto c = create_communicator(name.c_str(),
-                        num_sites_arg(groups.size()),
-                        this_site_arg(i), generation_arg(generation),
-                        root_site_arg(0));
+                        num_sites_arg(groups.size()), this_site_arg(i),
+                        generation_arg(generation), root_site_arg(0));
 
                     communicators.emplace_back(HPX_MOVE(c), this_site_arg(i));
                 }

--- a/libs/full/collectives/tests/unit/CMakeLists.txt
+++ b/libs/full/collectives/tests/unit/CMakeLists.txt
@@ -19,6 +19,7 @@ set(tests
     channel_communicator
     fold
     global_spmd_block
+    hierarchical_helpers
     reduce_direct
     remote_latch
 )

--- a/libs/full/collectives/tests/unit/CMakeLists.txt
+++ b/libs/full/collectives/tests/unit/CMakeLists.txt
@@ -1,28 +1,67 @@
-#Copyright(c) 2019 - 2025 Hartmut Kaiser
+# Copyright (c) 2019-2025 Hartmut Kaiser
 #
-#SPDX - License - Identifier : BSL - 1.0
-#Distributed under the Boost Software License, Version 1.0.(See accompanying
-#file LICENSE_1_0.txt or copy at http:    //www.boost.org/LICENSE_1_0.txt)
-set(tests all_gather all_gather_sync all_reduce all_reduce_sync all_to_all
-        all_to_all_sync barrier broadcast broadcast_component
-            broadcast_hierarchical broadcast_post broadcast_sync
-                channel_communicator fold global_spmd_block hierarchical_helpers
-                    reduce_direct remote_latch
-                        subtree_gather_scatter) if (HPX_WITH_NETWORKING)
-    set(tests ${tests} all_gather_hierarchical all_reduce_hierarchical
-            all_to_all_hierarchical barrier_hierarchical broadcast_direct
-                concurrent_collectives exclusive_scan_ exclusive_scan_sync
-                    gather gather_hierarchical gather_sync
-                        hierarchical_flat_fallback inclusive_scan_
-                            inclusive_scan_sync reduce reduce_hierarchical
-                                reduce_sync scatter scatter_hierarchical
-                                    scatter_sync) foreach (test ${tests}) set(${
-        test} _PARAMETERS LOCALITIES 2) endforeach() endif()
-        foreach (test ${tests}) set(sources ${test}.cpp) source_group(
-            "Source Files" FILES ${sources})
-#add example executable
-            add_hpx_executable(${test} _test INTERNAL_FLAGS SOURCES ${
-                sources} ${${test} _FLAGS} EXCLUDE_FROM_ALL HPX_PREFIX ${
-                HPX_BUILD_PREFIX} FOLDER "Tests/Unit/Modules/Full/Collectives")
-                add_hpx_unit_test("modules.collectives" ${test} ${
-                    ${test} _PARAMETERS}) endforeach()
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+set(tests
+    all_gather
+    all_gather_sync
+    all_reduce
+    all_reduce_sync
+    all_to_all
+    all_to_all_sync
+    barrier
+    broadcast
+    broadcast_component
+    broadcast_hierarchical
+    broadcast_post
+    broadcast_sync
+    channel_communicator
+    fold
+    global_spmd_block
+    hierarchical_helpers
+    reduce_direct
+    remote_latch
+    subtree_gather_scatter
+)
+if(HPX_WITH_NETWORKING)
+  set(tests
+      ${tests}
+      all_gather_hierarchical
+      all_reduce_hierarchical
+      all_to_all_hierarchical
+      barrier_hierarchical
+      broadcast_direct
+      concurrent_collectives
+      exclusive_scan_
+      exclusive_scan_sync
+      gather
+      gather_hierarchical
+      gather_sync
+      hierarchical_flat_fallback
+      inclusive_scan_
+      inclusive_scan_sync
+      reduce
+      reduce_hierarchical
+      reduce_sync
+      scatter
+      scatter_hierarchical
+      scatter_sync
+  )
+  foreach(test ${tests})
+    set(${test}_PARAMETERS LOCALITIES 2)
+  endforeach()
+endif()
+foreach(test ${tests})
+  set(sources ${test}.cpp)
+  source_group("Source Files" FILES ${sources})
+  # add example executable
+  add_hpx_executable(
+    ${test}_test INTERNAL_FLAGS
+    SOURCES ${sources} ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Unit/Modules/Full/Collectives"
+  )
+  add_hpx_unit_test("modules.collectives" ${test} ${${test}_PARAMETERS})
+endforeach()

--- a/libs/full/collectives/tests/unit/CMakeLists.txt
+++ b/libs/full/collectives/tests/unit/CMakeLists.txt
@@ -1,67 +1,28 @@
-# Copyright (c) 2019-2025 Hartmut Kaiser
+#Copyright(c) 2019 - 2025 Hartmut Kaiser
 #
-# SPDX-License-Identifier: BSL-1.0
-# Distributed under the Boost Software License, Version 1.0. (See accompanying
-# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
-set(tests
-    all_gather
-    all_gather_sync
-    all_reduce
-    all_reduce_sync
-    all_to_all
-    all_to_all_sync
-    barrier
-    broadcast
-    broadcast_component
-    broadcast_hierarchical
-    broadcast_post
-    broadcast_sync
-    channel_communicator
-    fold
-    global_spmd_block
-    hierarchical_helpers
-    reduce_direct
-    remote_latch
-    subtree_gather_scatter
-)
-if(HPX_WITH_NETWORKING)
-  set(tests
-      ${tests}
-      all_gather_hierarchical
-      all_reduce_hierarchical
-      all_to_all_hierarchical
-      barrier_hierarchical
-      broadcast_direct
-      concurrent_collectives
-      exclusive_scan_
-      exclusive_scan_sync
-      gather
-      gather_hierarchical
-      gather_sync
-      hierarchical_flat_fallback
-      inclusive_scan_
-      inclusive_scan_sync
-      reduce
-      reduce_hierarchical
-      reduce_sync
-      scatter
-      scatter_hierarchical
-      scatter_sync
-  )
-  foreach(test ${tests})
-    set(${test}_PARAMETERS LOCALITIES 2)
-  endforeach()
-endif()
-foreach(test ${tests})
-  set(sources ${test}.cpp)
-  source_group("Source Files" FILES ${sources})
-  # add example executable
-  add_hpx_executable(
-    ${test}_test INTERNAL_FLAGS
-    SOURCES ${sources} ${${test}_FLAGS}
-    EXCLUDE_FROM_ALL
-    HPX_PREFIX ${HPX_BUILD_PREFIX}
-    FOLDER "Tests/Unit/Modules/Full/Collectives"
-  )
-  add_hpx_unit_test("modules.collectives" ${test} ${${test}_PARAMETERS})
-endforeach()
+#SPDX - License - Identifier : BSL - 1.0
+#Distributed under the Boost Software License, Version 1.0.(See accompanying
+#file LICENSE_1_0.txt or copy at http:    //www.boost.org/LICENSE_1_0.txt)
+set(tests all_gather all_gather_sync all_reduce all_reduce_sync all_to_all
+        all_to_all_sync barrier broadcast broadcast_component
+            broadcast_hierarchical broadcast_post broadcast_sync
+                channel_communicator fold global_spmd_block hierarchical_helpers
+                    reduce_direct remote_latch
+                        subtree_gather_scatter) if (HPX_WITH_NETWORKING)
+    set(tests ${tests} all_gather_hierarchical all_reduce_hierarchical
+            all_to_all_hierarchical barrier_hierarchical broadcast_direct
+                concurrent_collectives exclusive_scan_ exclusive_scan_sync
+                    gather gather_hierarchical gather_sync
+                        hierarchical_flat_fallback inclusive_scan_
+                            inclusive_scan_sync reduce reduce_hierarchical
+                                reduce_sync scatter scatter_hierarchical
+                                    scatter_sync) foreach (test ${tests}) set(${
+        test} _PARAMETERS LOCALITIES 2) endforeach() endif()
+        foreach (test ${tests}) set(sources ${test}.cpp) source_group(
+            "Source Files" FILES ${sources})
+#add example executable
+            add_hpx_executable(${test} _test INTERNAL_FLAGS SOURCES ${
+                sources} ${${test} _FLAGS} EXCLUDE_FROM_ALL HPX_PREFIX ${
+                HPX_BUILD_PREFIX} FOLDER "Tests/Unit/Modules/Full/Collectives")
+                add_hpx_unit_test("modules.collectives" ${test} ${
+                    ${test} _PARAMETERS}) endforeach()

--- a/libs/full/collectives/tests/unit/CMakeLists.txt
+++ b/libs/full/collectives/tests/unit/CMakeLists.txt
@@ -22,12 +22,14 @@ set(tests
     hierarchical_helpers
     reduce_direct
     remote_latch
+    subtree_gather_scatter
 )
 if(HPX_WITH_NETWORKING)
   set(tests
       ${tests}
       all_gather_hierarchical
       all_reduce_hierarchical
+      all_to_all_hierarchical
       barrier_hierarchical
       broadcast_direct
       concurrent_collectives

--- a/libs/full/collectives/tests/unit/all_to_all_hierarchical.cpp
+++ b/libs/full/collectives/tests/unit/all_to_all_hierarchical.cpp
@@ -1,0 +1,165 @@
+//  Copyright (c) 2026 Anshuman Agrawal
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/modules/collectives.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace hpx::collectives;
+
+constexpr char const* all_to_all_hierarchical_basename =
+    "/test/all_to_all_hierarchical/";
+
+#if defined(HPX_DEBUG)
+constexpr int ITERATIONS = 10;
+#else
+constexpr int ITERATIONS = 50;
+#endif
+
+///////////////////////////////////////////////////////////////////////////
+// Uniform payload: each site fills all slots with the same value.
+// values[j] = site + iteration for all j. After exchange:
+// result[s] = s + iteration.
+void test_uniform_payload(std::uint32_t num_sites, int arity)
+{
+    std::vector<hpx::future<void>> sites;
+    sites.reserve(num_sites);
+
+    for (std::uint32_t site = 0; site != num_sites; ++site)
+    {
+        sites.push_back(hpx::async([=]() {
+            std::string basename(all_to_all_hierarchical_basename);
+            basename += "uniform_" + std::to_string(num_sites) + "_" +
+                std::to_string(arity) + "/";
+
+            auto const comms = create_hierarchical_communicator(
+                basename.c_str(), num_sites_arg(num_sites),
+                this_site_arg(site), arity_arg(arity),
+                generation_arg(), root_site_arg(),
+                flat_fallback_threshold_arg(0));
+
+            for (int i = 0; i != ITERATIONS; ++i)
+            {
+                std::vector<std::uint32_t> values(num_sites);
+                std::fill(values.begin(), values.end(), site + i);
+
+                auto result = all_to_all(hpx::launch::sync, comms,
+                    std::move(values), this_site_arg(site),
+                    generation_arg(i + 1));
+
+                HPX_TEST_EQ(result.size(),
+                    static_cast<std::size_t>(num_sites));
+                for (std::size_t j = 0; j != result.size(); ++j)
+                {
+                    HPX_TEST_EQ(result[j],
+                        static_cast<std::uint32_t>(j + i));
+                }
+            }
+        }));
+    }
+
+    hpx::wait_all(std::move(sites));
+}
+
+///////////////////////////////////////////////////////////////////////////
+// Distinct payload: values[j] = site * num_sites + j + i.
+// After exchange: result[s] = s * num_sites + this_site + i.
+// This tests that each (source, destination) pair carries a unique value
+// through the hierarchical tree.
+void test_distinct_payload(std::uint32_t num_sites, int arity)
+{
+    std::vector<hpx::future<void>> sites;
+    sites.reserve(num_sites);
+
+    for (std::uint32_t site = 0; site != num_sites; ++site)
+    {
+        sites.push_back(hpx::async([=]() {
+            std::string basename(all_to_all_hierarchical_basename);
+            basename += "distinct_" + std::to_string(num_sites) + "_" +
+                std::to_string(arity) + "/";
+
+            auto const comms = create_hierarchical_communicator(
+                basename.c_str(), num_sites_arg(num_sites),
+                this_site_arg(site), arity_arg(arity),
+                generation_arg(), root_site_arg(),
+                flat_fallback_threshold_arg(0));
+
+            for (int i = 0; i != ITERATIONS; ++i)
+            {
+                std::vector<std::uint32_t> values(num_sites);
+                for (std::uint32_t j = 0; j != num_sites; ++j)
+                {
+                    values[j] = site * num_sites + j + i;
+                }
+
+                auto result = all_to_all(hpx::launch::sync, comms,
+                    std::move(values), this_site_arg(site),
+                    generation_arg(i + 1));
+
+                HPX_TEST_EQ(result.size(),
+                    static_cast<std::size_t>(num_sites));
+                for (std::size_t s = 0; s != result.size(); ++s)
+                {
+                    HPX_TEST_EQ(result[s],
+                        static_cast<std::uint32_t>(
+                            s * num_sites + site + i));
+                }
+            }
+        }));
+    }
+
+    hpx::wait_all(std::move(sites));
+}
+
+int hpx_main()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        // Balanced cases
+        for (int arity : {2, 4})
+        {
+            for (std::uint32_t n : {2, 4, 8, 16})
+            {
+                test_uniform_payload(n, arity);
+                test_distinct_payload(n, arity);
+            }
+        }
+
+        // Unbalanced cases (num_sites not a power of arity)
+        for (int arity : {2, 3, 4})
+        {
+            for (std::uint32_t n : {3, 5, 7, 11})
+            {
+                test_uniform_payload(n, arity);
+                test_distinct_payload(n, arity);
+            }
+        }
+    }
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> const cfg = {"hpx.run_hpx_main!=1"};
+
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ(hpx::init(argc, argv, init_args), 0);
+    return hpx::util::report_errors();
+}
+
+#endif

--- a/libs/full/collectives/tests/unit/all_to_all_hierarchical.cpp
+++ b/libs/full/collectives/tests/unit/all_to_all_hierarchical.cpp
@@ -45,9 +45,8 @@ void test_uniform_payload(std::uint32_t num_sites, int arity)
                 std::to_string(arity) + "/";
 
             auto const comms = create_hierarchical_communicator(
-                basename.c_str(), num_sites_arg(num_sites),
-                this_site_arg(site), arity_arg(arity),
-                generation_arg(), root_site_arg(),
+                basename.c_str(), num_sites_arg(num_sites), this_site_arg(site),
+                arity_arg(arity), generation_arg(), root_site_arg(),
                 flat_fallback_threshold_arg(0));
 
             for (int i = 0; i != ITERATIONS; ++i)
@@ -55,16 +54,14 @@ void test_uniform_payload(std::uint32_t num_sites, int arity)
                 std::vector<std::uint32_t> values(num_sites);
                 std::fill(values.begin(), values.end(), site + i);
 
-                auto result = all_to_all(hpx::launch::sync, comms,
-                    std::move(values), this_site_arg(site),
-                    generation_arg(i + 1));
+                auto result =
+                    all_to_all(hpx::launch::sync, comms, std::move(values),
+                        this_site_arg(site), generation_arg(i + 1));
 
-                HPX_TEST_EQ(result.size(),
-                    static_cast<std::size_t>(num_sites));
+                HPX_TEST_EQ(result.size(), static_cast<std::size_t>(num_sites));
                 for (std::size_t j = 0; j != result.size(); ++j)
                 {
-                    HPX_TEST_EQ(result[j],
-                        static_cast<std::uint32_t>(j + i));
+                    HPX_TEST_EQ(result[j], static_cast<std::uint32_t>(j + i));
                 }
             }
         }));
@@ -91,9 +88,8 @@ void test_distinct_payload(std::uint32_t num_sites, int arity)
                 std::to_string(arity) + "/";
 
             auto const comms = create_hierarchical_communicator(
-                basename.c_str(), num_sites_arg(num_sites),
-                this_site_arg(site), arity_arg(arity),
-                generation_arg(), root_site_arg(),
+                basename.c_str(), num_sites_arg(num_sites), this_site_arg(site),
+                arity_arg(arity), generation_arg(), root_site_arg(),
                 flat_fallback_threshold_arg(0));
 
             for (int i = 0; i != ITERATIONS; ++i)
@@ -104,17 +100,15 @@ void test_distinct_payload(std::uint32_t num_sites, int arity)
                     values[j] = site * num_sites + j + i;
                 }
 
-                auto result = all_to_all(hpx::launch::sync, comms,
-                    std::move(values), this_site_arg(site),
-                    generation_arg(i + 1));
+                auto result =
+                    all_to_all(hpx::launch::sync, comms, std::move(values),
+                        this_site_arg(site), generation_arg(i + 1));
 
-                HPX_TEST_EQ(result.size(),
-                    static_cast<std::size_t>(num_sites));
+                HPX_TEST_EQ(result.size(), static_cast<std::size_t>(num_sites));
                 for (std::size_t s = 0; s != result.size(); ++s)
                 {
                     HPX_TEST_EQ(result[s],
-                        static_cast<std::uint32_t>(
-                            s * num_sites + site + i));
+                        static_cast<std::uint32_t>(s * num_sites + site + i));
                 }
             }
         }));

--- a/libs/full/collectives/tests/unit/hierarchical_helpers.cpp
+++ b/libs/full/collectives/tests/unit/hierarchical_helpers.cpp
@@ -19,6 +19,7 @@
 
 using hpx::collectives::detail::classify_site;
 using hpx::collectives::detail::get_top_level_groups;
+using hpx::collectives::detail::is_top_level_rep;
 using hpx::collectives::detail::top_level_group;
 
 void test_balanced_arity2()
@@ -213,6 +214,53 @@ void test_matches_recursive_fill()
     }
 }
 
+void test_is_top_level_rep_basic()
+{
+    // N=8, arity=2 -> groups [0,3] and [4,7]. Reps are 0 and 4.
+    HPX_TEST(is_top_level_rep(0, 8, 2));
+    HPX_TEST(!is_top_level_rep(1, 8, 2));
+    HPX_TEST(!is_top_level_rep(3, 8, 2));
+    HPX_TEST(is_top_level_rep(4, 8, 2));
+    HPX_TEST(!is_top_level_rep(5, 8, 2));
+    HPX_TEST(!is_top_level_rep(7, 8, 2));
+
+    // N=11, arity=4 -> groups [0,2], [3,5], [6,8], [9,10]. Reps: 0,3,6,9.
+    HPX_TEST(is_top_level_rep(0, 11, 4));
+    HPX_TEST(!is_top_level_rep(1, 11, 4));
+    HPX_TEST(!is_top_level_rep(2, 11, 4));
+    HPX_TEST(is_top_level_rep(3, 11, 4));
+    HPX_TEST(is_top_level_rep(6, 11, 4));
+    HPX_TEST(is_top_level_rep(9, 11, 4));
+    HPX_TEST(!is_top_level_rep(10, 11, 4));
+}
+
+void test_is_top_level_rep_exhaustive()
+{
+    // For various N and arity, exactly the leftmost site in each group
+    // should be a rep, and no other site.
+    for (std::size_t n = 1; n <= 32; ++n)
+    {
+        for (std::size_t arity = 2; arity <= 8; ++arity)
+        {
+            auto groups = get_top_level_groups(n, arity);
+
+            for (std::size_t site = 0; site != n; ++site)
+            {
+                bool expected = false;
+                for (auto const& g : groups)
+                {
+                    if (site == g.left)
+                    {
+                        expected = true;
+                        break;
+                    }
+                }
+                HPX_TEST_EQ(is_top_level_rep(site, n, arity), expected);
+            }
+        }
+    }
+}
+
 int hpx_main()
 {
     test_balanced_arity2();
@@ -225,6 +273,8 @@ int hpx_main()
     test_classify_site_basic();
     test_classify_site_exhaustive();
     test_matches_recursive_fill();
+    test_is_top_level_rep_basic();
+    test_is_top_level_rep_exhaustive();
 
     return hpx::finalize();
 }

--- a/libs/full/collectives/tests/unit/hierarchical_helpers.cpp
+++ b/libs/full/collectives/tests/unit/hierarchical_helpers.cpp
@@ -1,0 +1,243 @@
+//  Copyright (c) 2026 Anshuman Agrawal
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <hpx/collectives/detail/hierarchical_helpers.hpp>
+
+#include <cstddef>
+#include <numeric>
+#include <vector>
+
+using hpx::collectives::detail::classify_site;
+using hpx::collectives::detail::get_top_level_groups;
+using hpx::collectives::detail::top_level_group;
+
+void test_balanced_arity2()
+{
+    // N=8, arity=2 -> two groups of 4: [0,3] and [4,7]
+    auto groups = get_top_level_groups(8, 2);
+    HPX_TEST_EQ(groups.size(), static_cast<std::size_t>(2));
+
+    HPX_TEST_EQ(groups[0].left, static_cast<std::size_t>(0));
+    HPX_TEST_EQ(groups[0].right, static_cast<std::size_t>(3));
+    HPX_TEST_EQ(groups[0].size, static_cast<std::size_t>(4));
+
+    HPX_TEST_EQ(groups[1].left, static_cast<std::size_t>(4));
+    HPX_TEST_EQ(groups[1].right, static_cast<std::size_t>(7));
+    HPX_TEST_EQ(groups[1].size, static_cast<std::size_t>(4));
+}
+
+void test_balanced_arity4()
+{
+    // N=8, arity=4 -> four groups of 2: [0,1], [2,3], [4,5], [6,7]
+    auto groups = get_top_level_groups(8, 4);
+    HPX_TEST_EQ(groups.size(), static_cast<std::size_t>(4));
+
+    for (std::size_t i = 0; i != 4; ++i)
+    {
+        HPX_TEST_EQ(groups[i].left, i * 2);
+        HPX_TEST_EQ(groups[i].right, i * 2 + 1);
+        HPX_TEST_EQ(groups[i].size, static_cast<std::size_t>(2));
+    }
+}
+
+void test_unbalanced_n11_arity4()
+{
+    // N=11, arity=4 -> 11/4=2 rem 3
+    // groups: [0,2](3), [3,5](3), [6,8](3), [9,10](2)
+    auto groups = get_top_level_groups(11, 4);
+    HPX_TEST_EQ(groups.size(), static_cast<std::size_t>(4));
+
+    HPX_TEST_EQ(groups[0].left, static_cast<std::size_t>(0));
+    HPX_TEST_EQ(groups[0].right, static_cast<std::size_t>(2));
+    HPX_TEST_EQ(groups[0].size, static_cast<std::size_t>(3));
+
+    HPX_TEST_EQ(groups[1].left, static_cast<std::size_t>(3));
+    HPX_TEST_EQ(groups[1].right, static_cast<std::size_t>(5));
+    HPX_TEST_EQ(groups[1].size, static_cast<std::size_t>(3));
+
+    HPX_TEST_EQ(groups[2].left, static_cast<std::size_t>(6));
+    HPX_TEST_EQ(groups[2].right, static_cast<std::size_t>(8));
+    HPX_TEST_EQ(groups[2].size, static_cast<std::size_t>(3));
+
+    HPX_TEST_EQ(groups[3].left, static_cast<std::size_t>(9));
+    HPX_TEST_EQ(groups[3].right, static_cast<std::size_t>(10));
+    HPX_TEST_EQ(groups[3].size, static_cast<std::size_t>(2));
+}
+
+void test_unbalanced_n7_arity3()
+{
+    // N=7, arity=3 -> 7/3=2 rem 1
+    // groups: [0,2](3), [3,4](2), [5,6](2)
+    auto groups = get_top_level_groups(7, 3);
+    HPX_TEST_EQ(groups.size(), static_cast<std::size_t>(3));
+
+    HPX_TEST_EQ(groups[0].left, static_cast<std::size_t>(0));
+    HPX_TEST_EQ(groups[0].right, static_cast<std::size_t>(2));
+    HPX_TEST_EQ(groups[0].size, static_cast<std::size_t>(3));
+
+    HPX_TEST_EQ(groups[1].left, static_cast<std::size_t>(3));
+    HPX_TEST_EQ(groups[1].right, static_cast<std::size_t>(4));
+    HPX_TEST_EQ(groups[1].size, static_cast<std::size_t>(2));
+
+    HPX_TEST_EQ(groups[2].left, static_cast<std::size_t>(5));
+    HPX_TEST_EQ(groups[2].right, static_cast<std::size_t>(6));
+    HPX_TEST_EQ(groups[2].size, static_cast<std::size_t>(2));
+}
+
+void test_arity_exceeds_n()
+{
+    // N=3, arity=8 -> clamp arity to 3, three groups of 1
+    auto groups = get_top_level_groups(3, 8);
+    HPX_TEST_EQ(groups.size(), static_cast<std::size_t>(3));
+
+    for (std::size_t i = 0; i != 3; ++i)
+    {
+        HPX_TEST_EQ(groups[i].left, i);
+        HPX_TEST_EQ(groups[i].right, i);
+        HPX_TEST_EQ(groups[i].size, static_cast<std::size_t>(1));
+    }
+}
+
+void test_single_site()
+{
+    // N=1, arity=2 -> one group of 1
+    auto groups = get_top_level_groups(1, 2);
+    HPX_TEST_EQ(groups.size(), static_cast<std::size_t>(1));
+
+    HPX_TEST_EQ(groups[0].left, static_cast<std::size_t>(0));
+    HPX_TEST_EQ(groups[0].right, static_cast<std::size_t>(0));
+    HPX_TEST_EQ(groups[0].size, static_cast<std::size_t>(1));
+}
+
+void test_coverage_property()
+{
+    // For various N and arity, verify that the groups cover [0, N) exactly.
+    for (std::size_t n = 1; n <= 32; ++n)
+    {
+        for (std::size_t arity = 2; arity <= 8; ++arity)
+        {
+            auto groups = get_top_level_groups(n, arity);
+
+            std::size_t total_size = 0;
+            for (auto const& g : groups)
+            {
+                HPX_TEST_EQ(g.size, g.right - g.left + 1);
+                total_size += g.size;
+            }
+            HPX_TEST_EQ(total_size, n);
+
+            HPX_TEST_EQ(groups.front().left, static_cast<std::size_t>(0));
+            HPX_TEST_EQ(groups.back().right, n - 1);
+
+            for (std::size_t i = 1; i < groups.size(); ++i)
+            {
+                HPX_TEST_EQ(groups[i].left, groups[i - 1].right + 1);
+            }
+        }
+    }
+}
+
+void test_classify_site_basic()
+{
+    auto groups = get_top_level_groups(11, 4);
+
+    HPX_TEST_EQ(classify_site(0, groups), static_cast<std::size_t>(0));
+    HPX_TEST_EQ(classify_site(1, groups), static_cast<std::size_t>(0));
+    HPX_TEST_EQ(classify_site(2, groups), static_cast<std::size_t>(0));
+    HPX_TEST_EQ(classify_site(3, groups), static_cast<std::size_t>(1));
+    HPX_TEST_EQ(classify_site(5, groups), static_cast<std::size_t>(1));
+    HPX_TEST_EQ(classify_site(6, groups), static_cast<std::size_t>(2));
+    HPX_TEST_EQ(classify_site(9, groups), static_cast<std::size_t>(3));
+    HPX_TEST_EQ(classify_site(10, groups), static_cast<std::size_t>(3));
+}
+
+void test_classify_site_exhaustive()
+{
+    // Every site in [0, N) must classify to exactly one group.
+    for (std::size_t n = 1; n <= 32; ++n)
+    {
+        for (std::size_t arity = 2; arity <= 8; ++arity)
+        {
+            auto groups = get_top_level_groups(n, arity);
+
+            for (std::size_t site = 0; site != n; ++site)
+            {
+                std::size_t g = classify_site(site, groups);
+                HPX_TEST_NEQ(g, static_cast<std::size_t>(-1));
+                HPX_TEST(site >= groups[g].left && site <= groups[g].right);
+            }
+        }
+    }
+}
+
+void test_matches_recursive_fill()
+{
+    // Verify that get_top_level_groups produces the same partition as
+    // the top frame of recursively_fill_communicators. That function
+    // uses: division_steps = (right - left + 1) / arity,
+    //       remainder = (right - left + 1) % arity.
+    // We replicate that logic and compare.
+    for (std::size_t n = 1; n <= 32; ++n)
+    {
+        for (std::size_t arity = 2; arity <= 8; ++arity)
+        {
+            auto groups = get_top_level_groups(n, arity);
+
+            std::size_t effective_arity = (arity > n) ? n : arity;
+            std::size_t division_steps = n / effective_arity;
+            std::size_t remainder = n % effective_arity;
+
+            HPX_TEST_EQ(groups.size(), effective_arity);
+
+            std::size_t offset = 0;
+            for (std::size_t i = 0; i != effective_arity; ++i)
+            {
+                std::size_t expected_size =
+                    division_steps + (i < remainder ? 1 : 0);
+                HPX_TEST_EQ(groups[i].left, offset);
+                HPX_TEST_EQ(groups[i].size, expected_size);
+                HPX_TEST_EQ(groups[i].right, offset + expected_size - 1);
+                offset += expected_size;
+            }
+        }
+    }
+}
+
+int hpx_main()
+{
+    test_balanced_arity2();
+    test_balanced_arity4();
+    test_unbalanced_n11_arity4();
+    test_unbalanced_n7_arity3();
+    test_arity_exceeds_n();
+    test_single_site();
+    test_coverage_property();
+    test_classify_site_basic();
+    test_classify_site_exhaustive();
+    test_matches_recursive_fill();
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> const cfg = {"hpx.run_hpx_main!=1"};
+
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ(hpx::init(argc, argv, init_args), 0);
+    return hpx::util::report_errors();
+}
+
+#endif

--- a/libs/full/collectives/tests/unit/hierarchical_helpers.cpp
+++ b/libs/full/collectives/tests/unit/hierarchical_helpers.cpp
@@ -152,14 +152,14 @@ void test_classify_site_basic()
 {
     auto groups = get_top_level_groups(11, 4);
 
-    HPX_TEST_EQ(classify_site(0, groups), static_cast<std::size_t>(0));
-    HPX_TEST_EQ(classify_site(1, groups), static_cast<std::size_t>(0));
-    HPX_TEST_EQ(classify_site(2, groups), static_cast<std::size_t>(0));
-    HPX_TEST_EQ(classify_site(3, groups), static_cast<std::size_t>(1));
-    HPX_TEST_EQ(classify_site(5, groups), static_cast<std::size_t>(1));
-    HPX_TEST_EQ(classify_site(6, groups), static_cast<std::size_t>(2));
-    HPX_TEST_EQ(classify_site(9, groups), static_cast<std::size_t>(3));
-    HPX_TEST_EQ(classify_site(10, groups), static_cast<std::size_t>(3));
+    HPX_TEST_EQ(classify_site(0, groups), static_cast<std::ptrdiff_t>(0));
+    HPX_TEST_EQ(classify_site(1, groups), static_cast<std::ptrdiff_t>(0));
+    HPX_TEST_EQ(classify_site(2, groups), static_cast<std::ptrdiff_t>(0));
+    HPX_TEST_EQ(classify_site(3, groups), static_cast<std::ptrdiff_t>(1));
+    HPX_TEST_EQ(classify_site(5, groups), static_cast<std::ptrdiff_t>(1));
+    HPX_TEST_EQ(classify_site(6, groups), static_cast<std::ptrdiff_t>(2));
+    HPX_TEST_EQ(classify_site(9, groups), static_cast<std::ptrdiff_t>(3));
+    HPX_TEST_EQ(classify_site(10, groups), static_cast<std::ptrdiff_t>(3));
 }
 
 void test_classify_site_exhaustive()
@@ -173,8 +173,8 @@ void test_classify_site_exhaustive()
 
             for (std::size_t site = 0; site != n; ++site)
             {
-                std::size_t g = classify_site(site, groups);
-                HPX_TEST_NEQ(g, static_cast<std::size_t>(-1));
+                std::ptrdiff_t g = classify_site(site, groups);
+                HPX_TEST_NEQ(g, static_cast<std::ptrdiff_t>(-1));
                 HPX_TEST(site >= groups[g].left && site <= groups[g].right);
             }
         }

--- a/libs/full/collectives/tests/unit/hierarchical_helpers.cpp
+++ b/libs/full/collectives/tests/unit/hierarchical_helpers.cpp
@@ -11,7 +11,7 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/modules/testing.hpp>
 
-#include <hpx/collectives/detail/hierarchical_helpers.hpp>
+#include <hpx/modules/collectives.hpp>
 
 #include <cstddef>
 #include <numeric>

--- a/libs/full/collectives/tests/unit/subtree_gather_scatter.cpp
+++ b/libs/full/collectives/tests/unit/subtree_gather_scatter.cpp
@@ -12,9 +12,6 @@
 #include <hpx/modules/collectives.hpp>
 #include <hpx/modules/testing.hpp>
 
-#include <hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp>
-#include <hpx/collectives/detail/hierarchical_helpers.hpp>
-
 #include <cstdint>
 #include <string>
 #include <utility>

--- a/libs/full/collectives/tests/unit/subtree_gather_scatter.cpp
+++ b/libs/full/collectives/tests/unit/subtree_gather_scatter.cpp
@@ -44,13 +44,12 @@ void test_round_trip(std::uint32_t num_sites, int arity)
     {
         sites.push_back(hpx::async([=]() {
             std::string basename(subtree_gs_basename);
-            basename += std::to_string(num_sites) + "_" +
-                std::to_string(arity) + "/";
+            basename +=
+                std::to_string(num_sites) + "_" + std::to_string(arity) + "/";
 
             auto const comms = create_hierarchical_communicator(
-                basename.c_str(), num_sites_arg(num_sites),
-                this_site_arg(site), arity_arg(arity),
-                generation_arg(), root_site_arg(),
+                basename.c_str(), num_sites_arg(num_sites), this_site_arg(site),
+                arity_arg(arity), generation_arg(), root_site_arg(),
                 flat_fallback_threshold_arg(0));
 
             auto [ns, ts] = comms.get_info();
@@ -65,10 +64,8 @@ void test_round_trip(std::uint32_t num_sites, int arity)
                 if (is_rep)
                 {
                     // Gather: collect subtree data.
-                    auto gathered =
-                        detail::subtree_gather_at_top_rep(comms,
-                            std::uint32_t(site),
-                            generation_arg(gather_gen));
+                    auto gathered = detail::subtree_gather_at_top_rep(
+                        comms, std::uint32_t(site), generation_arg(gather_gen));
 
                     // Verify: gathered should contain contiguous site ids.
                     auto groups =
@@ -80,21 +77,19 @@ void test_round_trip(std::uint32_t num_sites, int arity)
                     for (std::size_t j = 0; j != gathered.size(); ++j)
                     {
                         HPX_TEST_EQ(gathered[j],
-                            static_cast<std::uint32_t>(
-                                groups[gidx].left + j));
+                            static_cast<std::uint32_t>(groups[gidx].left + j));
                     }
 
                     // Scatter: send each site its value back.
                     auto my_val = detail::subtree_scatter_at_top_rep(
-                        comms, HPX_MOVE(gathered),
-                        generation_arg(scatter_gen));
+                        comms, HPX_MOVE(gathered), generation_arg(scatter_gen));
                     HPX_TEST_EQ(my_val, site);
                 }
                 else
                 {
                     // Send our value to the rep.
-                    detail::subtree_send_to_top_rep(comms,
-                        std::uint32_t(site), generation_arg(gather_gen));
+                    detail::subtree_send_to_top_rep(
+                        comms, std::uint32_t(site), generation_arg(gather_gen));
 
                     // Receive our value back.
                     auto my_val =
@@ -127,9 +122,8 @@ void test_vector_payload(std::uint32_t num_sites, int arity)
                 std::to_string(arity) + "/";
 
             auto const comms = create_hierarchical_communicator(
-                basename.c_str(), num_sites_arg(num_sites),
-                this_site_arg(site), arity_arg(arity),
-                generation_arg(), root_site_arg(),
+                basename.c_str(), num_sites_arg(num_sites), this_site_arg(site),
+                arity_arg(arity), generation_arg(), root_site_arg(),
                 flat_fallback_threshold_arg(0));
 
             auto [ns, ts] = comms.get_info();
@@ -144,9 +138,8 @@ void test_vector_payload(std::uint32_t num_sites, int arity)
                 // Gather: each site contributes a vector<uint32_t>.
                 // gather_data flattens one nesting level per gather step,
                 // so the result is vector<vector<uint32_t>>.
-                auto gathered =
-                    detail::subtree_gather_at_top_rep(comms,
-                        HPX_MOVE(my_data), generation_arg(1));
+                auto gathered = detail::subtree_gather_at_top_rep(
+                    comms, HPX_MOVE(my_data), generation_arg(1));
 
                 auto groups =
                     detail::get_top_level_groups(ns, comms.get_arity());
@@ -163,8 +156,8 @@ void test_vector_payload(std::uint32_t num_sites, int arity)
                 {
                     std::uint32_t expected_site =
                         static_cast<std::uint32_t>(groups[gidx].left + j);
-                    HPX_TEST_EQ(gathered[j].size(),
-                        static_cast<std::size_t>(3));
+                    HPX_TEST_EQ(
+                        gathered[j].size(), static_cast<std::size_t>(3));
                     HPX_TEST_EQ(gathered[j][0], expected_site * 10);
                     HPX_TEST_EQ(gathered[j][1], expected_site * 10 + 1);
                     HPX_TEST_EQ(gathered[j][2], expected_site * 10 + 2);
@@ -186,10 +179,8 @@ void test_vector_payload(std::uint32_t num_sites, int arity)
                 detail::subtree_send_to_top_rep(
                     comms, HPX_MOVE(my_data), generation_arg(1));
 
-                auto my_result =
-                    detail::subtree_receive_from_top_rep<
-                        std::vector<std::uint32_t>>(
-                        comms, generation_arg(2));
+                auto my_result = detail::subtree_receive_from_top_rep<
+                    std::vector<std::uint32_t>>(comms, generation_arg(2));
 
                 HPX_TEST_EQ(my_result.size(), static_cast<std::size_t>(3));
                 HPX_TEST_EQ(my_result[0], site * 10);

--- a/libs/full/collectives/tests/unit/subtree_gather_scatter.cpp
+++ b/libs/full/collectives/tests/unit/subtree_gather_scatter.cpp
@@ -1,0 +1,247 @@
+//  Copyright (c) 2026 Anshuman Agrawal
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/modules/collectives.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp>
+#include <hpx/collectives/detail/hierarchical_helpers.hpp>
+
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace hpx::collectives;
+
+constexpr char const* subtree_gs_basename = "/test/subtree_gs/";
+
+#if defined(HPX_DEBUG)
+constexpr int ITERATIONS = 10;
+#else
+constexpr int ITERATIONS = 50;
+#endif
+
+///////////////////////////////////////////////////////////////////////////
+// Test: gather to rep then scatter back (round-trip), scalar payload.
+// Each site contributes its site id. After gather, the rep should hold
+// [left, left+1, ..., right]. After scatter, each site should get its
+// own id back.
+void test_round_trip(std::uint32_t num_sites, int arity)
+{
+    std::vector<hpx::future<void>> sites;
+    sites.reserve(num_sites);
+
+    for (std::uint32_t site = 0; site != num_sites; ++site)
+    {
+        sites.push_back(hpx::async([=]() {
+            std::string basename(subtree_gs_basename);
+            basename += std::to_string(num_sites) + "_" +
+                std::to_string(arity) + "/";
+
+            auto const comms = create_hierarchical_communicator(
+                basename.c_str(), num_sites_arg(num_sites),
+                this_site_arg(site), arity_arg(arity),
+                generation_arg(), root_site_arg(),
+                flat_fallback_threshold_arg(0));
+
+            auto [ns, ts] = comms.get_info();
+            bool const is_rep =
+                detail::is_top_level_rep(ts, ns, comms.get_arity());
+
+            for (int iter = 0; iter != ITERATIONS; ++iter)
+            {
+                std::size_t const gather_gen = iter * 2 + 1;
+                std::size_t const scatter_gen = iter * 2 + 2;
+
+                if (is_rep)
+                {
+                    // Gather: collect subtree data.
+                    auto gathered =
+                        detail::subtree_gather_at_top_rep(comms,
+                            std::uint32_t(site),
+                            generation_arg(gather_gen));
+
+                    // Verify: gathered should contain contiguous site ids.
+                    auto groups =
+                        detail::get_top_level_groups(ns, comms.get_arity());
+                    auto gidx = detail::classify_site(ts, groups);
+
+                    HPX_TEST_EQ(gathered.size(),
+                        static_cast<std::size_t>(groups[gidx].size));
+                    for (std::size_t j = 0; j != gathered.size(); ++j)
+                    {
+                        HPX_TEST_EQ(gathered[j],
+                            static_cast<std::uint32_t>(
+                                groups[gidx].left + j));
+                    }
+
+                    // Scatter: send each site its value back.
+                    auto my_val = detail::subtree_scatter_at_top_rep(
+                        comms, HPX_MOVE(gathered),
+                        generation_arg(scatter_gen));
+                    HPX_TEST_EQ(my_val, site);
+                }
+                else
+                {
+                    // Send our value to the rep.
+                    detail::subtree_send_to_top_rep(comms,
+                        std::uint32_t(site), generation_arg(gather_gen));
+
+                    // Receive our value back.
+                    auto my_val =
+                        detail::subtree_receive_from_top_rep<std::uint32_t>(
+                            comms, generation_arg(scatter_gen));
+                    HPX_TEST_EQ(my_val, site);
+                }
+            }
+        }));
+    }
+
+    hpx::wait_all(std::move(sites));
+}
+
+///////////////////////////////////////////////////////////////////////////
+// Test: vector payload round-trip. Each site contributes a vector<uint32_t>
+// of size 3: {site*10, site*10+1, site*10+2}. After gather, the rep should
+// have a flat vector of all contributions. After scatter, each site should
+// get its original vector back.
+void test_vector_payload(std::uint32_t num_sites, int arity)
+{
+    std::vector<hpx::future<void>> sites;
+    sites.reserve(num_sites);
+
+    for (std::uint32_t site = 0; site != num_sites; ++site)
+    {
+        sites.push_back(hpx::async([=]() {
+            std::string basename(subtree_gs_basename);
+            basename += "vec_" + std::to_string(num_sites) + "_" +
+                std::to_string(arity) + "/";
+
+            auto const comms = create_hierarchical_communicator(
+                basename.c_str(), num_sites_arg(num_sites),
+                this_site_arg(site), arity_arg(arity),
+                generation_arg(), root_site_arg(),
+                flat_fallback_threshold_arg(0));
+
+            auto [ns, ts] = comms.get_info();
+            bool const is_rep =
+                detail::is_top_level_rep(ts, ns, comms.get_arity());
+
+            std::vector<std::uint32_t> my_data = {
+                site * 10, site * 10 + 1, site * 10 + 2};
+
+            if (is_rep)
+            {
+                // Gather: each site contributes a vector<uint32_t>.
+                // gather_data flattens one nesting level per gather step,
+                // so the result is vector<vector<uint32_t>>.
+                auto gathered =
+                    detail::subtree_gather_at_top_rep(comms,
+                        HPX_MOVE(my_data), generation_arg(1));
+
+                auto groups =
+                    detail::get_top_level_groups(ns, comms.get_arity());
+                auto gidx = detail::classify_site(ts, groups);
+
+                // gathered is vector<vector<uint32_t>> with one entry
+                // per subtree site (gather_data flattens one level per
+                // gather step, preserving inner vectors).
+                HPX_TEST_EQ(gathered.size(),
+                    static_cast<std::size_t>(groups[gidx].size));
+
+                // Verify values.
+                for (std::size_t j = 0; j != groups[gidx].size; ++j)
+                {
+                    std::uint32_t expected_site =
+                        static_cast<std::uint32_t>(groups[gidx].left + j);
+                    HPX_TEST_EQ(gathered[j].size(),
+                        static_cast<std::size_t>(3));
+                    HPX_TEST_EQ(gathered[j][0], expected_site * 10);
+                    HPX_TEST_EQ(gathered[j][1], expected_site * 10 + 1);
+                    HPX_TEST_EQ(gathered[j][2], expected_site * 10 + 2);
+                }
+
+                // Scatter: gathered is already vector<vector<uint32_t>>,
+                // which is the right shape for scatter (one entry per
+                // subtree site). Pass directly.
+                auto my_result = detail::subtree_scatter_at_top_rep(
+                    comms, HPX_MOVE(gathered), generation_arg(2));
+
+                HPX_TEST_EQ(my_result.size(), static_cast<std::size_t>(3));
+                HPX_TEST_EQ(my_result[0], site * 10);
+                HPX_TEST_EQ(my_result[1], site * 10 + 1);
+                HPX_TEST_EQ(my_result[2], site * 10 + 2);
+            }
+            else
+            {
+                detail::subtree_send_to_top_rep(
+                    comms, HPX_MOVE(my_data), generation_arg(1));
+
+                auto my_result =
+                    detail::subtree_receive_from_top_rep<
+                        std::vector<std::uint32_t>>(
+                        comms, generation_arg(2));
+
+                HPX_TEST_EQ(my_result.size(), static_cast<std::size_t>(3));
+                HPX_TEST_EQ(my_result[0], site * 10);
+                HPX_TEST_EQ(my_result[1], site * 10 + 1);
+                HPX_TEST_EQ(my_result[2], site * 10 + 2);
+            }
+        }));
+    }
+
+    hpx::wait_all(std::move(sites));
+}
+
+int hpx_main()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        // Balanced, power-of-arity cases.
+        for (auto num_sites : {2u, 4u, 8u, 16u})
+        {
+            for (int arity : {2, 4})
+            {
+                test_round_trip(num_sites, arity);
+            }
+        }
+
+        // Unbalanced, non-power-of-arity cases.
+        for (auto num_sites : {3u, 5u, 7u, 9u, 11u})
+        {
+            for (int arity : {2, 3, 4})
+            {
+                test_round_trip(num_sites, arity);
+            }
+        }
+
+        // Vector payload tests.
+        test_vector_payload(8, 2);
+        test_vector_payload(11, 4);
+        test_vector_payload(5, 2);
+    }
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> const cfg = {"hpx.run_hpx_main!=1"};
+
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ(hpx::init(argc, argv, init_args), 0);
+    return hpx::util::report_errors();
+}
+
+#endif

--- a/libs/full/collectives/tests/unit/subtree_gather_scatter.cpp
+++ b/libs/full/collectives/tests/unit/subtree_gather_scatter.cpp
@@ -82,7 +82,8 @@ void test_round_trip(std::uint32_t num_sites, int arity)
 
                     // Scatter: send each site its value back.
                     auto my_val = detail::subtree_scatter_at_top_rep(
-                        comms, HPX_MOVE(gathered), generation_arg(scatter_gen));
+                        comms, HPX_MOVE(gathered), generation_arg(scatter_gen))
+                                      .get();
                     HPX_TEST_EQ(my_val, site);
                 }
                 else
@@ -94,7 +95,8 @@ void test_round_trip(std::uint32_t num_sites, int arity)
                     // Receive our value back.
                     auto my_val =
                         detail::subtree_receive_from_top_rep<std::uint32_t>(
-                            comms, generation_arg(scatter_gen));
+                            comms, generation_arg(scatter_gen))
+                            .get();
                     HPX_TEST_EQ(my_val, site);
                 }
             }
@@ -167,7 +169,8 @@ void test_vector_payload(std::uint32_t num_sites, int arity)
                 // which is the right shape for scatter (one entry per
                 // subtree site). Pass directly.
                 auto my_result = detail::subtree_scatter_at_top_rep(
-                    comms, HPX_MOVE(gathered), generation_arg(2));
+                    comms, HPX_MOVE(gathered), generation_arg(2))
+                                     .get();
 
                 HPX_TEST_EQ(my_result.size(), static_cast<std::size_t>(3));
                 HPX_TEST_EQ(my_result[0], site * 10);
@@ -180,7 +183,8 @@ void test_vector_payload(std::uint32_t num_sites, int arity)
                     comms, HPX_MOVE(my_data), generation_arg(1));
 
                 auto my_result = detail::subtree_receive_from_top_rep<
-                    std::vector<std::uint32_t>>(comms, generation_arg(2));
+                    std::vector<std::uint32_t>>(comms, generation_arg(2))
+                                     .get();
 
                 HPX_TEST_EQ(my_result.size(), static_cast<std::size_t>(3));
                 HPX_TEST_EQ(my_result[0], site * 10);


### PR DESCRIPTION
Refs #7200

## Proposed Changes

- add hierarchical `all_to_all` for `hierarchical_communicator`. three phases: subtree gather, representative exchange via flat `all_to_all` on the top communicator, subtree scatter.
- add `detail::get_top_level_groups` and `detail::classify_site` partition helpers. These are extracted from `recursively_fill_communicators` so the factory and all_to_all use the same grouping logic.
- add `subtree_gather_at_top_rep` and `subtree_scatter_at_top_rep`. These are the existing gather_here and scatter_to loops minus the final cross-top call. Other hierarchical collectives can use them later (if needed).
- flat fallback when `communicators.size() == 1`.
- Input validation: rejects default generation, generation 0, wrong vector size.

## Any background context you want to provide?

Design came out of Discussion #7200 with @hkaiser. Prior work in PR #7160 (hierarchical all_reduce/all_gather) and PR #7193 (flat fallback threshold).

The original design note proposed stride-three generation arithmetic. That turned out to be unnecessary. Phases 1 and 3 run on subtree communicators, Phase 2 runs on the top communicator. Different communicators, different gates. So Phases 1 and 2 can share gen `2k-1` on their respective communicators, and Phase 3 takes `2k` on subtree communicators. Stride-two, same as the existing hierarchical collectives. Nothing else needs to change.

Tests:
- Transpose identity (`In[i][j] = encode(i,j)`, check `Out[i][j] = encode(j,i)`)
- Balanced site counts: N = 2, 4, 8, 16 with arity 2, 4
- Unbalanced site counts: N = 3, 5, 7, 9, 11 with arity 2, 3, 4
- Flat fallback path (threshold=1024) and forced tree path (threshold=0)
- Bad inputs (wrong vector size, generation 0, default generation)