### PR TITLE
keep_future: expose empty env

### DIFF
--- a/libs/core/execution/include/hpx/execution/algorithms/keep_future.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/keep_future.hpp
@@ -62,6 +62,7 @@ namespace hpx::execution::experimental {
         struct keep_future_sender_base
         {
             std::decay_t<Future> future;
+            using env_type = hpx::execution::experimental::empty_env;
             using completion_signatures =
                 hpx::execution::experimental::completion_signatures<
                     hpx::execution::experimental::set_value_t(
@@ -69,6 +70,11 @@ namespace hpx::execution::experimental {
                     hpx::execution::experimental::set_error_t(
                         std::exception_ptr),
                     hpx::execution::experimental::set_stopped_t()>;
+
+            constexpr env_type get_env() const noexcept
+            {
+                return {};
+            }
         };
 
         HPX_CXX_CORE_EXPORT template <typename Future>

--- a/libs/core/execution/tests/unit/algorithm_run_loop.cpp
+++ b/libs/core/execution/tests/unit/algorithm_run_loop.cpp
@@ -1385,7 +1385,7 @@ void test_detach()
 
 void test_keep_future_sender()
 {
-    // the future should be passed to then, not it's contained value
+    // the future should be passed to then, not its contained value
     {
         auto sender = ex::keep_future(hpx::make_ready_future<void>());
         static_assert(ex::is_sender_v<decltype(sender)>);
@@ -1393,7 +1393,7 @@ void test_keep_future_sender()
             std::is_same_v<decltype(ex::get_env(sender)), ex::empty_env>);
     }
 
-    // the future should be passed to then, not it's contained value
+    // the future should be passed to then, not its contained value
     {
         ex::run_loop loop;
         auto t = hpx::thread([&] { loop.run(); });

--- a/libs/core/execution/tests/unit/algorithm_run_loop.cpp
+++ b/libs/core/execution/tests/unit/algorithm_run_loop.cpp
@@ -1387,6 +1387,13 @@ void test_keep_future_sender()
 {
     // the future should be passed to then, not it's contained value
     {
+        auto sender = ex::keep_future(hpx::make_ready_future<void>());
+        static_assert(
+            std::is_same_v<decltype(ex::get_env(sender)), ex::empty_env>);
+    }
+
+    // the future should be passed to then, not it's contained value
+    {
         ex::run_loop loop;
         auto t = hpx::thread([&] { loop.run(); });
         [[maybe_unused]] auto sched = loop.get_scheduler();

--- a/libs/core/execution/tests/unit/algorithm_run_loop.cpp
+++ b/libs/core/execution/tests/unit/algorithm_run_loop.cpp
@@ -1388,6 +1388,7 @@ void test_keep_future_sender()
     // the future should be passed to then, not it's contained value
     {
         auto sender = ex::keep_future(hpx::make_ready_future<void>());
+        static_assert(ex::is_sender_v<decltype(sender)>);
         static_assert(
             std::is_same_v<decltype(ex::get_env(sender)), ex::empty_env>);
     }


### PR DESCRIPTION
## Proposed Changes

- Add `get_env()` to `keep_future_sender_base` so `keep_future(...)` exposes an empty sender environment.
- Add a regression test in `algorithm_run_loop.cpp` to verify `ex::get_env(ex::keep_future(...))` returns `ex::empty_env`.
- Keep the existing `keep_future` sender behavior unchanged for value propagation.

## Any background context you want to provide?

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
