### PR TITLE
make_future: use run_loop scheduler accessor

### DIFF
--- a/libs/core/execution/include/hpx/execution/algorithms/make_future.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/make_future.hpp
@@ -32,11 +32,15 @@ namespace hpx::execution::experimental {
     // enforce proper formatting
     namespace detail {
 
+        using run_loop_scheduler_type =
+            decltype(std::declval<run_loop>().get_scheduler());
+
         // Recover the parent `run_loop&` from HPX's concrete run-loop
         // scheduler through its public accessor instead of depending on the
         // scheduled sender's environment layout.
         inline hpx::execution::experimental::run_loop&
-        get_run_loop_from_scheduler(run_loop_scheduler const& sched) noexcept
+        get_run_loop_from_scheduler(
+            run_loop_scheduler_type const& sched) noexcept
         {
             return sched.get_run_loop();
         }
@@ -181,8 +185,8 @@ namespace hpx::execution::experimental {
 
             template <typename Sender>
             future_data_with_run_loop(init_no_addref no_addref,
-                other_allocator const& alloc, run_loop_scheduler const& sched,
-                Sender&& sender)
+                other_allocator const& alloc,
+                run_loop_scheduler_type const& sched, Sender&& sender)
               : base_type(no_addref, alloc, HPX_FORWARD(Sender, sender))
               , loop(get_run_loop_from_scheduler(sched))
             {
@@ -292,7 +296,7 @@ namespace hpx::execution::experimental {
 
         ///////////////////////////////////////////////////////////////////////
         HPX_CXX_CORE_EXPORT template <typename Sender, typename Allocator>
-        auto make_future_with_run_loop(run_loop_scheduler const& sched,
+        auto make_future_with_run_loop(run_loop_scheduler_type const& sched,
             Sender&& sender, Allocator const& allocator)
         {
             using allocator_type = Allocator;

--- a/libs/core/execution/include/hpx/execution/algorithms/make_future.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/make_future.hpp
@@ -32,28 +32,15 @@ namespace hpx::execution::experimental {
     // enforce proper formatting
     namespace detail {
 
-        // Recover the parent `run_loop&` from a `run_loop::scheduler`.
-        //
-        // P2300 deliberately does not provide a public API to obtain the owning
-        // `run_loop&` from one of its schedulers. The only way to do this
-        // against the current stdexec implementation is to read the private
-        // `loop` member exposed by the scheduler's environment.
-        //
-        // The parameter is constrained to the concrete `run_loop::scheduler`
-        // type (rather than a generic template) because the implementation
-        // depends on `.loop` being the specific stdexec env layout.
-        // `run_loop::scheduler::schedule()` is `noexcept`, so the unconditional
-        // `noexcept` here is sound. The function is not marked `constexpr`
-        // because the `stdexec::schedule` CPO wrapper is not declared
-        // `constexpr` (GCC strict mode rejects calling it from a constexpr
-        // context, even though the underlying member is constexpr).
+        // Recover the parent `run_loop&` from HPX's concrete run-loop
+        // scheduler through its public accessor instead of depending on the
+        // scheduled sender's environment layout.
         inline hpx::execution::experimental::run_loop&
         get_run_loop_from_scheduler(
             decltype(std::declval<hpx::execution::experimental::run_loop>()
                     .get_scheduler()) const& sched) noexcept
         {
-            return static_cast<hpx::execution::experimental::run_loop&>(
-                *hpx::execution::experimental::get_env(schedule(sched)).loop);
+            return sched.get_run_loop();
         }
 
         template <typename OperationState>

--- a/libs/core/execution/include/hpx/execution/algorithms/make_future.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/make_future.hpp
@@ -296,7 +296,9 @@ namespace hpx::execution::experimental {
 
         ///////////////////////////////////////////////////////////////////////
         HPX_CXX_CORE_EXPORT template <typename Sender, typename Allocator>
-        auto make_future_with_run_loop(run_loop_scheduler_type const& sched,
+        auto make_future_with_run_loop(
+            decltype(std::declval<hpx::execution::experimental::run_loop>()
+                    .get_scheduler()) const& sched,
             Sender&& sender, Allocator const& allocator)
         {
             using allocator_type = Allocator;

--- a/libs/core/execution/include/hpx/execution/algorithms/make_future.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/make_future.hpp
@@ -36,9 +36,7 @@ namespace hpx::execution::experimental {
         // scheduler through its public accessor instead of depending on the
         // scheduled sender's environment layout.
         inline hpx::execution::experimental::run_loop&
-        get_run_loop_from_scheduler(
-            decltype(std::declval<hpx::execution::experimental::run_loop>()
-                    .get_scheduler()) const& sched) noexcept
+        get_run_loop_from_scheduler(run_loop_scheduler const& sched) noexcept
         {
             return sched.get_run_loop();
         }
@@ -183,9 +181,7 @@ namespace hpx::execution::experimental {
 
             template <typename Sender>
             future_data_with_run_loop(init_no_addref no_addref,
-                other_allocator const& alloc,
-                decltype(std::declval<hpx::execution::experimental::run_loop>()
-                        .get_scheduler()) const& sched,
+                other_allocator const& alloc, run_loop_scheduler const& sched,
                 Sender&& sender)
               : base_type(no_addref, alloc, HPX_FORWARD(Sender, sender))
               , loop(get_run_loop_from_scheduler(sched))
@@ -296,9 +292,7 @@ namespace hpx::execution::experimental {
 
         ///////////////////////////////////////////////////////////////////////
         HPX_CXX_CORE_EXPORT template <typename Sender, typename Allocator>
-        auto make_future_with_run_loop(
-            decltype(std::declval<hpx::execution::experimental::run_loop>()
-                    .get_scheduler()) const& sched,
+        auto make_future_with_run_loop(run_loop_scheduler const& sched,
             Sender&& sender, Allocator const& allocator)
         {
             using allocator_type = Allocator;

--- a/libs/core/execution/include/hpx/execution/algorithms/make_future.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/make_future.hpp
@@ -33,14 +33,14 @@ namespace hpx::execution::experimental {
     namespace detail {
 
         using run_loop_scheduler_type =
-            decltype(std::declval<run_loop>().get_scheduler());
+            decltype(std::declval<run_loop&>().get_scheduler());
 
         // Recover the parent `run_loop&` from HPX's concrete run-loop
         // scheduler through its public accessor instead of depending on the
         // scheduled sender's environment layout.
         inline hpx::execution::experimental::run_loop&
-        get_run_loop_from_scheduler(
-            run_loop_scheduler_type const& sched) noexcept
+        get_run_loop_from_scheduler(run_loop_scheduler_type const&
+                sched) noexcept(noexcept(sched.get_run_loop()))
         {
             return sched.get_run_loop();
         }


### PR DESCRIPTION
## Proposed Changes

  - Replace the fragile run-loop recovery in `make_future` with the public `run_loop_scheduler::get_run_loop()` accessor.
  - Avoid depending on the scheduled sender environment layout when constructing run-loop-backed future state.
  - Keep the existing `make_future(sched, sender)` behavior and public API unchanged.
   
## Any background context you want to provide?

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
