### PR TITLE
async_mpi: preserve sender environment

### DIFF
--- a/libs/core/async_mpi/include/hpx/async_mpi/transform_mpi.hpp
+++ b/libs/core/async_mpi/include/hpx/async_mpi/transform_mpi.hpp
@@ -248,6 +248,12 @@ namespace hpx::mpi::experimental {
             }
             // clang-format on
 
+            constexpr auto get_env() const
+                noexcept(noexcept(hpx::execution::experimental::get_env(s)))
+            {
+                return hpx::execution::experimental::get_env(s);
+            }
+
             template <typename R>
             constexpr auto connect(R&& r) &
             {

--- a/libs/core/async_mpi/include/hpx/async_mpi/transform_mpi.hpp
+++ b/libs/core/async_mpi/include/hpx/async_mpi/transform_mpi.hpp
@@ -248,7 +248,7 @@ namespace hpx::mpi::experimental {
             }
             // clang-format on
 
-            constexpr auto get_env() const
+            constexpr decltype(auto) get_env() const
                 noexcept(noexcept(hpx::execution::experimental::get_env(s)))
             {
                 return hpx::execution::experimental::get_env(s);

--- a/libs/core/async_mpi/tests/unit/algorithm_transform_mpi.cpp
+++ b/libs/core/async_mpi/tests/unit/algorithm_transform_mpi.cpp
@@ -17,6 +17,7 @@
 #include <atomic>
 #include <mpi.h>
 #include <string>
+#include <type_traits>
 #include <utility>
 
 namespace ex = hpx::execution::experimental;
@@ -33,8 +34,31 @@ auto tag_invoke(mpi::transform_mpi_t, custom_type<T>& c)
         ex::just(&c.x, 1, MPI_INT, 0, MPI_COMM_WORLD), MPI_Ibcast);
 }
 
+void test_transform_mpi_forwards_env()
+{
+    auto s = ex::schedule(ex::thread_pool_scheduler{});
+    using sender_type = decltype(s);
+    using original_scheduler_type =
+        std::decay_t<decltype(ex::get_completion_scheduler<ex::set_value_t>(
+            ex::get_env(std::declval<sender_type&>())))>;
+
+    auto transformed =
+        mpi::transform_mpi(std::move(s), [](MPI_Request* request) {
+            *request = MPI_REQUEST_NULL;
+            return MPI_SUCCESS;
+        });
+
+    using scheduler_type =
+        std::decay_t<decltype(ex::get_completion_scheduler<ex::set_value_t>(
+            ex::get_env(transformed)))>;
+
+    static_assert(std::is_same_v<scheduler_type, original_scheduler_type>);
+}
+
 int hpx_main()
 {
+    test_transform_mpi_forwards_env();
+
     int size, rank;
     MPI_Comm comm = MPI_COMM_WORLD;
     MPI_Comm_size(comm, &size);


### PR DESCRIPTION
## Proposed Changes

 - Preserve the wrapped sender environment in `async_mpi::transform_mpi_sender`.
 - Add a compile-time regression check that `transform_mpi` keeps the upstream completion scheduler visible.
 - Align `transform_mpi` with the existing `transform_stream` sender environment forwarding behavior.

## Any background context you want to provide?

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
