### PR TITLE
execution_base: trim leftover trait glue

### DIFF
--- a/libs/core/execution_base/include/hpx/execution_base/completion_signatures.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/completion_signatures.hpp
@@ -39,9 +39,72 @@ namespace hpx::execution::experimental {
         empty_variant() = delete;
     };
 
-    // Compatibility alias retained for existing bulk sender code.
-    template <typename... Ts>
-    using decayed_tuple = stdexec::__decayed_tuple<Ts...>;
+    namespace detail {
+
+        // use this remove_cv_ref instead of std::decay to avoid
+        // decaying function types, e.g. set_value_t() -> set_value_t(*)()
+        HPX_CXX_CORE_EXPORT template <typename T>
+        struct remove_cv_ref
+        {
+            using type = std::remove_cv_t<std::remove_reference_t<T>>;
+        };
+
+        HPX_CXX_CORE_EXPORT template <typename T>
+        using remove_cv_ref_t = meta::type<remove_cv_ref<T>>;
+
+        // clang-format off
+
+        // If sizeof...(Ts) is greater than zero, variant-or-empty<Ts...> names
+        // the type variant<Us...> where Us... is the pack decay_t<Ts>... with
+        // duplicate types removed.
+        HPX_CXX_CORE_EXPORT template <template <typename...> typename Variant>
+        struct decay_variant_or_empty
+        {
+            template <typename... Ts>
+            using apply = meta::invoke<
+                meta::if_<meta::bool_<sizeof...(Ts) != 0>,
+                    meta::transform<
+                        meta::func1<remove_cv_ref_t>,
+                        meta::unique<meta::func<Variant>>>,
+                    meta::constant<empty_variant>>,
+                Ts...>;
+        };
+
+        HPX_CXX_CORE_EXPORT template <template <typename...> typename Variant>
+        struct decay_variant
+        {
+            template <typename... Ts>
+            using apply = meta::invoke<
+                meta::transform<
+                    meta::func1<remove_cv_ref_t>,
+                    meta::unique<meta::func<Variant>>>,
+                Ts...>;
+        };
+
+        HPX_CXX_CORE_EXPORT template <template <typename...> typename Variant>
+        struct unique_variant
+        {
+            template <typename... Ts>
+            using apply =
+                meta::invoke<meta::unique<meta::func<Variant>>, Ts...>;
+        };
+        // clang-format on
+
+        HPX_CXX_CORE_EXPORT template <typename... Ts>
+        using decayed_variant =
+            meta::invoke<decay_variant_or_empty<hpx::variant>, Ts...>;
+
+        HPX_CXX_CORE_EXPORT template <template <typename...> typename Tuple>
+        struct decay_tuple
+        {
+            template <typename... Ts>
+            using apply = Tuple<remove_cv_ref_t<Ts>...>;
+        };
+
+        HPX_CXX_CORE_EXPORT template <typename... Ts>
+        using decayed_tuple = meta::invoke<decay_tuple<hpx::tuple>, Ts...>;
+
+    }    // namespace detail
 
     // A sender is a type that is describing an asynchronous operation. The
     // operation itself might not have started yet. In order to get the result
@@ -102,10 +165,33 @@ namespace hpx::execution::experimental {
     inline constexpr bool is_sender_of_v =
         is_sender_of<Sender, Signal, Env>::value;
 
+    namespace detail {
+        template <typename ValueTypes>
+        struct single_sender_value;
+
+        template <>
+        struct single_sender_value<hpx::variant<>>
+        {
+            using type = void;
+        };
+
+        template <>
+        struct single_sender_value<hpx::variant<hpx::tuple<>>>
+        {
+            using type = void;
+        };
+
+        template <typename T>
+        struct single_sender_value<hpx::variant<hpx::tuple<T>>>
+        {
+            using type = T;
+        };
+    }    // namespace detail
+
     template <typename Sender,
         typename Env = hpx::execution::experimental::empty_env>
-    using single_sender_value_t = stdexec::__single_sender_value_t<
-        value_types_of_t<Sender, Env, hpx::tuple, hpx::variant>>;
+    using single_sender_value_t = typename detail::single_sender_value<
+        value_types_of_t<Sender, Env, hpx::tuple, hpx::variant>>::type;
 
     HPX_CXX_CORE_EXPORT template <typename A, typename B>
     inline constexpr bool is_derived_from_v = std::derived_from<A, B>;

--- a/libs/core/execution_base/include/hpx/execution_base/completion_signatures.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/completion_signatures.hpp
@@ -39,72 +39,9 @@ namespace hpx::execution::experimental {
         empty_variant() = delete;
     };
 
-    namespace detail {
-
-        // use this remove_cv_ref instead of std::decay to avoid
-        // decaying function types, e.g. set_value_t() -> set_value_t(*)()
-        HPX_CXX_CORE_EXPORT template <typename T>
-        struct remove_cv_ref
-        {
-            using type = std::remove_cv_t<std::remove_reference_t<T>>;
-        };
-
-        HPX_CXX_CORE_EXPORT template <typename T>
-        using remove_cv_ref_t = meta::type<remove_cv_ref<T>>;
-
-        // clang-format off
-
-        // If sizeof...(Ts) is greater than zero, variant-or-empty<Ts...> names
-        // the type variant<Us...> where Us... is the pack decay_t<Ts>... with
-        // duplicate types removed.
-        HPX_CXX_CORE_EXPORT template <template <typename...> typename Variant>
-        struct decay_variant_or_empty
-        {
-            template <typename... Ts>
-            using apply = meta::invoke<
-                meta::if_<meta::bool_<sizeof...(Ts) != 0>,
-                    meta::transform<
-                        meta::func1<remove_cv_ref_t>,
-                        meta::unique<meta::func<Variant>>>,
-                    meta::constant<empty_variant>>,
-                Ts...>;
-        };
-
-        HPX_CXX_CORE_EXPORT template <template <typename...> typename Variant>
-        struct decay_variant
-        {
-            template <typename... Ts>
-            using apply = meta::invoke<
-                meta::transform<
-                    meta::func1<remove_cv_ref_t>,
-                    meta::unique<meta::func<Variant>>>,
-                Ts...>;
-        };
-
-        HPX_CXX_CORE_EXPORT template <template <typename...> typename Variant>
-        struct unique_variant
-        {
-            template <typename... Ts>
-            using apply =
-                meta::invoke<meta::unique<meta::func<Variant>>, Ts...>;
-        };
-        // clang-format on
-
-        HPX_CXX_CORE_EXPORT template <typename... Ts>
-        using decayed_variant =
-            meta::invoke<decay_variant_or_empty<hpx::variant>, Ts...>;
-
-        HPX_CXX_CORE_EXPORT template <template <typename...> typename Tuple>
-        struct decay_tuple
-        {
-            template <typename... Ts>
-            using apply = Tuple<remove_cv_ref_t<Ts>...>;
-        };
-
-        HPX_CXX_CORE_EXPORT template <typename... Ts>
-        using decayed_tuple = meta::invoke<decay_tuple<hpx::tuple>, Ts...>;
-
-    }    // namespace detail
+    // Compatibility alias retained for existing bulk sender code.
+    template <typename... Ts>
+    using decayed_tuple = stdexec::__decayed_tuple<Ts...>;
 
     // A sender is a type that is describing an asynchronous operation. The
     // operation itself might not have started yet. In order to get the result
@@ -165,45 +102,10 @@ namespace hpx::execution::experimental {
     inline constexpr bool is_sender_of_v =
         is_sender_of<Sender, Signal, Env>::value;
 
-    // As outlined in the original implementation:
-    //
-    // Alias template single-sender-value-type is defined as follows:
-    //
-    // 1. If value_types_of_t<S, E, Tuple, Variant> would have the form
-    // Variant<Tuple<T>>, then single-sender-value-type<S, E> is an alias for
-    // type T.
-    // 2. Otherwise, if value_types_of_t<S, E, Tuple, Variant> would
-    // have the form Variant<Tuple<>> or Variant<>, then
-    // single-sender-value-type<S, E> is an alias for type void.
-    // 3. Otherwise, single-sender-value-type<S, E> is ill-formed.
-    //
-    namespace detail {
-        template <typename ValueTypes>
-        struct single_sender_value;
-
-        template <>
-        struct single_sender_value<hpx::variant<>>
-        {
-            using type = void;
-        };
-
-        template <>
-        struct single_sender_value<hpx::variant<hpx::tuple<>>>
-        {
-            using type = void;
-        };
-
-        template <typename T>
-        struct single_sender_value<hpx::variant<hpx::tuple<T>>>
-        {
-            using type = T;
-        };
-    }    // namespace detail
-
     template <typename Sender,
         typename Env = hpx::execution::experimental::empty_env>
-    using single_sender_value_t = typename detail::single_sender_value<
-        value_types_of_t<Sender, Env, hpx::tuple, hpx::variant>>::type;
+    using single_sender_value_t = stdexec::__single_sender_value_t<
+        value_types_of_t<Sender, Env, hpx::tuple, hpx::variant>>;
 
     HPX_CXX_CORE_EXPORT template <typename A, typename B>
     inline constexpr bool is_derived_from_v = std::derived_from<A, B>;

--- a/libs/core/execution_base/include/hpx/execution_base/receiver.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/receiver.hpp
@@ -15,13 +15,18 @@
 namespace hpx::execution::experimental {
 
     template <typename Receiver>
-    using is_receiver = std::bool_constant<receiver<Receiver>>;
+    struct is_receiver : std::bool_constant<receiver<Receiver>>
+    {
+    };
 
     HPX_CXX_CORE_EXPORT template <typename Receiver>
     inline constexpr bool is_receiver_v = is_receiver<Receiver>::value;
 
     template <typename Receiver, typename Completions>
-    using is_receiver_of = std::bool_constant<receiver_of<Receiver, Completions>>;
+    struct is_receiver_of
+      : std::bool_constant<receiver_of<Receiver, Completions>>
+    {
+    };
 
     HPX_CXX_CORE_EXPORT template <typename Receiver, typename Completions>
     inline constexpr bool is_receiver_of_v =
@@ -30,8 +35,15 @@ namespace hpx::execution::experimental {
     namespace detail {
 
         template <typename CPO>
-        inline constexpr bool is_receiver_cpo_v = std::is_same_v<CPO, set_value_t> ||
-            std::is_same_v<CPO, set_error_t> || std::is_same_v<CPO, set_stopped_t>;
+        struct is_receiver_cpo
+          : std::bool_constant<std::is_same_v<CPO, set_value_t> ||
+                std::is_same_v<CPO, set_error_t> ||
+                std::is_same_v<CPO, set_stopped_t>>
+        {
+        };
+
+        template <typename CPO>
+        inline constexpr bool is_receiver_cpo_v = is_receiver_cpo<CPO>::value;
     }    // namespace detail
 
 }    // namespace hpx::execution::experimental

--- a/libs/core/execution_base/include/hpx/execution_base/receiver.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/receiver.hpp
@@ -14,19 +14,14 @@
 
 namespace hpx::execution::experimental {
 
-    HPX_CXX_CORE_EXPORT template <typename Receiver>
-    struct is_receiver : std::bool_constant<receiver<Receiver>>
-    {
-    };
+    template <typename Receiver>
+    using is_receiver = std::bool_constant<receiver<Receiver>>;
 
     HPX_CXX_CORE_EXPORT template <typename Receiver>
     inline constexpr bool is_receiver_v = is_receiver<Receiver>::value;
 
-    HPX_CXX_CORE_EXPORT template <typename Receiver, typename Completions>
-    struct is_receiver_of
-      : std::bool_constant<receiver_of<Receiver, Completions>>
-    {
-    };
+    template <typename Receiver, typename Completions>
+    using is_receiver_of = std::bool_constant<receiver_of<Receiver, Completions>>;
 
     HPX_CXX_CORE_EXPORT template <typename Receiver, typename Completions>
     inline constexpr bool is_receiver_of_v =
@@ -34,17 +29,9 @@ namespace hpx::execution::experimental {
 
     namespace detail {
 
-        // What about this implementation instead of using template specialization?
-        HPX_CXX_CORE_EXPORT template <typename CPO>
-        struct is_receiver_cpo
-          : std::bool_constant<std::is_same_v<CPO, set_value_t> ||
-                std::is_same_v<CPO, set_error_t> ||
-                std::is_same_v<CPO, set_stopped_t>>
-        {
-        };
-
-        HPX_CXX_CORE_EXPORT template <typename CPO>
-        inline constexpr bool is_receiver_cpo_v = is_receiver_cpo<CPO>::value;
+        template <typename CPO>
+        inline constexpr bool is_receiver_cpo_v = std::is_same_v<CPO, set_value_t> ||
+            std::is_same_v<CPO, set_error_t> || std::is_same_v<CPO, set_stopped_t>;
     }    // namespace detail
 
 }    // namespace hpx::execution::experimental


### PR DESCRIPTION
## Proposed Changes

- Trim leftover execution-base trait glue in `completion_signatures.hpp` by delegating `single_sender_value_t` to stdexec and removing the internal helper stack.
- Simplify `receiver.hpp` by turning the receiver helper wrappers into thin aliases and a small constexpr CPO check.
- Keep the existing public HPX compatibility surface intact so downstream executor and run-loop code continues to build and run unchanged.

## Any background context you want to provide?

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
