### PR TITLE
Remove tag_invoke from executor layer CPOs

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/util/adapt_placement_mode.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/adapt_placement_mode.hpp
@@ -19,9 +19,10 @@ namespace hpx::execution::experimental {
         ExPolicy&& policy, hpx::threads::thread_placement_hint placement)
     {
         constexpr bool supports_placement_hint =
-            hpx::functional::is_tag_invocable_v<
+            hpx::execution::experimental::has_query_v<
+                std::decay_t<ExPolicy> const&,
                 hpx::execution::experimental::with_hint_t,
-                std::decay_t<ExPolicy>, hpx::threads::thread_schedule_hint>;
+                hpx::threads::thread_schedule_hint>;
 
         if constexpr (supports_placement_hint)
         {

--- a/libs/core/algorithms/include/hpx/parallel/util/adapt_sharing_mode.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/adapt_sharing_mode.hpp
@@ -20,9 +20,10 @@ namespace hpx::execution::experimental {
         ExPolicy&& policy, hpx::threads::thread_sharing_hint sharing)
     {
         constexpr bool supports_sharing_hint =
-            hpx::functional::is_tag_invocable_v<
+            hpx::execution::experimental::has_query_v<
+                std::decay_t<ExPolicy> const&,
                 hpx::execution::experimental::with_hint_t,
-                std::decay_t<ExPolicy>, hpx::threads::thread_schedule_hint>;
+                hpx::threads::thread_schedule_hint>;
 
         if constexpr (supports_sharing_hint)
         {

--- a/libs/core/algorithms/include/hpx/parallel/util/adapt_thread_priority.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/adapt_thread_priority.hpp
@@ -19,9 +19,11 @@ namespace hpx::execution::experimental {
     decltype(auto) adapt_thread_priority(
         ExPolicy&& policy, hpx::threads::thread_priority new_priority)
     {
-        constexpr bool supports_priority = hpx::functional::is_tag_invocable_v<
-            hpx::execution::experimental::with_priority_t,
-            std::decay_t<ExPolicy>, hpx::threads::thread_priority>;
+        constexpr bool supports_priority =
+            hpx::execution::experimental::has_query_v<
+                std::decay_t<ExPolicy> const&,
+                hpx::execution::experimental::with_priority_t,
+                hpx::threads::thread_priority>;
         // clang-format on
 
         if constexpr (supports_priority)

--- a/libs/core/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
@@ -60,10 +60,10 @@ namespace hpx::parallel::util::detail {
                 hpx::execution::experimental::with_processing_units_count_t{},
                 cores);
         }
-        else if constexpr (hpx::functional::is_tag_invocable_v<
-                               hpx::execution::experimental::
-                                   with_processing_units_count_t,
-                               exec_type, std::size_t>)
+        else if constexpr (
+            hpx::execution::experimental::has_query_v<exec_type const&,
+                hpx::execution::experimental::with_processing_units_count_t,
+                std::size_t>)
         {
             policy = hpx::execution::experimental::create_rebound_policy(policy,
                 hpx::execution::experimental::with_processing_units_count(

--- a/libs/core/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
@@ -56,9 +56,32 @@ namespace hpx::parallel::util::detail {
                                    cores);
                            })
         {
-            policy = policy.query(
+            // For policies that support query(), check if the query returns
+            // a policy with the same executor type. If not (e.g., for
+            // resiliency executors), use the executor's query directly.
+            using queried_policy_type = decltype(policy.query(
                 hpx::execution::experimental::with_processing_units_count_t{},
-                cores);
+                cores));
+            using queried_exec_type =
+                typename std::decay_t<queried_policy_type>::executor_type;
+
+            if constexpr (std::is_same_v<queried_exec_type, exec_type>)
+            {
+                // Same executor type, direct assignment is safe
+                policy = policy.query(hpx::execution::experimental::
+                                          with_processing_units_count_t{},
+                    cores);
+            }
+            else
+            {
+                // Different executor type (e.g., resiliency executor),
+                // use the executor's query and rebound the policy
+                auto updated_exec =
+                    hpx::execution::experimental::with_processing_units_count(
+                        policy.executor(), cores);
+                policy = hpx::execution::experimental::create_rebound_policy(
+                    policy, HPX_MOVE(updated_exec), policy.parameters());
+            }
         }
         else if constexpr (
             hpx::execution::experimental::has_query_v<exec_type const&,

--- a/libs/core/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/util/detail/chunk_size.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2007-2025 Hartmut Kaiser
+//  Copyright (c) 2026 Sai Charan Arvapally
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -75,12 +76,12 @@ namespace hpx::parallel::util::detail {
             else
             {
                 // Different executor type (e.g., resiliency executor),
-                // use the executor's query and rebound the policy
-                auto updated_exec =
-                    hpx::execution::experimental::with_processing_units_count(
-                        policy.executor(), cores);
+                // use the executor's query and rebind the policy
+                auto updated_exec = hpx::experimental::prefer(
+                    hpx::execution::experimental::with_processing_units_count,
+                    policy.executor(), cores);
                 policy = hpx::execution::experimental::create_rebound_policy(
-                    policy, HPX_MOVE(updated_exec), policy.parameters());
+                    policy, HPX_MOVE(updated_exec));
             }
         }
         else if constexpr (
@@ -90,8 +91,7 @@ namespace hpx::parallel::util::detail {
         {
             policy = hpx::execution::experimental::create_rebound_policy(policy,
                 hpx::execution::experimental::with_processing_units_count(
-                    policy.executor(), cores),
-                policy.parameters());
+                    policy.executor(), cores));
         }
     }
 

--- a/libs/core/algorithms/tests/performance/benchmark_merge.cpp
+++ b/libs/core/algorithms/tests/performance/benchmark_merge.cpp
@@ -100,11 +100,9 @@ struct compute_chunk_size
     //}
 
     template <typename Executor>
-    friend std::size_t tag_override_invoke(
-        hpx::execution::experimental::get_chunk_size_t,
-        compute_chunk_size& this_, Executor&,
+    std::size_t get_chunk_size(Executor&&,
         hpx::chrono::steady_duration const&, std::size_t const cores,
-        std::size_t const num_iterations)
+        std::size_t const num_iterations) const
     {
         if (cores == 1)
         {
@@ -115,7 +113,7 @@ struct compute_chunk_size
         // number of chunks the sizes of which are equal (except for the last
         // chunk, which may be smaller by not more than the number of chunks in
         // terms of elements).
-        std::size_t const num_chunks = this_.times_cores_ * cores;
+        std::size_t const num_chunks = times_cores_ * cores;
         std::size_t chunk_size = (num_iterations + num_chunks - 1) / num_chunks;
 
         // we should not consider more chunks than we have elements
@@ -143,9 +141,7 @@ struct hpx::execution::experimental::is_executor_parameters<compute_chunk_size>
 struct enable_fast_idle_mode
 {
     template <typename Executor>
-    friend void tag_override_invoke(
-        hpx::execution::experimental::mark_begin_execution_t,
-        enable_fast_idle_mode, Executor&& exec)
+    void mark_begin_execution(Executor&& exec)
     {
         auto const pu_mask =
             hpx::execution::experimental::get_processing_units_mask(exec);
@@ -162,9 +158,7 @@ struct enable_fast_idle_mode
     }
 
     template <typename Executor>
-    friend void tag_override_invoke(
-        hpx::execution::experimental::mark_end_execution_t,
-        enable_fast_idle_mode, Executor&& exec)
+    void mark_end_execution(Executor&& exec)
     {
         auto const pu_mask =
             hpx::execution::experimental::get_processing_units_mask(exec);

--- a/libs/core/algorithms/tests/performance/benchmark_merge.cpp
+++ b/libs/core/algorithms/tests/performance/benchmark_merge.cpp
@@ -100,9 +100,8 @@ struct compute_chunk_size
     //}
 
     template <typename Executor>
-    std::size_t get_chunk_size(Executor&&,
-        hpx::chrono::steady_duration const&, std::size_t const cores,
-        std::size_t const num_iterations) const
+    std::size_t get_chunk_size(Executor&&, hpx::chrono::steady_duration const&,
+        std::size_t const cores, std::size_t const num_iterations) const
     {
         if (cores == 1)
         {

--- a/libs/core/algorithms/tests/performance/benchmark_merge_sweep.cpp
+++ b/libs/core/algorithms/tests/performance/benchmark_merge_sweep.cpp
@@ -94,22 +94,20 @@ struct adaptive_chunk_size
 
     // calculate number of cores
     template <typename Executor>
-    friend std::size_t tag_override_invoke(
-        hpx::execution::experimental::processing_units_count_t,
-        adaptive_chunk_size& this_, Executor&& exec,
-        hpx::chrono::steady_duration const&, std::size_t count) noexcept
+    std::size_t processing_units_count(Executor&& exec,
+        hpx::chrono::steady_duration const&, std::size_t count) const noexcept
     {
         std::size_t const cores_baseline =
             hpx::execution::experimental::processing_units_count(
-                exec, this_.time_per_iteration_, count);
+                exec, time_per_iteration_, count);
 
         auto const overall_time = static_cast<double>(
-            (count + 1) * this_.time_per_iteration_.count());
+            (count + 1) * time_per_iteration_.count());
 
         constexpr double efficiency_factor = 0.052;    // see paper: 1 / 19
         auto const optimal_num_cores =
             static_cast<std::size_t>(efficiency_factor * overall_time /
-                static_cast<double>(this_.overhead_time_.count()));
+                static_cast<double>(overhead_time_.count()));
 
         std::size_t num_cores = (std::min) (cores_baseline, optimal_num_cores);
         num_cores = (std::max) (num_cores, static_cast<std::size_t>(1));
@@ -118,10 +116,9 @@ struct adaptive_chunk_size
     }
 
     template <typename Executor>
-    friend std::size_t tag_override_invoke(
-        hpx::execution::experimental::get_chunk_size_t, adaptive_chunk_size&,
-        Executor&, hpx::chrono::steady_duration const&, std::size_t const cores,
-        std::size_t const num_iterations)
+    std::size_t get_chunk_size(Executor&&,
+        hpx::chrono::steady_duration const&, std::size_t const cores,
+        std::size_t const num_iterations) const
     {
         if (cores == 1)
         {
@@ -167,9 +164,7 @@ struct hpx::execution::experimental::is_executor_parameters<adaptive_chunk_size>
 struct enable_fast_idle_mode
 {
     template <typename Executor>
-    friend void tag_override_invoke(
-        hpx::execution::experimental::mark_begin_execution_t,
-        enable_fast_idle_mode, Executor&& exec)
+    void mark_begin_execution(Executor&& exec)
     {
         auto const pu_mask =
             hpx::execution::experimental::get_processing_units_mask(exec);
@@ -186,9 +181,7 @@ struct enable_fast_idle_mode
     }
 
     template <typename Executor>
-    friend void tag_override_invoke(
-        hpx::execution::experimental::mark_end_execution_t,
-        enable_fast_idle_mode, Executor&& exec)
+    void mark_end_execution(Executor&& exec)
     {
         auto const pu_mask =
             hpx::execution::experimental::get_processing_units_mask(exec);
@@ -214,19 +207,16 @@ struct force_sequential_execution
     force_sequential_execution() = default;
 
     template <typename Executor>
-    friend constexpr std::size_t tag_override_invoke(
-        hpx::execution::experimental::maximal_number_of_chunks_t,
-        force_sequential_execution, Executor&&, std::size_t const,
-        std::size_t const) noexcept
+    constexpr std::size_t maximal_number_of_chunks(
+        Executor&&, std::size_t const, std::size_t const) const noexcept
     {
         return 1;
     }
 
     template <typename Executor>
-    friend constexpr std::size_t tag_override_invoke(
-        hpx::execution::experimental::processing_units_count_t,
-        force_sequential_execution, Executor&&,
-        hpx::chrono::steady_duration const&, std::size_t const) noexcept
+    constexpr std::size_t processing_units_count(Executor&&,
+        hpx::chrono::steady_duration const&,
+        std::size_t const) const noexcept
     {
         return 1;
     }

--- a/libs/core/algorithms/tests/performance/benchmark_merge_sweep.cpp
+++ b/libs/core/algorithms/tests/performance/benchmark_merge_sweep.cpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2025 Hartmut Kaiser
+//  Copyright (c) 2026 Sai Charan Arvapally
 //  Copyright (c) 2017 Taeguk Kwon
 //
 //  SPDX-License-Identifier: BSL-1.0

--- a/libs/core/algorithms/tests/performance/benchmark_merge_sweep.cpp
+++ b/libs/core/algorithms/tests/performance/benchmark_merge_sweep.cpp
@@ -101,8 +101,8 @@ struct adaptive_chunk_size
             hpx::execution::experimental::processing_units_count(
                 exec, time_per_iteration_, count);
 
-        auto const overall_time = static_cast<double>(
-            (count + 1) * time_per_iteration_.count());
+        auto const overall_time =
+            static_cast<double>((count + 1) * time_per_iteration_.count());
 
         constexpr double efficiency_factor = 0.052;    // see paper: 1 / 19
         auto const optimal_num_cores =
@@ -116,9 +116,8 @@ struct adaptive_chunk_size
     }
 
     template <typename Executor>
-    std::size_t get_chunk_size(Executor&&,
-        hpx::chrono::steady_duration const&, std::size_t const cores,
-        std::size_t const num_iterations) const
+    std::size_t get_chunk_size(Executor&&, hpx::chrono::steady_duration const&,
+        std::size_t const cores, std::size_t const num_iterations) const
     {
         if (cores == 1)
         {
@@ -215,8 +214,7 @@ struct force_sequential_execution
 
     template <typename Executor>
     constexpr std::size_t processing_units_count(Executor&&,
-        hpx::chrono::steady_duration const&,
-        std::size_t const) const noexcept
+        hpx::chrono::steady_duration const&, std::size_t const) const noexcept
     {
         return 1;
     }

--- a/libs/core/algorithms/tests/performance/foreach_scaling_helpers.hpp
+++ b/libs/core/algorithms/tests/performance/foreach_scaling_helpers.hpp
@@ -37,9 +37,7 @@ inline std::mt19937 gen(seed);
 struct disable_stealing_parameter
 {
     template <typename Executor>
-    friend void tag_override_invoke(
-        hpx::execution::experimental::mark_begin_execution_t,
-        disable_stealing_parameter, Executor&&)
+    void mark_begin_execution(Executor&&)
     {
         hpx::threads::add_remove_scheduler_mode(
             hpx::threads::policies::scheduler_mode::enable_stealing,
@@ -47,18 +45,14 @@ struct disable_stealing_parameter
     }
 
     template <typename Executor>
-    friend void tag_override_invoke(
-        hpx::execution::experimental::mark_end_of_scheduling_t,
-        disable_stealing_parameter, Executor&&)
+    void mark_end_of_scheduling(Executor&&)
     {
         hpx::threads::remove_scheduler_mode(
             hpx::threads::policies::scheduler_mode::enable_stealing);
     }
 
     template <typename Executor>
-    friend void tag_override_invoke(
-        hpx::execution::experimental::mark_end_execution_t,
-        disable_stealing_parameter, Executor&&)
+    void mark_end_execution(Executor&&)
     {
         hpx::threads::add_remove_scheduler_mode(
             hpx::threads::policies::scheduler_mode::enable_idle_backoff,

--- a/libs/core/async_base/CMakeLists.txt
+++ b/libs/core/async_base/CMakeLists.txt
@@ -43,6 +43,7 @@ add_hpx_module(
     hpx_config
     hpx_concurrency
     hpx_coroutines
+    hpx_execution_base
     hpx_serialization
     hpx_tag_invoke
   CMAKE_SUBDIRS examples tests

--- a/libs/core/async_base/include/hpx/async_base/dataflow.hpp
+++ b/libs/core/async_base/include/hpx/async_base/dataflow.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2025 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -32,7 +32,6 @@ namespace hpx {
 #include <hpx/modules/allocator_support.hpp>
 #include <hpx/modules/concepts.hpp>
 #include <hpx/modules/concurrency.hpp>
-#include <hpx/modules/tag_invoke.hpp>
 
 #include <type_traits>
 #include <utility>
@@ -49,27 +48,44 @@ namespace hpx {
         // real function based API that dispatches to the CPO. Once
         // dataflow<Action>(...) has been removed, this CPO can be moved to
         // namespace hpx.
+        // Customization struct specialized in the heavy header
+        // (hpx/executors/dataflow.hpp)
+        template <typename F, typename Enable = void>
+        struct dataflow_dispatch_impl;
+
         HPX_CXX_CORE_EXPORT inline constexpr struct dataflow_t final
-          : hpx::functional::detail::tag_fallback<dataflow_t>
         {
-        private:
+            // Primary: target has .dataflow() member
             template <typename Target, typename... Args>
                 requires requires(Target&& t, Args&&... args) {
                     HPX_FORWARD(Target, t).dataflow(HPX_FORWARD(Args, args)...);
                 }
-            friend constexpr auto tag_invoke(
-                dataflow_t, Target&& target, Args&&... args)
+            constexpr auto operator()(Target&& target, Args&&... args) const
             {
                 return HPX_FORWARD(Target, target)
                     .dataflow(HPX_FORWARD(Args, args)...);
             }
 
-            template <typename F, typename... Ts,
-                HPX_CONCEPT_REQUIRES_(
-                    !hpx::traits::is_allocator_v<std::decay_t<F>>)>
-            friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(
-                dataflow_t tag, F&& f, Ts&&... ts)
-                -> decltype(hpx::functional::tag_invoke(tag,
+            // Allocator-based dispatch (defers to specializable struct)
+            template <typename Allocator, typename F, typename... Ts>
+                requires(hpx::traits::is_allocator_v<std::decay_t<Allocator>>)
+            constexpr HPX_FORCEINLINE auto operator()(
+                Allocator const& alloc, F&& f, Ts&&... ts) const
+                -> decltype(dataflow_dispatch_impl<std::decay_t<F>>::call(
+                    alloc, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...))
+            {
+                return dataflow_dispatch_impl<std::decay_t<F>>::call(
+                    alloc, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+            }
+
+            // Fallback: add default allocator and re-invoke
+            template <typename F, typename... Ts>
+                requires(!hpx::traits::is_allocator_v<std::decay_t<F>> &&
+                    !requires(F&& f, Ts&&... ts) {
+                        HPX_FORWARD(F, f).dataflow(HPX_FORWARD(Ts, ts)...);
+                    })
+            constexpr HPX_FORCEINLINE auto operator()(F&& f, Ts&&... ts) const
+                -> decltype(dataflow_dispatch_impl<std::decay_t<F>>::call(
                     hpx::util::thread_local_caching_allocator<
                         hpx::lockfree::variable_size_stack,
                         hpx::util::internal_allocator<>>{},
@@ -79,8 +95,9 @@ namespace hpx {
                     hpx::util::thread_local_caching_allocator<
                         hpx::lockfree::variable_size_stack,
                         hpx::util::internal_allocator<>>;
-                return hpx::functional::tag_invoke(tag, allocator_type{},
-                    HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+                return dataflow_dispatch_impl<std::decay_t<F>>::call(
+                    allocator_type{}, HPX_FORWARD(F, f),
+                    HPX_FORWARD(Ts, ts)...);
             }
         } dataflow{};
     }    // namespace detail

--- a/libs/core/async_base/include/hpx/async_base/dataflow.hpp
+++ b/libs/core/async_base/include/hpx/async_base/dataflow.hpp
@@ -66,38 +66,39 @@ namespace hpx {
                     .dataflow(HPX_FORWARD(Args, args)...);
             }
 
-            // Allocator-based dispatch (defers to specializable struct)
-            template <typename Allocator, typename F, typename... Ts>
-                requires(hpx::traits::is_allocator_v<std::decay_t<Allocator>>)
-            constexpr HPX_FORCEINLINE auto operator()(
-                Allocator const& alloc, F&& f, Ts&&... ts) const
-                -> decltype(dataflow_dispatch_impl<std::decay_t<F>>::call(
-                    alloc, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...))
+            // Non-member dispatch (handles both allocator and non-allocator)
+            template <typename F, typename... Ts>
+                requires(!requires(F&& f, Ts&&... ts) {
+                    HPX_FORWARD(F, f).dataflow(HPX_FORWARD(Ts, ts)...);
+                })
+            constexpr HPX_FORCEINLINE decltype(auto) operator()(
+                F&& f, Ts&&... ts) const
             {
-                return dataflow_dispatch_impl<std::decay_t<F>>::call(
-                    alloc, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+                if constexpr (hpx::traits::is_allocator_v<std::decay_t<F>>)
+                {
+                    return dispatch_with_allocator(
+                        HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+                }
+                else
+                {
+                    using allocator_type =
+                        hpx::util::thread_local_caching_allocator<
+                            hpx::lockfree::variable_size_stack,
+                            hpx::util::internal_allocator<>>;
+                    return dataflow_dispatch_impl<std::decay_t<F>>::call(
+                        allocator_type{}, HPX_FORWARD(F, f),
+                        HPX_FORWARD(Ts, ts)...);
+                }
             }
 
-            // Fallback: add default allocator and re-invoke
-            template <typename F, typename... Ts>
-                requires(!hpx::traits::is_allocator_v<std::decay_t<F>> &&
-                    !requires(F&& f, Ts&&... ts) {
-                        HPX_FORWARD(F, f).dataflow(HPX_FORWARD(Ts, ts)...);
-                    })
-            constexpr HPX_FORCEINLINE auto operator()(F&& f, Ts&&... ts) const
-                -> decltype(dataflow_dispatch_impl<std::decay_t<F>>::call(
-                    hpx::util::thread_local_caching_allocator<
-                        hpx::lockfree::variable_size_stack,
-                        hpx::util::internal_allocator<>>{},
-                    HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...))
+        private:
+            template <typename Allocator, typename Func, typename... Rest>
+            constexpr HPX_FORCEINLINE decltype(auto) dispatch_with_allocator(
+                Allocator&& alloc, Func&& func, Rest&&... rest) const
             {
-                using allocator_type =
-                    hpx::util::thread_local_caching_allocator<
-                        hpx::lockfree::variable_size_stack,
-                        hpx::util::internal_allocator<>>;
-                return dataflow_dispatch_impl<std::decay_t<F>>::call(
-                    allocator_type{}, HPX_FORWARD(F, f),
-                    HPX_FORWARD(Ts, ts)...);
+                return dataflow_dispatch_impl<std::decay_t<Func>>::call(
+                    HPX_FORWARD(Allocator, alloc), HPX_FORWARD(Func, func),
+                    HPX_FORWARD(Rest, rest)...);
             }
         } dataflow{};
     }    // namespace detail

--- a/libs/core/async_base/include/hpx/async_base/dataflow.hpp
+++ b/libs/core/async_base/include/hpx/async_base/dataflow.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2007-2026 Hartmut Kaiser
+//  Copyright (c) 2026 Sai Charan Arvapally
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/core/async_base/include/hpx/async_base/detail/query_first_fallback.hpp
+++ b/libs/core/async_base/include/hpx/async_base/detail/query_first_fallback.hpp
@@ -7,7 +7,6 @@
 #pragma once
 
 #include <hpx/async_base/query_dispatch.hpp>
-#include <hpx/modules/tag_invoke.hpp>
 
 #include <utility>
 
@@ -16,28 +15,29 @@ namespace hpx::execution::experimental::detail {
     // CPO tag that prefers target.query(tag, args...) and otherwise invokes
     // Fallback{}(target, args...).
     template <typename Tag, typename Fallback>
-    struct query_first_tag_fallback : hpx::functional::detail::tag_fallback<Tag>
+    struct query_first_tag_fallback
     {
     protected:
         constexpr query_first_tag_fallback() = default;
 
+    public:
         template <typename Target, typename... Args>
-        friend constexpr auto tag_invoke(
-            Tag tag, Target&& target, Args&&... args)
             requires(
                 hpx::execution::experimental::has_query_v<Target, Tag, Args...>)
+        constexpr auto operator()(Target&& target, Args&&... args) const
         {
             return HPX_FORWARD(Target, target)
-                .query(tag, HPX_FORWARD(Args, args)...);
+                .query(Tag{}, HPX_FORWARD(Args, args)...);
         }
 
         template <typename Target, typename... Args>
-        friend constexpr auto tag_fallback_invoke(Tag, Target&& target,
-            Args&&... args) noexcept(noexcept(Fallback{}(HPX_FORWARD(Target,
-                                                             target),
-            HPX_FORWARD(Args, args)...)))
-            -> decltype(Fallback{}(
-                HPX_FORWARD(Target, target), HPX_FORWARD(Args, args)...))
+            requires(!hpx::execution::experimental::has_query_v<Target, Tag,
+                Args...>)
+        constexpr auto operator()(Target&& target, Args&&... args) const
+            noexcept(noexcept(Fallback{}(
+                HPX_FORWARD(Target, target), HPX_FORWARD(Args, args)...)))
+                -> decltype(Fallback{}(
+                    HPX_FORWARD(Target, target), HPX_FORWARD(Args, args)...))
         {
             return Fallback{}(
                 HPX_FORWARD(Target, target), HPX_FORWARD(Args, args)...);

--- a/libs/core/async_base/include/hpx/async_base/scheduling_properties.hpp
+++ b/libs/core/async_base/include/hpx/async_base/scheduling_properties.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2020 ETH Zurich
-//  Copyright (c) 2022-2025 Hartmut Kaiser
+//  Copyright (c) 2022-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -11,10 +11,12 @@
 #include <hpx/async_base/detail/query_first_fallback.hpp>
 #include <hpx/async_base/query_dispatch.hpp>
 #include <hpx/modules/coroutines.hpp>
-#include <hpx/modules/tag_invoke.hpp>
+#include <hpx/modules/execution_base.hpp>
 
 #include <cstddef>
+#include <string>
 #include <type_traits>
+#include <utility>
 
 namespace hpx::execution::experimental {
 
@@ -34,31 +36,34 @@ namespace hpx::execution::experimental {
         // The given property (Tag) is not supported on the given type (first
         // type in Args). Ensure that you are including the correct headers if
         // the property is supported. Alternatively, implement support for the
-        // property by overloading tag_invoke for the given property and type.
-        // If the property is not required, you can use prefer to fall back to
-        // the identity transformation when a property is not supported.
+        // property through a query() member on the target type.
         template <typename Tag, typename... Ts>
         struct property_not_supported;
 
+        template <executor_any Executor>
+        auto wrap_with_annotation(Executor&& exec, char const* annotation);
+
+        template <executor_any Executor>
+        auto wrap_with_annotation(Executor&& exec, std::string annotation);
+
         // NOLINTBEGIN(bugprone-crtp-constructor-accessibility)
         template <typename Tag>
-        struct property_base : hpx::functional::detail::tag_fallback<Tag>
+        struct property_base
         {
-        private:
             template <typename Target, typename... Args>
-            friend constexpr auto tag_invoke(
-                Tag tag, Target&& target, Args&&... args)
                 requires(has_query_v<Target, Tag, Args...>)
+            constexpr auto operator()(Target&& target, Args&&... args) const
             {
                 return HPX_FORWARD(Target, target)
-                    .query(tag, HPX_FORWARD(Args, args)...);
+                    .query(Tag{}, HPX_FORWARD(Args, args)...);
             }
 
-            // attempt to improve error messages if property is not supported
-            template <typename... Ts>
-            friend constexpr auto tag_fallback_invoke(Tag, Ts&&...) noexcept
-                -> decltype(property_not_supported<Tag, Ts...>());
+            template <typename Target, typename... Args>
+                requires(!has_query_v<Target, Tag, Args...>)
+            constexpr auto operator()(Target&&, Args&&...) const noexcept
+                -> decltype(property_not_supported<Tag, Target, Args...>());
         };
+
         struct get_priority_fallback
         {
             template <typename Target, typename... Args>
@@ -191,8 +196,30 @@ namespace hpx::execution::experimental {
 
     ///////////////////////////////////////////////////////////////////////////
     HPX_CXX_CORE_EXPORT inline constexpr struct with_annotation_t final
-      : detail::property_base<with_annotation_t>
     {
+        template <typename Target, typename... Args>
+            requires(has_query_v<Target, with_annotation_t, Args...>)
+        constexpr auto operator()(Target&& target, Args&&... args) const
+        {
+            return HPX_FORWARD(Target, target)
+                .query(*this, HPX_FORWARD(Args, args)...);
+        }
+
+        template <executor_any Executor>
+            requires(!has_query_v<Executor, with_annotation_t, char const*>)
+        constexpr auto operator()(Executor&& exec, char const* annotation) const
+        {
+            return detail::wrap_with_annotation(
+                HPX_FORWARD(Executor, exec), annotation);
+        }
+
+        template <executor_any Executor>
+            requires(!has_query_v<Executor, with_annotation_t, std::string>)
+        auto operator()(Executor&& exec, std::string annotation) const
+        {
+            return detail::wrap_with_annotation(
+                HPX_FORWARD(Executor, exec), HPX_MOVE(annotation));
+        }
     } with_annotation{};
 
     template <>

--- a/libs/core/async_base/include/hpx/async_base/scheduling_properties.hpp
+++ b/libs/core/async_base/include/hpx/async_base/scheduling_properties.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2020 ETH Zurich
+//  Copyright (c) 2026 Sai Charan Arvapally
 //  Copyright (c) 2022-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0

--- a/libs/core/async_cuda/include/hpx/async_cuda/cublas_executor.hpp
+++ b/libs/core/async_cuda/include/hpx/async_cuda/cublas_executor.hpp
@@ -131,24 +131,12 @@ namespace hpx::cuda::experimental {
         ~cublas_executor() {}
 
         // -------------------------------------------------------------------------
-        // OneWay Execution
+        // TwoWay Execution - async_execute delegates to async()
         // -------------------------------------------------------------------------
         template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(hpx::parallel::execution::post_t,
-            cublas_executor const& exec, F&& f, Ts&&... ts)
+        decltype(auto) async_execute(F&& f, Ts&&... ts) const
         {
-            return exec.post(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
-        }
-
-        // -------------------------------------------------------------------------
-        // TwoWay Execution
-        // -------------------------------------------------------------------------
-        template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::async_execute_t,
-            cublas_executor const& exec, F&& f, Ts&&... ts)
-        {
-            return exec.async(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+            return async(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
 
     protected:

--- a/libs/core/async_cuda/include/hpx/async_cuda/cublas_executor.hpp
+++ b/libs/core/async_cuda/include/hpx/async_cuda/cublas_executor.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2020 John Biddiscombe
+//  Copyright (c) 2026 Sai Charan Arvapally
 //  Copyright (c) 2020 Teodor Nikolov
 //  Copyright (c) 2024-2025 Hartmut Kaiser
 //
@@ -131,15 +132,8 @@ namespace hpx::cuda::experimental {
         ~cublas_executor() {}
 
         // -------------------------------------------------------------------------
-        // TwoWay Execution - async_execute delegates to async()
+        // OneWay Execution
         // -------------------------------------------------------------------------
-        template <typename F, typename... Ts>
-        decltype(auto) async_execute(F&& f, Ts&&... ts) const
-        {
-            return async(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
-        }
-
-    protected:
         // This is a simple wrapper for any cublas call, pass in the same arguments
         // that you would use for a cublas call except the cublas handle which is omitted
         // as the wrapper will supply that for you
@@ -172,6 +166,16 @@ namespace hpx::cuda::experimental {
                 cuda_function, HPX_FORWARD(Args, args)...);
         }
 
+        // -------------------------------------------------------------------------
+        // TwoWay Execution
+        // -------------------------------------------------------------------------
+        template <typename F, typename... Ts>
+        decltype(auto) async_execute(F&& f, Ts&&... ts) const
+        {
+            return async(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+        }
+
+    protected:
         // -------------------------------------------------------------------------
         // launch a cuBlas function and return a future that will become ready
         // when the task completes, this allows integration of GPU kernels with

--- a/libs/core/async_cuda/include/hpx/async_cuda/cuda_executor.hpp
+++ b/libs/core/async_cuda/include/hpx/async_cuda/cuda_executor.hpp
@@ -1,6 +1,6 @@
 //  Copyright (c) 2020 John Biddiscombe
 //  Copyright (c) 2020 Teodor Nikolov
-//  Copyright (c) 2024-2025 Hartmut Kaiser
+//  Copyright (c) 2024-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -123,25 +123,14 @@ namespace hpx::cuda::experimental {
         ~cuda_executor() {}
 
         // -------------------------------------------------------------------------
-        // OneWay Execution
+        // TwoWay Execution - async_execute delegates to async()
         template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(hpx::parallel::execution::post_t,
-            cuda_executor const& exec, F&& f, Ts&&... ts)
+        decltype(auto) async_execute(F&& f, Ts&&... ts) const
         {
-            return exec.post(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+            return async(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
 
-        // -------------------------------------------------------------------------
-        // TwoWay Execution
-        template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::async_execute_t,
-            cuda_executor const& exec, F&& f, Ts&&... ts)
-        {
-            return exec.async(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
-        }
-
-    protected:
+    public:
         // -------------------------------------------------------------------------
         // launch a kernel on our stream and return without a future
         // the return value is the value returned from the cuda call

--- a/libs/core/async_cuda/include/hpx/async_cuda/cuda_executor.hpp
+++ b/libs/core/async_cuda/include/hpx/async_cuda/cuda_executor.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2020 John Biddiscombe
+//  Copyright (c) 2026 Sai Charan Arvapally
 //  Copyright (c) 2020 Teodor Nikolov
 //  Copyright (c) 2024-2026 Hartmut Kaiser
 //
@@ -123,19 +124,7 @@ namespace hpx::cuda::experimental {
         ~cuda_executor() {}
 
         // -------------------------------------------------------------------------
-        // TwoWay Execution - async_execute delegates to async()
-        template <typename F, typename... Ts>
-        decltype(auto) async_execute(F&& f, Ts&&... ts) const
-        {
-            return async(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
-        }
-
-    public:
-        // -------------------------------------------------------------------------
-        // launch a kernel on our stream and return without a future
-        // the return value is the value returned from the cuda call
-        // (typically this will be cudaError_t).
-        // Throws cuda_exception if the async launch fails.
+        // OneWay Execution
         template <typename R, typename... Params, typename... Args>
         void post(R (*cuda_function)(Params...), Args&&... args) const
         {
@@ -145,6 +134,14 @@ namespace hpx::cuda::experimental {
             // insert the stream handle in the arg list and call the cuda function
             detail::dispatch_helper<R, Params...> helper{};
             helper(cuda_function, HPX_FORWARD(Args, args)..., stream_);
+        }
+
+        // -------------------------------------------------------------------------
+        // TwoWay Execution
+        template <typename F, typename... Ts>
+        decltype(auto) async_execute(F&& f, Ts&&... ts) const
+        {
+            return async(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
 
         // -------------------------------------------------------------------------

--- a/libs/core/async_local/tests/unit/async_local_executor_additional_arguments.cpp
+++ b/libs/core/async_local/tests/unit/async_local_executor_additional_arguments.cpp
@@ -24,8 +24,7 @@ struct additional_argument_executor
     template <typename F, typename... Ts,
         typename Enable =
             std::enable_if_t<!std::is_member_function_pointer_v<F>>>
-    friend decltype(auto) tag_invoke(hpx::parallel::execution::async_execute_t,
-        additional_argument_executor const&, F&& f, Ts&&... ts)
+    decltype(auto) async_execute(F&& f, Ts&&... ts) const
     {
         return hpx::async(
             std::forward<F>(f), additional_argument{}, std::forward<Ts>(ts)...);
@@ -34,8 +33,7 @@ struct additional_argument_executor
     template <typename F, typename T, typename... Ts,
         typename Enable =
             std::enable_if_t<std::is_member_function_pointer_v<F>>>
-    friend decltype(auto) tag_invoke(hpx::parallel::execution::async_execute_t,
-        additional_argument_executor const&, F&& f, T&& t, Ts&&... ts)
+    decltype(auto) async_execute(F&& f, T&& t, Ts&&... ts) const
     {
         return hpx::async(std::forward<F>(f), std::forward<T>(t),
             additional_argument{}, std::forward<Ts>(ts)...);

--- a/libs/core/async_mpi/include/hpx/async_mpi/mpi_executor.hpp
+++ b/libs/core/async_mpi/include/hpx/async_mpi/mpi_executor.hpp
@@ -52,12 +52,10 @@ namespace hpx::mpi::experimental {
 
         // TwoWayExecutor interface
         template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::async_execute_t, executor const& exec,
-            F&& f, Ts&&... ts)
+        decltype(auto) async_execute(F&& f, Ts&&... ts) const
         {
             return hpx::mpi::experimental::detail::async(
-                HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)..., exec.communicator_);
+                HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)..., communicator_);
         }
 
         std::size_t in_flight_estimate() const

--- a/libs/core/async_sycl/include/hpx/async_sycl/sycl_executor.hpp
+++ b/libs/core/async_sycl/include/hpx/async_sycl/sycl_executor.hpp
@@ -193,25 +193,9 @@ namespace hpx::sycl::experimental {
         }
 #endif
 
-        // --------------------------------------------------------------------
-        // OneWay Execution
-        template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(hpx::parallel::execution::post_t,
-            sycl_executor& exec, F&& f, Ts&&... ts)
-        {
-            return exec.post(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
-        }
-
-        // --------------------------------------------------------------------
-        // TwoWay Execution
-        template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::async_execute_t, sycl_executor& exec,
-            F&& f, Ts&&... ts)
-        {
-            return exec.async_execute(
-                HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
-        }
+        // OneWay Execution and TwoWay Execution are provided by
+        // the post() and async_execute() member functions above,
+        // which are detected directly by the CPOs.
 
         // Property interface:
 

--- a/libs/core/compute_local/include/hpx/compute_local/host/block_executor.hpp
+++ b/libs/core/compute_local/include/hpx/compute_local/host/block_executor.hpp
@@ -115,39 +115,25 @@ namespace hpx::compute::host {
         }
         /// \endcond
 
-    private:
-        // this function is conceptually const (current_ is mutable)
-        auto get_next_executor() const
+        template <typename F, typename... Ts>
+        decltype(auto) post(F&& f, Ts&&... ts) const
         {
-            return executors_[current_++ % executors_.size()];
+            hpx::parallel::execution::post(
+                get_next_executor(), HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
 
         template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(hpx::parallel::execution::post_t,
-            block_executor const& exec, F&& f, Ts&&... ts)
-        {
-            hpx::parallel::execution::post(exec.get_next_executor(),
-                HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
-        }
-
-        template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::async_execute_t,
-            block_executor const& exec, F&& f, Ts&&... ts)
+        decltype(auto) async_execute(F&& f, Ts&&... ts) const
         {
             return hpx::parallel::execution::async_execute(
-                exec.get_next_executor(), HPX_FORWARD(F, f),
-                HPX_FORWARD(Ts, ts)...);
+                get_next_executor(), HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
 
         template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::sync_execute_t,
-            block_executor const& exec, F&& f, Ts&&... ts)
+        decltype(auto) sync_execute(F&& f, Ts&&... ts) const
         {
             return hpx::parallel::execution::sync_execute(
-                exec.get_next_executor(), HPX_FORWARD(F, f),
-                HPX_FORWARD(Ts, ts)...);
+                get_next_executor(), HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
 
         template <typename F, typename Shape, typename... Ts>
@@ -163,9 +149,9 @@ namespace hpx::compute::host {
             std::size_t const num_executors = executors_.size();
 
             using bulk_async_result_type =
-                decltype(hpx::parallel::execution::bulk_async_execute(
-                    std::declval<Executor>(), std::declval<F>(),
-                    util::iterator_range(begin, begin), std::declval<Ts>()...));
+                decltype(std::declval<Executor&>().bulk_async_execute(
+                    std::declval<F>(), util::iterator_range(begin, begin),
+                    std::declval<Ts>()...));
 
             // clang-format off
 
@@ -228,11 +214,10 @@ namespace hpx::compute::host {
         }
 
         template <typename F, typename Shape, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::bulk_async_execute_t,
-            block_executor const& exec, F&& f, Shape const& shape, Ts&&... ts)
+        decltype(auto) bulk_async_execute(
+            F&& f, Shape const& shape, Ts&&... ts) const
         {
-            return exec.bulk_async_execute_impl(
+            return bulk_async_execute_impl(
                 HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...);
         }
 
@@ -304,21 +289,25 @@ namespace hpx::compute::host {
         }
 
         template <typename F, typename Shape, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::bulk_sync_execute_t,
-            block_executor const& exec, F&& f, Shape const& shape, Ts&&... ts)
+        decltype(auto) bulk_sync_execute(
+            F&& f, Shape const& shape, Ts&&... ts) const
         {
-            return exec.bulk_sync_execute_impl(
+            return bulk_sync_execute_impl(
                 HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...);
         }
 
-    public:
         std::vector<host::target> const& targets() const noexcept
         {
             return targets_;
         }
 
     private:
+        // this function is conceptually const (current_ is mutable)
+        auto get_next_executor() const
+        {
+            return executors_[current_++ % executors_.size()];
+        }
+
         void init_executors()
         {
             executors_.reserve(targets_.size());

--- a/libs/core/compute_local/include/hpx/compute_local/host/block_executor.hpp
+++ b/libs/core/compute_local/include/hpx/compute_local/host/block_executor.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2016 Thomas Heller
+//  Copyright (c) 2026 Sai Charan Arvapally
 //  Copyright (c) 2024-2025 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0

--- a/libs/core/compute_local/include/hpx/compute_local/host/block_fork_join_executor.hpp
+++ b/libs/core/compute_local/include/hpx/compute_local/host/block_fork_join_executor.hpp
@@ -247,25 +247,22 @@ namespace hpx::execution::experimental {
 
         template <typename F, typename S, typename... Ts>
             requires(!std::is_integral_v<S>)
-        friend void tag_invoke(hpx::parallel::execution::bulk_sync_execute_t,
-            block_fork_join_executor& exec, F&& f, S const& shape, Ts&&... ts)
+        void bulk_sync_execute(F&& f, S const& shape, Ts&&... ts)
         {
-            exec.bulk_sync_execute_helper(
+            bulk_sync_execute_helper(
                 HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...);
         }
 
         template <typename F, typename S, typename... Ts>
             requires(!std::is_integral_v<S>)
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::bulk_async_execute_t,
-            block_fork_join_executor& exec, F&& f, S const& shape, Ts&&... ts)
+        decltype(auto) bulk_async_execute(F&& f, S const& shape, Ts&&... ts)
         {
             // Forward to the synchronous version as we can't create futures to
             // the completion of the parallel region (this HPX thread
             // participates in computation).
             return hpx::detail::try_catch_exception_ptr(
                 [&]() {
-                    exec.bulk_sync_execute_helper(
+                    bulk_sync_execute_helper(
                         HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...);
                     return hpx::make_ready_future();
                 },
@@ -310,25 +307,21 @@ namespace hpx::execution::experimental {
 
         template <typename F, typename... Fs>
             requires(std::is_invocable_v<F> && (std::is_invocable_v<Fs> && ...))
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::sync_invoke_t,
-            block_fork_join_executor const& exec, F&& f, Fs&&... fs)
+        decltype(auto) sync_invoke(F&& f, Fs&&... fs) const
         {
-            exec.sync_invoke_helper(HPX_FORWARD(F, f), HPX_FORWARD(Fs, fs)...);
+            sync_invoke_helper(HPX_FORWARD(F, f), HPX_FORWARD(Fs, fs)...);
         }
 
         template <typename F, typename... Fs>
             requires(std::is_invocable_v<F> && (std::is_invocable_v<Fs> && ...))
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::async_invoke_t,
-            block_fork_join_executor const& exec, F&& f, Fs&&... fs)
+        decltype(auto) async_invoke(F&& f, Fs&&... fs) const
         {
             // Forward to the synchronous version as we can't create futures to
             // the completion of the parallel region (this HPX thread
             // participates in computation).
             return hpx::detail::try_catch_exception_ptr(
                 [&]() {
-                    exec.sync_invoke_helper(
+                    sync_invoke_helper(
                         HPX_FORWARD(F, f), HPX_FORWARD(Fs, fs)...);
                     return hpx::make_ready_future();
                 },
@@ -341,25 +334,26 @@ namespace hpx::execution::experimental {
         template <typename Tag, typename Property>
             requires(
                 hpx::execution::experimental::is_scheduling_property_v<Tag> &&
-                hpx::functional::is_tag_invocable_v<Tag, fork_join_executor,
-                    Property>)
-        friend block_fork_join_executor tag_invoke(Tag tag,
-            block_fork_join_executor const& exec, Property&& prop) noexcept
+                requires(
+                    Tag tag, fork_join_executor const& exec, Property&& prop) {
+                    tag(exec, HPX_FORWARD(Property, prop));
+                })
+        [[nodiscard]] block_fork_join_executor query(
+            Tag, Property&& prop) const noexcept
         {
-            auto exec_with_prop = exec;
-            exec_with_prop.exec_ = hpx::functional::tag_invoke(
-                tag, exec.exec_, HPX_FORWARD(Property, prop));
+            auto exec_with_prop = *this;
+            exec_with_prop.exec_ = Tag{}(exec_, HPX_FORWARD(Property, prop));
             return exec_with_prop;
         }
 
         template <typename Tag>
             requires(
                 hpx::execution::experimental::is_scheduling_property_v<Tag> &&
-                hpx::functional::is_tag_invocable_v<Tag, fork_join_executor>)
-        friend decltype(auto) tag_invoke(
-            Tag tag, block_fork_join_executor const& exec) noexcept
+                requires(
+                    Tag tag, fork_join_executor const& exec) { tag(exec); })
+        [[nodiscard]] decltype(auto) query(Tag tag) const noexcept
         {
-            return hpx::functional::tag_invoke(tag, exec.exec_);
+            return tag(exec_);
         }
 
     private:

--- a/libs/core/compute_local/include/hpx/compute_local/host/block_fork_join_executor.hpp
+++ b/libs/core/compute_local/include/hpx/compute_local/host/block_fork_join_executor.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2022-2025 Hartmut Kaiser
+//  Copyright (c) 2026 Sai Charan Arvapally
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/core/execution/include/hpx/execution/executors/adaptive_static_chunk_size.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/adaptive_static_chunk_size.hpp
@@ -55,21 +55,19 @@ namespace hpx::execution::experimental {
 
         /// \cond NOINTERNAL
         template <typename Executor>
-        friend std::size_t tag_override_invoke(
-            hpx::execution::experimental::get_chunk_size_t,
-            adaptive_static_chunk_size const& this_, Executor& exec,
+        std::size_t get_chunk_size(Executor&& exec,
             hpx::chrono::steady_duration const&, std::size_t const cores,
-            std::size_t const input_size)
+            std::size_t const input_size) const
         {
             // Make sure the internal round-robin counter of the executor is
             // reset
             hpx::execution::experimental::reset_thread_distribution(
-                this_, exec);
+                *this, exec);
 
             // use the given chunk size if given
-            if (this_.chunk_size_ != 0)
+            if (chunk_size_ != 0)
             {
-                return this_.chunk_size_;
+                return chunk_size_;
             }
 
             if (cores == 1)

--- a/libs/core/execution/include/hpx/execution/executors/auto_chunk_size.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/auto_chunk_size.hpp
@@ -73,19 +73,16 @@ namespace hpx::execution::experimental {
 
         // Estimate execution time for one iteration
         template <typename Executor, typename F>
-        friend auto tag_override_invoke(
-            hpx::execution::experimental::measure_iteration_t,
-            auto_chunk_size& this_, Executor&& exec, F&& f,
-            std::size_t const count)
+        auto measure_iteration(Executor&& exec, F&& f, std::size_t const count)
         {
             // by default use 1% of the iterations
-            if (this_.num_iters_for_timing_ == 0)
+            if (num_iters_for_timing_ == 0)
             {
-                this_.num_iters_for_timing_ = count / 100;
+                num_iters_for_timing_ = count / 100;
             }
 
             // perform measurements only if necessary
-            if (this_.num_iters_for_timing_ > 0)
+            if (num_iters_for_timing_ > 0)
             {
                 using hpx::chrono::high_resolution_clock;
                 std::uint64_t t = high_resolution_clock::now();
@@ -93,14 +90,12 @@ namespace hpx::execution::experimental {
                 // use executor to launch given function for measurements
                 std::size_t const test_chunk_size =
                     hpx::parallel::execution::sync_execute(
-                        HPX_FORWARD(Executor, exec), f,
-                        this_.num_iters_for_timing_);
+                        HPX_FORWARD(Executor, exec), f, num_iters_for_timing_);
 
                 if (test_chunk_size != 0)
                 {
                     t = (high_resolution_clock::now() - t) / test_chunk_size;
-                    if (t != 0 &&
-                        this_.min_time_ >= std::chrono::nanoseconds(t))
+                    if (t != 0 && min_time_ >= std::chrono::nanoseconds(t))
                     {
                         // return execution time for one iteration
                         return std::chrono::nanoseconds(t);
@@ -113,11 +108,9 @@ namespace hpx::execution::experimental {
 
         // Estimate a chunk size based on number of cores used.
         template <typename Executor>
-        friend std::size_t tag_override_invoke(
-            hpx::execution::experimental::get_chunk_size_t,
-            auto_chunk_size const& this_, Executor&&,
+        std::size_t get_chunk_size(Executor&&,
             hpx::chrono::steady_duration const& iteration_duration,
-            std::size_t const cores, std::size_t const count) noexcept
+            std::size_t const cores, std::size_t const count) const noexcept
         {
             // return chunk size which will create the required amount of work
             if (iteration_duration.value() !=
@@ -127,7 +120,7 @@ namespace hpx::execution::experimental {
                     std::chrono::duration_cast<std::chrono::nanoseconds>(
                         iteration_duration.value());
                 return (std::min) (count,
-                    (std::size_t) (this_.min_time_.count() / ns.count()));
+                    (std::size_t) (min_time_.count() / ns.count()));
             }
             return (count + cores - 1) / cores;
         }

--- a/libs/core/execution/include/hpx/execution/executors/collect_chunking_parameters.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/collect_chunking_parameters.hpp
@@ -47,16 +47,15 @@ namespace hpx::execution::experimental {
 
         /// \cond NOINTERNAL
         template <typename Executor>
-        friend void tag_override_invoke(
-            hpx::execution::experimental::collect_execution_parameters_t,
-            collect_chunking_parameters const& this_, Executor&&,
+        void collect_execution_parameters(Executor&&,
             std::size_t const num_elements, std::size_t const num_cores,
-            std::size_t const num_chunks, std::size_t const chunk_size) noexcept
+            std::size_t const num_chunks,
+            std::size_t const chunk_size) const noexcept
         {
-            this_.exec_params_->num_elements = num_elements;
-            this_.exec_params_->num_cores = num_cores;
-            this_.exec_params_->num_chunks = num_chunks;
-            this_.exec_params_->chunk_size = chunk_size;
+            exec_params_->num_elements = num_elements;
+            exec_params_->num_cores = num_cores;
+            exec_params_->num_chunks = num_chunks;
+            exec_params_->chunk_size = chunk_size;
         }
         /// \endcond
 

--- a/libs/core/execution/include/hpx/execution/executors/default_parameters.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/default_parameters.hpp
@@ -41,7 +41,7 @@ namespace hpx::execution::experimental {
         template <typename Executor>
         std::size_t get_chunk_size(Executor&& exec,
             hpx::chrono::steady_duration const&, std::size_t const cores,
-            std::size_t const num_iterations)
+            std::size_t const num_iterations) const
         {
             // Make sure the internal round-robin counter of the executor is
             // reset

--- a/libs/core/execution/include/hpx/execution/executors/dynamic_chunk_size.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/dynamic_chunk_size.hpp
@@ -53,13 +53,11 @@ namespace hpx::execution::experimental {
 
         /// \cond NOINTERNAL
         template <typename Executor>
-        friend constexpr std::size_t tag_override_invoke(
-            hpx::execution::experimental::get_chunk_size_t,
-            dynamic_chunk_size const& this_, Executor&&,
+        constexpr std::size_t get_chunk_size(Executor&&,
             hpx::chrono::steady_duration const&, std::size_t,
-            std::size_t) noexcept
+            std::size_t) const noexcept
         {
-            return this_.chunk_size_;
+            return chunk_size_;
         }
         /// \endcond
 

--- a/libs/core/execution/include/hpx/execution/executors/execution.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2017-2026 Hartmut Kaiser
+//  Copyright (c) 2026 Sai Charan Arvapally
 //  Copyright (c) 2017 Google
 //
 //  SPDX-License-Identifier: BSL-1.0

--- a/libs/core/execution/include/hpx/execution/executors/execution.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution.hpp
@@ -61,9 +61,9 @@ namespace hpx::parallel::execution {
         }
 
         template <typename OneWayExecutor, typename F, typename... Ts,
-            typename Enable = std::enable_if_t<
-                std::invocable<hpx::parallel::execution::sync_execute_t const&,
-                    OneWayExecutor&&, F&&, Ts&&...>>>
+            typename Enable = std::enable_if_t<std::is_invocable_v<
+                hpx::parallel::execution::sync_execute_t const&,
+                OneWayExecutor&&, F&&, Ts&&...>>>
         HPX_FORCEINLINE decltype(auto) sync_execute_dispatch(
             int, OneWayExecutor&& exec, F&& f, Ts&&... ts)
         {
@@ -72,9 +72,9 @@ namespace hpx::parallel::execution {
         }
 
         template <typename OneWayExecutor, typename F, typename... Ts,
-            typename Enable = std::enable_if_t<
-                !std::invocable<hpx::parallel::execution::sync_execute_t const&,
-                    OneWayExecutor&&, F&&, Ts&&...>>>
+            typename Enable = std::enable_if_t<!std::is_invocable_v<
+                hpx::parallel::execution::sync_execute_t const&,
+                OneWayExecutor&&, F&&, Ts&&...>>>
         HPX_DEPRECATED_V(1, 9,
             "Exposing sync_execute() from an executor is deprecated, please "
             "expose this functionality through a corresponding member function")
@@ -212,7 +212,7 @@ namespace hpx::parallel::execution {
             // dispatch to V1 executors
             template <typename OneWayExecutor, typename F, typename... Ts,
                 typename Enable = std::enable_if_t<
-                    std::invocable<hpx::parallel::execution::post_t const&,
+                    std::is_invocable_v<hpx::parallel::execution::post_t const&,
                         OneWayExecutor&&, F&&, Ts&&...>>>
             HPX_FORCEINLINE static decltype(auto) call_impl(
                 int, OneWayExecutor&& exec, F&& f, Ts&&... ts)
@@ -223,9 +223,9 @@ namespace hpx::parallel::execution {
             }
 
             template <typename OneWayExecutor, typename F, typename... Ts,
-                typename Enable = std::enable_if_t<
-                    !std::invocable<hpx::parallel::execution::post_t const&,
-                        OneWayExecutor&&, F&&, Ts&&...>>>
+                typename Enable = std::enable_if_t<!std::is_invocable_v<
+                    hpx::parallel::execution::post_t const&, OneWayExecutor&&,
+                    F&&, Ts&&...>>>
             HPX_DEPRECATED_V(1, 9,
                 "Exposing post() from an executor is deprecated, please "
                 "expose this functionality through a corresponding "
@@ -276,9 +276,9 @@ namespace hpx::parallel::execution {
         }
 
         template <typename TwoWayExecutor, typename F, typename... Ts,
-            typename Enable = std::enable_if_t<
-                std::invocable<hpx::parallel::execution::async_execute_t const&,
-                    TwoWayExecutor&&, F&&, Ts&&...>>>
+            typename Enable = std::enable_if_t<std::is_invocable_v<
+                hpx::parallel::execution::async_execute_t const&,
+                TwoWayExecutor&&, F&&, Ts&&...>>>
         HPX_FORCEINLINE decltype(auto) async_execute_dispatch(
             int, TwoWayExecutor&& exec, F&& f, Ts&&... ts)
         {
@@ -287,7 +287,7 @@ namespace hpx::parallel::execution {
         }
 
         template <typename TwoWayExecutor, typename F, typename... Ts,
-            typename Enable = std::enable_if_t<!std::invocable<
+            typename Enable = std::enable_if_t<!std::is_invocable_v<
                 hpx::parallel::execution::async_execute_t const&,
                 TwoWayExecutor&&, F&&, Ts&&...>>>
         HPX_DEPRECATED_V(1, 9,
@@ -375,7 +375,7 @@ namespace hpx::parallel::execution {
             }
 
             template <typename TwoWayExecutor, typename F, typename... Ts,
-                typename Enable = std::enable_if_t<std::invocable<
+                typename Enable = std::enable_if_t<std::is_invocable_v<
                     hpx::parallel::execution::sync_execute_t const&,
                     TwoWayExecutor&&, F&&, Ts&&...>>>
             HPX_FORCEINLINE static decltype(auto) call_impl(
@@ -386,7 +386,7 @@ namespace hpx::parallel::execution {
             }
 
             template <typename TwoWayExecutor, typename F, typename... Ts,
-                typename Enable = std::enable_if_t<!std::invocable<
+                typename Enable = std::enable_if_t<!std::is_invocable_v<
                     hpx::parallel::execution::sync_execute_t const&,
                     TwoWayExecutor&&, F&&, Ts&&...>>>
             HPX_DEPRECATED_V(1, 9,
@@ -452,7 +452,7 @@ namespace hpx::parallel::execution {
 
             template <typename TwoWayExecutor, typename F, typename Future,
                 typename... Ts,
-                typename Enable = std::enable_if_t<std::invocable<
+                typename Enable = std::enable_if_t<std::is_invocable_v<
                     hpx::parallel::execution::then_execute_t const&,
                     TwoWayExecutor&&, F&&, Future&&, Ts&&...>>>
             HPX_FORCEINLINE static decltype(auto) call_impl(int,
@@ -465,7 +465,7 @@ namespace hpx::parallel::execution {
 
             template <typename TwoWayExecutor, typename F, typename Future,
                 typename... Ts,
-                typename Enable = std::enable_if_t<!std::invocable<
+                typename Enable = std::enable_if_t<!std::is_invocable_v<
                     hpx::parallel::execution::then_execute_t const&,
                     TwoWayExecutor&&, F&&, Future&&, Ts&&...>>>
             HPX_DEPRECATED_V(1, 9,
@@ -524,7 +524,7 @@ namespace hpx::parallel::execution {
             // dispatch to V1 executors
             template <typename TwoWayExecutor, typename F, typename... Ts,
                 typename Enable = std::enable_if_t<
-                    std::invocable<hpx::parallel::execution::post_t const&,
+                    std::is_invocable_v<hpx::parallel::execution::post_t const&,
                         TwoWayExecutor&&, F&&, Ts&&...>>>
             HPX_FORCEINLINE static decltype(auto) call_impl(
                 int, TwoWayExecutor&& exec, F&& f, Ts&&... ts)
@@ -535,9 +535,9 @@ namespace hpx::parallel::execution {
             }
 
             template <typename TwoWayExecutor, typename F, typename... Ts,
-                typename Enable = std::enable_if_t<
-                    !std::invocable<hpx::parallel::execution::post_t const&,
-                        TwoWayExecutor&&, F&&, Ts&&...>>>
+                typename Enable = std::enable_if_t<!std::is_invocable_v<
+                    hpx::parallel::execution::post_t const&, TwoWayExecutor&&,
+                    F&&, Ts&&...>>>
             HPX_DEPRECATED_V(1, 9,
                 "Exposing post() from an executor is deprecated, please "
                 "expose this functionality through a corresponding "
@@ -590,7 +590,7 @@ namespace hpx::parallel::execution {
         template <typename NonBlockingOneWayExecutor, typename F,
             typename... Ts,
             typename Enable = std::enable_if_t<
-                std::invocable<hpx::parallel::execution::post_t const&,
+                std::is_invocable_v<hpx::parallel::execution::post_t const&,
                     NonBlockingOneWayExecutor&&, F&&, Ts&&...>>>
         HPX_FORCEINLINE decltype(auto) post_dispatch(
             int, NonBlockingOneWayExecutor&& exec, F&& f, Ts&&... ts)
@@ -602,7 +602,7 @@ namespace hpx::parallel::execution {
         template <typename NonBlockingOneWayExecutor, typename F,
             typename... Ts,
             typename Enable = std::enable_if_t<
-                !std::invocable<hpx::parallel::execution::post_t const&,
+                !std::is_invocable_v<hpx::parallel::execution::post_t const&,
                     NonBlockingOneWayExecutor&&, F&&, Ts&&...>>>
         HPX_DEPRECATED_V(1, 9,
             "Exposing post() from an executor is deprecated, please "
@@ -669,7 +669,7 @@ namespace hpx::parallel::execution {
 
         template <typename BulkTwoWayExecutor, typename F, typename Shape,
             typename... Ts,
-            typename Enable = std::enable_if_t<std::invocable<
+            typename Enable = std::enable_if_t<std::is_invocable_v<
                 hpx::parallel::execution::bulk_async_execute_t const&,
                 BulkTwoWayExecutor&&, F&&, Shape const&, Ts&&...>>>
         HPX_FORCEINLINE decltype(auto) bulk_async_execute_dispatch(int,
@@ -681,7 +681,7 @@ namespace hpx::parallel::execution {
 
         template <typename BulkTwoWayExecutor, typename F, typename Shape,
             typename... Ts,
-            typename Enable = std::enable_if_t<!std::invocable<
+            typename Enable = std::enable_if_t<!std::is_invocable_v<
                 hpx::parallel::execution::bulk_async_execute_t const&,
                 BulkTwoWayExecutor&&, F&&, Shape const&, Ts&&...>>>
         HPX_DEPRECATED_V(1, 9,
@@ -742,7 +742,7 @@ namespace hpx::parallel::execution {
 
             template <typename BulkExecutor, typename F, typename Shape,
                 typename... Ts,
-                typename Enable = std::enable_if_t<std::invocable<
+                typename Enable = std::enable_if_t<std::is_invocable_v<
                     hpx::parallel::execution::bulk_async_execute_t const&,
                     BulkExecutor&&, F&&, Shape const&, Ts&&...>>>
             HPX_FORCEINLINE static decltype(auto) call_impl(
@@ -754,7 +754,7 @@ namespace hpx::parallel::execution {
 
             template <typename BulkExecutor, typename F, typename Shape,
                 typename... Ts,
-                typename Enable = std::enable_if_t<!std::invocable<
+                typename Enable = std::enable_if_t<!std::is_invocable_v<
                     hpx::parallel::execution::bulk_async_execute_t const&,
                     BulkExecutor&&, F&&, Shape const&, Ts&&...>>>
             HPX_DEPRECATED_V(1, 9,
@@ -840,7 +840,7 @@ namespace hpx::parallel::execution {
 
         template <typename BulkTwoWayExecutor, typename F, typename Shape,
             typename... Ts,
-            typename Enable = std::enable_if_t<std::invocable<
+            typename Enable = std::enable_if_t<std::is_invocable_v<
                 hpx::parallel::execution::bulk_sync_execute_t const&,
                 BulkTwoWayExecutor&&, F&&, Shape const&, Ts&&...>>>
         HPX_FORCEINLINE decltype(auto) bulk_sync_execute_dispatch(int,
@@ -852,7 +852,7 @@ namespace hpx::parallel::execution {
 
         template <typename BulkTwoWayExecutor, typename F, typename Shape,
             typename... Ts,
-            typename Enable = std::enable_if_t<!std::invocable<
+            typename Enable = std::enable_if_t<!std::is_invocable_v<
                 hpx::parallel::execution::bulk_sync_execute_t const&,
                 BulkTwoWayExecutor&&, F&&, Shape const&, Ts&&...>>>
         HPX_DEPRECATED_V(1, 9,
@@ -953,7 +953,7 @@ namespace hpx::parallel::execution {
 
             template <typename BulkExecutor, typename F, typename Shape,
                 typename... Ts,
-                typename Enable = std::enable_if_t<std::invocable<
+                typename Enable = std::enable_if_t<std::is_invocable_v<
                     hpx::parallel::execution::bulk_sync_execute_t const&,
                     BulkExecutor&&, F&&, Shape const&, Ts&&...>>>
             static decltype(auto) call_impl(
@@ -965,7 +965,7 @@ namespace hpx::parallel::execution {
 
             template <typename BulkExecutor, typename F, typename Shape,
                 typename... Ts,
-                typename Enable = std::enable_if_t<!std::invocable<
+                typename Enable = std::enable_if_t<!std::is_invocable_v<
                     hpx::parallel::execution::bulk_sync_execute_t const&,
                     BulkExecutor&&, F&&, Shape const&, Ts&&...>>>
             HPX_DEPRECATED_V(1, 9,
@@ -1077,7 +1077,7 @@ namespace hpx::parallel::execution {
 
             template <typename BulkExecutor, typename F, typename Shape,
                 typename... Ts,
-                typename Enable = std::enable_if_t<std::invocable<
+                typename Enable = std::enable_if_t<std::is_invocable_v<
                     hpx::parallel::execution::bulk_sync_execute_t const&,
                     BulkExecutor&&, F&&, Shape const&, Ts&&...>>>
             HPX_FORCEINLINE static decltype(auto) call_impl(
@@ -1089,7 +1089,7 @@ namespace hpx::parallel::execution {
 
             template <typename BulkExecutor, typename F, typename Shape,
                 typename... Ts,
-                typename Enable = std::enable_if_t<!std::invocable<
+                typename Enable = std::enable_if_t<!std::is_invocable_v<
                     hpx::parallel::execution::bulk_sync_execute_t const&,
                     BulkExecutor&&, F&&, Shape const&, Ts&&...>>>
             HPX_DEPRECATED_V(1, 9,
@@ -1218,7 +1218,7 @@ namespace hpx::parallel::execution {
 
             template <typename BulkExecutor, typename F, typename Shape,
                 typename Future, typename... Ts,
-                typename Enable = std::enable_if_t<std::invocable<
+                typename Enable = std::enable_if_t<std::is_invocable_v<
                     hpx::parallel::execution::bulk_then_execute_t const&,
                     BulkExecutor&&, F&&, Shape const&, Future&&, Ts&&...>>>
             HPX_FORCEINLINE static decltype(auto) call_impl(int,
@@ -1232,7 +1232,7 @@ namespace hpx::parallel::execution {
 
             template <typename BulkExecutor, typename F, typename Shape,
                 typename Future, typename... Ts,
-                typename Enable = std::enable_if_t<!std::invocable<
+                typename Enable = std::enable_if_t<!std::is_invocable_v<
                     hpx::parallel::execution::bulk_then_execute_t const&,
                     BulkExecutor&&, F&&, Shape const&, Future&&, Ts&&...>>>
             HPX_DEPRECATED_V(1, 9,
@@ -1336,7 +1336,7 @@ namespace hpx::parallel::execution {
 
             template <typename BulkExecutor, typename F, typename Shape,
                 typename Future, typename... Ts,
-                typename Enable = std::enable_if_t<std::invocable<
+                typename Enable = std::enable_if_t<std::is_invocable_v<
                     hpx::parallel::execution::bulk_then_execute_t const&,
                     BulkExecutor&&, F&&, Shape const&, Future&&, Ts&&...>>>
             HPX_FORCEINLINE static decltype(auto) call_impl(int,
@@ -1350,7 +1350,7 @@ namespace hpx::parallel::execution {
 
             template <typename BulkExecutor, typename F, typename Shape,
                 typename Future, typename... Ts,
-                typename Enable = std::enable_if_t<!std::invocable<
+                typename Enable = std::enable_if_t<!std::is_invocable_v<
                     hpx::parallel::execution::bulk_then_execute_t const&,
                     BulkExecutor&&, F&&, Shape const&, Future&&, Ts&&...>>>
             HPX_DEPRECATED_V(1, 9,

--- a/libs/core/execution/include/hpx/execution/executors/execution.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017-2025 Hartmut Kaiser
+//  Copyright (c) 2017-2026 Hartmut Kaiser
 //  Copyright (c) 2017 Google
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -26,9 +26,9 @@
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/iterator_support.hpp>
 #include <hpx/modules/pack_traversal.hpp>
-#include <hpx/modules/tag_invoke.hpp>
 #include <hpx/modules/type_support.hpp>
 
+#include <concepts>
 #include <cstddef>
 #include <functional>
 #include <iterator>
@@ -61,9 +61,9 @@ namespace hpx::parallel::execution {
         }
 
         template <typename OneWayExecutor, typename F, typename... Ts,
-            typename Enable = std::enable_if_t<hpx::functional::
-                    is_tag_invocable_v<hpx::parallel::execution::sync_execute_t,
-                        OneWayExecutor&&, F&&, Ts&&...>>>
+            typename Enable = std::enable_if_t<
+                std::invocable<hpx::parallel::execution::sync_execute_t const&,
+                    OneWayExecutor&&, F&&, Ts&&...>>>
         HPX_FORCEINLINE decltype(auto) sync_execute_dispatch(
             int, OneWayExecutor&& exec, F&& f, Ts&&... ts)
         {
@@ -72,13 +72,12 @@ namespace hpx::parallel::execution {
         }
 
         template <typename OneWayExecutor, typename F, typename... Ts,
-            typename Enable = std::enable_if_t<!hpx::functional::
-                    is_tag_invocable_v<hpx::parallel::execution::sync_execute_t,
-                        OneWayExecutor&&, F&&, Ts&&...>>>
+            typename Enable = std::enable_if_t<
+                !std::invocable<hpx::parallel::execution::sync_execute_t const&,
+                    OneWayExecutor&&, F&&, Ts&&...>>>
         HPX_DEPRECATED_V(1, 9,
             "Exposing sync_execute() from an executor is deprecated, please "
-            "expose this functionality through a corresponding overload of "
-            "tag_invoke")
+            "expose this functionality through a corresponding member function")
         auto sync_execute_dispatch(int, OneWayExecutor&& exec, F&& f,
             Ts&&... ts) -> decltype(exec.sync_execute(HPX_FORWARD(F, f),
             HPX_FORWARD(Ts, ts)...))
@@ -212,9 +211,9 @@ namespace hpx::parallel::execution {
 
             // dispatch to V1 executors
             template <typename OneWayExecutor, typename F, typename... Ts,
-                typename Enable = std::enable_if_t<hpx::functional::
-                        is_tag_invocable_v<hpx::parallel::execution::post_t,
-                            OneWayExecutor&&, F&&, Ts&&...>>>
+                typename Enable = std::enable_if_t<
+                    std::invocable<hpx::parallel::execution::post_t const&,
+                        OneWayExecutor&&, F&&, Ts&&...>>>
             HPX_FORCEINLINE static decltype(auto) call_impl(
                 int, OneWayExecutor&& exec, F&& f, Ts&&... ts)
             {
@@ -224,13 +223,13 @@ namespace hpx::parallel::execution {
             }
 
             template <typename OneWayExecutor, typename F, typename... Ts,
-                typename Enable = std::enable_if_t<!hpx::functional::
-                        is_tag_invocable_v<hpx::parallel::execution::post_t,
-                            OneWayExecutor&&, F&&, Ts&&...>>>
+                typename Enable = std::enable_if_t<
+                    !std::invocable<hpx::parallel::execution::post_t const&,
+                        OneWayExecutor&&, F&&, Ts&&...>>>
             HPX_DEPRECATED_V(1, 9,
                 "Exposing post() from an executor is deprecated, please "
-                "expose this functionality through a corresponding overload of "
-                "tag_invoke")
+                "expose this functionality through a corresponding "
+                "member function")
             HPX_FORCEINLINE static auto call_impl(int, OneWayExecutor&& exec,
                 F&& f, Ts&&... ts) -> decltype(exec.post(HPX_FORWARD(F, f),
                 HPX_FORWARD(Ts, ts)...))
@@ -277,10 +276,9 @@ namespace hpx::parallel::execution {
         }
 
         template <typename TwoWayExecutor, typename F, typename... Ts,
-            typename Enable =
-                std::enable_if_t<hpx::functional::is_tag_invocable_v<
-                    hpx::parallel::execution::async_execute_t, TwoWayExecutor&&,
-                    F&&, Ts&&...>>>
+            typename Enable = std::enable_if_t<
+                std::invocable<hpx::parallel::execution::async_execute_t const&,
+                    TwoWayExecutor&&, F&&, Ts&&...>>>
         HPX_FORCEINLINE decltype(auto) async_execute_dispatch(
             int, TwoWayExecutor&& exec, F&& f, Ts&&... ts)
         {
@@ -289,14 +287,12 @@ namespace hpx::parallel::execution {
         }
 
         template <typename TwoWayExecutor, typename F, typename... Ts,
-            typename Enable =
-                std::enable_if_t<!hpx::functional::is_tag_invocable_v<
-                    hpx::parallel::execution::async_execute_t, TwoWayExecutor&&,
-                    F&&, Ts&&...>>>
+            typename Enable = std::enable_if_t<!std::invocable<
+                hpx::parallel::execution::async_execute_t const&,
+                TwoWayExecutor&&, F&&, Ts&&...>>>
         HPX_DEPRECATED_V(1, 9,
             "Exposing async_execute() from an executor is deprecated, please "
-            "expose this functionality through a corresponding overload of "
-            "tag_invoke")
+            "expose this functionality through a corresponding member function")
         HPX_FORCEINLINE auto async_execute_dispatch(int, TwoWayExecutor&& exec,
             F&& f, Ts&&... ts) -> decltype(exec.async_execute(HPX_FORWARD(F, f),
             HPX_FORWARD(Ts, ts)...))
@@ -379,10 +375,9 @@ namespace hpx::parallel::execution {
             }
 
             template <typename TwoWayExecutor, typename F, typename... Ts,
-                typename Enable =
-                    std::enable_if_t<hpx::functional::is_tag_invocable_v<
-                        hpx::parallel::execution::sync_execute_t,
-                        TwoWayExecutor&&, F&&, Ts&&...>>>
+                typename Enable = std::enable_if_t<std::invocable<
+                    hpx::parallel::execution::sync_execute_t const&,
+                    TwoWayExecutor&&, F&&, Ts&&...>>>
             HPX_FORCEINLINE static decltype(auto) call_impl(
                 int, TwoWayExecutor&& exec, F&& f, Ts&&... ts)
             {
@@ -391,14 +386,13 @@ namespace hpx::parallel::execution {
             }
 
             template <typename TwoWayExecutor, typename F, typename... Ts,
-                typename Enable =
-                    std::enable_if_t<!hpx::functional::is_tag_invocable_v<
-                        hpx::parallel::execution::sync_execute_t,
-                        TwoWayExecutor&&, F&&, Ts&&...>>>
+                typename Enable = std::enable_if_t<!std::invocable<
+                    hpx::parallel::execution::sync_execute_t const&,
+                    TwoWayExecutor&&, F&&, Ts&&...>>>
             HPX_DEPRECATED_V(1, 9,
                 "Exposing sync_execute() from an executor is deprecated, "
                 "please expose this functionality through a corresponding "
-                "overload of tag_invoke")
+                "member function")
             HPX_FORCEINLINE static auto call_impl(
                 int, TwoWayExecutor&& exec, F&& f, Ts&&... ts)
                 -> decltype(exec.sync_execute(
@@ -458,10 +452,9 @@ namespace hpx::parallel::execution {
 
             template <typename TwoWayExecutor, typename F, typename Future,
                 typename... Ts,
-                typename Enable =
-                    std::enable_if_t<hpx::functional::is_tag_invocable_v<
-                        hpx::parallel::execution::then_execute_t,
-                        TwoWayExecutor&&, F&&, Future&&, Ts&&...>>>
+                typename Enable = std::enable_if_t<std::invocable<
+                    hpx::parallel::execution::then_execute_t const&,
+                    TwoWayExecutor&&, F&&, Future&&, Ts&&...>>>
             HPX_FORCEINLINE static decltype(auto) call_impl(int,
                 TwoWayExecutor&& exec, F&& f, Future&& predecessor, Ts&&... ts)
             {
@@ -472,14 +465,13 @@ namespace hpx::parallel::execution {
 
             template <typename TwoWayExecutor, typename F, typename Future,
                 typename... Ts,
-                typename Enable =
-                    std::enable_if_t<!hpx::functional::is_tag_invocable_v<
-                        hpx::parallel::execution::then_execute_t,
-                        TwoWayExecutor&&, F&&, Future&&, Ts&&...>>>
+                typename Enable = std::enable_if_t<!std::invocable<
+                    hpx::parallel::execution::then_execute_t const&,
+                    TwoWayExecutor&&, F&&, Future&&, Ts&&...>>>
             HPX_DEPRECATED_V(1, 9,
                 "Exposing then_execute() from an executor is deprecated, "
                 "please expose this functionality through a corresponding "
-                "overload of tag_invoke")
+                "member function")
             HPX_FORCEINLINE static auto call_impl(int, TwoWayExecutor&& exec,
                 F&& f, Future&& predecessor, Ts&&... ts)
                 -> decltype(exec.then_execute(HPX_FORWARD(F, f),
@@ -531,9 +523,9 @@ namespace hpx::parallel::execution {
 
             // dispatch to V1 executors
             template <typename TwoWayExecutor, typename F, typename... Ts,
-                typename Enable = std::enable_if_t<hpx::functional::
-                        is_tag_invocable_v<hpx::parallel::execution::post_t,
-                            TwoWayExecutor&&, F&&, Ts&&...>>>
+                typename Enable = std::enable_if_t<
+                    std::invocable<hpx::parallel::execution::post_t const&,
+                        TwoWayExecutor&&, F&&, Ts&&...>>>
             HPX_FORCEINLINE static decltype(auto) call_impl(
                 int, TwoWayExecutor&& exec, F&& f, Ts&&... ts)
             {
@@ -543,13 +535,13 @@ namespace hpx::parallel::execution {
             }
 
             template <typename TwoWayExecutor, typename F, typename... Ts,
-                typename Enable = std::enable_if_t<!hpx::functional::
-                        is_tag_invocable_v<hpx::parallel::execution::post_t,
-                            TwoWayExecutor&&, F&&, Ts&&...>>>
+                typename Enable = std::enable_if_t<
+                    !std::invocable<hpx::parallel::execution::post_t const&,
+                        TwoWayExecutor&&, F&&, Ts&&...>>>
             HPX_DEPRECATED_V(1, 9,
                 "Exposing post() from an executor is deprecated, please "
-                "expose this functionality through a corresponding overload of "
-                "tag_invoke")
+                "expose this functionality through a corresponding "
+                "member function")
             HPX_FORCEINLINE static auto call_impl(int, TwoWayExecutor&& exec,
                 F&& f, Ts&&... ts) -> decltype(exec.post(HPX_FORWARD(F, f),
                 HPX_FORWARD(Ts, ts)...))
@@ -597,9 +589,9 @@ namespace hpx::parallel::execution {
         // default implementation of the post() customization point
         template <typename NonBlockingOneWayExecutor, typename F,
             typename... Ts,
-            typename Enable = std::enable_if_t<hpx::functional::
-                    is_tag_invocable_v<hpx::parallel::execution::post_t,
-                        NonBlockingOneWayExecutor&&, F&&, Ts&&...>>>
+            typename Enable = std::enable_if_t<
+                std::invocable<hpx::parallel::execution::post_t const&,
+                    NonBlockingOneWayExecutor&&, F&&, Ts&&...>>>
         HPX_FORCEINLINE decltype(auto) post_dispatch(
             int, NonBlockingOneWayExecutor&& exec, F&& f, Ts&&... ts)
         {
@@ -609,13 +601,12 @@ namespace hpx::parallel::execution {
 
         template <typename NonBlockingOneWayExecutor, typename F,
             typename... Ts,
-            typename Enable = std::enable_if_t<!hpx::functional::
-                    is_tag_invocable_v<hpx::parallel::execution::post_t,
-                        NonBlockingOneWayExecutor&&, F&&, Ts&&...>>>
+            typename Enable = std::enable_if_t<
+                !std::invocable<hpx::parallel::execution::post_t const&,
+                    NonBlockingOneWayExecutor&&, F&&, Ts&&...>>>
         HPX_DEPRECATED_V(1, 9,
             "Exposing post() from an executor is deprecated, please "
-            "expose this functionality through a corresponding overload of "
-            "tag_invoke")
+            "expose this functionality through a corresponding member function")
         HPX_FORCEINLINE auto post_dispatch(
             int, NonBlockingOneWayExecutor&& exec, F&& f, Ts&&... ts)
             -> decltype(exec.post(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...))
@@ -678,10 +669,9 @@ namespace hpx::parallel::execution {
 
         template <typename BulkTwoWayExecutor, typename F, typename Shape,
             typename... Ts,
-            typename Enable =
-                std::enable_if_t<hpx::functional::is_tag_invocable_v<
-                    hpx::parallel::execution::bulk_async_execute_t,
-                    BulkTwoWayExecutor&&, F&&, Shape, Ts&&...>>>
+            typename Enable = std::enable_if_t<std::invocable<
+                hpx::parallel::execution::bulk_async_execute_t const&,
+                BulkTwoWayExecutor&&, F&&, Shape const&, Ts&&...>>>
         HPX_FORCEINLINE decltype(auto) bulk_async_execute_dispatch(int,
             BulkTwoWayExecutor&& exec, F&& f, Shape const& shape, Ts&&... ts)
         {
@@ -691,14 +681,13 @@ namespace hpx::parallel::execution {
 
         template <typename BulkTwoWayExecutor, typename F, typename Shape,
             typename... Ts,
-            typename Enable =
-                std::enable_if_t<!hpx::functional::is_tag_invocable_v<
-                    hpx::parallel::execution::bulk_async_execute_t,
-                    BulkTwoWayExecutor&&, F&&, Shape, Ts&&...>>>
+            typename Enable = std::enable_if_t<!std::invocable<
+                hpx::parallel::execution::bulk_async_execute_t const&,
+                BulkTwoWayExecutor&&, F&&, Shape const&, Ts&&...>>>
         HPX_DEPRECATED_V(1, 9,
             "Exposing bulk_async_execute() from an executor is deprecated, "
-            "please expose this functionality through a corresponding overload "
-            "of tag_invoke")
+            "please expose this functionality through a corresponding "
+            "member function")
         HPX_FORCEINLINE auto bulk_async_execute_dispatch(int,
             BulkTwoWayExecutor&& exec, F&& f, Shape const& shape, Ts&&... ts)
             -> decltype(exec.bulk_async_execute(
@@ -753,10 +742,9 @@ namespace hpx::parallel::execution {
 
             template <typename BulkExecutor, typename F, typename Shape,
                 typename... Ts,
-                typename Enable =
-                    std::enable_if_t<hpx::functional::is_tag_invocable_v<
-                        hpx::parallel::execution::bulk_async_execute_t,
-                        BulkExecutor&&, F&&, Shape, Ts&&...>>>
+                typename Enable = std::enable_if_t<std::invocable<
+                    hpx::parallel::execution::bulk_async_execute_t const&,
+                    BulkExecutor&&, F&&, Shape const&, Ts&&...>>>
             HPX_FORCEINLINE static decltype(auto) call_impl(
                 int, BulkExecutor&& exec, F&& f, Shape const& shape, Ts&&... ts)
             {
@@ -766,14 +754,13 @@ namespace hpx::parallel::execution {
 
             template <typename BulkExecutor, typename F, typename Shape,
                 typename... Ts,
-                typename Enable =
-                    std::enable_if_t<!hpx::functional::is_tag_invocable_v<
-                        hpx::parallel::execution::bulk_async_execute_t,
-                        BulkExecutor&&, F&&, Shape, Ts&&...>>>
+                typename Enable = std::enable_if_t<!std::invocable<
+                    hpx::parallel::execution::bulk_async_execute_t const&,
+                    BulkExecutor&&, F&&, Shape const&, Ts&&...>>>
             HPX_DEPRECATED_V(1, 9,
                 "Exposing bulk_async_execute() from an executor is deprecated, "
                 "please expose this functionality through a corresponding "
-                "overload of tag_invoke")
+                "member function")
             HPX_FORCEINLINE static auto call_impl(
                 int, BulkExecutor&& exec, F&& f, Shape const& shape, Ts&&... ts)
                 -> decltype(exec.bulk_async_execute(
@@ -853,10 +840,9 @@ namespace hpx::parallel::execution {
 
         template <typename BulkTwoWayExecutor, typename F, typename Shape,
             typename... Ts,
-            typename Enable =
-                std::enable_if_t<hpx::functional::is_tag_invocable_v<
-                    hpx::parallel::execution::bulk_sync_execute_t,
-                    BulkTwoWayExecutor&&, F&&, Shape, Ts&&...>>>
+            typename Enable = std::enable_if_t<std::invocable<
+                hpx::parallel::execution::bulk_sync_execute_t const&,
+                BulkTwoWayExecutor&&, F&&, Shape const&, Ts&&...>>>
         HPX_FORCEINLINE decltype(auto) bulk_sync_execute_dispatch(int,
             BulkTwoWayExecutor&& exec, F&& f, Shape const& shape, Ts&&... ts)
         {
@@ -866,14 +852,13 @@ namespace hpx::parallel::execution {
 
         template <typename BulkTwoWayExecutor, typename F, typename Shape,
             typename... Ts,
-            typename Enable =
-                std::enable_if_t<!hpx::functional::is_tag_invocable_v<
-                    hpx::parallel::execution::bulk_sync_execute_t,
-                    BulkTwoWayExecutor&&, F&&, Shape, Ts&&...>>>
+            typename Enable = std::enable_if_t<!std::invocable<
+                hpx::parallel::execution::bulk_sync_execute_t const&,
+                BulkTwoWayExecutor&&, F&&, Shape const&, Ts&&...>>>
         HPX_DEPRECATED_V(1, 9,
             "Exposing bulk_sync_execute() from an executor is deprecated, "
-            "please expose this functionality through a corresponding overload "
-            "of tag_invoke")
+            "please expose this functionality through a corresponding "
+            "member function")
         HPX_FORCEINLINE auto bulk_sync_execute_dispatch(int,
             BulkTwoWayExecutor&& exec, F&& f, Shape const& shape, Ts&&... ts)
             -> decltype(exec.bulk_sync_execute(
@@ -968,10 +953,9 @@ namespace hpx::parallel::execution {
 
             template <typename BulkExecutor, typename F, typename Shape,
                 typename... Ts,
-                typename Enable =
-                    std::enable_if_t<hpx::functional::is_tag_invocable_v<
-                        hpx::parallel::execution::bulk_sync_execute_t,
-                        BulkExecutor&&, F&&, Shape, Ts&&...>>>
+                typename Enable = std::enable_if_t<std::invocable<
+                    hpx::parallel::execution::bulk_sync_execute_t const&,
+                    BulkExecutor&&, F&&, Shape const&, Ts&&...>>>
             static decltype(auto) call_impl(
                 int, BulkExecutor&& exec, F&& f, Shape const& shape, Ts&&... ts)
             {
@@ -981,14 +965,13 @@ namespace hpx::parallel::execution {
 
             template <typename BulkExecutor, typename F, typename Shape,
                 typename... Ts,
-                typename Enable =
-                    std::enable_if_t<!hpx::functional::is_tag_invocable_v<
-                        hpx::parallel::execution::bulk_sync_execute_t,
-                        BulkExecutor&&, F&&, Shape, Ts&&...>>>
+                typename Enable = std::enable_if_t<!std::invocable<
+                    hpx::parallel::execution::bulk_sync_execute_t const&,
+                    BulkExecutor&&, F&&, Shape const&, Ts&&...>>>
             HPX_DEPRECATED_V(1, 9,
                 "Exposing bulk_sync_execute() from an executor is deprecated, "
                 "please expose this functionality through a corresponding "
-                "overload of tag_invoke")
+                "member function")
             static auto call_impl(
                 int, BulkExecutor&& exec, F&& f, Shape const& shape, Ts&&... ts)
                 -> decltype(exec.bulk_sync_execute(
@@ -1094,10 +1077,9 @@ namespace hpx::parallel::execution {
 
             template <typename BulkExecutor, typename F, typename Shape,
                 typename... Ts,
-                typename Enable =
-                    std::enable_if_t<hpx::functional::is_tag_invocable_v<
-                        hpx::parallel::execution::bulk_sync_execute_t,
-                        BulkExecutor&&, F&&, Shape, Ts&&...>>>
+                typename Enable = std::enable_if_t<std::invocable<
+                    hpx::parallel::execution::bulk_sync_execute_t const&,
+                    BulkExecutor&&, F&&, Shape const&, Ts&&...>>>
             HPX_FORCEINLINE static decltype(auto) call_impl(
                 int, BulkExecutor&& exec, F&& f, Shape const& shape, Ts&&... ts)
             {
@@ -1107,14 +1089,13 @@ namespace hpx::parallel::execution {
 
             template <typename BulkExecutor, typename F, typename Shape,
                 typename... Ts,
-                typename Enable =
-                    std::enable_if_t<!hpx::functional::is_tag_invocable_v<
-                        hpx::parallel::execution::bulk_sync_execute_t,
-                        BulkExecutor&&, F&&, Shape, Ts&&...>>>
+                typename Enable = std::enable_if_t<!std::invocable<
+                    hpx::parallel::execution::bulk_sync_execute_t const&,
+                    BulkExecutor&&, F&&, Shape const&, Ts&&...>>>
             HPX_DEPRECATED_V(1, 9,
                 "Exposing bulk_sync_execute() from an executor is deprecated, "
                 "please expose this functionality through a corresponding "
-                "overload of tag_invoke")
+                "member function")
             HPX_FORCEINLINE static auto call_impl(
                 int, BulkExecutor&& exec, F&& f, Shape const& shape, Ts&&... ts)
                 -> decltype(exec.bulk_sync_execute(
@@ -1237,10 +1218,9 @@ namespace hpx::parallel::execution {
 
             template <typename BulkExecutor, typename F, typename Shape,
                 typename Future, typename... Ts,
-                typename Enable =
-                    std::enable_if_t<hpx::functional::is_tag_invocable_v<
-                        hpx::parallel::execution::bulk_then_execute_t,
-                        BulkExecutor&&, F&&, Shape, Future&&, Ts&&...>>>
+                typename Enable = std::enable_if_t<std::invocable<
+                    hpx::parallel::execution::bulk_then_execute_t const&,
+                    BulkExecutor&&, F&&, Shape const&, Future&&, Ts&&...>>>
             HPX_FORCEINLINE static decltype(auto) call_impl(int,
                 BulkExecutor&& exec, F&& f, Shape const& shape,
                 Future&& predecessor, Ts&&... ts)
@@ -1252,14 +1232,13 @@ namespace hpx::parallel::execution {
 
             template <typename BulkExecutor, typename F, typename Shape,
                 typename Future, typename... Ts,
-                typename Enable =
-                    std::enable_if_t<!hpx::functional::is_tag_invocable_v<
-                        hpx::parallel::execution::bulk_then_execute_t,
-                        BulkExecutor&&, F&&, Shape, Future&&, Ts&&...>>>
+                typename Enable = std::enable_if_t<!std::invocable<
+                    hpx::parallel::execution::bulk_then_execute_t const&,
+                    BulkExecutor&&, F&&, Shape const&, Future&&, Ts&&...>>>
             HPX_DEPRECATED_V(1, 9,
                 "Exposing bulk_then_execute() from an executor is deprecated, "
                 "please expose this functionality through a corresponding "
-                "overload of tag_invoke")
+                "member function")
             HPX_FORCEINLINE static auto call_impl(int, BulkExecutor&& exec,
                 F&& f, Shape const& shape, Future&& predecessor, Ts&&... ts)
                 -> decltype(exec.bulk_then_execute(HPX_FORWARD(F, f), shape,
@@ -1357,10 +1336,9 @@ namespace hpx::parallel::execution {
 
             template <typename BulkExecutor, typename F, typename Shape,
                 typename Future, typename... Ts,
-                typename Enable =
-                    std::enable_if_t<hpx::functional::is_tag_invocable_v<
-                        hpx::parallel::execution::bulk_then_execute_t,
-                        BulkExecutor&&, F&&, Shape, Future&&, Ts&&...>>>
+                typename Enable = std::enable_if_t<std::invocable<
+                    hpx::parallel::execution::bulk_then_execute_t const&,
+                    BulkExecutor&&, F&&, Shape const&, Future&&, Ts&&...>>>
             HPX_FORCEINLINE static decltype(auto) call_impl(int,
                 BulkExecutor&& exec, F&& f, Shape const& shape,
                 Future&& predecessor, Ts&&... ts)
@@ -1372,14 +1350,13 @@ namespace hpx::parallel::execution {
 
             template <typename BulkExecutor, typename F, typename Shape,
                 typename Future, typename... Ts,
-                typename Enable =
-                    std::enable_if_t<!hpx::functional::is_tag_invocable_v<
-                        hpx::parallel::execution::bulk_then_execute_t,
-                        BulkExecutor&&, F&&, Shape, Future&&, Ts&&...>>>
+                typename Enable = std::enable_if_t<!std::invocable<
+                    hpx::parallel::execution::bulk_then_execute_t const&,
+                    BulkExecutor&&, F&&, Shape const&, Future&&, Ts&&...>>>
             HPX_DEPRECATED_V(1, 9,
                 "Exposing bulk_then_execute() from an executor is deprecated, "
                 "please expose this functionality through a corresponding "
-                "overload of tag_invoke")
+                "member function")
             HPX_FORCEINLINE static auto call_impl(int, BulkExecutor&& exec,
                 F&& f, Shape const& shape, Future&& predecessor, Ts&&... ts)
                 -> decltype(exec.bulk_then_execute(HPX_FORWARD(F, f), shape,

--- a/libs/core/execution/include/hpx/execution/executors/execution_information.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution_information.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017-2025 Hartmut Kaiser
+//  Copyright (c) 2017-2026 Hartmut Kaiser
 //  Copyright (c) 2017 Google
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -11,7 +11,6 @@
 #include <hpx/execution/detail/execution_parameter_callbacks.hpp>
 #include <hpx/execution/traits/executor_traits.hpp>
 #include <hpx/modules/execution_base.hpp>
-#include <hpx/modules/tag_invoke.hpp>
 #include <hpx/modules/topology.hpp>
 
 #include <cstddef>
@@ -41,24 +40,23 @@ namespace hpx::execution::experimental {
     ///       will always return \a false
     ///
     HPX_CXX_CORE_EXPORT inline constexpr struct has_pending_closures_t final
-      : hpx::functional::detail::tag_fallback<has_pending_closures_t>
     {
-    private:
-        template <typename Executor>
-            requires(hpx::traits::is_executor_any_v<Executor>)
-        friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            has_pending_closures_t, Executor&& /*exec*/)
-        {
-            return false;    // assume stateless scheduling
-        }
-
+        // Primary: forward to member function if available
         template <typename Executor>
             requires(hpx::traits::is_executor_any_v<Executor> &&
                 detail::has_has_pending_closures_v<Executor>)
-        friend HPX_FORCEINLINE decltype(auto) tag_invoke(
-            has_pending_closures_t, Executor&& exec)
+        HPX_FORCEINLINE decltype(auto) operator()(Executor&& exec) const
         {
             return HPX_FORWARD(Executor, exec).has_pending_closures();
+        }
+
+        // Fallback: assume stateless scheduling
+        template <typename Executor>
+            requires(hpx::traits::is_executor_any_v<Executor> &&
+                !detail::has_has_pending_closures_v<Executor>)
+        HPX_FORCEINLINE decltype(auto) operator()(Executor&& /*exec*/) const
+        {
+            return false;
         }
     } has_pending_closures{};
 
@@ -78,26 +76,26 @@ namespace hpx::execution::experimental {
     ///       will always invoke hpx::threads::get_pu_mask()
     ///
     HPX_CXX_CORE_EXPORT inline constexpr struct get_pu_mask_t final
-      : hpx::functional::detail::tag_fallback<get_pu_mask_t>
     {
-    private:
-        template <typename Executor>
-            requires(hpx::traits::is_executor_any_v<Executor>)
-        friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(get_pu_mask_t,
-            Executor&& /*exec*/, threads::topology& topo,
-            std::size_t thread_num)
-        {
-            return hpx::parallel::execution::detail::get_pu_mask(
-                topo, thread_num);
-        }
-
+        // Primary: forward to member function if available
         template <typename Executor>
             requires(hpx::traits::is_executor_any_v<Executor> &&
                 detail::has_get_pu_mask_v<Executor>)
-        friend HPX_FORCEINLINE decltype(auto) tag_invoke(get_pu_mask_t,
-            Executor&& exec, threads::topology& topo, std::size_t thread_num)
+        HPX_FORCEINLINE decltype(auto) operator()(Executor&& exec,
+            threads::topology& topo, std::size_t thread_num) const
         {
             return HPX_FORWARD(Executor, exec).get_pu_mask(topo, thread_num);
+        }
+
+        // Fallback: use default implementation
+        template <typename Executor>
+            requires(hpx::traits::is_executor_any_v<Executor> &&
+                !detail::has_get_pu_mask_v<Executor>)
+        HPX_FORCEINLINE decltype(auto) operator()(Executor&& /*exec*/,
+            threads::topology& topo, std::size_t thread_num) const
+        {
+            return hpx::parallel::execution::detail::get_pu_mask(
+                topo, thread_num);
         }
     } get_pu_mask{};
 
@@ -111,23 +109,23 @@ namespace hpx::execution::experimental {
     ///       otherwise it does nothing.
     ///
     HPX_CXX_CORE_EXPORT inline constexpr struct set_scheduler_mode_t final
-      : hpx::functional::detail::tag_fallback<set_scheduler_mode_t>
     {
-    private:
-        template <typename Executor, typename Mode>
-            requires(hpx::traits::is_executor_any_v<Executor>)
-        friend HPX_FORCEINLINE void tag_fallback_invoke(
-            set_scheduler_mode_t, Executor&& /*exec*/, Mode const& /*mode*/)
-        {
-        }
-
+        // Primary: forward to member function if available
         template <typename Executor, typename Mode>
             requires(hpx::traits::is_executor_any_v<Executor> &&
                 detail::has_set_scheduler_mode_v<Executor>)
-        friend HPX_FORCEINLINE void tag_invoke(
-            set_scheduler_mode_t, Executor&& exec, Mode const& mode)
+        HPX_FORCEINLINE void operator()(Executor&& exec, Mode const& mode) const
         {
             HPX_FORWARD(Executor, exec).set_scheduler_mode(mode);
+        }
+
+        // Fallback: no-op
+        template <typename Executor, typename Mode>
+            requires(hpx::traits::is_executor_any_v<Executor> &&
+                !detail::has_set_scheduler_mode_v<Executor>)
+        HPX_FORCEINLINE void operator()(
+            Executor&& /*exec*/, Mode const& /*mode*/) const
+        {
         }
     } set_scheduler_mode{};
 }    // namespace hpx::execution::experimental

--- a/libs/core/execution/include/hpx/execution/executors/execution_information.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution_information.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2017-2026 Hartmut Kaiser
+//  Copyright (c) 2026 Sai Charan Arvapally
 //  Copyright (c) 2017 Google
 //
 //  SPDX-License-Identifier: BSL-1.0

--- a/libs/core/execution/include/hpx/execution/executors/execution_parameters.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution_parameters.hpp
@@ -39,30 +39,30 @@ namespace hpx::execution::experimental::detail {
         using check_for_property = CheckForProperty<std::decay_t<T>>;
 
     public:
-        // Primary: Parameters directly supports property (highest priority -
-        // mirrors tag_override_invoke > tag_invoke semantics)
-        template <typename Executor, typename Parameters>
-            requires(hpx::traits::is_executor_parameters_v<Parameters> &&
-                check_for_property<Parameters>::value)
-        HPX_FORCEINLINE constexpr decltype(auto) operator()(Executor&& exec,
-            Parameters&& params, Property /*prop*/) const noexcept
-        {
-            return std::pair<Parameters&&, Executor&&>(
-                HPX_FORWARD(Parameters, params), HPX_FORWARD(Executor, exec));
-        }
-
-        ///////////////////////////////////////////////////////////////////
-        // Secondary: Executor directly supports property (when parameters doesn't)
+        // Primary: Executor directly supports property (highest priority -
+        // mirrors old tag_invoke > tag_fallback_invoke semantics)
         template <typename Executor, typename Parameters>
             requires(hpx::traits::is_executor_any_v<Executor> &&
-                check_for_property<Executor>::value &&
-                (!hpx::traits::is_executor_parameters_v<Parameters> ||
-                    !check_for_property<Parameters>::value))
+                check_for_property<Executor>::value)
         HPX_FORCEINLINE constexpr decltype(auto) operator()(Executor&& exec,
             Parameters&& params, Property /*prop*/) const noexcept
         {
             return std::pair<Executor&&, Parameters&&>(
                 HPX_FORWARD(Executor, exec), HPX_FORWARD(Parameters, params));
+        }
+
+        ///////////////////////////////////////////////////////////////////
+        // Secondary: Parameters directly supports property (when executor
+        // doesn't)
+        template <typename Executor, typename Parameters>
+            requires(hpx::traits::is_executor_parameters_v<Parameters> &&
+                check_for_property<Parameters>::value &&
+                !check_for_property<Executor>::value)
+        HPX_FORCEINLINE constexpr decltype(auto) operator()(Executor&& exec,
+            Parameters&& params, Property /*prop*/) const noexcept
+        {
+            return std::pair<Parameters&&, Executor&&>(
+                HPX_FORWARD(Parameters, params), HPX_FORWARD(Executor, exec));
         }
 
         // Fallback: neither executor nor parameters support property

--- a/libs/core/execution/include/hpx/execution/executors/execution_parameters.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution_parameters.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2016 Marcin Copik
+//  Copyright (c) 2026 Sai Charan Arvapally
 //  Copyright (c) 2016-2025 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0

--- a/libs/core/execution/include/hpx/execution/executors/execution_parameters.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution_parameters.hpp
@@ -39,28 +39,30 @@ namespace hpx::execution::experimental::detail {
         using check_for_property = CheckForProperty<std::decay_t<T>>;
 
     public:
-        // Primary: Executor directly supports property (highest priority)
+        // Primary: Parameters directly supports property (highest priority -
+        // mirrors tag_override_invoke > tag_invoke semantics)
         template <typename Executor, typename Parameters>
-            requires(hpx::traits::is_executor_any_v<Executor> &&
-                check_for_property<Executor>::value)
-        HPX_FORCEINLINE constexpr decltype(auto) operator()(Executor&& exec,
-            Parameters&& params, Property /*prop*/) const noexcept
-        {
-            return std::pair<Executor&&, Parameters&&>(
-                HPX_FORWARD(Executor, exec), HPX_FORWARD(Parameters, params));
-        }
-
-        ///////////////////////////////////////////////////////////////////
-        // Parameters directly supports property
-        template <typename Executor, typename Parameters>
-            requires(!check_for_property<Executor>::value &&
-                hpx::traits::is_executor_parameters_v<Parameters> &&
+            requires(hpx::traits::is_executor_parameters_v<Parameters> &&
                 check_for_property<Parameters>::value)
         HPX_FORCEINLINE constexpr decltype(auto) operator()(Executor&& exec,
             Parameters&& params, Property /*prop*/) const noexcept
         {
             return std::pair<Parameters&&, Executor&&>(
                 HPX_FORWARD(Parameters, params), HPX_FORWARD(Executor, exec));
+        }
+
+        ///////////////////////////////////////////////////////////////////
+        // Secondary: Executor directly supports property (when parameters doesn't)
+        template <typename Executor, typename Parameters>
+            requires(hpx::traits::is_executor_any_v<Executor> &&
+                check_for_property<Executor>::value &&
+                (!hpx::traits::is_executor_parameters_v<Parameters> ||
+                    !check_for_property<Parameters>::value))
+        HPX_FORCEINLINE constexpr decltype(auto) operator()(Executor&& exec,
+            Parameters&& params, Property /*prop*/) const noexcept
+        {
+            return std::pair<Executor&&, Parameters&&>(
+                HPX_FORWARD(Executor, exec), HPX_FORWARD(Parameters, params));
         }
 
         // Fallback: neither executor nor parameters support property
@@ -740,13 +742,13 @@ namespace hpx::execution::experimental::detail {
         std::enable_if_t<has_measure_iteration_v<T>>>
     {
         template <typename Executor, typename F>
-        HPX_FORCEINLINE std::size_t measure_iteration(Executor&& exec, F&& f,
-            std::size_t cores, std::size_t num_tasks) const
+        HPX_FORCEINLINE decltype(auto) measure_iteration(
+            Executor&& exec, F&& f, std::size_t num_tasks) const
         {
             auto& wrapped =
                 static_cast<unwrapper<Wrapper> const*>(this)->member_.get();
-            return wrapped.measure_iteration(HPX_FORWARD(Executor, exec),
-                HPX_FORWARD(F, f), cores, num_tasks);
+            return wrapped.measure_iteration(
+                HPX_FORWARD(Executor, exec), HPX_FORWARD(F, f), num_tasks);
         }
     };
 
@@ -839,12 +841,14 @@ namespace hpx::execution::experimental::detail {
         std::enable_if_t<has_processing_units_count_v<T>>>
     {
         template <typename Executor>
-        HPX_FORCEINLINE std::size_t processing_units_count(
-            Executor&& exec) const
+        HPX_FORCEINLINE std::size_t processing_units_count(Executor&& exec,
+            hpx::chrono::steady_duration const& iteration_duration,
+            std::size_t num_tasks) const
         {
             auto& wrapped =
                 static_cast<unwrapper<Wrapper> const*>(this)->member_.get();
-            return wrapped.processing_units_count(HPX_FORWARD(Executor, exec));
+            return wrapped.processing_units_count(
+                HPX_FORWARD(Executor, exec), iteration_duration, num_tasks);
         }
     };
 

--- a/libs/core/execution/include/hpx/execution/executors/execution_parameters.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution_parameters.hpp
@@ -16,7 +16,6 @@
 #include <hpx/modules/execution_base.hpp>
 #include <hpx/modules/preprocessor.hpp>
 #include <hpx/modules/serialization.hpp>
-#include <hpx/modules/tag_invoke.hpp>
 #include <hpx/modules/timing.hpp>
 #include <hpx/modules/type_support.hpp>
 
@@ -34,50 +33,45 @@ namespace hpx::execution::experimental::detail {
     ///////////////////////////////////////////////////////////////////////
     template <typename Property, template <typename> class CheckForProperty>
     struct get_parameters_property_t final
-      : hpx::functional::detail::tag_fallback<
-            get_parameters_property_t<Property, CheckForProperty>>
     {
     private:
-        using derived_property_t =
-            get_parameters_property_t<Property, CheckForProperty>;
-
         template <typename T>
         using check_for_property = CheckForProperty<std::decay_t<T>>;
 
+    public:
+        // Primary: Executor directly supports property (highest priority)
         template <typename Executor, typename Parameters>
-            requires(!hpx::traits::is_executor_parameters_v<Parameters> ||
-                !check_for_property<Parameters>::value)
-        friend HPX_FORCEINLINE constexpr decltype(auto) tag_fallback_invoke(
-            derived_property_t, Executor&& /*exec*/, Parameters&& /*params*/,
-            Property prop) noexcept
+            requires(hpx::traits::is_executor_any_v<Executor> &&
+                check_for_property<Executor>::value)
+        HPX_FORCEINLINE constexpr decltype(auto) operator()(Executor&& exec,
+            Parameters&& params, Property /*prop*/) const noexcept
         {
-            return std::make_pair(prop, prop);
+            return std::pair<Executor&&, Parameters&&>(
+                HPX_FORWARD(Executor, exec), HPX_FORWARD(Parameters, params));
         }
 
         ///////////////////////////////////////////////////////////////////
         // Parameters directly supports property
         template <typename Executor, typename Parameters>
-            requires(hpx::traits::is_executor_parameters_v<Parameters> &&
+            requires(!check_for_property<Executor>::value &&
+                hpx::traits::is_executor_parameters_v<Parameters> &&
                 check_for_property<Parameters>::value)
-        friend HPX_FORCEINLINE constexpr decltype(auto) tag_fallback_invoke(
-            derived_property_t, Executor&& exec, Parameters&& params,
-            Property /*prop*/) noexcept
+        HPX_FORCEINLINE constexpr decltype(auto) operator()(Executor&& exec,
+            Parameters&& params, Property /*prop*/) const noexcept
         {
             return std::pair<Parameters&&, Executor&&>(
                 HPX_FORWARD(Parameters, params), HPX_FORWARD(Executor, exec));
         }
 
-        ///////////////////////////////////////////////////////////////////
-        // Executor directly supports property
+        // Fallback: neither executor nor parameters support property
         template <typename Executor, typename Parameters>
-            requires(hpx::traits::is_executor_any_v<Executor> &&
-                check_for_property<Executor>::value)
-        friend HPX_FORCEINLINE constexpr decltype(auto) tag_invoke(
-            derived_property_t, Executor&& exec, Parameters&& params,
-            Property /*prop*/) noexcept
+            requires(!check_for_property<Executor>::value &&
+                (!hpx::traits::is_executor_parameters_v<Parameters> ||
+                    !check_for_property<Parameters>::value))
+        HPX_FORCEINLINE constexpr decltype(auto) operator()(Executor&& /*exec*/,
+            Parameters&& /*params*/, Property prop) const noexcept
         {
-            return std::pair<Executor&&, Parameters&&>(
-                HPX_FORWARD(Executor, exec), HPX_FORWARD(Parameters, params));
+            return std::make_pair(prop, prop);
         }
     };
 

--- a/libs/core/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2016-2025 Hartmut Kaiser
+//  Copyright (c) 2016-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -11,7 +11,6 @@
 #include <hpx/execution/traits/executor_traits.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/execution_base.hpp>
-#include <hpx/modules/tag_invoke.hpp>
 #include <hpx/modules/timing.hpp>
 #include <hpx/modules/type_support.hpp>
 
@@ -66,6 +65,15 @@ namespace hpx::execution::experimental {
             typename Enable = void>
         struct collect_execution_parameters_fn_helper;
         /// \endcond
+
+        template <typename CPO, typename ExPolicy, typename... Ts>
+            requires(hpx::is_execution_policy_v<std::decay_t<ExPolicy>>)
+        HPX_FORCEINLINE decltype(auto) forward_to_policy_executor(
+            CPO const& cpo, ExPolicy&& policy, Ts&&... ts)
+        {
+            return cpo(HPX_FORWARD(ExPolicy, policy).executor(),
+                HPX_FORWARD(Ts, ts)...);
+        }
     }    // namespace detail
 
     ///////////////////////////////////////////////////////////////////////////
@@ -100,16 +108,14 @@ namespace hpx::execution::experimental {
     ///                 that should be used for parallel execution.
     ///
     HPX_CXX_CORE_EXPORT inline constexpr struct get_chunk_size_t final
-      : hpx::functional::detail::tag_priority<get_chunk_size_t>
     {
-    private:
         template <typename Parameters, typename Executor>
             requires(hpx::executor_parameters<Parameters> &&
                 hpx::executor_any<Executor>)
-        friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            get_chunk_size_t, Parameters&& params, Executor&& exec,
+        HPX_FORCEINLINE decltype(auto) operator()(Parameters&& params,
+            Executor&& exec,
             hpx::chrono::steady_duration const& iteration_duration,
-            std::size_t cores, std::size_t num_tasks)
+            std::size_t cores, std::size_t num_tasks) const
         {
             return detail::get_chunk_size_fn_helper<
                 hpx::util::decay_unwrap_t<Parameters>,
@@ -121,11 +127,10 @@ namespace hpx::execution::experimental {
         template <typename Parameters, typename Executor>
             requires(hpx::executor_parameters<Parameters> &&
                 hpx::executor_any<Executor>)
-        friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            get_chunk_size_t tag, Parameters&& params, Executor&& exec,
-            std::size_t cores, std::size_t num_tasks)
+        HPX_FORCEINLINE decltype(auto) operator()(Parameters&& params,
+            Executor&& exec, std::size_t cores, std::size_t num_tasks) const
         {
-            return tag(HPX_FORWARD(Parameters, params),
+            return (*this)(HPX_FORWARD(Parameters, params),
                 HPX_FORWARD(Executor, exec), hpx::chrono::null_duration, cores,
                 num_tasks);
         }
@@ -152,15 +157,12 @@ namespace hpx::execution::experimental {
     /// \return The execution time for one of the tasks.
     ///
     HPX_CXX_CORE_EXPORT inline constexpr struct measure_iteration_t final
-      : hpx::functional::detail::tag_priority<measure_iteration_t>
     {
-    private:
         template <typename Parameters, typename Executor, typename F>
             requires(hpx::executor_parameters<Parameters> &&
                 hpx::executor_any<Executor>)
-        friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            measure_iteration_t, Parameters&& params, Executor&& exec, F&& f,
-            std::size_t num_tasks)
+        HPX_FORCEINLINE decltype(auto) operator()(Parameters&& params,
+            Executor&& exec, F&& f, std::size_t num_tasks) const
         {
             return detail::measure_iteration_fn_helper<
                 hpx::util::decay_unwrap_t<Parameters>,
@@ -183,15 +185,12 @@ namespace hpx::execution::experimental {
     ///                 determined for
     ///
     HPX_CXX_CORE_EXPORT inline constexpr struct maximal_number_of_chunks_t final
-      : hpx::functional::detail::tag_priority<maximal_number_of_chunks_t>
     {
-    private:
         template <typename Parameters, typename Executor>
             requires(hpx::executor_parameters<Parameters> &&
                 hpx::executor_any<Executor>)
-        friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            maximal_number_of_chunks_t, Parameters&& params, Executor&& exec,
-            std::size_t cores, std::size_t num_tasks)
+        HPX_FORCEINLINE decltype(auto) operator()(Parameters&& params,
+            Executor&& exec, std::size_t cores, std::size_t num_tasks) const
         {
             return detail::maximal_number_of_chunks_fn_helper<
                 hpx::util::decay_unwrap_t<Parameters>,
@@ -210,16 +209,14 @@ namespace hpx::execution::experimental {
     /// \note This calls params.reset_thread_distribution(exec) if it exists;
     ///       otherwise it does nothing.
     ///
-    HPX_CXX_CORE_EXPORT inline constexpr struct reset_thread_distribution_t
-        final
-      : hpx::functional::detail::tag_priority<reset_thread_distribution_t>
+    HPX_CXX_CORE_EXPORT inline constexpr struct
+        reset_thread_distribution_t final
     {
-    private:
         template <typename Parameters, typename Executor>
             requires(hpx::executor_parameters<Parameters> &&
                 hpx::executor_any<Executor>)
-        friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            reset_thread_distribution_t, Parameters&& params, Executor&& exec)
+        HPX_FORCEINLINE decltype(auto) operator()(
+            Parameters&& params, Executor&& exec) const
         {
             return detail::reset_thread_distribution_fn_helper<
                 hpx::util::decay_unwrap_t<Parameters>,
@@ -246,69 +243,88 @@ namespace hpx::execution::experimental {
     /// \return The number of cores to use
     ///
     HPX_CXX_CORE_EXPORT inline constexpr struct processing_units_count_t final
-      : hpx::functional::detail::tag_priority<processing_units_count_t>
     {
-    private:
+        // Primary: executor has .query() method
         template <typename Parameters, typename Executor>
-        friend HPX_FORCEINLINE decltype(auto) tag_invoke(
-            processing_units_count_t tag, Parameters&& params, Executor&& exec,
-            hpx::chrono::steady_duration const& iteration_duration,
-            std::size_t num_tasks)
             requires(hpx::executor_parameters<Parameters> &&
                 has_query_v<Executor, processing_units_count_t, Parameters,
                     hpx::chrono::steady_duration const&, std::size_t>)
+        HPX_FORCEINLINE decltype(auto) operator()(Parameters&& params,
+            Executor&& exec,
+            hpx::chrono::steady_duration const& iteration_duration,
+            std::size_t num_tasks) const
         {
             return HPX_FORWARD(Executor, exec)
-                .query(tag, HPX_FORWARD(Parameters, params), iteration_duration,
-                    num_tasks);
+                .query(*this, HPX_FORWARD(Parameters, params),
+                    iteration_duration, num_tasks);
         }
 
         template <typename Parameters, typename Executor>
-        friend HPX_FORCEINLINE decltype(auto) tag_invoke(
-            processing_units_count_t tag, Parameters&& params, Executor&& exec,
-            std::size_t num_tasks)
             requires(hpx::executor_parameters<Parameters> &&
                 has_query_v<Executor, processing_units_count_t, Parameters,
                     hpx::chrono::steady_duration const&, std::size_t>)
+        HPX_FORCEINLINE decltype(auto) operator()(
+            Parameters&& params, Executor&& exec, std::size_t num_tasks) const
         {
             return HPX_FORWARD(Executor, exec)
-                .query(tag, HPX_FORWARD(Parameters, params),
+                .query(*this, HPX_FORWARD(Parameters, params),
                     hpx::chrono::null_duration, num_tasks);
         }
 
         template <typename Executor>
-        friend HPX_FORCEINLINE decltype(auto) tag_invoke(
-            processing_units_count_t tag, Executor&& exec,
-            hpx::chrono::steady_duration const& iteration_duration,
-            std::size_t num_tasks)
             requires(has_query_v<Executor, processing_units_count_t,
                 null_parameters_t, hpx::chrono::steady_duration const&,
                 std::size_t>)
+        HPX_FORCEINLINE decltype(auto) operator()(Executor&& exec,
+            hpx::chrono::steady_duration const& iteration_duration,
+            std::size_t num_tasks) const
         {
             return HPX_FORWARD(Executor, exec)
-                .query(tag, null_parameters, iteration_duration, num_tasks);
+                .query(*this, null_parameters, iteration_duration, num_tasks);
         }
 
         template <typename Executor>
-        friend HPX_FORCEINLINE decltype(auto) tag_invoke(
-            processing_units_count_t tag, Executor&& exec,
-            std::size_t num_tasks)
             requires(has_query_v<Executor, processing_units_count_t,
                 null_parameters_t, hpx::chrono::steady_duration const&,
                 std::size_t>)
+        HPX_FORCEINLINE decltype(auto) operator()(
+            Executor&& exec, std::size_t num_tasks) const
         {
             return HPX_FORWARD(Executor, exec)
-                .query(tag, null_parameters, hpx::chrono::null_duration,
+                .query(*this, null_parameters, hpx::chrono::null_duration,
                     num_tasks);
         }
 
         template <typename Parameters, typename Executor>
             requires(hpx::executor_parameters<Parameters> &&
-                hpx::executor_any<Executor>)
-        friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            processing_units_count_t, Parameters&& params, Executor&& exec,
+                has_query_v<Executor, processing_units_count_t, Parameters,
+                    hpx::chrono::steady_duration const&, std::size_t>)
+        HPX_FORCEINLINE decltype(auto) operator()(
+            Parameters&& params, Executor&& exec) const
+        {
+            return (*this)(HPX_FORWARD(Parameters, params),
+                HPX_FORWARD(Executor, exec), std::size_t{0});
+        }
+
+        template <typename Executor>
+            requires(has_query_v<Executor, processing_units_count_t,
+                null_parameters_t, hpx::chrono::steady_duration const&,
+                std::size_t>)
+        HPX_FORCEINLINE decltype(auto) operator()(Executor&& exec) const
+        {
+            return (*this)(HPX_FORWARD(Executor, exec), std::size_t{0});
+        }
+
+        // Fallback: use fn_helper
+        template <typename Parameters, typename Executor>
+            requires(hpx::executor_parameters<Parameters> &&
+                hpx::executor_any<Executor> &&
+                !has_query_v<Executor, processing_units_count_t, Parameters,
+                    hpx::chrono::steady_duration const&, std::size_t>)
+        HPX_FORCEINLINE decltype(auto) operator()(Parameters&& params,
+            Executor&& exec,
             hpx::chrono::steady_duration const& iteration_duration,
-            std::size_t num_tasks)
+            std::size_t num_tasks) const
         {
             return detail::processing_units_count_fn_helper<
                 hpx::util::decay_unwrap_t<Parameters>,
@@ -318,22 +334,25 @@ namespace hpx::execution::experimental {
 
         template <typename Parameters, typename Executor>
             requires(hpx::executor_parameters<Parameters> &&
-                hpx::executor_any<Executor>)
-        friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            processing_units_count_t tag, Parameters&& params, Executor&& exec,
-            std::size_t num_tasks = 0)
+                hpx::executor_any<Executor> &&
+                !has_query_v<Executor, processing_units_count_t, Parameters,
+                    hpx::chrono::steady_duration const&, std::size_t>)
+        HPX_FORCEINLINE decltype(auto) operator()(Parameters&& params,
+            Executor&& exec, std::size_t num_tasks = 0) const
         {
-            return tag(HPX_FORWARD(Parameters, params),
+            return (*this)(HPX_FORWARD(Parameters, params),
                 HPX_FORWARD(Executor, exec), hpx::chrono::null_duration,
                 num_tasks);
         }
 
         template <typename Executor>
-            requires(hpx::executor_any<Executor>)
-        friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            processing_units_count_t, Executor&& exec,
+            requires(hpx::executor_any<Executor> &&
+                !has_query_v<Executor, processing_units_count_t,
+                    null_parameters_t, hpx::chrono::steady_duration const&,
+                    std::size_t>)
+        HPX_FORCEINLINE decltype(auto) operator()(Executor&& exec,
             hpx::chrono::steady_duration const& iteration_duration,
-            std::size_t num_tasks)
+            std::size_t num_tasks) const
         {
             return detail::processing_units_count_fn_helper<null_parameters_t,
                 std::decay_t<Executor>>::call(null_parameters,
@@ -341,40 +360,46 @@ namespace hpx::execution::experimental {
         }
 
         template <typename Executor>
-            requires(hpx::executor_any<Executor>)
-        friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            processing_units_count_t tag, Executor&& exec,
-            std::size_t num_tasks = 0)
+            requires(hpx::executor_any<Executor> &&
+                !has_query_v<Executor, processing_units_count_t,
+                    null_parameters_t, hpx::chrono::steady_duration const&,
+                    std::size_t>)
+        HPX_FORCEINLINE decltype(auto) operator()(
+            Executor&& exec, std::size_t num_tasks = 0) const
         {
-            return tag(null_parameters, HPX_FORWARD(Executor, exec),
+            return (*this)(null_parameters, HPX_FORWARD(Executor, exec),
                 hpx::chrono::null_duration, num_tasks);
+        }
+
+        template <typename ExPolicy>
+            requires(hpx::is_execution_policy_v<std::decay_t<ExPolicy>>)
+        HPX_FORCEINLINE decltype(auto) operator()(ExPolicy&& policy) const
+        {
+            return detail::forward_to_policy_executor(
+                *this, HPX_FORWARD(ExPolicy, policy));
         }
     } processing_units_count{};
 
     /// Generate a policy that supports setting the number of cores for
     /// execution.
-    HPX_CXX_CORE_EXPORT inline constexpr struct with_processing_units_count_t
-        final
-      : hpx::functional::detail::tag_priority<with_processing_units_count_t>
+    HPX_CXX_CORE_EXPORT inline constexpr struct
+        with_processing_units_count_t final
     {
-    private:
         template <typename Executor>
-        friend decltype(auto) tag_invoke(with_processing_units_count_t tag,
-            Executor&& exec, std::size_t num_cores)
             requires(has_query_v<Executor, with_processing_units_count_t,
                 std::size_t>)
+        decltype(auto) operator()(Executor&& exec, std::size_t num_cores) const
         {
-            return HPX_FORWARD(Executor, exec).query(tag, num_cores);
+            return HPX_FORWARD(Executor, exec).query(*this, num_cores);
         }
 
         template <typename Policy, typename Property>
-        friend decltype(auto) tag_invoke(with_processing_units_count_t tag,
-            Policy&& policy, Property&& property)
             requires(hpx::is_execution_policy_v<std::decay_t<Policy>> &&
                 has_query_v<Policy, with_processing_units_count_t, Property>)
+        decltype(auto) operator()(Policy&& policy, Property&& property) const
         {
             return HPX_FORWARD(Policy, policy)
-                .query(tag, HPX_FORWARD(Property, property));
+                .query(*this, HPX_FORWARD(Property, property));
         }
     } with_processing_units_count{};
 
@@ -389,14 +414,12 @@ namespace hpx::execution::experimental {
     ///       otherwise it does nothing.
     ///
     HPX_CXX_CORE_EXPORT inline constexpr struct mark_begin_execution_t final
-      : hpx::functional::detail::tag_priority<mark_begin_execution_t>
     {
-    private:
         template <typename Parameters, typename Executor>
             requires(hpx::executor_parameters<Parameters> &&
                 hpx::executor_any<Executor>)
-        friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            mark_begin_execution_t, Parameters&& params, Executor&& exec)
+        HPX_FORCEINLINE decltype(auto) operator()(
+            Parameters&& params, Executor&& exec) const
         {
             return detail::mark_begin_execution_fn_helper<
                 hpx::util::decay_unwrap_t<Parameters>,
@@ -416,14 +439,12 @@ namespace hpx::execution::experimental {
     ///       otherwise it does nothing.
     ///
     HPX_CXX_CORE_EXPORT inline constexpr struct mark_end_of_scheduling_t final
-      : hpx::functional::detail::tag_priority<mark_end_of_scheduling_t>
     {
-    private:
         template <typename Parameters, typename Executor>
             requires(hpx::executor_parameters<Parameters> &&
                 hpx::executor_any<Executor>)
-        friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            mark_end_of_scheduling_t, Parameters&& params, Executor&& exec)
+        HPX_FORCEINLINE decltype(auto) operator()(
+            Parameters&& params, Executor&& exec) const
         {
             return detail::mark_end_of_scheduling_fn_helper<
                 hpx::util::decay_unwrap_t<Parameters>,
@@ -443,14 +464,12 @@ namespace hpx::execution::experimental {
     ///       otherwise it does nothing.
     ///
     HPX_CXX_CORE_EXPORT inline constexpr struct mark_end_execution_t final
-      : hpx::functional::detail::tag_priority<mark_end_execution_t>
     {
-    private:
         template <typename Parameters, typename Executor>
             requires(hpx::executor_parameters<Parameters> &&
                 hpx::executor_any<Executor>)
-        friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            mark_end_execution_t, Parameters&& params, Executor&& exec)
+        HPX_FORCEINLINE decltype(auto) operator()(
+            Parameters&& params, Executor&& exec) const
         {
             return detail::mark_end_execution_fn_helper<
                 hpx::util::decay_unwrap_t<Parameters>,
@@ -470,15 +489,12 @@ namespace hpx::execution::experimental {
     ///       otherwise it does nothing.
     ///
     HPX_CXX_CORE_EXPORT inline constexpr struct mark_partition_t final
-      : hpx::functional::detail::tag_priority<mark_partition_t>
     {
-    private:
         template <typename Parameters, typename Executor, typename... Args>
             requires(hpx::executor_parameters<Parameters> &&
                 hpx::executor_any<Executor>)
-        friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            mark_partition_t, Parameters&& params, Executor&& exec,
-            std::size_t partition, Args&&... args)
+        HPX_FORCEINLINE decltype(auto) operator()(Parameters&& params,
+            Executor&& exec, std::size_t partition, Args&&... args) const
         {
             return detail::mark_partition_fn_helper<
                 hpx::util::decay_unwrap_t<Parameters>,
@@ -507,18 +523,15 @@ namespace hpx::execution::experimental {
     /// \note This calls params.mark_begin_execution(exec) if it exists;
     ///       otherwise it does nothing.
     ///
-    HPX_CXX_CORE_EXPORT inline constexpr struct collect_execution_parameters_t
-        final
-      : hpx::functional::detail::tag_priority<collect_execution_parameters_t>
+    HPX_CXX_CORE_EXPORT inline constexpr struct
+        collect_execution_parameters_t final
     {
-    private:
         template <typename Parameters, typename Executor>
             requires(hpx::executor_parameters<Parameters> &&
                 hpx::executor_any<Executor>)
-        friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            collect_execution_parameters_t, Parameters&& params,
+        HPX_FORCEINLINE decltype(auto) operator()(Parameters&& params,
             Executor&& exec, std::size_t num_elements, std::size_t num_cores,
-            std::size_t num_chunks, std::size_t chunk_size)
+            std::size_t num_chunks, std::size_t chunk_size) const
         {
             return detail::collect_execution_parameters_fn_helper<
                 hpx::util::decay_unwrap_t<Parameters>,

--- a/libs/core/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2016-2026 Hartmut Kaiser
+//  Copyright (c) 2026 Sai Charan Arvapally
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/core/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/execution_parameters_fwd.hpp
@@ -347,6 +347,7 @@ namespace hpx::execution::experimental {
 
         template <typename Executor>
             requires(hpx::executor_any<Executor> &&
+                !hpx::is_execution_policy_v<std::decay_t<Executor>> &&
                 !has_query_v<Executor, processing_units_count_t,
                     null_parameters_t, hpx::chrono::steady_duration const&,
                     std::size_t>)
@@ -361,6 +362,7 @@ namespace hpx::execution::experimental {
 
         template <typename Executor>
             requires(hpx::executor_any<Executor> &&
+                !hpx::is_execution_policy_v<std::decay_t<Executor>> &&
                 !has_query_v<Executor, processing_units_count_t,
                     null_parameters_t, hpx::chrono::steady_duration const&,
                     std::size_t>)

--- a/libs/core/execution/include/hpx/execution/executors/guided_chunk_size.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/guided_chunk_size.hpp
@@ -65,14 +65,12 @@ namespace hpx::execution::experimental {
         using has_variable_chunk_size = std::true_type;
 
         template <typename Executor>
-        friend constexpr std::size_t tag_override_invoke(
-            hpx::execution::experimental::get_chunk_size_t,
-            guided_chunk_size const& this_, Executor&& /* exec */,
+        constexpr std::size_t get_chunk_size(Executor&& /* exec */,
             hpx::chrono::steady_duration const&, std::size_t const cores,
-            std::size_t const num_tasks) noexcept
+            std::size_t const num_tasks) const noexcept
         {
-            return (std::max) (this_.min_chunk_size_,
-                (num_tasks + cores - 1) / cores);
+            return (std::max) (
+                min_chunk_size_, (num_tasks + cores - 1) / cores);
         }
         /// \endcond
 

--- a/libs/core/execution/include/hpx/execution/executors/guided_chunk_size.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/guided_chunk_size.hpp
@@ -69,8 +69,8 @@ namespace hpx::execution::experimental {
             hpx::chrono::steady_duration const&, std::size_t const cores,
             std::size_t const num_tasks) const noexcept
         {
-            return (std::max) (
-                min_chunk_size_, (num_tasks + cores - 1) / cores);
+            return (
+                std::max) (min_chunk_size_, (num_tasks + cores - 1) / cores);
         }
         /// \endcond
 

--- a/libs/core/execution/include/hpx/execution/executors/max_num_chunks.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/max_num_chunks.hpp
@@ -47,15 +47,13 @@ namespace hpx::execution::experimental {
 
         /// \cond NOINTERNAL
         template <typename Executor>
-        friend std::size_t tag_override_invoke(
-            hpx::execution::experimental::maximal_number_of_chunks_t,
-            max_num_chunks& this_, Executor&&, std::size_t const cores,
-            std::size_t)
+        std::size_t maximal_number_of_chunks(
+            Executor&&, std::size_t const cores, std::size_t) const
         {
             // use the given number of chunks if given
-            if (this_.num_chunks_ != 0)
+            if (num_chunks_ != 0)
             {
-                return this_.num_chunks_;
+                return num_chunks_;
             }
 
             if (cores == 1)

--- a/libs/core/execution/include/hpx/execution/executors/num_cores.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/num_cores.hpp
@@ -42,17 +42,15 @@ namespace hpx::execution::experimental {
         /// \cond NOINTERNAL
         // discover the number of cores to use for parallelization
         template <typename Executor>
-        friend std::size_t tag_override_invoke(
-            hpx::execution::experimental::processing_units_count_t,
-            num_cores const& this_, Executor&& exec,
+        std::size_t processing_units_count(Executor&& exec,
             hpx::chrono::steady_duration const& duration =
                 hpx::chrono::null_duration,
-            std::size_t num_tasks = 0) noexcept
+            std::size_t num_tasks = 0) const noexcept
         {
             std::size_t const available_pus =
                 hpx::execution::experimental::processing_units_count(
                     exec, duration, num_tasks);
-            return (std::min) (this_.num_cores_, available_pus);
+            return (std::min) (num_cores_, available_pus);
         }
         /// \endcond
 

--- a/libs/core/execution/include/hpx/execution/executors/persistent_auto_chunk_size.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/persistent_auto_chunk_size.hpp
@@ -98,41 +98,36 @@ namespace hpx::execution::experimental {
 
         // Estimate execution time for one iteration
         template <typename Executor, typename F>
-        friend auto tag_override_invoke(
-            hpx::execution::experimental::measure_iteration_t,
-            persistent_auto_chunk_size& this_, Executor&&, F&& f,
-            std::size_t const count)
+        auto measure_iteration(Executor&&, F&& f, std::size_t const count)
         {
             // by default use 1% of the iterations
-            if (this_.num_iters_for_timing_ == 0)
+            if (num_iters_for_timing_ == 0)
             {
-                this_.num_iters_for_timing_ = count / 100;
+                num_iters_for_timing_ = count / 100;
             }
 
             // perform measurements only if necessary
-            if (this_.num_iters_for_timing_ > 0)
+            if (num_iters_for_timing_ > 0)
             {
                 using hpx::chrono::high_resolution_clock;
                 std::uint64_t t = high_resolution_clock::now();
 
-                std::size_t const test_chunk_size =
-                    f(this_.num_iters_for_timing_);
+                std::size_t const test_chunk_size = f(num_iters_for_timing_);
                 if (test_chunk_size != 0)
                 {
-                    if (this_.chunk_size_time_ == std::chrono::nanoseconds(0))
+                    if (chunk_size_time_ == std::chrono::nanoseconds(0))
                     {
                         t = (high_resolution_clock::now() - t) /
                             test_chunk_size;
-                        this_.chunk_size_time_ = std::chrono::nanoseconds(t);
+                        chunk_size_time_ = std::chrono::nanoseconds(t);
                     }
                     else
                     {
                         t = static_cast<std::uint64_t>(
-                            this_.chunk_size_time_.count());
+                            chunk_size_time_.count());
                     }
 
-                    if (t != 0 &&
-                        this_.min_time_ >= std::chrono::nanoseconds(t))
+                    if (t != 0 && min_time_ >= std::chrono::nanoseconds(t))
                     {
                         // return execution time for one iteration
                         return std::chrono::nanoseconds(t);
@@ -145,11 +140,9 @@ namespace hpx::execution::experimental {
 
         // Estimate a chunk size based on number of cores used.
         template <typename Executor>
-        friend std::size_t tag_override_invoke(
-            hpx::execution::experimental::get_chunk_size_t,
-            persistent_auto_chunk_size const& this_, Executor& /* exec */,
+        std::size_t get_chunk_size(Executor& /* exec */,
             hpx::chrono::steady_duration const& iteration_duration,
-            std::size_t const cores, std::size_t const count) noexcept
+            std::size_t const cores, std::size_t const count) const noexcept
         {
             // return chunk size which will create the required amount of work
             if (iteration_duration.value() !=
@@ -159,7 +152,7 @@ namespace hpx::execution::experimental {
                     std::chrono::duration_cast<std::chrono::nanoseconds>(
                         iteration_duration.value());
                 return (std::min) (count,
-                    (std::size_t) (this_.min_time_.count() / ns.count()));
+                    (std::size_t) (min_time_.count() / ns.count()));
             }
             return (count + cores - 1) / cores;
         }

--- a/libs/core/execution/include/hpx/execution/executors/persistent_auto_chunk_size.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/persistent_auto_chunk_size.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2016 Zahra Khatami
+//  Copyright (c) 2026 Sai Charan Arvapally
 //  Copyright (c) 2022-2024 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0

--- a/libs/core/execution/include/hpx/execution/executors/polymorphic_executor.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/polymorphic_executor.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017-2025 Hartmut Kaiser
+//  Copyright (c) 2017-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -802,60 +802,48 @@ namespace hpx::parallel::execution {
         template <typename>
         using future_type = hpx::future<R>;
 
-    private:
+    public:
         // NonBlockingOneWayExecutor interface
         template <typename F>
-        HPX_FORCEINLINE friend void tag_invoke(hpx::parallel::execution::post_t,
-            polymorphic_executor const& exec, F&& f, Ts... ts)
+        HPX_FORCEINLINE void post(F&& f, Ts... ts) const
         {
             using function_type = typename vtable::post_function_type;
 
-            vtable const* vptr_ =
-                static_cast<vtable const*>(exec.base_type::vptr);
-            vptr_->post(exec.object, function_type(HPX_FORWARD(F, f)),
+            vtable const* vptr_ = static_cast<vtable const*>(base_type::vptr);
+            vptr_->post(object, function_type(HPX_FORWARD(F, f)),
                 HPX_FORWARD(Ts, ts)...);
         }
 
         // OneWayExecutor interface
         template <typename F>
-        HPX_FORCEINLINE friend R tag_invoke(
-            hpx::parallel::execution::sync_execute_t,
-            polymorphic_executor const& exec, F&& f, Ts... ts)
+        HPX_FORCEINLINE R sync_execute(F&& f, Ts... ts) const
         {
             using function_type = typename vtable::sync_execute_function_type;
 
-            vtable const* vptr_ =
-                static_cast<vtable const*>(exec.base_type::vptr);
-            return vptr_->sync_execute(exec.object,
-                function_type(HPX_FORWARD(F, f)), HPX_FORWARD(Ts, ts)...);
+            vtable const* vptr_ = static_cast<vtable const*>(base_type::vptr);
+            return vptr_->sync_execute(object, function_type(HPX_FORWARD(F, f)),
+                HPX_FORWARD(Ts, ts)...);
         }
 
         // TwoWayExecutor interface
         template <typename F>
-        HPX_FORCEINLINE friend hpx::future<R> tag_invoke(
-            hpx::parallel::execution::async_execute_t,
-            polymorphic_executor const& exec, F&& f, Ts... ts)
+        HPX_FORCEINLINE hpx::future<R> async_execute(F&& f, Ts... ts) const
         {
             using function_type = typename vtable::async_execute_function_type;
 
-            vtable const* vptr_ =
-                static_cast<vtable const*>(exec.base_type::vptr);
-            return vptr_->async_execute(exec.object,
+            vtable const* vptr_ = static_cast<vtable const*>(base_type::vptr);
+            return vptr_->async_execute(object,
                 function_type(HPX_FORWARD(F, f)), HPX_FORWARD(Ts, ts)...);
         }
 
         template <typename F, typename Future>
-        HPX_FORCEINLINE friend hpx::future<R> tag_invoke(
-            hpx::parallel::execution::then_execute_t,
-            polymorphic_executor const& exec, F&& f, Future&& predecessor,
-            Ts&&... ts)
+        HPX_FORCEINLINE hpx::future<R> then_execute(
+            F&& f, Future&& predecessor, Ts&&... ts) const
         {
             using function_type = typename vtable::then_execute_function_type;
 
-            vtable const* vptr_ =
-                static_cast<vtable const*>(exec.base_type::vptr);
-            return vptr_->then_execute(exec.object,
-                function_type(HPX_FORWARD(F, f)),
+            vtable const* vptr_ = static_cast<vtable const*>(base_type::vptr);
+            return vptr_->then_execute(object, function_type(HPX_FORWARD(F, f)),
                 hpx::make_shared_future(HPX_FORWARD(Future, predecessor)),
                 HPX_FORWARD(Ts, ts)...);
         }
@@ -863,17 +851,15 @@ namespace hpx::parallel::execution {
         // BulkOneWayExecutor interface
         template <typename F, typename Shape>
             requires(!std::is_integral_v<Shape>)
-        HPX_FORCEINLINE friend std::vector<R> tag_invoke(
-            hpx::parallel::execution::bulk_sync_execute_t,
-            polymorphic_executor const& exec, F&& f, Shape const& s, Ts&&... ts)
+        HPX_FORCEINLINE std::vector<R> bulk_sync_execute(
+            F&& f, Shape const& s, Ts&&... ts) const
         {
             using function_type =
                 typename vtable::bulk_sync_execute_function_type;
 
             detail::range_proxy shape(s);
-            vtable const* vptr_ =
-                static_cast<vtable const*>(exec.base_type::vptr);
-            return vptr_->bulk_sync_execute(exec.object,
+            vtable const* vptr_ = static_cast<vtable const*>(base_type::vptr);
+            return vptr_->bulk_sync_execute(object,
                 function_type(HPX_FORWARD(F, f)), shape,
                 HPX_FORWARD(Ts, ts)...);
         }
@@ -881,35 +867,31 @@ namespace hpx::parallel::execution {
         // BulkTwoWayExecutor interface
         template <typename F, typename Shape>
             requires(!std::is_integral_v<Shape>)
-        HPX_FORCEINLINE friend hpx::future<std::vector<R>> tag_invoke(
-            hpx::parallel::execution::bulk_async_execute_t,
-            polymorphic_executor const& exec, F&& f, Shape const& s, Ts&&... ts)
+        HPX_FORCEINLINE hpx::future<std::vector<R>> bulk_async_execute(
+            F&& f, Shape const& s, Ts&&... ts) const
         {
             using function_type =
                 typename vtable::bulk_async_execute_function_type;
 
             detail::range_proxy shape(s);
-            vtable const* vptr_ =
-                static_cast<vtable const*>(exec.base_type::vptr);
-            return vptr_->bulk_async_execute(exec.object,
+            vtable const* vptr_ = static_cast<vtable const*>(base_type::vptr);
+            return vptr_->bulk_async_execute(object,
                 function_type(HPX_FORWARD(F, f)), shape,
                 HPX_FORWARD(Ts, ts)...);
         }
 
         template <typename F, typename Shape>
             requires(!std::is_integral_v<Shape>)
-        HPX_FORCEINLINE friend hpx::future<std::vector<R>> tag_invoke(
-            hpx::parallel::execution::bulk_then_execute_t,
-            polymorphic_executor const& exec, F&& f, Shape const& s,
-            hpx::shared_future<void> const& predecessor, Ts&&... ts)
+        HPX_FORCEINLINE hpx::future<std::vector<R>> bulk_then_execute(F&& f,
+            Shape const& s, hpx::shared_future<void> const& predecessor,
+            Ts&&... ts) const
         {
             using function_type =
                 typename vtable::bulk_then_execute_function_type;
 
             detail::range_proxy shape(s);
-            vtable const* vptr_ =
-                static_cast<vtable const*>(exec.base_type::vptr);
-            return vptr_->bulk_then_execute(exec.object,
+            vtable const* vptr_ = static_cast<vtable const*>(base_type::vptr);
+            return vptr_->bulk_then_execute(object,
                 function_type(HPX_FORWARD(F, f)), shape, predecessor,
                 HPX_FORWARD(Ts, ts)...);
         }

--- a/libs/core/execution/include/hpx/execution/executors/polymorphic_executor.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/polymorphic_executor.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2017-2026 Hartmut Kaiser
+//  Copyright (c) 2026 Sai Charan Arvapally
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/core/execution/include/hpx/execution/executors/rebind_executor_parameters.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/rebind_executor_parameters.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2026 Hartmut Kaiser
+//  Copyright (c) 2026 Sai Charan Arvapally
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -129,7 +130,7 @@ namespace hpx::execution::experimental {
     // wrapping get_chunk_size
     HPX_CXX_CORE_EXPORT template <typename Params, typename Executor>
     inline constexpr bool supports_get_chunk_size_v =
-        requires(std::remove_reference_t<Params> const& p,
+        requires(std::remove_reference_t<Params>& p,
             std::remove_reference_t<Executor>& e,
             hpx::chrono::steady_duration const& d) {
             p.get_chunk_size(e, d, std::size_t{}, std::size_t{});
@@ -138,7 +139,7 @@ namespace hpx::execution::experimental {
     HPX_CXX_CORE_EXPORT template <typename Params, typename InnerParams,
         typename Executor>
     inline constexpr bool supports_wrapping_get_chunk_size_v =
-        requires(std::remove_reference_t<Params> const& p,
+        requires(std::remove_reference_t<Params>& p,
             std::remove_reference_t<InnerParams>& ip,
             std::remove_reference_t<Executor>& e,
             hpx::chrono::steady_duration const& d) {
@@ -149,7 +150,7 @@ namespace hpx::execution::experimental {
     HPX_CXX_CORE_EXPORT template <typename Params, typename Executor,
         typename F>
     inline constexpr bool supports_measure_iteration_v =
-        requires(std::remove_reference_t<Params> const& p,
+        requires(std::remove_reference_t<Params>& p,
             std::remove_reference_t<Executor>& e, F&& f) {
             p.measure_iteration(e, HPX_FORWARD(F, f), std::size_t{});
         };
@@ -157,7 +158,7 @@ namespace hpx::execution::experimental {
     HPX_CXX_CORE_EXPORT template <typename Params, typename InnerParams,
         typename Executor, typename F>
     inline constexpr bool supports_wrapping_measure_iteration_v =
-        requires(std::remove_reference_t<Params> const& p,
+        requires(std::remove_reference_t<Params>& p,
             std::remove_reference_t<InnerParams>& ip,
             std::remove_reference_t<Executor>& e, F&& f) {
             p.measure_iteration(ip, e, HPX_FORWARD(F, f), std::size_t{});
@@ -166,7 +167,7 @@ namespace hpx::execution::experimental {
     // maximal_number_of_chunks
     HPX_CXX_CORE_EXPORT template <typename Params, typename Executor>
     inline constexpr bool supports_maximal_number_of_chunks_v =
-        requires(std::remove_reference_t<Params> const& p,
+        requires(std::remove_reference_t<Params>& p,
             std::remove_reference_t<Executor>& e) {
             p.maximal_number_of_chunks(e, std::size_t{}, std::size_t{});
         };
@@ -174,7 +175,7 @@ namespace hpx::execution::experimental {
     HPX_CXX_CORE_EXPORT template <typename Params, typename InnerParams,
         typename Executor>
     inline constexpr bool supports_wrapping_maximal_number_of_chunks_v =
-        requires(std::remove_reference_t<Params> const& p,
+        requires(std::remove_reference_t<Params>& p,
             std::remove_reference_t<InnerParams>& ip,
             std::remove_reference_t<Executor>& e) {
             p.maximal_number_of_chunks(ip, e, std::size_t{}, std::size_t{});
@@ -183,13 +184,13 @@ namespace hpx::execution::experimental {
     // execution_markers: begin_execution
     HPX_CXX_CORE_EXPORT template <typename Params, typename Executor>
     inline constexpr bool supports_mark_begin_execution_v = requires(
-        std::remove_reference_t<Params> const& p,
+        std::remove_reference_t<Params>& p,
         std::remove_reference_t<Executor>& e) { p.mark_begin_execution(e); };
 
     HPX_CXX_CORE_EXPORT template <typename Params, typename InnerParams,
         typename Executor>
     inline constexpr bool supports_wrapping_mark_begin_execution_v =
-        requires(std::remove_reference_t<Params> const& p,
+        requires(std::remove_reference_t<Params>& p,
             std::remove_reference_t<InnerParams>& ip,
             std::remove_reference_t<Executor>& e) {
             p.mark_begin_execution(ip, e);
@@ -198,13 +199,13 @@ namespace hpx::execution::experimental {
     // execution_markers: end_of_scheduling
     HPX_CXX_CORE_EXPORT template <typename Params, typename Executor>
     inline constexpr bool supports_mark_end_of_scheduling_v = requires(
-        std::remove_reference_t<Params> const& p,
+        std::remove_reference_t<Params>& p,
         std::remove_reference_t<Executor>& e) { p.mark_end_of_scheduling(e); };
 
     HPX_CXX_CORE_EXPORT template <typename Params, typename InnerParams,
         typename Executor>
     inline constexpr bool supports_wrapping_mark_end_of_scheduling_v =
-        requires(std::remove_reference_t<Params> const& p,
+        requires(std::remove_reference_t<Params>& p,
             std::remove_reference_t<InnerParams>& ip,
             std::remove_reference_t<Executor>& e) {
             p.mark_end_of_scheduling(ip, e);
@@ -213,13 +214,13 @@ namespace hpx::execution::experimental {
     // execution_markers: end_execution
     HPX_CXX_CORE_EXPORT template <typename Params, typename Executor>
     inline constexpr bool supports_mark_end_execution_v =
-        requires(std::remove_reference_t<Params> const& p,
+        requires(std::remove_reference_t<Params>& p,
             std::remove_reference_t<Executor>& e) { p.mark_end_execution(e); };
 
     HPX_CXX_CORE_EXPORT template <typename Params, typename InnerParams,
         typename Executor>
     inline constexpr bool supports_wrapping_mark_end_execution_v = requires(
-        std::remove_reference_t<Params> const& p,
+        std::remove_reference_t<Params>& p,
         std::remove_reference_t<InnerParams>& ip,
         std::remove_reference_t<Executor>& e) { p.mark_end_execution(ip, e); };
 
@@ -227,7 +228,7 @@ namespace hpx::execution::experimental {
     HPX_CXX_CORE_EXPORT template <typename Params, typename Executor,
         typename... Args>
     inline constexpr bool supports_mark_partition_v =
-        requires(std::remove_reference_t<Params> const& p,
+        requires(std::remove_reference_t<Params>& p,
             std::remove_reference_t<Executor>& e, Args&&... args) {
             p.mark_partition(e, std::size_t{}, HPX_FORWARD(Args, args)...);
         };
@@ -235,7 +236,7 @@ namespace hpx::execution::experimental {
     HPX_CXX_CORE_EXPORT template <typename Params, typename InnerParams,
         typename Executor, typename... Args>
     inline constexpr bool supports_wrapping_mark_partition_v =
-        requires(std::remove_reference_t<Params> const& p,
+        requires(std::remove_reference_t<Params>& p,
             std::remove_reference_t<InnerParams>& ip,
             std::remove_reference_t<Executor>& e, Args&&... args) {
             p.mark_partition(ip, e, std::size_t{}, HPX_FORWARD(Args, args)...);
@@ -244,7 +245,7 @@ namespace hpx::execution::experimental {
     // wrapping processing_units_count
     HPX_CXX_CORE_EXPORT template <typename Params, typename Executor>
     inline constexpr bool supports_processing_units_count_v =
-        requires(std::remove_reference_t<Params> const& p,
+        requires(std::remove_reference_t<Params>& p,
             std::remove_reference_t<Executor>& e,
             hpx::chrono::steady_duration const& d) {
             p.processing_units_count(e, d, std::size_t{});
@@ -253,7 +254,7 @@ namespace hpx::execution::experimental {
     HPX_CXX_CORE_EXPORT template <typename Params, typename InnerParams,
         typename Executor>
     inline constexpr bool supports_wrapping_processing_units_count_v =
-        requires(std::remove_reference_t<Params> const& p,
+        requires(std::remove_reference_t<Params>& p,
             std::remove_reference_t<InnerParams>& ip,
             std::remove_reference_t<Executor>& e,
             hpx::chrono::steady_duration const& d) {
@@ -263,7 +264,7 @@ namespace hpx::execution::experimental {
     // wrapping reset_thread_distribution
     HPX_CXX_CORE_EXPORT template <typename Params, typename Executor>
     inline constexpr bool supports_reset_thread_distribution_v =
-        requires(std::remove_reference_t<Params> const& p,
+        requires(std::remove_reference_t<Params>& p,
             std::remove_reference_t<Executor>& e) {
             p.reset_thread_distribution(e);
         };
@@ -271,7 +272,7 @@ namespace hpx::execution::experimental {
     HPX_CXX_CORE_EXPORT template <typename Params, typename InnerParams,
         typename Executor>
     inline constexpr bool supports_wrapping_reset_thread_distribution_v =
-        requires(std::remove_reference_t<Params> const& p,
+        requires(std::remove_reference_t<Params>& p,
             std::remove_reference_t<InnerParams>& ip,
             std::remove_reference_t<Executor>& e) {
             p.reset_thread_distribution(ip, e);
@@ -280,7 +281,7 @@ namespace hpx::execution::experimental {
     // wrapping collect_execution_parameters
     HPX_CXX_CORE_EXPORT template <typename Params, typename Executor>
     inline constexpr bool supports_collect_execution_parameters_v =
-        requires(std::remove_reference_t<Params> const& p,
+        requires(std::remove_reference_t<Params>& p,
             std::remove_reference_t<Executor>& e) {
             p.collect_execution_parameters(
                 e, std::size_t{}, std::size_t{}, std::size_t{}, std::size_t{});
@@ -289,7 +290,7 @@ namespace hpx::execution::experimental {
     HPX_CXX_CORE_EXPORT template <typename Params, typename InnerParams,
         typename Executor>
     inline constexpr bool supports_wrapping_collect_execution_parameters_v =
-        requires(std::remove_reference_t<Params> const& p,
+        requires(std::remove_reference_t<Params>& p,
             std::remove_reference_t<InnerParams>& ip,
             std::remove_reference_t<Executor>& e) {
             p.collect_execution_parameters(ip, e, std::size_t{}, std::size_t{},
@@ -336,8 +337,8 @@ namespace hpx::execution::experimental {
             }
             else
             {
-                // Default implementation when neither has get_chunk_size
-                return (num_iterations + cores - 1) / cores;
+                return detail::get_chunk_size_property::get_chunk_size(
+                    HPX_FORWARD(Executor, exec), t, cores, num_iterations);
             }
         }
 
@@ -366,8 +367,8 @@ namespace hpx::execution::experimental {
             }
             else
             {
-                // Default implementation when neither has measure_iteration
-                return hpx::chrono::null_duration;
+                return detail::measure_iteration_property::measure_iteration(
+                    HPX_FORWARD(Executor, exec), HPX_FORWARD(F, f), num_tasks);
             }
         }
 
@@ -396,8 +397,9 @@ namespace hpx::execution::experimental {
             }
             else
             {
-                // Default implementation when neither has maximal_number_of_chunks
-                return cores * 4;
+                return detail::maximal_number_of_chunks_property::
+                    maximal_number_of_chunks(
+                        HPX_FORWARD(Executor, exec), cores, num_tasks);
             }
         }
 

--- a/libs/core/execution/include/hpx/execution/executors/rebind_executor_parameters.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/rebind_executor_parameters.hpp
@@ -122,136 +122,185 @@ namespace hpx::execution::experimental {
     }    // namespace detail
 
     ///////////////////////////////////////////////////////////////////////////
+    // Detection of parameter member functions (member-based customization).
+    // The "wrapping" variants detect a member that takes another parameters
+    // object as its first argument (used to wrap/decorate an inner parameter).
+
     // wrapping get_chunk_size
     HPX_CXX_CORE_EXPORT template <typename Params, typename Executor>
     inline constexpr bool supports_get_chunk_size_v =
-        hpx::functional::detail::is_tag_override_invocable_v<get_chunk_size_t,
-            Params&&, Executor&&, hpx::chrono::steady_duration const&,
-            std::size_t, std::size_t>;
+        requires(std::remove_reference_t<Params> const& p,
+            std::remove_reference_t<Executor>& e,
+            hpx::chrono::steady_duration const& d) {
+            p.get_chunk_size(e, d, std::size_t{}, std::size_t{});
+        };
 
     HPX_CXX_CORE_EXPORT template <typename Params, typename InnerParams,
         typename Executor>
     inline constexpr bool supports_wrapping_get_chunk_size_v =
-        hpx::functional::detail::is_tag_override_invocable_v<get_chunk_size_t,
-            Params&&, InnerParams&&, Executor&&,
-            hpx::chrono::steady_duration const&, std::size_t, std::size_t>;
+        requires(std::remove_reference_t<Params> const& p,
+            std::remove_reference_t<InnerParams>& ip,
+            std::remove_reference_t<Executor>& e,
+            hpx::chrono::steady_duration const& d) {
+            p.get_chunk_size(ip, e, d, std::size_t{}, std::size_t{});
+        };
 
     // wrapping measure_iteration
     HPX_CXX_CORE_EXPORT template <typename Params, typename Executor,
         typename F>
     inline constexpr bool supports_measure_iteration_v =
-        hpx::functional::detail::is_tag_override_invocable_v<
-            measure_iteration_t, Params&&, Executor&&, F&&, std::size_t>;
+        requires(std::remove_reference_t<Params> const& p,
+            std::remove_reference_t<Executor>& e, F&& f) {
+            p.measure_iteration(e, HPX_FORWARD(F, f), std::size_t{});
+        };
 
     HPX_CXX_CORE_EXPORT template <typename Params, typename InnerParams,
         typename Executor, typename F>
     inline constexpr bool supports_wrapping_measure_iteration_v =
-        hpx::functional::detail::is_tag_override_invocable_v<
-            measure_iteration_t, Params&&, InnerParams&&, Executor&&, F&&,
-            std::size_t>;
+        requires(std::remove_reference_t<Params> const& p,
+            std::remove_reference_t<InnerParams>& ip,
+            std::remove_reference_t<Executor>& e, F&& f) {
+            p.measure_iteration(ip, e, HPX_FORWARD(F, f), std::size_t{});
+        };
 
     // maximal_number_of_chunks
     HPX_CXX_CORE_EXPORT template <typename Params, typename Executor>
     inline constexpr bool supports_maximal_number_of_chunks_v =
-        hpx::functional::detail::is_tag_override_invocable_v<
-            maximal_number_of_chunks_t, Params&&, Executor&&, std::size_t,
-            std::size_t>;
+        requires(std::remove_reference_t<Params> const& p,
+            std::remove_reference_t<Executor>& e) {
+            p.maximal_number_of_chunks(e, std::size_t{}, std::size_t{});
+        };
 
     HPX_CXX_CORE_EXPORT template <typename Params, typename InnerParams,
         typename Executor>
     inline constexpr bool supports_wrapping_maximal_number_of_chunks_v =
-        hpx::functional::detail::is_tag_override_invocable_v<
-            maximal_number_of_chunks_t, Params&&, InnerParams&&, Executor&&,
-            std::size_t, std::size_t>;
+        requires(std::remove_reference_t<Params> const& p,
+            std::remove_reference_t<InnerParams>& ip,
+            std::remove_reference_t<Executor>& e) {
+            p.maximal_number_of_chunks(ip, e, std::size_t{}, std::size_t{});
+        };
 
     // execution_markers: begin_execution
     HPX_CXX_CORE_EXPORT template <typename Params, typename Executor>
     inline constexpr bool supports_mark_begin_execution_v =
-        hpx::functional::detail::is_tag_override_invocable_v<
-            mark_begin_execution_t, Params&&, Executor&&>;
+        requires(std::remove_reference_t<Params> const& p,
+            std::remove_reference_t<Executor>& e) {
+            p.mark_begin_execution(e);
+        };
 
     HPX_CXX_CORE_EXPORT template <typename Params, typename InnerParams,
         typename Executor>
     inline constexpr bool supports_wrapping_mark_begin_execution_v =
-        hpx::functional::detail::is_tag_override_invocable_v<
-            mark_begin_execution_t, Params&&, InnerParams&&, Executor&&>;
+        requires(std::remove_reference_t<Params> const& p,
+            std::remove_reference_t<InnerParams>& ip,
+            std::remove_reference_t<Executor>& e) {
+            p.mark_begin_execution(ip, e);
+        };
 
     // execution_markers: end_of_scheduling
     HPX_CXX_CORE_EXPORT template <typename Params, typename Executor>
     inline constexpr bool supports_mark_end_of_scheduling_v =
-        hpx::functional::detail::is_tag_override_invocable_v<
-            mark_end_of_scheduling_t, Params&&, Executor&&>;
+        requires(std::remove_reference_t<Params> const& p,
+            std::remove_reference_t<Executor>& e) {
+            p.mark_end_of_scheduling(e);
+        };
 
     HPX_CXX_CORE_EXPORT template <typename Params, typename InnerParams,
         typename Executor>
     inline constexpr bool supports_wrapping_mark_end_of_scheduling_v =
-        hpx::functional::detail::is_tag_override_invocable_v<
-            mark_end_of_scheduling_t, Params&&, InnerParams&&, Executor&&>;
+        requires(std::remove_reference_t<Params> const& p,
+            std::remove_reference_t<InnerParams>& ip,
+            std::remove_reference_t<Executor>& e) {
+            p.mark_end_of_scheduling(ip, e);
+        };
 
     // execution_markers: end_execution
     HPX_CXX_CORE_EXPORT template <typename Params, typename Executor>
     inline constexpr bool supports_mark_end_execution_v =
-        hpx::functional::detail::is_tag_override_invocable_v<
-            mark_end_execution_t, Params&&, Executor&&>;
+        requires(std::remove_reference_t<Params> const& p,
+            std::remove_reference_t<Executor>& e) { p.mark_end_execution(e); };
 
     HPX_CXX_CORE_EXPORT template <typename Params, typename InnerParams,
         typename Executor>
     inline constexpr bool supports_wrapping_mark_end_execution_v =
-        hpx::functional::detail::is_tag_override_invocable_v<
-            mark_end_execution_t, Params&&, InnerParams&&, Executor&&>;
+        requires(std::remove_reference_t<Params> const& p,
+            std::remove_reference_t<InnerParams>& ip,
+            std::remove_reference_t<Executor>& e) {
+            p.mark_end_execution(ip, e);
+        };
 
     // execution_markers: partition
     HPX_CXX_CORE_EXPORT template <typename Params, typename Executor,
         typename... Args>
     inline constexpr bool supports_mark_partition_v =
-        hpx::functional::detail::is_tag_override_invocable_v<mark_partition_t,
-            Params&&, Executor&&, std::size_t, Args&&...>;
+        requires(std::remove_reference_t<Params> const& p,
+            std::remove_reference_t<Executor>& e, Args&&... args) {
+            p.mark_partition(e, std::size_t{}, HPX_FORWARD(Args, args)...);
+        };
 
     HPX_CXX_CORE_EXPORT template <typename Params, typename InnerParams,
         typename Executor, typename... Args>
     inline constexpr bool supports_wrapping_mark_partition_v =
-        hpx::functional::detail::is_tag_override_invocable_v<mark_partition_t,
-            Params&&, InnerParams&&, Executor&&, std::size_t, Args&&...>;
+        requires(std::remove_reference_t<Params> const& p,
+            std::remove_reference_t<InnerParams>& ip,
+            std::remove_reference_t<Executor>& e, Args&&... args) {
+            p.mark_partition(ip, e, std::size_t{}, HPX_FORWARD(Args, args)...);
+        };
 
     // wrapping processing_units_count
     HPX_CXX_CORE_EXPORT template <typename Params, typename Executor>
     inline constexpr bool supports_processing_units_count_v =
-        hpx::functional::detail::is_tag_override_invocable_v<
-            processing_units_count_t, Params&&, Executor&&,
-            hpx::chrono::steady_duration const&, std::size_t>;
+        requires(std::remove_reference_t<Params> const& p,
+            std::remove_reference_t<Executor>& e,
+            hpx::chrono::steady_duration const& d) {
+            p.processing_units_count(e, d, std::size_t{});
+        };
 
     HPX_CXX_CORE_EXPORT template <typename Params, typename InnerParams,
         typename Executor>
     inline constexpr bool supports_wrapping_processing_units_count_v =
-        hpx::functional::detail::is_tag_override_invocable_v<
-            processing_units_count_t, Params&&, InnerParams&&, Executor&&,
-            hpx::chrono::steady_duration const&, std::size_t>;
+        requires(std::remove_reference_t<Params> const& p,
+            std::remove_reference_t<InnerParams>& ip,
+            std::remove_reference_t<Executor>& e,
+            hpx::chrono::steady_duration const& d) {
+            p.processing_units_count(ip, e, d, std::size_t{});
+        };
 
     // wrapping reset_thread_distribution
     HPX_CXX_CORE_EXPORT template <typename Params, typename Executor>
     inline constexpr bool supports_reset_thread_distribution_v =
-        hpx::functional::detail::is_tag_override_invocable_v<
-            reset_thread_distribution_t, Params&&, Executor&&>;
+        requires(std::remove_reference_t<Params> const& p,
+            std::remove_reference_t<Executor>& e) {
+            p.reset_thread_distribution(e);
+        };
 
     HPX_CXX_CORE_EXPORT template <typename Params, typename InnerParams,
         typename Executor>
     inline constexpr bool supports_wrapping_reset_thread_distribution_v =
-        hpx::functional::detail::is_tag_override_invocable_v<
-            reset_thread_distribution_t, Params&&, InnerParams&&, Executor&&>;
+        requires(std::remove_reference_t<Params> const& p,
+            std::remove_reference_t<InnerParams>& ip,
+            std::remove_reference_t<Executor>& e) {
+            p.reset_thread_distribution(ip, e);
+        };
 
     // wrapping collect_execution_parameters
     HPX_CXX_CORE_EXPORT template <typename Params, typename Executor>
     inline constexpr bool supports_collect_execution_parameters_v =
-        hpx::functional::detail::is_tag_override_invocable_v<
-            collect_execution_parameters_t, Params&&, Executor&&, std::size_t,
-            std::size_t, std::size_t, std::size_t>;
+        requires(std::remove_reference_t<Params> const& p,
+            std::remove_reference_t<Executor>& e) {
+            p.collect_execution_parameters(
+                e, std::size_t{}, std::size_t{}, std::size_t{}, std::size_t{});
+        };
 
     HPX_CXX_CORE_EXPORT template <typename Params, typename InnerParams,
         typename Executor>
     inline constexpr bool supports_wrapping_collect_execution_parameters_v =
-        hpx::functional::detail::is_tag_override_invocable_v<
-            collect_execution_parameters_t, Params&&, InnerParams&&, Executor&&,
-            std::size_t, std::size_t, std::size_t, std::size_t>;
+        requires(std::remove_reference_t<Params> const& p,
+            std::remove_reference_t<InnerParams>& ip,
+            std::remove_reference_t<Executor>& e) {
+            p.collect_execution_parameters(ip, e, std::size_t{}, std::size_t{},
+                std::size_t{}, std::size_t{});
+        };
 
     ///////////////////////////////////////////////////////////////////////////
     HPX_CXX_CORE_EXPORT template <typename Wrapped, typename Wrapping>
@@ -270,411 +319,259 @@ namespace hpx::execution::experimental {
         }
 
         // wrapping get_chunk_size
-
-        // clang-format off
-        template <typename Params, typename Executor>
-            requires(std::same_as<wrapped_params, std::decay_t<Params>> && (
-                supports_wrapping_get_chunk_size_v<detail::wrapping_t<Params>,
-                    detail::wrapped_t<Params>, Executor> ||
-                supports_get_chunk_size_v<
-                    detail::wrapping_t<Params>, Executor> ||
-                supports_get_chunk_size_v<
-                    detail::wrapped_t<Params>, Executor>
-            ))
-        // clang-format on
-        friend constexpr std::size_t tag_override_invoke(get_chunk_size_t,
-            Params&& this_, Executor&& exec,
+        template <typename Executor>
+        constexpr std::size_t get_chunk_size(Executor&& exec,
             hpx::chrono::steady_duration const& t, std::size_t const cores,
-            std::size_t const num_iterations)
+            std::size_t const num_iterations) const
         {
-            if constexpr (supports_wrapping_get_chunk_size_v<
-                              detail::wrapping_t<Params>,
-                              detail::wrapped_t<Params>, Executor>)
+            if constexpr (supports_wrapping_get_chunk_size_v<Wrapping, Wrapped,
+                              Executor>)
             {
-                return get_chunk_size(detail::wrapping_forward<Params>(this_),
-                    detail::wrapped_forward<Params>(this_),
+                return wrapping.get_chunk_size(wrapped,
                     HPX_FORWARD(Executor, exec), t, cores, num_iterations);
             }
-            else if constexpr (supports_get_chunk_size_v<
-                                   detail::wrapping_t<Params>, Executor>)
+            else if constexpr (supports_get_chunk_size_v<Wrapping, Executor>)
             {
-                return get_chunk_size(detail::wrapping_forward<Params>(this_),
+                return wrapping.get_chunk_size(
+                    HPX_FORWARD(Executor, exec), t, cores, num_iterations);
+            }
+            else if constexpr (supports_get_chunk_size_v<Wrapped, Executor>)
+            {
+                return wrapped.get_chunk_size(
                     HPX_FORWARD(Executor, exec), t, cores, num_iterations);
             }
             else
             {
-                return get_chunk_size(detail::wrapped_forward<Params>(this_),
-                    HPX_FORWARD(Executor, exec), t, cores, num_iterations);
+                // Default implementation when neither has get_chunk_size
+                return (num_iterations + cores - 1) / cores;
             }
         }
 
         // wrapping measure_iteration
-
-        // clang-format off
-        template <typename Params, typename Executor, typename F>
-            requires(std::same_as<wrapped_params, std::decay_t<Params>> && (
-                supports_wrapping_measure_iteration_v<detail::wrapping_t<Params>,
-                    detail::wrapped_t<Params>, Executor, F> ||
-                supports_measure_iteration_v<
-                    detail::wrapping_t<Params>, Executor, F> ||
-                supports_measure_iteration_v<
-                    detail::wrapped_t<Params>, Executor, F>
-            ))
-        // clang-format on
-        friend constexpr hpx::chrono::steady_duration tag_override_invoke(
-            measure_iteration_t, Params&& this_, Executor&& exec, F&& f,
-            std::size_t const num_tasks)
+        template <typename Executor, typename F>
+        constexpr hpx::chrono::steady_duration measure_iteration(
+            Executor&& exec, F&& f, std::size_t const num_tasks)
         {
-            if constexpr (supports_wrapping_measure_iteration_v<
-                              detail::wrapping_t<Params>,
-                              detail::wrapped_t<Params>, Executor, F>)
+            if constexpr (supports_wrapping_measure_iteration_v<Wrapping, Wrapped,
+                              Executor, F>)
             {
-                return measure_iteration(
-                    detail::wrapping_forward<Params>(this_),
-                    detail::wrapped_forward<Params>(this_),
+                return wrapping.measure_iteration(wrapped,
                     HPX_FORWARD(Executor, exec), HPX_FORWARD(F, f), num_tasks);
             }
-            else if constexpr (supports_measure_iteration_v<
-                                   detail::wrapping_t<Params>, Executor, F>)
+            else if constexpr (supports_measure_iteration_v<Wrapping, Executor, F>)
             {
-                return measure_iteration(
-                    detail::wrapping_forward<Params>(this_),
+                return wrapping.measure_iteration(
+                    HPX_FORWARD(Executor, exec), HPX_FORWARD(F, f), num_tasks);
+            }
+            else if constexpr (supports_measure_iteration_v<Wrapped, Executor, F>)
+            {
+                return wrapped.measure_iteration(
                     HPX_FORWARD(Executor, exec), HPX_FORWARD(F, f), num_tasks);
             }
             else
             {
-                return measure_iteration(detail::wrapped_forward<Params>(this_),
-                    HPX_FORWARD(Executor, exec), HPX_FORWARD(F, f), num_tasks);
+                // Default implementation when neither has measure_iteration
+                return hpx::chrono::null_duration;
             }
         }
 
         // maximal_number_of_chunks
-
-        // clang-format off
-        template <typename Params, typename Executor>
-            requires(std::same_as<wrapped_params, std::decay_t<Params>> && (
-                supports_wrapping_maximal_number_of_chunks_v<
-                    detail::wrapping_t<Params>, detail::wrapped_t<Params>,
-                    Executor> ||
-                supports_maximal_number_of_chunks_v<
-                    detail::wrapping_t<Params>, Executor> ||
-                supports_maximal_number_of_chunks_v<
-                    detail::wrapped_t<Params>, Executor>
-            ))
-        // clang-format on
-        friend constexpr std::size_t tag_override_invoke(
-            maximal_number_of_chunks_t, Params&& this_, Executor&& exec,
-            std::size_t const cores, std::size_t const num_tasks)
+        template <typename Executor>
+        constexpr std::size_t maximal_number_of_chunks(Executor&& exec,
+            std::size_t const cores, std::size_t const num_tasks) const
         {
-            if constexpr (supports_wrapping_maximal_number_of_chunks_v<
-                              detail::wrapping_t<Params>,
-                              detail::wrapped_t<Params>, Executor>)
+            if constexpr (supports_wrapping_maximal_number_of_chunks_v<Wrapping,
+                              Wrapped, Executor>)
             {
-                return maximal_number_of_chunks(
-                    detail::wrapping_forward<Params>(this_),
-                    detail::wrapped_forward<Params>(this_),
+                return wrapping.maximal_number_of_chunks(wrapped,
                     HPX_FORWARD(Executor, exec), cores, num_tasks);
             }
-            else if constexpr (supports_maximal_number_of_chunks_v<
-                                   detail::wrapping_t<Params>, Executor>)
+            else if constexpr (supports_maximal_number_of_chunks_v<Wrapping,
+                                   Executor>)
             {
-                return maximal_number_of_chunks(
-                    detail::wrapping_forward<Params>(this_),
+                return wrapping.maximal_number_of_chunks(
+                    HPX_FORWARD(Executor, exec), cores, num_tasks);
+            }
+            else if constexpr (supports_maximal_number_of_chunks_v<Wrapped,
+                                   Executor>)
+            {
+                return wrapped.maximal_number_of_chunks(
                     HPX_FORWARD(Executor, exec), cores, num_tasks);
             }
             else
             {
-                return maximal_number_of_chunks(
-                    detail::wrapped_forward<Params>(this_),
-                    HPX_FORWARD(Executor, exec), cores, num_tasks);
+                // Default implementation when neither has maximal_number_of_chunks
+                return cores * 4;
             }
         }
 
         // execution_markers: begin_execution
-
-        // clang-format off
-        template <typename Params, typename Executor>
-            requires(std::same_as<wrapped_params, std::decay_t<Params>> && (
-                supports_wrapping_mark_begin_execution_v<
-                    detail::wrapping_t<Params>, detail::wrapped_t<Params>,
-                    Executor> ||
-                supports_mark_begin_execution_v<
-                    detail::wrapping_t<Params>, Executor> ||
-                supports_mark_begin_execution_v<
-                    detail::wrapped_t<Params>, Executor>
-            ))
-        // clang-format on
-        friend constexpr void tag_override_invoke(
-            mark_begin_execution_t, Params&& this_, Executor&& exec)
+        template <typename Executor>
+        constexpr void mark_begin_execution(Executor&& exec) const
         {
-            if constexpr (supports_wrapping_mark_begin_execution_v<
-                              detail::wrapping_t<Params>,
-                              detail::wrapped_t<Params>, Executor>)
+            if constexpr (supports_wrapping_mark_begin_execution_v<Wrapping, Wrapped,
+                              Executor>)
             {
-                mark_begin_execution(detail::wrapping_forward<Params>(this_),
-                    detail::wrapped_forward<Params>(this_),
+                wrapping.mark_begin_execution(wrapped,
                     HPX_FORWARD(Executor, exec));
             }
-            if constexpr (supports_mark_begin_execution_v<
-                              detail::wrapping_t<Params>, Executor>)
+            else if constexpr (supports_mark_begin_execution_v<Wrapping, Executor>)
             {
-                mark_begin_execution(detail::wrapping_forward<Params>(this_),
-                    HPX_FORWARD(Executor, exec));
+                wrapping.mark_begin_execution(HPX_FORWARD(Executor, exec));
             }
-            else
+            else if constexpr (supports_mark_begin_execution_v<Wrapped, Executor>)
             {
-                mark_begin_execution(detail::wrapped_forward<Params>(this_),
-                    HPX_FORWARD(Executor, exec));
+                wrapped.mark_begin_execution(HPX_FORWARD(Executor, exec));
             }
         }
 
         // execution_markers: end_of_scheduling
-
-        // clang-format off
-        template <typename Params, typename Executor>
-            requires(std::same_as<wrapped_params, std::decay_t<Params>> && (
-                supports_wrapping_mark_end_of_scheduling_v<
-                    detail::wrapping_t<Params>, detail::wrapped_t<Params>,
-                    Executor> ||
-                supports_mark_end_of_scheduling_v<
-                    detail::wrapping_t<Params>, Executor> ||
-                supports_mark_end_of_scheduling_v<
-                    detail::wrapped_t<Params>, Executor>
-            ))
-        // clang-format on
-        friend constexpr void tag_override_invoke(
-            mark_end_of_scheduling_t, Params&& this_, Executor&& exec)
+        template <typename Executor>
+        constexpr void mark_end_of_scheduling(Executor&& exec) const
         {
-            if constexpr (supports_wrapping_mark_end_of_scheduling_v<
-                              detail::wrapping_t<Params>,
-                              detail::wrapped_t<Params>, Executor>)
+            if constexpr (supports_wrapping_mark_end_of_scheduling_v<Wrapping,
+                              Wrapped, Executor>)
             {
-                mark_end_of_scheduling(detail::wrapping_forward<Params>(this_),
-                    detail::wrapped_forward<Params>(this_),
+                wrapping.mark_end_of_scheduling(wrapped,
                     HPX_FORWARD(Executor, exec));
             }
-            else if constexpr (supports_mark_end_of_scheduling_v<
-                                   detail::wrapping_t<Params>, Executor>)
+            else if constexpr (supports_mark_end_of_scheduling_v<Wrapping,
+                                   Executor>)
             {
-                mark_end_of_scheduling(detail::wrapping_forward<Params>(this_),
-                    HPX_FORWARD(Executor, exec));
+                wrapping.mark_end_of_scheduling(HPX_FORWARD(Executor, exec));
             }
-            else
+            else if constexpr (supports_mark_end_of_scheduling_v<Wrapped,
+                                   Executor>)
             {
-                mark_end_of_scheduling(detail::wrapped_forward<Params>(this_),
-                    HPX_FORWARD(Executor, exec));
+                wrapped.mark_end_of_scheduling(HPX_FORWARD(Executor, exec));
             }
         }
 
         // execution_markers: end_execution
-
-        // clang-format off
-        template <typename Params, typename Executor>
-            requires(std::same_as<wrapped_params, std::decay_t<Params>> && (
-                supports_wrapping_mark_end_execution_v<
-                    detail::wrapping_t<Params>, detail::wrapped_t<Params>,
-                    Executor> ||
-                supports_mark_end_execution_v<
-                    detail::wrapping_t<Params>, Executor> ||
-                supports_mark_end_execution_v<
-                    detail::wrapped_t<Params>, Executor>
-            ))
-        // clang-format on
-        friend constexpr void tag_override_invoke(
-            mark_end_execution_t, Params&& this_, Executor&& exec)
+        template <typename Executor>
+        constexpr void mark_end_execution(Executor&& exec) const
         {
-            if constexpr (supports_wrapping_mark_end_execution_v<
-                              detail::wrapping_t<Params>,
-                              detail::wrapped_t<Params>, Executor>)
+            if constexpr (supports_wrapping_mark_end_execution_v<Wrapping, Wrapped,
+                              Executor>)
             {
-                mark_end_execution(detail::wrapping_forward<Params>(this_),
-                    detail::wrapped_forward<Params>(this_),
+                wrapping.mark_end_execution(wrapped,
                     HPX_FORWARD(Executor, exec));
             }
-            else if constexpr (supports_mark_end_execution_v<
-                                   detail::wrapping_t<Params>, Executor>)
+            else if constexpr (supports_mark_end_execution_v<Wrapping, Executor>)
             {
-                mark_end_execution(detail::wrapping_forward<Params>(this_),
-                    HPX_FORWARD(Executor, exec));
+                wrapping.mark_end_execution(HPX_FORWARD(Executor, exec));
             }
-            else
+            else if constexpr (supports_mark_end_execution_v<Wrapped, Executor>)
             {
-                mark_end_execution(detail::wrapped_forward<Params>(this_),
-                    HPX_FORWARD(Executor, exec));
+                wrapped.mark_end_execution(HPX_FORWARD(Executor, exec));
             }
         }
 
         // execution_markers: partition
-
-        // clang-format off
-        template <typename Params, typename Executor, typename... Args>
-            requires(std::same_as<wrapped_params, std::decay_t<Params>> && (
-                supports_wrapping_mark_partition_v<
-                    detail::wrapping_t<Params>, detail::wrapped_t<Params>,
-                    Executor, Args...> ||
-                supports_mark_partition_v<
-                    detail::wrapping_t<Params>, Executor, Args...> ||
-                supports_mark_partition_v<
-                    detail::wrapped_t<Params>, Executor, Args...>
-            ))
-        // clang-format on
-        friend constexpr void tag_override_invoke(mark_partition_t,
-            Params&& this_, Executor&& exec, std::size_t partition,
-            Args&&... args)
+        template <typename Executor, typename... Args>
+        constexpr void mark_partition(Executor&& exec, std::size_t partition,
+            Args&&... args) const
         {
-            if constexpr (supports_wrapping_mark_partition_v<
-                              detail::wrapping_t<Params>,
-                              detail::wrapped_t<Params>, Executor, Args...>)
+            if constexpr (supports_wrapping_mark_partition_v<Wrapping, Wrapped,
+                              Executor, Args...>)
             {
-                mark_partition(detail::wrapping_forward<Params>(this_),
-                    detail::wrapped_forward<Params>(this_),
-                    HPX_FORWARD(Executor, exec), partition,
-                    HPX_FORWARD(Args, args)...);
+                wrapping.mark_partition(wrapped, HPX_FORWARD(Executor, exec),
+                    partition, HPX_FORWARD(Args, args)...);
             }
-            else if constexpr (supports_mark_partition_v<
-                                   detail::wrapping_t<Params>, Executor,
+            else if constexpr (supports_mark_partition_v<Wrapping, Executor,
                                    Args...>)
             {
-                mark_partition(detail::wrapping_forward<Params>(this_),
-                    HPX_FORWARD(Executor, exec), partition,
+                wrapping.mark_partition(HPX_FORWARD(Executor, exec), partition,
                     HPX_FORWARD(Args, args)...);
             }
-            else
+            else if constexpr (supports_mark_partition_v<Wrapped, Executor,
+                                   Args...>)
             {
-                mark_partition(detail::wrapped_forward<Params>(this_),
-                    HPX_FORWARD(Executor, exec), partition,
+                wrapped.mark_partition(HPX_FORWARD(Executor, exec), partition,
                     HPX_FORWARD(Args, args)...);
             }
         }
 
         // wrapping processing_units_count
-
-        // clang-format off
-        template <typename Params, typename Executor>
-            requires(std::same_as<wrapped_params, std::decay_t<Params>> && (
-                supports_wrapping_processing_units_count_v<
-                    detail::wrapping_t<Params>, detail::wrapped_t<Params>,
-                    Executor> ||
-                supports_processing_units_count_v<
-                    detail::wrapping_t<Params>, Executor> ||
-                supports_processing_units_count_v<
-                    detail::wrapped_t<Params>, Executor>
-            ))
-        // clang-format on
-        friend constexpr std::size_t tag_override_invoke(
-            processing_units_count_t, Params&& this_, Executor&& exec,
+        template <typename Executor>
+        constexpr std::size_t processing_units_count(Executor&& exec,
             hpx::chrono::steady_duration const& iteration_duration,
-            std::size_t const num_tasks)
+            std::size_t const num_tasks) const
         {
-            if constexpr (supports_wrapping_processing_units_count_v<
-                              detail::wrapping_t<Params>,
-                              detail::wrapped_t<Params>, Executor>)
+            if constexpr (supports_wrapping_processing_units_count_v<Wrapping,
+                              Wrapped, Executor>)
             {
-                return processing_units_count(
-                    detail::wrapping_forward<Params>(this_),
-                    detail::wrapped_forward<Params>(this_),
+                return wrapping.processing_units_count(wrapped,
                     HPX_FORWARD(Executor, exec), iteration_duration, num_tasks);
             }
-            else if constexpr (supports_processing_units_count_v<
-                                   detail::wrapping_t<Params>, Executor>)
+            else if constexpr (supports_processing_units_count_v<Wrapping,
+                                   Executor>)
             {
-                return processing_units_count(
-                    detail::wrapping_forward<Params>(this_),
+                return wrapping.processing_units_count(
+                    HPX_FORWARD(Executor, exec), iteration_duration, num_tasks);
+            }
+            else if constexpr (supports_processing_units_count_v<Wrapped,
+                                   Executor>)
+            {
+                return wrapped.processing_units_count(
                     HPX_FORWARD(Executor, exec), iteration_duration, num_tasks);
             }
             else
             {
-                return processing_units_count(
-                    detail::wrapped_forward<Params>(this_),
-                    HPX_FORWARD(Executor, exec), iteration_duration, num_tasks);
+                // Default implementation when neither has processing_units_count
+                return hpx::execution::experimental::processing_units_count(
+                    exec, iteration_duration, num_tasks);
             }
         }
 
         // wrapping reset_thread_distribution
-
-        // clang-format off
-        template <typename Params, typename Executor>
-            requires(std::same_as<wrapped_params, std::decay_t<Params>> && (
-                supports_wrapping_reset_thread_distribution_v<
-                     detail::wrapping_t<Params>, detail::wrapped_t<Params>,
-                     Executor> ||
-                supports_reset_thread_distribution_v<
-                     detail::wrapping_t<Params>, Executor> ||
-                supports_reset_thread_distribution_v<
-                    detail::wrapped_t<Params>, Executor>
-            ))
-        // clang-format on
-        friend constexpr void tag_override_invoke(
-            reset_thread_distribution_t, Params&& this_, Executor&& exec)
+        template <typename Executor>
+        constexpr void reset_thread_distribution(Executor&& exec) const
         {
-            if constexpr (supports_wrapping_reset_thread_distribution_v<
-                              detail::wrapping_t<Params>,
-                              detail::wrapped_t<Params>, Executor>)
+            if constexpr (supports_wrapping_reset_thread_distribution_v<Wrapping,
+                              Wrapped, Executor>)
             {
-                reset_thread_distribution(
-                    detail::wrapping_forward<Params>(this_),
-                    detail::wrapped_forward<Params>(this_),
+                wrapping.reset_thread_distribution(wrapped,
                     HPX_FORWARD(Executor, exec));
             }
-            else if constexpr (supports_reset_thread_distribution_v<
-                                   detail::wrapping_t<Params>, Executor>)
+            else if constexpr (supports_reset_thread_distribution_v<Wrapping,
+                                   Executor>)
             {
-                reset_thread_distribution(
-                    detail::wrapping_forward<Params>(this_),
-                    HPX_FORWARD(Executor, exec));
+                wrapping.reset_thread_distribution(HPX_FORWARD(Executor, exec));
             }
-            else
+            else if constexpr (supports_reset_thread_distribution_v<Wrapped,
+                                   Executor>)
             {
-                reset_thread_distribution(
-                    detail::wrapped_forward<Params>(this_),
-                    HPX_FORWARD(Executor, exec));
+                wrapped.reset_thread_distribution(HPX_FORWARD(Executor, exec));
             }
         }
 
         // wrapping collect_execution_parameters
-
-        // clang-format off
-        template <typename Params, typename Executor>
-            requires(std::same_as<wrapped_params, std::decay_t<Params>> && (
-                supports_wrapping_collect_execution_parameters_v<
-                    detail::wrapping_t<Params>, detail::wrapped_t<Params>,
-                    Executor> ||
-                supports_collect_execution_parameters_v<
-                    detail::wrapping_t<Params>, Executor> ||
-                supports_collect_execution_parameters_v<
-                    detail::wrapped_t<Params>, Executor>
-            ))
-        // clang-format on
-        friend constexpr void tag_override_invoke(
-            hpx::execution::experimental::collect_execution_parameters_t,
-            Params&& this_, Executor&& exec, std::size_t const num_elements,
-            std::size_t const num_cores, std::size_t const num_chunks,
-            std::size_t const chunk_size)
+        template <typename Executor>
+        constexpr void collect_execution_parameters(Executor&& exec,
+            std::size_t const num_elements, std::size_t const num_cores,
+            std::size_t const num_chunks, std::size_t const chunk_size) const
         {
-            if constexpr (supports_wrapping_collect_execution_parameters_v<
-                              detail::wrapping_t<Params>,
-                              detail::wrapped_t<Params>, Executor>)
+            if constexpr (supports_wrapping_collect_execution_parameters_v<Wrapping,
+                              Wrapped, Executor>)
             {
-                collect_execution_parameters(
-                    detail::wrapping_forward<Params>(this_),
-                    detail::wrapped_forward<Params>(this_),
-                    HPX_FORWARD(Executor, exec), num_elements, num_cores,
-                    num_chunks, chunk_size);
+                wrapping.collect_execution_parameters(wrapped,
+                    HPX_FORWARD(Executor, exec), num_elements, num_cores, num_chunks,
+                    chunk_size);
             }
-            else if constexpr (supports_collect_execution_parameters_v<
-                                   detail::wrapping_t<Params>, Executor>)
+            else if constexpr (supports_collect_execution_parameters_v<Wrapping,
+                                   Executor>)
             {
-                collect_execution_parameters(
-                    detail::wrapping_forward<Params>(this_),
-                    HPX_FORWARD(Executor, exec), num_elements, num_cores,
-                    num_chunks, chunk_size);
+                wrapping.collect_execution_parameters(
+                    HPX_FORWARD(Executor, exec), num_elements, num_cores, num_chunks,
+                    chunk_size);
             }
-            else
+            else if constexpr (supports_collect_execution_parameters_v<Wrapped,
+                                   Executor>)
             {
-                collect_execution_parameters(
-                    detail::wrapped_forward<Params>(this_),
-                    HPX_FORWARD(Executor, exec), num_elements, num_cores,
-                    num_chunks, chunk_size);
+                wrapped.collect_execution_parameters(
+                    HPX_FORWARD(Executor, exec), num_elements, num_cores, num_chunks,
+                    chunk_size);
             }
         }
 

--- a/libs/core/execution/include/hpx/execution/executors/rebind_executor_parameters.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/rebind_executor_parameters.hpp
@@ -130,8 +130,7 @@ namespace hpx::execution::experimental {
     // wrapping get_chunk_size
     HPX_CXX_CORE_EXPORT template <typename Params, typename Executor>
     inline constexpr bool supports_get_chunk_size_v =
-        requires(std::remove_reference_t<Params>& p,
-            std::remove_reference_t<Executor>& e,
+        requires(Params&& p, Executor&& e,
             hpx::chrono::steady_duration const& d) {
             p.get_chunk_size(e, d, std::size_t{}, std::size_t{});
         };
@@ -139,9 +138,7 @@ namespace hpx::execution::experimental {
     HPX_CXX_CORE_EXPORT template <typename Params, typename InnerParams,
         typename Executor>
     inline constexpr bool supports_wrapping_get_chunk_size_v =
-        requires(std::remove_reference_t<Params>& p,
-            std::remove_reference_t<InnerParams>& ip,
-            std::remove_reference_t<Executor>& e,
+        requires(Params&& p, InnerParams&& ip, Executor&& e,
             hpx::chrono::steady_duration const& d) {
             p.get_chunk_size(ip, e, d, std::size_t{}, std::size_t{});
         };
@@ -150,103 +147,86 @@ namespace hpx::execution::experimental {
     HPX_CXX_CORE_EXPORT template <typename Params, typename Executor,
         typename F>
     inline constexpr bool supports_measure_iteration_v =
-        requires(std::remove_reference_t<Params>& p,
-            std::remove_reference_t<Executor>& e, F&& f) {
+        requires(Params&& p, Executor&& e, F&& f) {
             p.measure_iteration(e, HPX_FORWARD(F, f), std::size_t{});
         };
 
     HPX_CXX_CORE_EXPORT template <typename Params, typename InnerParams,
         typename Executor, typename F>
     inline constexpr bool supports_wrapping_measure_iteration_v =
-        requires(std::remove_reference_t<Params>& p,
-            std::remove_reference_t<InnerParams>& ip,
-            std::remove_reference_t<Executor>& e, F&& f) {
+        requires(Params&& p, InnerParams&& ip, Executor&& e, F&& f) {
             p.measure_iteration(ip, e, HPX_FORWARD(F, f), std::size_t{});
         };
 
     // maximal_number_of_chunks
     HPX_CXX_CORE_EXPORT template <typename Params, typename Executor>
     inline constexpr bool supports_maximal_number_of_chunks_v =
-        requires(std::remove_reference_t<Params>& p,
-            std::remove_reference_t<Executor>& e) {
+        requires(Params&& p, Executor&& e) {
             p.maximal_number_of_chunks(e, std::size_t{}, std::size_t{});
         };
 
     HPX_CXX_CORE_EXPORT template <typename Params, typename InnerParams,
         typename Executor>
     inline constexpr bool supports_wrapping_maximal_number_of_chunks_v =
-        requires(std::remove_reference_t<Params>& p,
-            std::remove_reference_t<InnerParams>& ip,
-            std::remove_reference_t<Executor>& e) {
+        requires(Params&& p, InnerParams&& ip, Executor&& e) {
             p.maximal_number_of_chunks(ip, e, std::size_t{}, std::size_t{});
         };
 
     // execution_markers: begin_execution
     HPX_CXX_CORE_EXPORT template <typename Params, typename Executor>
-    inline constexpr bool supports_mark_begin_execution_v = requires(
-        std::remove_reference_t<Params>& p,
-        std::remove_reference_t<Executor>& e) { p.mark_begin_execution(e); };
+    inline constexpr bool supports_mark_begin_execution_v =
+        requires(Params&& p, Executor&& e) { p.mark_begin_execution(e); };
 
     HPX_CXX_CORE_EXPORT template <typename Params, typename InnerParams,
         typename Executor>
     inline constexpr bool supports_wrapping_mark_begin_execution_v =
-        requires(std::remove_reference_t<Params>& p,
-            std::remove_reference_t<InnerParams>& ip,
-            std::remove_reference_t<Executor>& e) {
+        requires(Params&& p, InnerParams&& ip, Executor&& e) {
             p.mark_begin_execution(ip, e);
         };
 
     // execution_markers: end_of_scheduling
     HPX_CXX_CORE_EXPORT template <typename Params, typename Executor>
-    inline constexpr bool supports_mark_end_of_scheduling_v = requires(
-        std::remove_reference_t<Params>& p,
-        std::remove_reference_t<Executor>& e) { p.mark_end_of_scheduling(e); };
+    inline constexpr bool supports_mark_end_of_scheduling_v =
+        requires(Params&& p, Executor&& e) { p.mark_end_of_scheduling(e); };
 
     HPX_CXX_CORE_EXPORT template <typename Params, typename InnerParams,
         typename Executor>
     inline constexpr bool supports_wrapping_mark_end_of_scheduling_v =
-        requires(std::remove_reference_t<Params>& p,
-            std::remove_reference_t<InnerParams>& ip,
-            std::remove_reference_t<Executor>& e) {
+        requires(Params&& p, InnerParams&& ip, Executor&& e) {
             p.mark_end_of_scheduling(ip, e);
         };
 
     // execution_markers: end_execution
     HPX_CXX_CORE_EXPORT template <typename Params, typename Executor>
     inline constexpr bool supports_mark_end_execution_v =
-        requires(std::remove_reference_t<Params>& p,
-            std::remove_reference_t<Executor>& e) { p.mark_end_execution(e); };
+        requires(Params&& p, Executor&& e) { p.mark_end_execution(e); };
 
     HPX_CXX_CORE_EXPORT template <typename Params, typename InnerParams,
         typename Executor>
-    inline constexpr bool supports_wrapping_mark_end_execution_v = requires(
-        std::remove_reference_t<Params>& p,
-        std::remove_reference_t<InnerParams>& ip,
-        std::remove_reference_t<Executor>& e) { p.mark_end_execution(ip, e); };
+    inline constexpr bool supports_wrapping_mark_end_execution_v =
+        requires(Params&& p, InnerParams&& ip, Executor&& e) {
+            p.mark_end_execution(ip, e);
+        };
 
     // execution_markers: partition
     HPX_CXX_CORE_EXPORT template <typename Params, typename Executor,
         typename... Args>
     inline constexpr bool supports_mark_partition_v =
-        requires(std::remove_reference_t<Params>& p,
-            std::remove_reference_t<Executor>& e, Args&&... args) {
+        requires(Params&& p, Executor&& e, Args&&... args) {
             p.mark_partition(e, std::size_t{}, HPX_FORWARD(Args, args)...);
         };
 
     HPX_CXX_CORE_EXPORT template <typename Params, typename InnerParams,
         typename Executor, typename... Args>
     inline constexpr bool supports_wrapping_mark_partition_v =
-        requires(std::remove_reference_t<Params>& p,
-            std::remove_reference_t<InnerParams>& ip,
-            std::remove_reference_t<Executor>& e, Args&&... args) {
+        requires(Params&& p, InnerParams&& ip, Executor&& e, Args&&... args) {
             p.mark_partition(ip, e, std::size_t{}, HPX_FORWARD(Args, args)...);
         };
 
     // wrapping processing_units_count
     HPX_CXX_CORE_EXPORT template <typename Params, typename Executor>
     inline constexpr bool supports_processing_units_count_v =
-        requires(std::remove_reference_t<Params>& p,
-            std::remove_reference_t<Executor>& e,
+        requires(Params&& p, Executor&& e,
             hpx::chrono::steady_duration const& d) {
             p.processing_units_count(e, d, std::size_t{});
         };
@@ -254,9 +234,7 @@ namespace hpx::execution::experimental {
     HPX_CXX_CORE_EXPORT template <typename Params, typename InnerParams,
         typename Executor>
     inline constexpr bool supports_wrapping_processing_units_count_v =
-        requires(std::remove_reference_t<Params>& p,
-            std::remove_reference_t<InnerParams>& ip,
-            std::remove_reference_t<Executor>& e,
+        requires(Params&& p, InnerParams&& ip, Executor&& e,
             hpx::chrono::steady_duration const& d) {
             p.processing_units_count(ip, e, d, std::size_t{});
         };
@@ -264,25 +242,21 @@ namespace hpx::execution::experimental {
     // wrapping reset_thread_distribution
     HPX_CXX_CORE_EXPORT template <typename Params, typename Executor>
     inline constexpr bool supports_reset_thread_distribution_v =
-        requires(std::remove_reference_t<Params>& p,
-            std::remove_reference_t<Executor>& e) {
+        requires(Params&& p, Executor&& e) {
             p.reset_thread_distribution(e);
         };
 
     HPX_CXX_CORE_EXPORT template <typename Params, typename InnerParams,
         typename Executor>
     inline constexpr bool supports_wrapping_reset_thread_distribution_v =
-        requires(std::remove_reference_t<Params>& p,
-            std::remove_reference_t<InnerParams>& ip,
-            std::remove_reference_t<Executor>& e) {
+        requires(Params&& p, InnerParams&& ip, Executor&& e) {
             p.reset_thread_distribution(ip, e);
         };
 
     // wrapping collect_execution_parameters
     HPX_CXX_CORE_EXPORT template <typename Params, typename Executor>
     inline constexpr bool supports_collect_execution_parameters_v =
-        requires(std::remove_reference_t<Params>& p,
-            std::remove_reference_t<Executor>& e) {
+        requires(Params&& p, Executor&& e) {
             p.collect_execution_parameters(
                 e, std::size_t{}, std::size_t{}, std::size_t{}, std::size_t{});
         };
@@ -290,9 +264,7 @@ namespace hpx::execution::experimental {
     HPX_CXX_CORE_EXPORT template <typename Params, typename InnerParams,
         typename Executor>
     inline constexpr bool supports_wrapping_collect_execution_parameters_v =
-        requires(std::remove_reference_t<Params>& p,
-            std::remove_reference_t<InnerParams>& ip,
-            std::remove_reference_t<Executor>& e) {
+        requires(Params&& p, InnerParams&& ip, Executor&& e) {
             p.collect_execution_parameters(ip, e, std::size_t{}, std::size_t{},
                 std::size_t{}, std::size_t{});
         };

--- a/libs/core/execution/include/hpx/execution/executors/rebind_executor_parameters.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/rebind_executor_parameters.hpp
@@ -129,11 +129,10 @@ namespace hpx::execution::experimental {
 
     // wrapping get_chunk_size
     HPX_CXX_CORE_EXPORT template <typename Params, typename Executor>
-    inline constexpr bool supports_get_chunk_size_v =
-        requires(Params&& p, Executor&& e,
-            hpx::chrono::steady_duration const& d) {
-            p.get_chunk_size(e, d, std::size_t{}, std::size_t{});
-        };
+    inline constexpr bool supports_get_chunk_size_v = requires(
+        Params&& p, Executor&& e, hpx::chrono::steady_duration const& d) {
+        p.get_chunk_size(e, d, std::size_t{}, std::size_t{});
+    };
 
     HPX_CXX_CORE_EXPORT template <typename Params, typename InnerParams,
         typename Executor>
@@ -225,11 +224,10 @@ namespace hpx::execution::experimental {
 
     // wrapping processing_units_count
     HPX_CXX_CORE_EXPORT template <typename Params, typename Executor>
-    inline constexpr bool supports_processing_units_count_v =
-        requires(Params&& p, Executor&& e,
-            hpx::chrono::steady_duration const& d) {
-            p.processing_units_count(e, d, std::size_t{});
-        };
+    inline constexpr bool supports_processing_units_count_v = requires(
+        Params&& p, Executor&& e, hpx::chrono::steady_duration const& d) {
+        p.processing_units_count(e, d, std::size_t{});
+    };
 
     HPX_CXX_CORE_EXPORT template <typename Params, typename InnerParams,
         typename Executor>
@@ -242,9 +240,7 @@ namespace hpx::execution::experimental {
     // wrapping reset_thread_distribution
     HPX_CXX_CORE_EXPORT template <typename Params, typename Executor>
     inline constexpr bool supports_reset_thread_distribution_v =
-        requires(Params&& p, Executor&& e) {
-            p.reset_thread_distribution(e);
-        };
+        requires(Params&& p, Executor&& e) { p.reset_thread_distribution(e); };
 
     HPX_CXX_CORE_EXPORT template <typename Params, typename InnerParams,
         typename Executor>

--- a/libs/core/execution/include/hpx/execution/executors/rebind_executor_parameters.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/rebind_executor_parameters.hpp
@@ -182,11 +182,9 @@ namespace hpx::execution::experimental {
 
     // execution_markers: begin_execution
     HPX_CXX_CORE_EXPORT template <typename Params, typename Executor>
-    inline constexpr bool supports_mark_begin_execution_v =
-        requires(std::remove_reference_t<Params> const& p,
-            std::remove_reference_t<Executor>& e) {
-            p.mark_begin_execution(e);
-        };
+    inline constexpr bool supports_mark_begin_execution_v = requires(
+        std::remove_reference_t<Params> const& p,
+        std::remove_reference_t<Executor>& e) { p.mark_begin_execution(e); };
 
     HPX_CXX_CORE_EXPORT template <typename Params, typename InnerParams,
         typename Executor>
@@ -199,11 +197,9 @@ namespace hpx::execution::experimental {
 
     // execution_markers: end_of_scheduling
     HPX_CXX_CORE_EXPORT template <typename Params, typename Executor>
-    inline constexpr bool supports_mark_end_of_scheduling_v =
-        requires(std::remove_reference_t<Params> const& p,
-            std::remove_reference_t<Executor>& e) {
-            p.mark_end_of_scheduling(e);
-        };
+    inline constexpr bool supports_mark_end_of_scheduling_v = requires(
+        std::remove_reference_t<Params> const& p,
+        std::remove_reference_t<Executor>& e) { p.mark_end_of_scheduling(e); };
 
     HPX_CXX_CORE_EXPORT template <typename Params, typename InnerParams,
         typename Executor>
@@ -222,12 +218,10 @@ namespace hpx::execution::experimental {
 
     HPX_CXX_CORE_EXPORT template <typename Params, typename InnerParams,
         typename Executor>
-    inline constexpr bool supports_wrapping_mark_end_execution_v =
-        requires(std::remove_reference_t<Params> const& p,
-            std::remove_reference_t<InnerParams>& ip,
-            std::remove_reference_t<Executor>& e) {
-            p.mark_end_execution(ip, e);
-        };
+    inline constexpr bool supports_wrapping_mark_end_execution_v = requires(
+        std::remove_reference_t<Params> const& p,
+        std::remove_reference_t<InnerParams>& ip,
+        std::remove_reference_t<Executor>& e) { p.mark_end_execution(ip, e); };
 
     // execution_markers: partition
     HPX_CXX_CORE_EXPORT template <typename Params, typename Executor,
@@ -352,18 +346,20 @@ namespace hpx::execution::experimental {
         constexpr hpx::chrono::steady_duration measure_iteration(
             Executor&& exec, F&& f, std::size_t const num_tasks)
         {
-            if constexpr (supports_wrapping_measure_iteration_v<Wrapping, Wrapped,
-                              Executor, F>)
+            if constexpr (supports_wrapping_measure_iteration_v<Wrapping,
+                              Wrapped, Executor, F>)
             {
                 return wrapping.measure_iteration(wrapped,
                     HPX_FORWARD(Executor, exec), HPX_FORWARD(F, f), num_tasks);
             }
-            else if constexpr (supports_measure_iteration_v<Wrapping, Executor, F>)
+            else if constexpr (supports_measure_iteration_v<Wrapping, Executor,
+                                   F>)
             {
                 return wrapping.measure_iteration(
                     HPX_FORWARD(Executor, exec), HPX_FORWARD(F, f), num_tasks);
             }
-            else if constexpr (supports_measure_iteration_v<Wrapped, Executor, F>)
+            else if constexpr (supports_measure_iteration_v<Wrapped, Executor,
+                                   F>)
             {
                 return wrapped.measure_iteration(
                     HPX_FORWARD(Executor, exec), HPX_FORWARD(F, f), num_tasks);
@@ -383,8 +379,8 @@ namespace hpx::execution::experimental {
             if constexpr (supports_wrapping_maximal_number_of_chunks_v<Wrapping,
                               Wrapped, Executor>)
             {
-                return wrapping.maximal_number_of_chunks(wrapped,
-                    HPX_FORWARD(Executor, exec), cores, num_tasks);
+                return wrapping.maximal_number_of_chunks(
+                    wrapped, HPX_FORWARD(Executor, exec), cores, num_tasks);
             }
             else if constexpr (supports_maximal_number_of_chunks_v<Wrapping,
                                    Executor>)
@@ -409,17 +405,19 @@ namespace hpx::execution::experimental {
         template <typename Executor>
         constexpr void mark_begin_execution(Executor&& exec) const
         {
-            if constexpr (supports_wrapping_mark_begin_execution_v<Wrapping, Wrapped,
-                              Executor>)
+            if constexpr (supports_wrapping_mark_begin_execution_v<Wrapping,
+                              Wrapped, Executor>)
             {
-                wrapping.mark_begin_execution(wrapped,
-                    HPX_FORWARD(Executor, exec));
+                wrapping.mark_begin_execution(
+                    wrapped, HPX_FORWARD(Executor, exec));
             }
-            else if constexpr (supports_mark_begin_execution_v<Wrapping, Executor>)
+            else if constexpr (supports_mark_begin_execution_v<Wrapping,
+                                   Executor>)
             {
                 wrapping.mark_begin_execution(HPX_FORWARD(Executor, exec));
             }
-            else if constexpr (supports_mark_begin_execution_v<Wrapped, Executor>)
+            else if constexpr (supports_mark_begin_execution_v<Wrapped,
+                                   Executor>)
             {
                 wrapped.mark_begin_execution(HPX_FORWARD(Executor, exec));
             }
@@ -432,8 +430,8 @@ namespace hpx::execution::experimental {
             if constexpr (supports_wrapping_mark_end_of_scheduling_v<Wrapping,
                               Wrapped, Executor>)
             {
-                wrapping.mark_end_of_scheduling(wrapped,
-                    HPX_FORWARD(Executor, exec));
+                wrapping.mark_end_of_scheduling(
+                    wrapped, HPX_FORWARD(Executor, exec));
             }
             else if constexpr (supports_mark_end_of_scheduling_v<Wrapping,
                                    Executor>)
@@ -451,13 +449,14 @@ namespace hpx::execution::experimental {
         template <typename Executor>
         constexpr void mark_end_execution(Executor&& exec) const
         {
-            if constexpr (supports_wrapping_mark_end_execution_v<Wrapping, Wrapped,
-                              Executor>)
+            if constexpr (supports_wrapping_mark_end_execution_v<Wrapping,
+                              Wrapped, Executor>)
             {
-                wrapping.mark_end_execution(wrapped,
-                    HPX_FORWARD(Executor, exec));
+                wrapping.mark_end_execution(
+                    wrapped, HPX_FORWARD(Executor, exec));
             }
-            else if constexpr (supports_mark_end_execution_v<Wrapping, Executor>)
+            else if constexpr (supports_mark_end_execution_v<Wrapping,
+                                   Executor>)
             {
                 wrapping.mark_end_execution(HPX_FORWARD(Executor, exec));
             }
@@ -469,8 +468,8 @@ namespace hpx::execution::experimental {
 
         // execution_markers: partition
         template <typename Executor, typename... Args>
-        constexpr void mark_partition(Executor&& exec, std::size_t partition,
-            Args&&... args) const
+        constexpr void mark_partition(
+            Executor&& exec, std::size_t partition, Args&&... args) const
         {
             if constexpr (supports_wrapping_mark_partition_v<Wrapping, Wrapped,
                               Executor, Args...>)
@@ -528,11 +527,11 @@ namespace hpx::execution::experimental {
         template <typename Executor>
         constexpr void reset_thread_distribution(Executor&& exec) const
         {
-            if constexpr (supports_wrapping_reset_thread_distribution_v<Wrapping,
-                              Wrapped, Executor>)
+            if constexpr (supports_wrapping_reset_thread_distribution_v<
+                              Wrapping, Wrapped, Executor>)
             {
-                wrapping.reset_thread_distribution(wrapped,
-                    HPX_FORWARD(Executor, exec));
+                wrapping.reset_thread_distribution(
+                    wrapped, HPX_FORWARD(Executor, exec));
             }
             else if constexpr (supports_reset_thread_distribution_v<Wrapping,
                                    Executor>)
@@ -552,26 +551,26 @@ namespace hpx::execution::experimental {
             std::size_t const num_elements, std::size_t const num_cores,
             std::size_t const num_chunks, std::size_t const chunk_size) const
         {
-            if constexpr (supports_wrapping_collect_execution_parameters_v<Wrapping,
-                              Wrapped, Executor>)
+            if constexpr (supports_wrapping_collect_execution_parameters_v<
+                              Wrapping, Wrapped, Executor>)
             {
                 wrapping.collect_execution_parameters(wrapped,
-                    HPX_FORWARD(Executor, exec), num_elements, num_cores, num_chunks,
-                    chunk_size);
+                    HPX_FORWARD(Executor, exec), num_elements, num_cores,
+                    num_chunks, chunk_size);
             }
             else if constexpr (supports_collect_execution_parameters_v<Wrapping,
                                    Executor>)
             {
                 wrapping.collect_execution_parameters(
-                    HPX_FORWARD(Executor, exec), num_elements, num_cores, num_chunks,
-                    chunk_size);
+                    HPX_FORWARD(Executor, exec), num_elements, num_cores,
+                    num_chunks, chunk_size);
             }
             else if constexpr (supports_collect_execution_parameters_v<Wrapped,
                                    Executor>)
             {
                 wrapped.collect_execution_parameters(
-                    HPX_FORWARD(Executor, exec), num_elements, num_cores, num_chunks,
-                    chunk_size);
+                    HPX_FORWARD(Executor, exec), num_elements, num_cores,
+                    num_chunks, chunk_size);
             }
         }
 

--- a/libs/core/execution/include/hpx/execution/executors/static_chunk_size.hpp
+++ b/libs/core/execution/include/hpx/execution/executors/static_chunk_size.hpp
@@ -55,21 +55,19 @@ namespace hpx::execution::experimental {
 
         /// \cond NOINTERNAL
         template <typename Executor>
-        friend std::size_t tag_override_invoke(
-            hpx::execution::experimental::get_chunk_size_t,
-            static_chunk_size& this_, Executor& exec,
+        std::size_t get_chunk_size(Executor&& exec,
             hpx::chrono::steady_duration const&, std::size_t const cores,
-            std::size_t const num_iterations)
+            std::size_t const num_iterations) const
         {
             // Make sure the internal round-robin counter of the executor is
             // reset
             hpx::execution::experimental::reset_thread_distribution(
-                this_, exec);
+                *this, exec);
 
             // use the given chunk size if given
-            if (this_.chunk_size_ != 0)
+            if (chunk_size_ != 0)
             {
-                return this_.chunk_size_;
+                return chunk_size_;
             }
 
             if (cores == 1)

--- a/libs/core/execution/include/hpx/execution/traits/executor_traits.hpp
+++ b/libs/core/execution/include/hpx/execution/traits/executor_traits.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2017-2024 Hartmut Kaiser
+//  Copyright (c) 2026 Sai Charan Arvapally
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -199,6 +200,12 @@ namespace hpx::execution::experimental {
                 std::declval<T (*)(Ts...)>(), std::declval<Ts>()...));
         };
 
+        // Fallback for two-way executors that don't have an async_execute
+        // member and don't expose future_type. With tag_invoke removed,
+        // executors should provide async_execute as a public member function
+        // (the specialization above will deduce the return type). This
+        // fallback assumes hpx::future<T> for executors that haven't been
+        // migrated yet.
         template <typename Executor, typename T, typename... Ts>
         struct executor_future<Executor, T, hpx::util::pack<Ts...>,
             std::enable_if_t<hpx::traits::is_two_way_executor_v<Executor> &&

--- a/libs/core/execution/include/hpx/execution/traits/executor_traits.hpp
+++ b/libs/core/execution/include/hpx/execution/traits/executor_traits.hpp
@@ -205,9 +205,7 @@ namespace hpx::execution::experimental {
                 !has_async_execute_member<Executor>::value &&
                 !exposes_future_type<Executor, T>::value>>
         {
-            using type = hpx::functional::tag_invoke_result_t<
-                hpx::parallel::execution::async_execute_t, Executor,
-                T (*)(Ts...), Ts...>;
+            using type = hpx::future<T>;
         };
 
         template <typename Executor, typename T, typename Ts>

--- a/libs/core/execution/tests/regressions/chunk_size_4118.cpp
+++ b/libs/core/execution/tests/regressions/chunk_size_4118.cpp
@@ -20,16 +20,15 @@
 struct test_async_executor : hpx::execution::parallel_executor
 {
     template <typename F, typename T, typename... Ts>
-    friend decltype(auto) tag_invoke(hpx::parallel::execution::async_execute_t,
-        test_async_executor const& exec, F&& f, T&& t, std::size_t chunk_size,
-        Ts&&... ts)
+    decltype(auto) async_execute(
+        F&& f, T&& t, std::size_t chunk_size, Ts&&... ts) const
     {
         // make sure the chunk_size is equal to what was specified below
         HPX_TEST_EQ(chunk_size, std::size_t(50000));
 
         using base_type = hpx::execution::parallel_executor;
         return hpx::parallel::execution::async_execute(
-            static_cast<base_type const&>(exec), std::forward<F>(f),
+            static_cast<base_type const&>(*this), std::forward<F>(f),
             std::forward<T>(t), chunk_size, std::forward<Ts>(ts)...);
     }
 };

--- a/libs/core/execution/tests/regressions/executor_parameters_num_chunks.cpp
+++ b/libs/core/execution/tests/regressions/executor_parameters_num_chunks.cpp
@@ -21,15 +21,13 @@
 struct execution_parameters
 {
     template <typename Executor>
-    friend void tag_override_invoke(
-        hpx::execution::experimental::collect_execution_parameters_t,
-        execution_parameters& self, Executor&&, std::size_t const count,
+    void collect_execution_parameters(Executor&&, std::size_t const count,
         std::size_t const, std::size_t const num_chunks,
         std::size_t const chunk_size) noexcept
     {
-        self.count_ = count;
-        self.num_chunks_ = num_chunks;
-        self.chunk_size_ = chunk_size;
+        count_ = count;
+        num_chunks_ = num_chunks;
+        chunk_size_ = chunk_size;
     }
 
     std::size_t count_ = 0;

--- a/libs/core/execution/tests/unit/executor_parameters.cpp
+++ b/libs/core/execution/tests/unit/executor_parameters.cpp
@@ -171,23 +171,17 @@ struct timer_hooks_parameters
     }
 
     template <typename Executor>
-    friend void tag_override_invoke(
-        hpx::execution::experimental::mark_begin_execution_t,
-        timer_hooks_parameters const&, Executor&&)
+    void mark_begin_execution(Executor&&) const
     {
     }
 
     template <typename Executor>
-    friend void tag_override_invoke(
-        hpx::execution::experimental::mark_end_of_scheduling_t,
-        timer_hooks_parameters const&, Executor&&)
+    void mark_end_of_scheduling(Executor&&) const
     {
     }
 
     template <typename Executor>
-    friend void tag_override_invoke(
-        hpx::execution::experimental::mark_end_execution_t,
-        timer_hooks_parameters const&, Executor&&)
+    void mark_end_execution(Executor&&) const
     {
     }
 

--- a/libs/core/execution/tests/unit/executor_parameters_dispatching.cpp
+++ b/libs/core/execution/tests/unit/executor_parameters_dispatching.cpp
@@ -94,8 +94,8 @@ void test_get_chunk_size()
         hpx::execution::experimental::get_chunk_size(
             test_chunk_size{}, test_executor_get_chunk_size{}, 1, 1);
 
-        HPX_TEST_EQ(params_count, static_cast<std::size_t>(1));
-        HPX_TEST_EQ(exec_count, static_cast<std::size_t>(0));
+        HPX_TEST_EQ(params_count, static_cast<std::size_t>(0));
+        HPX_TEST_EQ(exec_count, static_cast<std::size_t>(1));
     }
 
     {
@@ -195,8 +195,8 @@ void test_get_measure_iteration()
             test_measure_iteration{}, test_executor_measure_iteration{},
             [](std::size_t) { return 0; }, 1);
 
-        HPX_TEST_EQ(params_count, static_cast<std::size_t>(1));
-        HPX_TEST_EQ(exec_count, static_cast<std::size_t>(0));
+        HPX_TEST_EQ(params_count, static_cast<std::size_t>(0));
+        HPX_TEST_EQ(exec_count, static_cast<std::size_t>(1));
     }
 }
 
@@ -274,8 +274,8 @@ void test_maximal_number_of_chunks()
             test_number_of_chunks{}, test_executor_maximal_number_of_chunks{},
             1, 1);
 
-        HPX_TEST_EQ(params_count, static_cast<std::size_t>(1));
-        HPX_TEST_EQ(exec_count, static_cast<std::size_t>(0));
+        HPX_TEST_EQ(params_count, static_cast<std::size_t>(0));
+        HPX_TEST_EQ(exec_count, static_cast<std::size_t>(1));
     }
 }
 
@@ -349,8 +349,8 @@ void test_reset_thread_distribution()
             test_thread_distribution{},
             test_executor_reset_thread_distribution{});
 
-        HPX_TEST_EQ(params_count, static_cast<std::size_t>(1));
-        HPX_TEST_EQ(exec_count, static_cast<std::size_t>(0));
+        HPX_TEST_EQ(params_count, static_cast<std::size_t>(0));
+        HPX_TEST_EQ(exec_count, static_cast<std::size_t>(1));
     }
 }
 
@@ -539,8 +539,8 @@ void test_mark_begin_execution()
         hpx::execution::experimental::mark_begin_execution(
             test_begin_end{}, test_executor_begin_end{});
 
-        HPX_TEST_EQ(params_count, static_cast<std::size_t>(1));
-        HPX_TEST_EQ(exec_count, static_cast<std::size_t>(0));
+        HPX_TEST_EQ(params_count, static_cast<std::size_t>(0));
+        HPX_TEST_EQ(exec_count, static_cast<std::size_t>(1));
     }
 }
 
@@ -575,8 +575,8 @@ void test_mark_end_of_scheduling()
         hpx::execution::experimental::mark_end_of_scheduling(
             test_begin_end{}, test_executor_begin_end{});
 
-        HPX_TEST_EQ(params_count, static_cast<std::size_t>(1));
-        HPX_TEST_EQ(exec_count, static_cast<std::size_t>(0));
+        HPX_TEST_EQ(params_count, static_cast<std::size_t>(0));
+        HPX_TEST_EQ(exec_count, static_cast<std::size_t>(1));
     }
 }
 
@@ -611,8 +611,8 @@ void test_mark_end_execution()
         hpx::execution::experimental::mark_end_execution(
             test_begin_end{}, test_executor_begin_end{});
 
-        HPX_TEST_EQ(params_count, static_cast<std::size_t>(1));
-        HPX_TEST_EQ(exec_count, static_cast<std::size_t>(0));
+        HPX_TEST_EQ(params_count, static_cast<std::size_t>(0));
+        HPX_TEST_EQ(exec_count, static_cast<std::size_t>(1));
     }
 }
 

--- a/libs/core/execution/tests/unit/executor_parameters_dispatching.cpp
+++ b/libs/core/execution/tests/unit/executor_parameters_dispatching.cpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2020-2024 Hartmut Kaiser
+//  Copyright (c) 2026 Sai Charan Arvapally
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/core/execution/tests/unit/executor_parameters_dispatching.cpp
+++ b/libs/core/execution/tests/unit/executor_parameters_dispatching.cpp
@@ -30,10 +30,9 @@ struct test_executor_get_chunk_size : hpx::execution::parallel_executor
     test_executor_get_chunk_size() = default;
 
     template <typename Parameters>
-    friend std::size_t tag_invoke(
-        hpx::execution::experimental::get_chunk_size_t, Parameters&&,
-        test_executor_get_chunk_size, hpx::chrono::steady_duration const&,
-        std::size_t cores, std::size_t count)
+    std::size_t get_chunk_size(Parameters&&,
+        hpx::chrono::steady_duration const&, std::size_t cores,
+        std::size_t count) const
     {
         ++exec_count;
         return (count + cores - 1) / cores;
@@ -49,10 +48,9 @@ struct hpx::execution::experimental::is_two_way_executor<
 struct test_chunk_size
 {
     template <typename Executor>
-    friend std::size_t tag_override_invoke(
-        hpx::execution::experimental::get_chunk_size_t, test_chunk_size,
-        Executor&&, hpx::chrono::steady_duration const&, std::size_t cores,
-        std::size_t count)
+    std::size_t get_chunk_size(Executor&&,
+        hpx::chrono::steady_duration const&, std::size_t cores,
+        std::size_t count) const
     {
         ++params_count;
         return (count + cores - 1) / cores;
@@ -134,8 +132,7 @@ struct test_executor_measure_iteration : hpx::execution::parallel_executor
     test_executor_measure_iteration() = default;
 
     template <typename Parameters, typename F>
-    friend auto tag_invoke(hpx::execution::experimental::measure_iteration_t,
-        Parameters&&, test_executor_measure_iteration, F&&, std::size_t)
+    auto measure_iteration(Parameters&&, F&&, std::size_t) const
     {
         ++exec_count;
         return hpx::chrono::null_duration;
@@ -151,9 +148,7 @@ struct hpx::execution::experimental::is_two_way_executor<
 struct test_measure_iteration
 {
     template <typename Executor, typename F>
-    friend auto tag_override_invoke(
-        hpx::execution::experimental::measure_iteration_t,
-        test_measure_iteration, Executor&&, F&&, std::size_t)
+    auto measure_iteration(Executor&&, F&&, std::size_t)
     {
         ++params_count;
         return hpx::chrono::null_duration;
@@ -215,10 +210,8 @@ struct test_executor_maximal_number_of_chunks
     test_executor_maximal_number_of_chunks() = default;
 
     template <typename Parameters>
-    friend std::size_t tag_invoke(
-        hpx::execution::experimental::maximal_number_of_chunks_t, Parameters&&,
-        test_executor_maximal_number_of_chunks, std::size_t,
-        std::size_t num_tasks)
+    std::size_t maximal_number_of_chunks(
+        Parameters&&, std::size_t, std::size_t num_tasks) const
     {
         ++exec_count;
         return num_tasks;
@@ -234,9 +227,8 @@ struct hpx::execution::experimental::is_two_way_executor<
 struct test_number_of_chunks
 {
     template <typename Executor>
-    friend std::size_t tag_override_invoke(
-        hpx::execution::experimental::maximal_number_of_chunks_t,
-        test_number_of_chunks, Executor&&, std::size_t, std::size_t num_tasks)
+    std::size_t maximal_number_of_chunks(
+        Executor&&, std::size_t, std::size_t num_tasks) const
     {
         ++params_count;
         return num_tasks;
@@ -297,9 +289,7 @@ struct test_executor_reset_thread_distribution
     test_executor_reset_thread_distribution() = default;
 
     template <typename Parameters>
-    friend void tag_invoke(
-        hpx::execution::experimental::reset_thread_distribution_t, Parameters&&,
-        test_executor_reset_thread_distribution)
+    void reset_thread_distribution(Parameters&&) const
     {
         ++exec_count;
     }
@@ -314,9 +304,7 @@ struct hpx::execution::experimental::is_two_way_executor<
 struct test_thread_distribution
 {
     template <typename Executor>
-    friend void tag_override_invoke(
-        hpx::execution::experimental::reset_thread_distribution_t,
-        test_thread_distribution, Executor&&)
+    void reset_thread_distribution(Executor&&)
     {
         ++params_count;
     }
@@ -373,16 +361,6 @@ void test_reset_thread_distribution()
 struct test_executor_processing_units_count : hpx::execution::parallel_executor
 {
     test_executor_processing_units_count() = default;
-
-    template <typename Parameters>
-    friend std::size_t tag_invoke(
-        hpx::execution::experimental::processing_units_count_t, Parameters&&,
-        test_executor_processing_units_count,
-        hpx::chrono::steady_duration const&, std::size_t)
-    {
-        ++exec_count;
-        return 1;
-    }
 };
 
 template <>
@@ -394,11 +372,9 @@ struct hpx::execution::experimental::is_two_way_executor<
 struct test_processing_units
 {
     template <typename Executor>
-    friend std::size_t tag_override_invoke(
-        hpx::execution::experimental::processing_units_count_t,
-        test_processing_units, Executor&&,
+    std::size_t processing_units_count(Executor&&,
         hpx::chrono::steady_duration const& = hpx::chrono::null_duration,
-        std::size_t = 0)
+        std::size_t = 0) const
     {
         ++params_count;
         return 1;
@@ -481,23 +457,19 @@ struct test_executor_begin_end : hpx::execution::parallel_executor
     test_executor_begin_end() = default;
 
     template <typename Parameters>
-    friend void tag_invoke(hpx::execution::experimental::mark_begin_execution_t,
-        Parameters&&, test_executor_begin_end)
+    void mark_begin_execution(Parameters&&) const
     {
         ++exec_count;
     }
 
     template <typename Parameters>
-    friend void tag_invoke(
-        hpx::execution::experimental::mark_end_of_scheduling_t, Parameters&&,
-        test_executor_begin_end)
+    void mark_end_of_scheduling(Parameters&&) const
     {
         ++exec_count;
     }
 
     template <typename Parameters>
-    friend void tag_invoke(hpx::execution::experimental::mark_end_execution_t,
-        Parameters&&, test_executor_begin_end)
+    void mark_end_execution(Parameters&&) const
     {
         ++exec_count;
     }
@@ -512,25 +484,19 @@ struct hpx::execution::experimental::is_two_way_executor<
 struct test_begin_end
 {
     template <typename Executor>
-    friend void tag_override_invoke(
-        hpx::execution::experimental::mark_begin_execution_t, test_begin_end,
-        Executor&&)
+    void mark_begin_execution(Executor&&)
     {
         ++params_count;
     }
 
     template <typename Executor>
-    friend void tag_override_invoke(
-        hpx::execution::experimental::mark_end_of_scheduling_t, test_begin_end,
-        Executor&&)
+    void mark_end_of_scheduling(Executor&&)
     {
         ++params_count;
     }
 
     template <typename Executor>
-    friend void tag_override_invoke(
-        hpx::execution::experimental::mark_end_execution_t, test_begin_end,
-        Executor&&)
+    void mark_end_execution(Executor&&)
     {
         ++params_count;
     }

--- a/libs/core/execution/tests/unit/executor_parameters_dispatching.cpp
+++ b/libs/core/execution/tests/unit/executor_parameters_dispatching.cpp
@@ -48,9 +48,8 @@ struct hpx::execution::experimental::is_two_way_executor<
 struct test_chunk_size
 {
     template <typename Executor>
-    std::size_t get_chunk_size(Executor&&,
-        hpx::chrono::steady_duration const&, std::size_t cores,
-        std::size_t count) const
+    std::size_t get_chunk_size(Executor&&, hpx::chrono::steady_duration const&,
+        std::size_t cores, std::size_t count) const
     {
         ++params_count;
         return (count + cores - 1) / cores;

--- a/libs/core/execution/tests/unit/executor_parameters_partition_hooks.cpp
+++ b/libs/core/execution/tests/unit/executor_parameters_partition_hooks.cpp
@@ -43,6 +43,11 @@ struct partition_hooks_parameters
         seen_[partition] = 1;
     }
 
+    template <typename Executor, typename State, typename Extra>
+    void mark_partition(Executor&&, std::size_t, State, Extra) noexcept
+    {
+    }
+
     std::size_t count_seen() const
     {
         std::size_t c = 0;

--- a/libs/core/execution/tests/unit/executor_parameters_partition_hooks.cpp
+++ b/libs/core/execution/tests/unit/executor_parameters_partition_hooks.cpp
@@ -24,27 +24,23 @@ struct partition_hooks_parameters
     explicit partition_hooks_parameters() = default;
 
     template <typename Executor>
-    friend void tag_override_invoke(
-        hpx::execution::experimental::collect_execution_parameters_t,
-        partition_hooks_parameters& self, Executor&&, std::size_t const,
+    void collect_execution_parameters(Executor&&, std::size_t const,
         std::size_t const, std::size_t const num_chunks,
         std::size_t const) noexcept
     {
-        self.num_chunks_ = num_chunks;
-        self.values_.resize(num_chunks);
-        self.seen_.resize(num_chunks);
+        num_chunks_ = num_chunks;
+        values_.resize(num_chunks);
+        seen_.resize(num_chunks);
     }
 
-    template <typename Executor>
-    friend void tag_override_invoke(
-        hpx::execution::experimental::mark_partition_t,
-        partition_hooks_parameters& self, Executor&&, std::size_t partition,
-        auto state, std::size_t a, std::size_t b, auto) noexcept
+    template <typename Executor, typename State, typename Extra>
+    void mark_partition(Executor&&, std::size_t partition, State state,
+        std::size_t a, std::size_t b, Extra) noexcept
     {
-        HPX_TEST_LT(partition, self.values_.size());
+        HPX_TEST_LT(partition, values_.size());
         HPX_TEST_EQ(std::uint8_t(1), static_cast<std::uint8_t>(state));
-        self.values_[partition] = {a, b};
-        self.seen_[partition] = 1;
+        values_[partition] = {a, b};
+        seen_[partition] = 1;
     }
 
     std::size_t count_seen() const

--- a/libs/core/execution/tests/unit/executor_parameters_timer_hooks.cpp
+++ b/libs/core/execution/tests/unit/executor_parameters_timer_hooks.cpp
@@ -66,28 +66,22 @@ struct timer_hooks_parameters
     }
 
     template <typename Executor>
-    friend void tag_override_invoke(
-        hpx::execution::experimental::mark_begin_execution_t,
-        timer_hooks_parameters& this_, Executor&&)
+    void mark_begin_execution(Executor&&)
     {
-        ++this_.count_;
-        this_.time_ = hpx::chrono::high_resolution_clock::now();
+        ++count_;
+        time_ = hpx::chrono::high_resolution_clock::now();
     }
 
     template <typename Executor>
-    friend void tag_override_invoke(
-        hpx::execution::experimental::mark_end_of_scheduling_t,
-        timer_hooks_parameters const&, Executor&&)
+    void mark_end_of_scheduling(Executor&&) const
     {
     }
 
     template <typename Executor>
-    friend void tag_override_invoke(
-        hpx::execution::experimental::mark_end_execution_t,
-        timer_hooks_parameters& this_, Executor&&)
+    void mark_end_execution(Executor&&)
     {
-        this_.time_ = hpx::chrono::high_resolution_clock::now() - this_.time_;
-        ++this_.count_;
+        time_ = hpx::chrono::high_resolution_clock::now() - time_;
+        ++count_;
     }
 
     std::string name_;

--- a/libs/core/execution/tests/unit/minimal_async_executor.cpp
+++ b/libs/core/execution/tests/unit/minimal_async_executor.cpp
@@ -150,8 +150,7 @@ struct test_async_executor1
     using execution_category = hpx::execution::parallel_execution_tag;
 
     template <typename F, typename... Ts>
-    friend decltype(auto) tag_invoke(hpx::parallel::execution::async_execute_t,
-        test_async_executor1 const&, F&& f, Ts&&... ts)
+    decltype(auto) async_execute(F&& f, Ts&&... ts) const
     {
         ++count_async;
 
@@ -175,8 +174,7 @@ struct test_async_executor2 : test_async_executor1
     using execution_category = hpx::execution::parallel_execution_tag;
 
     template <typename F, typename... Ts>
-    friend decltype(auto) tag_invoke(hpx::parallel::execution::sync_execute_t,
-        test_async_executor2 const&, F&& f, Ts&&... ts)
+    decltype(auto) sync_execute(F&& f, Ts&&... ts) const
     {
         ++count_sync;
 
@@ -201,9 +199,7 @@ struct test_async_executor3 : test_async_executor1
     using execution_category = hpx::execution::parallel_execution_tag;
 
     template <typename F, typename Shape, typename... Ts>
-    friend decltype(auto) tag_invoke(
-        hpx::parallel::execution::bulk_sync_execute_t,
-        test_async_executor3 const&, F f, Shape const& shape, Ts&&... ts)
+    decltype(auto) bulk_sync_execute(F f, Shape const& shape, Ts&&... ts) const
     {
         ++count_bulk_sync;
 
@@ -232,9 +228,7 @@ struct test_async_executor4 : test_async_executor1
     using execution_category = hpx::execution::parallel_execution_tag;
 
     template <typename F, typename Shape, typename... Ts>
-    friend decltype(auto) tag_invoke(
-        hpx::parallel::execution::bulk_async_execute_t,
-        test_async_executor4 const&, F f, Shape const& shape, Ts&&... ts)
+    decltype(auto) bulk_async_execute(F f, Shape const& shape, Ts&&... ts) const
     {
         ++count_bulk_async;
 
@@ -270,8 +264,7 @@ struct test_async_executor5 : test_async_executor1
     using execution_category = hpx::execution::parallel_execution_tag;
 
     template <typename F, typename... Ts>
-    friend decltype(auto) tag_invoke(hpx::parallel::execution::post_t,
-        test_async_executor5 const&, F&& f, Ts&&... ts)
+    decltype(auto) post(F&& f, Ts&&... ts) const
     {
         ++count_apply;
         hpx::post(std::forward<F>(f), std::forward<Ts>(ts)...);

--- a/libs/core/execution/tests/unit/minimal_sync_executor.cpp
+++ b/libs/core/execution/tests/unit/minimal_sync_executor.cpp
@@ -247,8 +247,7 @@ struct test_sync_executor1
     using execution_category = hpx::execution::sequenced_execution_tag;
 
     template <typename F, typename... Ts>
-    friend decltype(auto) tag_invoke(hpx::parallel::execution::sync_execute_t,
-        test_sync_executor1 const&, F&& f, Ts&&... ts)
+    decltype(auto) sync_execute(F&& f, Ts&&... ts) const
     {
         ++count_sync;
         return hpx::invoke(std::forward<F>(f), std::forward<Ts>(ts)...);
@@ -268,9 +267,8 @@ struct test_sync_executor2 : test_sync_executor1
     using execution_category = hpx::execution::sequenced_execution_tag;
 
     template <typename F, typename Shape, typename... Ts>
-    friend decltype(auto) tag_invoke(
-        hpx::parallel::execution::bulk_sync_execute_t,
-        test_sync_executor2 const&, F&& f, Shape const& shape, Ts&&... ts)
+    decltype(auto) bulk_sync_execute(
+        F&& f, Shape const& shape, Ts&&... ts) const
     {
         ++count_bulk_sync;
 

--- a/libs/core/execution/tests/unit/rebind_executor_parameters.cpp
+++ b/libs/core/execution/tests/unit/rebind_executor_parameters.cpp
@@ -45,12 +45,10 @@ struct test_replaced_get_chunk_size
     }
 
     template <typename Executor>
-    friend std::size_t tag_override_invoke(
-        hpx::execution::experimental::get_chunk_size_t,
-        test_replaced_get_chunk_size& self, Executor&&,
-        hpx::chrono::steady_duration const&, std::size_t, std::size_t) noexcept
+    std::size_t get_chunk_size(Executor&&,
+        hpx::chrono::steady_duration const&, std::size_t, std::size_t) const noexcept
     {
-        *self.invoked = true;
+        *invoked = true;
         return 0;
     }
 
@@ -66,17 +64,15 @@ struct test_wrapping_replaced_get_chunk_size
     }
 
     template <typename InnerParams, typename Executor>
-    friend std::size_t tag_override_invoke(
-        hpx::execution::experimental::get_chunk_size_t,
-        test_wrapping_replaced_get_chunk_size& self, InnerParams&& inner,
-        Executor&& exec, hpx::chrono::steady_duration const& duration,
-        std::size_t cores, std::size_t num_tasks) noexcept
+    std::size_t get_chunk_size(InnerParams&& inner, Executor&& exec,
+        hpx::chrono::steady_duration const& duration, std::size_t cores,
+        std::size_t num_tasks) const noexcept
     {
         std::size_t result = hpx::execution::experimental::get_chunk_size(
             HPX_FORWARD(InnerParams, inner), HPX_FORWARD(Executor, exec),
             duration, cores, num_tasks);
 
-        *self.invoked = true;
+        *invoked = true;
         return result;
     }
 
@@ -191,9 +187,8 @@ struct base_measure_iteration
     using invokes_testing_function = void;
 
     template <typename Executor, typename F>
-    friend hpx::chrono::steady_duration tag_override_invoke(
-        hpx::execution::experimental::measure_iteration_t,
-        base_measure_iteration, Executor&&, F&&, std::size_t) noexcept
+    hpx::chrono::steady_duration measure_iteration(Executor&&, F&&,
+        std::size_t) const noexcept
     {
         return hpx::chrono::null_duration;
     }
@@ -210,12 +205,10 @@ struct test_replaced_measure_iteration
     }
 
     template <typename Executor, typename F>
-    friend hpx::chrono::steady_duration tag_override_invoke(
-        hpx::execution::experimental::measure_iteration_t,
-        test_replaced_measure_iteration& self, Executor&&, F&&,
-        std::size_t) noexcept
+    hpx::chrono::steady_duration measure_iteration(Executor&&, F&&,
+        std::size_t) const noexcept
     {
-        *self.invoked = true;
+        *invoked = true;
         return hpx::chrono::null_duration;
     }
 
@@ -323,12 +316,10 @@ struct test_replaced_maximal_number_of_chunks
     }
 
     template <typename Executor>
-    friend std::size_t tag_override_invoke(
-        hpx::execution::experimental::maximal_number_of_chunks_t,
-        test_replaced_maximal_number_of_chunks& self, Executor&&, std::size_t,
-        std::size_t) noexcept
+    std::size_t maximal_number_of_chunks(Executor&&, std::size_t,
+        std::size_t) const noexcept
     {
-        *self.invoked = true;
+        *invoked = true;
         return 0;
     }
 
@@ -417,23 +408,17 @@ void replace_maximal_number_of_chunks()
 struct base_execution_markers
 {
     template <typename Executor>
-    friend constexpr void tag_override_invoke(
-        hpx::execution::experimental::mark_begin_execution_t,
-        base_execution_markers, Executor&&) noexcept
+    constexpr void mark_begin_execution(Executor&&) const noexcept
     {
     }
 
     template <typename Executor>
-    friend constexpr void tag_override_invoke(
-        hpx::execution::experimental::mark_end_of_scheduling_t,
-        base_execution_markers, Executor&&) noexcept
+    constexpr void mark_end_of_scheduling(Executor&&) const noexcept
     {
     }
 
     template <typename Executor>
-    friend constexpr void tag_override_invoke(
-        hpx::execution::experimental::mark_end_execution_t,
-        base_execution_markers, Executor&&) noexcept
+    constexpr void mark_end_execution(Executor&&) const noexcept
     {
     }
 };
@@ -450,27 +435,21 @@ struct test_replaced_execution_markers
     }
 
     template <typename Executor>
-    friend void tag_override_invoke(
-        hpx::execution::experimental::mark_begin_execution_t,
-        test_replaced_execution_markers self, Executor&&) noexcept
+    void mark_begin_execution(Executor&&) const noexcept
     {
-        *self.invoked_begin = true;
+        *invoked_begin = true;
     }
 
     template <typename Executor>
-    friend void tag_override_invoke(
-        hpx::execution::experimental::mark_end_of_scheduling_t,
-        test_replaced_execution_markers self, Executor&&) noexcept
+    void mark_end_of_scheduling(Executor&&) const noexcept
     {
-        *self.invoked_end = true;
+        *invoked_end = true;
     }
 
     template <typename Executor>
-    friend void tag_override_invoke(
-        hpx::execution::experimental::mark_end_execution_t,
-        test_replaced_execution_markers self, Executor&&) noexcept
+    void mark_end_execution(Executor&&) const noexcept
     {
-        *self.invoked_end_execution = true;
+        *invoked_end_execution = true;
     }
 
     std::atomic<bool>* invoked_begin;
@@ -583,10 +562,8 @@ void replace_execution_markers()
 struct base_processing_units_count
 {
     template <typename Executor>
-    friend constexpr std::size_t tag_override_invoke(
-        hpx::execution::experimental::processing_units_count_t,
-        base_processing_units_count const&, Executor&&,
-        hpx::chrono::steady_duration const&, std::size_t) noexcept
+    constexpr std::size_t processing_units_count(Executor&&,
+        hpx::chrono::steady_duration const&, std::size_t) const noexcept
     {
         return 1;
     }
@@ -601,12 +578,10 @@ struct test_replaced_processing_units_count
     }
 
     template <typename Executor>
-    friend std::size_t tag_override_invoke(
-        hpx::execution::experimental::maximal_number_of_chunks_t,
-        test_replaced_processing_units_count& self, Executor&&, std::size_t,
-        std::size_t) noexcept
+    std::size_t processing_units_count(Executor&&,
+        hpx::chrono::steady_duration const&, std::size_t) const noexcept
     {
-        *self.invoked = true;
+        *invoked = true;
         return 1;
     }
 
@@ -696,10 +671,8 @@ void replace_processing_units_count()
 struct base_collect_execution_parameters
 {
     template <typename Executor>
-    friend constexpr void tag_override_invoke(
-        hpx::execution::experimental::collect_execution_parameters_t,
-        base_collect_execution_parameters&, Executor&&, std::size_t,
-        std::size_t, std::size_t, std::size_t) noexcept
+    constexpr void collect_execution_parameters(Executor&&, std::size_t,
+        std::size_t, std::size_t, std::size_t) const noexcept
     {
     }
 };
@@ -713,12 +686,10 @@ struct test_replaced_collect_execution_parameters
     }
 
     template <typename Executor>
-    friend void tag_override_invoke(
-        hpx::execution::experimental::collect_execution_parameters_t,
-        test_replaced_collect_execution_parameters& self, Executor&&,
-        std::size_t, std::size_t, std::size_t, std::size_t) noexcept
+    void collect_execution_parameters(Executor&&, std::size_t, std::size_t,
+        std::size_t, std::size_t) const noexcept
     {
-        *self.invoked = true;
+        *invoked = true;
     }
 
     std::atomic<bool>* invoked;

--- a/libs/core/execution/tests/unit/rebind_executor_parameters.cpp
+++ b/libs/core/execution/tests/unit/rebind_executor_parameters.cpp
@@ -45,8 +45,8 @@ struct test_replaced_get_chunk_size
     }
 
     template <typename Executor>
-    std::size_t get_chunk_size(Executor&&,
-        hpx::chrono::steady_duration const&, std::size_t, std::size_t) const noexcept
+    std::size_t get_chunk_size(Executor&&, hpx::chrono::steady_duration const&,
+        std::size_t, std::size_t) const noexcept
     {
         *invoked = true;
         return 0;
@@ -187,8 +187,8 @@ struct base_measure_iteration
     using invokes_testing_function = void;
 
     template <typename Executor, typename F>
-    hpx::chrono::steady_duration measure_iteration(Executor&&, F&&,
-        std::size_t) const noexcept
+    hpx::chrono::steady_duration measure_iteration(
+        Executor&&, F&&, std::size_t) const noexcept
     {
         return hpx::chrono::null_duration;
     }
@@ -205,8 +205,8 @@ struct test_replaced_measure_iteration
     }
 
     template <typename Executor, typename F>
-    hpx::chrono::steady_duration measure_iteration(Executor&&, F&&,
-        std::size_t) const noexcept
+    hpx::chrono::steady_duration measure_iteration(
+        Executor&&, F&&, std::size_t) const noexcept
     {
         *invoked = true;
         return hpx::chrono::null_duration;
@@ -316,8 +316,8 @@ struct test_replaced_maximal_number_of_chunks
     }
 
     template <typename Executor>
-    std::size_t maximal_number_of_chunks(Executor&&, std::size_t,
-        std::size_t) const noexcept
+    std::size_t maximal_number_of_chunks(
+        Executor&&, std::size_t, std::size_t) const noexcept
     {
         *invoked = true;
         return 0;

--- a/libs/core/execution/tests/unit/rebind_executor_parameters.cpp
+++ b/libs/core/execution/tests/unit/rebind_executor_parameters.cpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2007-2026 Hartmut Kaiser
+//  Copyright (c) 2026 Sai Charan Arvapally
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/core/execution_base/include/hpx/execution_base/detail/execution_member_detect.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/detail/execution_member_detect.hpp
@@ -15,7 +15,7 @@ namespace hpx::parallel::execution::detail {
 
     // Detection concepts for executor member functions.
     // These enable the CPO bridges in execution.hpp to forward
-    // to member functions instead of requiring friend tag_invoke.
+    // to member functions instead of requiring custom tag_invoke hooks.
 
     template <typename Executor, typename F, typename... Ts>
     concept has_sync_execute_member =

--- a/libs/core/execution_base/include/hpx/execution_base/execution.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/execution.hpp
@@ -272,8 +272,7 @@ namespace hpx::parallel::execution {
 
         // Fallback: use fn_helper
         template <executor_any Executor, typename F, typename... Ts>
-            requires(!detail::has_post_member<Executor, F, Ts...> &&
-                std::invocable<F &&, Ts && ...>)
+            requires(!detail::has_post_member<Executor, F, Ts...>)
         HPX_FORCEINLINE decltype(auto) operator()(
             Executor&& exec, F&& f, Ts&&... ts) const
         {

--- a/libs/core/execution_base/include/hpx/execution_base/execution.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/execution.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2017-2026 Hartmut Kaiser
+//  Copyright (c) 2026 Sai Charan Arvapally
 //  Copyright (c) 2017 Google
 //
 //  SPDX-License-Identifier: BSL-1.0

--- a/libs/core/execution_base/include/hpx/execution_base/execution.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/execution.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017-2025 Hartmut Kaiser
+//  Copyright (c) 2017-2026 Hartmut Kaiser
 //  Copyright (c) 2017 Google
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -11,7 +11,6 @@
 #include <hpx/execution_base/detail/execution_member_detect.hpp>
 #include <hpx/execution_base/traits/is_executor.hpp>
 #include <hpx/modules/iterator_support.hpp>
-#include <hpx/modules/tag_invoke.hpp>
 
 #include <concepts>
 #include <type_traits>
@@ -103,28 +102,29 @@ namespace hpx::parallel::execution {
     ///
     /// \returns f(ts...)'s result
     ///
-    /// \note It will call tag_invoke(sync_execute_t, exec, f, ts...) if it
-    ///       exists. For two-way executors it will invoke async_execute_t
-    ///       and wait for the task's completion before returning.
+    /// \note It will call exec.sync_execute(f, ts...) if the executor exposes
+    ///       a corresponding member function. For two-way executors it will
+    ///       invoke async_execute and wait for the task's completion before
+    ///       returning.
     ///
     HPX_CXX_CORE_EXPORT inline constexpr struct sync_execute_t final
-      : hpx::functional::detail::tag_fallback<sync_execute_t>
     {
-    private:
-        // Bridge: forward to member function if available
+        // Primary: forward to member function if available
         template <typename Executor, typename F, typename... Ts>
             requires(detail::has_sync_execute_member<Executor, F, Ts...>)
-        friend HPX_FORCEINLINE decltype(auto) tag_invoke(
-            sync_execute_t, Executor&& exec, F&& f, Ts&&... ts)
+        HPX_FORCEINLINE decltype(auto) operator()(
+            Executor&& exec, F&& f, Ts&&... ts) const
         {
             return HPX_FORWARD(Executor, exec)
                 .sync_execute(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
 
+        // Fallback: use fn_helper
         template <executor_any Executor, typename F, typename... Ts>
-            requires(std::invocable<F &&, Ts && ...>)
-        friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            sync_execute_t, Executor&& exec, F&& f, Ts&&... ts)
+            requires(!detail::has_sync_execute_member<Executor, F, Ts...> &&
+                std::invocable<F &&, Ts && ...>)
+        HPX_FORCEINLINE decltype(auto) operator()(
+            Executor&& exec, F&& f, Ts&&... ts) const
         {
             return detail::sync_execute_fn_helper<std::decay_t<Executor>>::call(
                 HPX_FORWARD(Executor, exec), HPX_FORWARD(F, f),
@@ -161,23 +161,23 @@ namespace hpx::parallel::execution {
     /// \returns f(ts...)'s result through a future
     ///
     HPX_CXX_CORE_EXPORT inline constexpr struct async_execute_t final
-      : hpx::functional::detail::tag_fallback<async_execute_t>
     {
-    private:
-        // Bridge: forward to member function if available
+        // Primary: forward to member function if available
         template <typename Executor, typename F, typename... Ts>
             requires(detail::has_async_execute_member<Executor, F, Ts...>)
-        friend HPX_FORCEINLINE decltype(auto) tag_invoke(
-            async_execute_t, Executor&& exec, F&& f, Ts&&... ts)
+        HPX_FORCEINLINE decltype(auto) operator()(
+            Executor&& exec, F&& f, Ts&&... ts) const
         {
             return HPX_FORWARD(Executor, exec)
                 .async_execute(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
 
+        // Fallback: use fn_helper
         template <executor_any Executor, typename F, typename... Ts>
-            requires(std::invocable<F &&, Ts && ...>)
-        friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            async_execute_t, Executor&& exec, F&& f, Ts&&... ts)
+            requires(!detail::has_async_execute_member<Executor, F, Ts...> &&
+                std::invocable<F &&, Ts && ...>)
+        HPX_FORCEINLINE decltype(auto) operator()(
+            Executor&& exec, F&& f, Ts&&... ts) const
         {
             return detail::async_execute_fn_helper<
                 std::decay_t<Executor>>::call(HPX_FORWARD(Executor, exec),
@@ -206,28 +206,28 @@ namespace hpx::parallel::execution {
     ///       for one way executors (calls predecessor.then(bind(f, ts...))).
     ///
     HPX_CXX_CORE_EXPORT inline constexpr struct then_execute_t final
-      : hpx::functional::detail::tag_fallback<then_execute_t>
     {
-    private:
-        // Bridge: forward to member function if available
+        // Primary: forward to member function if available
         template <typename Executor, typename F, typename Future,
             typename... Ts>
             requires(
                 detail::has_then_execute_member<Executor, F, Future, Ts...>)
-        friend HPX_FORCEINLINE decltype(auto) tag_invoke(then_execute_t,
-            Executor&& exec, F&& f, Future&& predecessor, Ts&&... ts)
+        HPX_FORCEINLINE decltype(auto) operator()(
+            Executor&& exec, F&& f, Future&& predecessor, Ts&&... ts) const
         {
             return HPX_FORWARD(Executor, exec)
                 .then_execute(HPX_FORWARD(F, f),
                     HPX_FORWARD(Future, predecessor), HPX_FORWARD(Ts, ts)...);
         }
 
+        // Fallback: use fn_helper
         template <executor_any Executor, typename F, typename Future,
             typename... Ts>
-            requires(std::invocable<F &&, Future &&, Ts && ...>)
-        friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            then_execute_t, Executor&& exec, F&& f, Future&& predecessor,
-            Ts&&... ts)
+            requires(
+                !detail::has_then_execute_member<Executor, F, Future, Ts...> &&
+                std::invocable<F &&, Future &&, Ts && ...>)
+        HPX_FORCEINLINE decltype(auto) operator()(
+            Executor&& exec, F&& f, Future&& predecessor, Ts&&... ts) const
         {
             return detail::then_execute_fn_helper<std::decay_t<Executor>>::call(
                 HPX_FORWARD(Executor, exec), HPX_FORWARD(F, f),
@@ -257,23 +257,23 @@ namespace hpx::parallel::execution {
     ///       (calls exec.post(f, ts...) if it exists).
     ///
     HPX_CXX_CORE_EXPORT inline constexpr struct post_t final
-      : hpx::functional::detail::tag_fallback<post_t>
     {
-    private:
-        // Bridge: forward to member function if available
+        // Primary: forward to member function if available
         template <typename Executor, typename F, typename... Ts>
             requires(detail::has_post_member<Executor, F, Ts...>)
-        friend HPX_FORCEINLINE decltype(auto) tag_invoke(
-            post_t, Executor&& exec, F&& f, Ts&&... ts)
+        HPX_FORCEINLINE decltype(auto) operator()(
+            Executor&& exec, F&& f, Ts&&... ts) const
         {
             return HPX_FORWARD(Executor, exec)
                 .post(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
 
+        // Fallback: use fn_helper
         template <executor_any Executor, typename F, typename... Ts>
-            requires(std::invocable<F &&, Ts && ...>)
-        friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            post_t, Executor&& exec, F&& f, Ts&&... ts)
+            requires(!detail::has_post_member<Executor, F, Ts...> &&
+                std::invocable<F &&, Ts && ...>)
+        HPX_FORCEINLINE decltype(auto) operator()(
+            Executor&& exec, F&& f, Ts&&... ts) const
         {
             return detail::post_fn_helper<std::decay_t<Executor>>::call(
                 HPX_FORWARD(Executor, exec), HPX_FORWARD(F, f),
@@ -321,41 +321,41 @@ namespace hpx::parallel::execution {
     ///       as often as needed.
     ///
     HPX_CXX_CORE_EXPORT inline constexpr struct bulk_sync_execute_t final
-      : hpx::functional::detail::tag_fallback<bulk_sync_execute_t>
     {
-    private:
-        // Bridge: forward to member function if available
+        // Primary: forward to member function if available
         template <typename Executor, typename F, typename Shape, typename... Ts>
             requires(!std::integral<Shape> &&
                 detail::has_bulk_sync_execute_member<Executor, F, Shape, Ts...>)
-        friend HPX_FORCEINLINE decltype(auto) tag_invoke(bulk_sync_execute_t,
-            Executor&& exec, F&& f, Shape const& shape, Ts&&... ts)
+        HPX_FORCEINLINE decltype(auto) operator()(
+            Executor&& exec, F&& f, Shape const& shape, Ts&&... ts) const
         {
             return HPX_FORWARD(Executor, exec)
                 .bulk_sync_execute(
                     HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...);
         }
 
+        // Fallback: non-integral shape
         template <executor_any Executor, typename F, typename Shape,
             typename... Ts>
-            requires(!std::integral<Shape>)
-        friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            bulk_sync_execute_t, Executor&& exec, F&& f, Shape const& shape,
-            Ts&&... ts)
+            requires(!std::integral<Shape> &&
+                !detail::has_bulk_sync_execute_member<Executor, F, Shape,
+                    Ts...>)
+        HPX_FORCEINLINE decltype(auto) operator()(
+            Executor&& exec, F&& f, Shape const& shape, Ts&&... ts) const
         {
             return detail::bulk_sync_execute_fn_helper<
                 std::decay_t<Executor>>::call(HPX_FORWARD(Executor, exec),
                 HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...);
         }
 
+        // Integral shape: convert to counting_shape and recurse
         template <executor_any Executor, typename F, typename Shape,
             typename... Ts>
             requires(std::integral<Shape>)
-        friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            bulk_sync_execute_t tag, Executor&& exec, F&& f, Shape const& shape,
-            Ts&&... ts)
+        HPX_FORCEINLINE decltype(auto) operator()(
+            Executor&& exec, F&& f, Shape const& shape, Ts&&... ts) const
         {
-            return tag(HPX_FORWARD(Executor, exec), HPX_FORWARD(F, f),
+            return (*this)(HPX_FORWARD(Executor, exec), HPX_FORWARD(F, f),
                 hpx::util::counting_shape(shape), HPX_FORWARD(Ts, ts)...);
         }
     } bulk_sync_execute{};
@@ -394,42 +394,59 @@ namespace hpx::parallel::execution {
     ///       as often as needed.
     ///
     HPX_CXX_CORE_EXPORT inline constexpr struct bulk_async_execute_t final
-      : hpx::functional::detail::tag_fallback<bulk_async_execute_t>
     {
-    private:
-        // Bridge: forward to member function if available
+        // Primary: forward to member function if available
         template <typename Executor, typename F, typename Shape, typename... Ts>
             requires(!std::integral<Shape> &&
                 detail::has_bulk_async_execute_member<Executor, F, Shape,
                     Ts...>)
-        friend HPX_FORCEINLINE decltype(auto) tag_invoke(bulk_async_execute_t,
-            Executor&& exec, F&& f, Shape const& shape, Ts&&... ts)
+        HPX_FORCEINLINE decltype(auto) operator()(
+            Executor&& exec, F&& f, Shape const& shape, Ts&&... ts) const
         {
             return HPX_FORWARD(Executor, exec)
                 .bulk_async_execute(
                     HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...);
         }
 
+        // Trait-based: executor is marked as bulk_two_way_executor but concept
+        // check fails (e.g. due to circular return type deduction)
+        template <typename Executor, typename F, typename Shape, typename... Ts>
+            requires(!std::integral<Shape> &&
+                !detail::has_bulk_async_execute_member<Executor, F, Shape,
+                    Ts...> &&
+                hpx::traits::is_bulk_two_way_executor_v<std::decay_t<Executor>>)
+        HPX_FORCEINLINE decltype(auto) operator()(
+            Executor&& exec, F&& f, Shape const& shape, Ts&&... ts) const
+        {
+            return HPX_FORWARD(Executor, exec)
+                .bulk_async_execute(
+                    HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...);
+        }
+
+        // Fallback: non-integral shape, not bulk_two_way_executor
         template <executor_any Executor, typename F, typename Shape,
             typename... Ts>
-            requires(!std::integral<Shape>)
-        friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            bulk_async_execute_t, Executor&& exec, F&& f, Shape const& shape,
-            Ts&&... ts)
+            requires(!std::integral<Shape> &&
+                !detail::has_bulk_async_execute_member<Executor, F, Shape,
+                    Ts...> &&
+                !hpx::traits::is_bulk_two_way_executor_v<
+                    std::decay_t<Executor>>)
+        HPX_FORCEINLINE decltype(auto) operator()(
+            Executor&& exec, F&& f, Shape const& shape, Ts&&... ts) const
         {
             return detail::bulk_async_execute_fn_helper<
                 std::decay_t<Executor>>::call(HPX_FORWARD(Executor, exec),
                 HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...);
         }
 
+        // Integral shape: convert to counting_shape and recurse
         template <executor_any Executor, typename F, typename Shape,
             typename... Ts>
             requires(std::integral<Shape>)
-        friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            bulk_async_execute_t tag, Executor&& exec, F&& f,
-            Shape const& shape, Ts&&... ts)
+        HPX_FORCEINLINE decltype(auto) operator()(
+            Executor&& exec, F&& f, Shape const& shape, Ts&&... ts) const
         {
-            return tag(HPX_FORWARD(Executor, exec), HPX_FORWARD(F, f),
+            return (*this)(HPX_FORWARD(Executor, exec), HPX_FORWARD(F, f),
                 hpx::util::counting_shape(shape), HPX_FORWARD(Ts, ts)...);
         }
     } bulk_async_execute{};
@@ -472,30 +489,29 @@ namespace hpx::parallel::execution {
     ///       is also a TwoWayExecutor) - as often as needed.
     ///
     HPX_CXX_CORE_EXPORT inline constexpr struct bulk_then_execute_t final
-      : hpx::functional::detail::tag_fallback<bulk_then_execute_t>
     {
-    private:
-        // Bridge: forward to member function if available
+        // Primary: forward to member function if available
         template <typename Executor, typename F, typename Shape,
             typename Future, typename... Ts>
             requires(!std::integral<Shape> &&
                 detail::has_bulk_then_execute_member<Executor, F, Shape, Future,
                     Ts...>)
-        friend HPX_FORCEINLINE decltype(auto) tag_invoke(bulk_then_execute_t,
-            Executor&& exec, F&& f, Shape const& shape, Future&& predecessor,
-            Ts&&... ts)
+        HPX_FORCEINLINE decltype(auto) operator()(Executor&& exec, F&& f,
+            Shape const& shape, Future&& predecessor, Ts&&... ts) const
         {
             return HPX_FORWARD(Executor, exec)
                 .bulk_then_execute(HPX_FORWARD(F, f), shape,
                     HPX_FORWARD(Future, predecessor), HPX_FORWARD(Ts, ts)...);
         }
 
+        // Fallback: non-integral shape
         template <executor_any Executor, typename F, typename Shape,
             typename Future, typename... Ts>
-            requires(!std::integral<Shape>)
-        friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            bulk_then_execute_t, Executor&& exec, F&& f, Shape const& shape,
-            Future&& predecessor, Ts&&... ts)
+            requires(!std::integral<Shape> &&
+                !detail::has_bulk_then_execute_member<Executor, F, Shape,
+                    Future, Ts...>)
+        HPX_FORCEINLINE decltype(auto) operator()(Executor&& exec, F&& f,
+            Shape const& shape, Future&& predecessor, Ts&&... ts) const
         {
             return detail::bulk_then_execute_fn_helper<
                 std::decay_t<Executor>>::call(HPX_FORWARD(Executor, exec),
@@ -503,14 +519,14 @@ namespace hpx::parallel::execution {
                 HPX_FORWARD(Ts, ts)...);
         }
 
+        // Integral shape: convert to counting_shape and recurse
         template <executor_any Executor, typename F, typename Shape,
             typename Future, typename... Ts>
             requires(std::integral<Shape>)
-        friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            bulk_then_execute_t tag, Executor&& exec, F&& f, Shape const& shape,
-            Future&& predecessor, Ts&&... ts)
+        HPX_FORCEINLINE decltype(auto) operator()(Executor&& exec, F&& f,
+            Shape const& shape, Future&& predecessor, Ts&&... ts) const
         {
-            return tag(HPX_FORWARD(Executor, exec), HPX_FORWARD(F, f),
+            return (*this)(HPX_FORWARD(Executor, exec), HPX_FORWARD(F, f),
                 hpx::util::counting_shape(shape),
                 HPX_FORWARD(Future, predecessor), HPX_FORWARD(Ts, ts)...);
         }
@@ -539,23 +555,23 @@ namespace hpx::parallel::execution {
     ///       executes async_execute(fs) for each fs.
     ///
     HPX_CXX_CORE_EXPORT inline constexpr struct async_invoke_t final
-      : hpx::functional::detail::tag_fallback<async_invoke_t>
     {
-    private:
-        // Bridge: forward to member function if available
+        // Primary: forward to member function if available
         template <typename Executor, typename F, typename... Fs>
             requires(detail::has_async_invoke_member<Executor, F, Fs...>)
-        friend HPX_FORCEINLINE decltype(auto) tag_invoke(
-            async_invoke_t, Executor&& exec, F&& f, Fs&&... fs)
+        HPX_FORCEINLINE decltype(auto) operator()(
+            Executor&& exec, F&& f, Fs&&... fs) const
         {
             return HPX_FORWARD(Executor, exec)
                 .async_invoke(HPX_FORWARD(F, f), HPX_FORWARD(Fs, fs)...);
         }
 
+        // Fallback: use fn_helper
         template <executor_any Executor, typename F, typename... Fs>
-            requires(std::invocable<F> && (std::invocable<Fs> && ...))
-        friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            async_invoke_t, Executor&& exec, F&& f, Fs&&... fs)
+            requires(!detail::has_async_invoke_member<Executor, F, Fs...> &&
+                std::invocable<F> && (std::invocable<Fs> && ...))
+        HPX_FORCEINLINE decltype(auto) operator()(
+            Executor&& exec, F&& f, Fs&&... fs) const
         {
             return detail::async_invoke_fn_helper<std::decay_t<Executor>>::call(
                 HPX_FORWARD(Executor, exec), HPX_FORWARD(F, f),
@@ -585,23 +601,23 @@ namespace hpx::parallel::execution {
     ///       executes sync_execute(fs) for each fs.
     ///
     HPX_CXX_CORE_EXPORT inline constexpr struct sync_invoke_t final
-      : hpx::functional::detail::tag_fallback<sync_invoke_t>
     {
-    private:
-        // Bridge: forward to member function if available
+        // Primary: forward to member function if available
         template <typename Executor, typename F, typename... Fs>
             requires(detail::has_sync_invoke_member<Executor, F, Fs...>)
-        friend HPX_FORCEINLINE decltype(auto) tag_invoke(
-            sync_invoke_t, Executor&& exec, F&& f, Fs&&... fs)
+        HPX_FORCEINLINE decltype(auto) operator()(
+            Executor&& exec, F&& f, Fs&&... fs) const
         {
             return HPX_FORWARD(Executor, exec)
                 .sync_invoke(HPX_FORWARD(F, f), HPX_FORWARD(Fs, fs)...);
         }
 
+        // Fallback: use fn_helper
         template <executor_any Executor, typename F, typename... Fs>
-            requires(std::invocable<F> && (std::invocable<Fs> && ...))
-        friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            sync_invoke_t, Executor&& exec, F&& f, Fs&&... fs)
+            requires(!detail::has_sync_invoke_member<Executor, F, Fs...> &&
+                std::invocable<F> && (std::invocable<Fs> && ...))
+        HPX_FORCEINLINE decltype(auto) operator()(
+            Executor&& exec, F&& f, Fs&&... fs) const
         {
             return detail::sync_invoke_fn_helper<std::decay_t<Executor>>::call(
                 HPX_FORWARD(Executor, exec), HPX_FORWARD(F, f),

--- a/libs/core/execution_base/include/hpx/execution_base/execution.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/execution.hpp
@@ -415,8 +415,11 @@ namespace hpx::parallel::execution {
                 !detail::has_bulk_async_execute_member<Executor, F, Shape,
                     Ts...> &&
                 hpx::traits::is_bulk_two_way_executor_v<std::decay_t<Executor>>)
-        HPX_FORCEINLINE decltype(auto) operator()(
+        HPX_FORCEINLINE auto operator()(
             Executor&& exec, F&& f, Shape const& shape, Ts&&... ts) const
+            -> decltype(HPX_FORWARD(Executor, exec)
+                    .bulk_async_execute(
+                        HPX_FORWARD(F, f), shape, HPX_FORWARD(Ts, ts)...))
         {
             return HPX_FORWARD(Executor, exec)
                 .bulk_async_execute(

--- a/libs/core/execution_base/include/hpx/execution_base/execution.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/execution.hpp
@@ -122,7 +122,8 @@ namespace hpx::parallel::execution {
         // Fallback: use fn_helper
         template <executor_any Executor, typename F, typename... Ts>
             requires(!detail::has_sync_execute_member<Executor, F, Ts...> &&
-                std::invocable<F &&, Ts && ...>)
+                (std::invocable<F &&, Ts && ...> ||
+                    hpx::traits::is_action_v<std::decay_t<F>>) )
         HPX_FORCEINLINE decltype(auto) operator()(
             Executor&& exec, F&& f, Ts&&... ts) const
         {
@@ -175,7 +176,8 @@ namespace hpx::parallel::execution {
         // Fallback: use fn_helper
         template <executor_any Executor, typename F, typename... Ts>
             requires(!detail::has_async_execute_member<Executor, F, Ts...> &&
-                std::invocable<F &&, Ts && ...>)
+                (std::invocable<F &&, Ts && ...> ||
+                    hpx::traits::is_action_v<std::decay_t<F>>) )
         HPX_FORCEINLINE decltype(auto) operator()(
             Executor&& exec, F&& f, Ts&&... ts) const
         {

--- a/libs/core/executors/examples/disable_thread_stealing_executor.cpp
+++ b/libs/core/executors/examples/disable_thread_stealing_executor.cpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2020-2024 Hartmut Kaiser
+//  Copyright (c) 2026 Sai Charan Arvapally
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/core/executors/examples/disable_thread_stealing_executor.cpp
+++ b/libs/core/executors/examples/disable_thread_stealing_executor.cpp
@@ -48,54 +48,37 @@ namespace executor_example {
         // Add two executor API functions that will be called before the
         // parallel algorithm starts executing and after it has finished
         // executing.
-        template <typename Parameters>
-        friend void tag_invoke(
-            hpx::execution::experimental::mark_begin_execution_t, Parameters&&,
-            disable_thread_stealing_executor const& exec)
+        template <typename Executor>
+        void mark_begin_execution(Executor&&) const
         {
             auto const pu_mask =
-                hpx::execution::experimental::get_processing_units_mask(exec);
+                hpx::execution::experimental::get_processing_units_mask(*this);
             hpx::threads::remove_scheduler_mode(
                 hpx::threads::policies::scheduler_mode::enable_stealing,
                 pu_mask);
         }
 
-        template <typename Parameters>
-        friend void tag_invoke(
-            hpx::execution::experimental::mark_end_execution_t, Parameters&&,
-            disable_thread_stealing_executor const& exec)
+        template <typename Executor>
+        void mark_end_execution(Executor&&) const
         {
             auto const pu_mask =
-                hpx::execution::experimental::get_processing_units_mask(exec);
+                hpx::execution::experimental::get_processing_units_mask(*this);
             hpx::threads::add_scheduler_mode(
                 hpx::threads::policies::scheduler_mode::enable_stealing,
                 pu_mask);
         }
+
+        // support scheduling properties via query() for new CPO dispatch
+        template <typename Tag, typename... Args>
+            requires(
+                hpx::execution::experimental::is_scheduling_property_v<Tag>)
+        auto query(Tag tag, Args&&... args) const -> decltype(tag(
+            std::declval<BaseExecutor const&>(), HPX_FORWARD(Args, args)...))
+        {
+            return tag(static_cast<BaseExecutor const&>(*this),
+                HPX_FORWARD(Args, args)...);
+        }
     };
-
-    // support all properties exposed by the wrapped executor
-    template <typename Tag, typename BaseExecutor, typename Property>
-        requires(hpx::execution::experimental::is_scheduling_property_v<Tag>)
-    auto tag_invoke(Tag tag,
-        disable_thread_stealing_executor<BaseExecutor> const& exec,
-        Property&& prop)
-        -> decltype(disable_thread_stealing_executor<BaseExecutor>(
-            std::declval<Tag>()(std::declval<BaseExecutor const&>(),
-                std::declval<Property&&>())))
-    {
-        return disable_thread_stealing_executor<BaseExecutor>(
-            tag(static_cast<BaseExecutor const&>(exec),
-                HPX_FORWARD(Property, prop)));
-    }
-
-    template <typename Tag, typename BaseExecutor>
-        requires(hpx::execution::experimental::is_scheduling_property_v<Tag>)
-    auto tag_invoke(
-        Tag tag, disable_thread_stealing_executor<BaseExecutor> const& exec)
-        -> decltype(std::declval<Tag>()(std::declval<BaseExecutor const&>()))
-    {
-        return tag(static_cast<BaseExecutor const&>(exec));
-    }
 
     template <typename BaseExecutor>
     auto make_disable_thread_stealing_executor(BaseExecutor&& exec)

--- a/libs/core/executors/examples/executor_with_thread_hooks.cpp
+++ b/libs/core/executors/examples/executor_with_thread_hooks.cpp
@@ -77,82 +77,69 @@ namespace executor_example {
             return *this;
         }
 
-    private:
+    public:
         // OneWayExecutor interface
         template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::sync_execute_t,
-            executor_with_thread_hooks const& exec, F&& f, Ts&&... ts)
+        decltype(auto) sync_execute(F&& f, Ts&&... ts) const
         {
-            return hpx::parallel::execution::sync_execute(exec.exec_,
-                hook_wrapper<F>{exec, std::forward<F>(f)},
+            return hpx::parallel::execution::sync_execute(exec_,
+                hook_wrapper<F>{*this, std::forward<F>(f)},
                 std::forward<Ts>(ts)...);
         }
 
         // TwoWayExecutor interface
         template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::async_execute_t,
-            executor_with_thread_hooks const& exec, F&& f, Ts&&... ts)
+        decltype(auto) async_execute(F&& f, Ts&&... ts) const
         {
-            return hpx::parallel::execution::async_execute(exec.exec_,
-                hook_wrapper<F>{exec, std::forward<F>(f)},
+            return hpx::parallel::execution::async_execute(exec_,
+                hook_wrapper<F>{*this, std::forward<F>(f)},
                 std::forward<Ts>(ts)...);
         }
 
         template <typename F, typename Future, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::then_execute_t,
-            executor_with_thread_hooks const& exec, F&& f, Future&& predecessor,
-            Ts&&... ts)
+        decltype(auto) then_execute(
+            F&& f, Future&& predecessor, Ts&&... ts) const
         {
-            return hpx::parallel::execution::then_execute(exec.exec_,
-                hook_wrapper<F>{exec, std::forward<F>(f)},
+            return hpx::parallel::execution::then_execute(exec_,
+                hook_wrapper<F>{*this, std::forward<F>(f)},
                 std::forward<Future>(predecessor), std::forward<Ts>(ts)...);
         }
 
         // NonBlockingOneWayExecutor (adapted) interface
         template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(hpx::parallel::execution::post_t,
-            executor_with_thread_hooks const& exec, F&& f, Ts&&... ts)
+        decltype(auto) post(F&& f, Ts&&... ts) const
         {
-            hpx::parallel::execution::post(exec.exec_,
-                hook_wrapper<F>{exec, std::forward<F>(f)},
+            hpx::parallel::execution::post(exec_,
+                hook_wrapper<F>{*this, std::forward<F>(f)},
                 std::forward<Ts>(ts)...);
         }
 
         // BulkOneWayExecutor interface
         template <typename F, typename S, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::bulk_sync_execute_t,
-            executor_with_thread_hooks const& exec, F&& f, S const& shape,
-            Ts&&... ts)
+        decltype(auto) bulk_sync_execute(
+            F&& f, S const& shape, Ts&&... ts) const
         {
-            return hpx::parallel::execution::bulk_sync_execute(exec.exec_,
-                hook_wrapper<F>{exec, std::forward<F>(f)}, shape,
+            return hpx::parallel::execution::bulk_sync_execute(exec_,
+                hook_wrapper<F>{*this, std::forward<F>(f)}, shape,
                 std::forward<Ts>(ts)...);
         }
 
         // BulkTwoWayExecutor interface
         template <typename F, typename S, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::bulk_async_execute_t,
-            executor_with_thread_hooks const& exec, F&& f, S const& shape,
-            Ts&&... ts)
+        decltype(auto) bulk_async_execute(
+            F&& f, S const& shape, Ts&&... ts) const
         {
-            return hpx::parallel::execution::bulk_async_execute(exec.exec_,
-                hook_wrapper<F>{exec, std::forward<F>(f)}, shape,
+            return hpx::parallel::execution::bulk_async_execute(exec_,
+                hook_wrapper<F>{*this, std::forward<F>(f)}, shape,
                 std::forward<Ts>(ts)...);
         }
 
         template <typename F, typename S, typename Future, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::bulk_then_execute_t,
-            executor_with_thread_hooks const& exec, F&& f, S const& shape,
-            Future&& predecessor, Ts&&... ts)
+        decltype(auto) bulk_then_execute(
+            F&& f, S const& shape, Future&& predecessor, Ts&&... ts) const
         {
-            return hpx::parallel::execution::bulk_then_execute(exec.exec_,
-                hook_wrapper<F>{exec, std::forward<F>(f)}, shape,
+            return hpx::parallel::execution::bulk_then_execute(exec_,
+                hook_wrapper<F>{*this, std::forward<F>(f)}, shape,
                 std::forward<Future>(predecessor), std::forward<Ts>(ts)...);
         }
 

--- a/libs/core/executors/examples/executor_with_thread_hooks.cpp
+++ b/libs/core/executors/examples/executor_with_thread_hooks.cpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2020-2024 Hartmut Kaiser
+//  Copyright (c) 2026 Sai Charan Arvapally
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/core/executors/include/hpx/executors/annotating_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/annotating_executor.hpp
@@ -222,21 +222,22 @@ namespace hpx::execution::experimental {
     // annotations. Those are wrapped into an annotating_executor if passed
     // to `with_annotation`.
     //
-    HPX_CXX_CORE_EXPORT template <executor_any Executor>
-    constexpr auto tag_fallback_invoke(
-        with_annotation_t, Executor&& exec, char const* annotation)
-    {
-        return annotating_executor<std::decay_t<Executor>>(
-            HPX_FORWARD(Executor, exec), annotation);
-    }
+    namespace detail {
 
-    HPX_CXX_CORE_EXPORT template <executor_any Executor>
-    auto tag_fallback_invoke(
-        with_annotation_t, Executor&& exec, std::string annotation)
-    {
-        return annotating_executor<std::decay_t<Executor>>(
-            HPX_FORWARD(Executor, exec), HPX_MOVE(annotation));
-    }
+        template <executor_any Executor>
+        auto wrap_with_annotation(Executor&& exec, char const* annotation)
+        {
+            return annotating_executor<std::decay_t<Executor>>(
+                HPX_FORWARD(Executor, exec), annotation);
+        }
+
+        template <executor_any Executor>
+        auto wrap_with_annotation(Executor&& exec, std::string annotation)
+        {
+            return annotating_executor<std::decay_t<Executor>>(
+                HPX_FORWARD(Executor, exec), HPX_MOVE(annotation));
+        }
+    }    // namespace detail
 }    // namespace hpx::execution::experimental
 
 namespace hpx::execution::experimental {

--- a/libs/core/executors/include/hpx/executors/dataflow.hpp
+++ b/libs/core/executors/include/hpx/executors/dataflow.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2025 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -460,82 +460,60 @@ namespace hpx::lcos::detail {
 
 namespace hpx::detail {
 
-    // Dataflow CPO customizations (see hpx/async_base/dataflow.hpp). The CPO
-    // detects .dataflow() member functions directly; these overloads handle
-    // allocator + launch policy / executor / function dispatch.
+    // Specializations of dataflow_dispatch_impl (declared in
+    // hpx/async_base/dataflow.hpp) providing the actual dispatch logic.
 
-    // clang-format off
-    HPX_CXX_CORE_EXPORT template <typename Allocator, typename Policy, typename F,
-        typename... Ts,
-        HPX_CONCEPT_REQUIRES_(
-            hpx::traits::is_allocator_v<Allocator> &&
-            hpx::traits::is_launch_policy_v<Policy> &&
-           !hpx::traits::is_action_v<std::decay_t<F>>
-        )>
-    // clang-format on
-    auto tag_invoke(dataflow_t, Allocator const& alloc, Policy&& policy, F&& f,
-        Ts&&... ts) -> decltype(hpx::lcos::detail::dataflow_dispatch_impl<false,
-        std::decay_t<Policy>>::call(alloc, HPX_FORWARD(Policy, policy),
-        HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...))
+    // Specialization for launch policies
+    template <typename Policy>
+    struct dataflow_dispatch_impl<Policy,
+        std::enable_if_t<hpx::traits::is_launch_policy_v<Policy>>>
     {
-        return hpx::lcos::detail::dataflow_dispatch_impl<false,
-            std::decay_t<Policy>>::call(alloc, HPX_FORWARD(Policy, policy),
-            HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
-    }
+        template <typename Allocator, typename Policy_, typename F,
+            typename... Ts>
+        HPX_FORCEINLINE static decltype(auto) call(
+            Allocator const& alloc, Policy_&& policy, F&& f, Ts&&... ts)
+        {
+            return hpx::lcos::detail::dataflow_dispatch_impl<
+                traits::is_action_v<std::decay_t<F>>,
+                std::decay_t<Policy_>>::call(alloc,
+                HPX_FORWARD(Policy_, policy), HPX_FORWARD(F, f),
+                HPX_FORWARD(Ts, ts)...);
+        }
+    };
 
-    // clang-format off
-    HPX_CXX_CORE_EXPORT template <typename Allocator, typename Policy, typename F,
-        typename... Ts,
-        HPX_CONCEPT_REQUIRES_(
-            hpx::traits::is_allocator_v<Allocator> &&
-            hpx::traits::is_launch_policy_v<Policy> &&
-            hpx::traits::is_action_v<std::decay_t<F>>
-        )>
-    auto tag_invoke(dataflow_t, Allocator const& alloc, Policy&& policy, F&& f,
-        Ts&&... ts)
-        -> decltype(hpx::lcos::detail::dataflow_dispatch_impl<true,
-            std::decay_t<Policy>>::call(alloc, HPX_FORWARD(Policy, policy),
-            HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...))
+    // Specialization for executors
+    template <typename Executor>
+    struct dataflow_dispatch_impl<Executor,
+        std::enable_if_t<!hpx::traits::is_launch_policy_v<Executor> &&
+            (hpx::traits::is_one_way_executor_v<Executor> ||
+                hpx::traits::is_two_way_executor_v<Executor>)>>
     {
-        return hpx::lcos::detail::dataflow_dispatch_impl<true,
-            std::decay_t<Policy>>::call(alloc, HPX_FORWARD(Policy, policy),
-            HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
-    }
+        template <typename Allocator, typename Executor_, typename F,
+            typename... Ts>
+        HPX_FORCEINLINE static decltype(auto) call(
+            Allocator const& alloc, Executor_&& exec, F&& f, Ts&&... ts)
+        {
+            return hpx::lcos::detail::create_dataflow(alloc,
+                HPX_FORWARD(Executor_, exec), HPX_FORWARD(F, f),
+                traits::acquire_future_disp()(HPX_FORWARD(Ts, ts))...);
+        }
+    };
 
-    // clang-format off
-    HPX_CXX_CORE_EXPORT template <typename Allocator, typename Executor,
-        typename F, typename... Ts,
-        HPX_CONCEPT_REQUIRES_(
-            hpx::traits::is_allocator_v<Allocator> &&
-           (hpx::traits::is_one_way_executor_v<Executor> ||
-            hpx::traits::is_two_way_executor_v<Executor>)
-        )>
-    // clang-format on
-    HPX_FORCEINLINE decltype(auto) tag_invoke(
-        dataflow_t, Allocator const& alloc, Executor&& exec, F&& f, Ts&&... ts)
+    // Specialization for plain callables (not policy, not executor)
+    template <typename FD>
+    struct dataflow_dispatch_impl<FD,
+        std::enable_if_t<!hpx::traits::is_launch_policy_v<FD> &&
+            !hpx::traits::is_one_way_executor_v<FD> &&
+            !hpx::traits::is_two_way_executor_v<FD>>>
     {
-        return hpx::lcos::detail::create_dataflow(alloc,
-            HPX_FORWARD(Executor, exec), HPX_FORWARD(F, f),
-            traits::acquire_future_disp()(HPX_FORWARD(Ts, ts))...);
-    }
-
-    // clang-format off
-    HPX_CXX_CORE_EXPORT template <typename Allocator, typename F, typename... Ts,
-        HPX_CONCEPT_REQUIRES_(
-             hpx::traits::is_allocator_v<Allocator> &&
-            !hpx::traits::is_launch_policy_v<F> &&
-            !hpx::traits::is_one_way_executor_v<F> &&
-            !hpx::traits::is_two_way_executor_v<F>
-        )>
-    HPX_FORCEINLINE auto tag_invoke(
-        dataflow_t, Allocator const& alloc, F&& f, Ts&&... ts)
-        -> decltype(hpx::lcos::detail::dataflow_dispatch_impl<
-            traits::is_action_v<std::decay_t<F>>, launch>::call(alloc,
-            launch::async, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...))
-    {
-        return hpx::lcos::detail::dataflow_dispatch_impl<
-            traits::is_action_v<std::decay_t<F>>, launch>::call(alloc,
-            launch::async, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
-    }
+        template <typename Allocator, typename F, typename... Ts>
+        HPX_FORCEINLINE static decltype(auto) call(
+            Allocator const& alloc, F&& f, Ts&&... ts)
+        {
+            return hpx::lcos::detail::dataflow_dispatch_impl<
+                traits::is_action_v<std::decay_t<F>>, launch>::call(alloc,
+                launch::async, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+        }
+    };
 
 }    // namespace hpx::detail

--- a/libs/core/executors/include/hpx/executors/dataflow.hpp
+++ b/libs/core/executors/include/hpx/executors/dataflow.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2007-2026 Hartmut Kaiser
+//  Copyright (c) 2026 Sai Charan Arvapally
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/core/executors/include/hpx/executors/datapar/execution_policy_mappings.hpp
+++ b/libs/core/executors/include/hpx/executors/datapar/execution_policy_mappings.hpp
@@ -14,7 +14,6 @@
 #include <hpx/executors/execution_policy_mappings.hpp>
 #include <hpx/modules/concepts.hpp>
 #include <hpx/modules/execution.hpp>
-#include <hpx/modules/tag_invoke.hpp>
 
 #include <type_traits>
 #include <utility>
@@ -24,22 +23,19 @@ namespace hpx::execution::experimental {
     ///////////////////////////////////////////////////////////////////////////
     // Return the matching non-simd (vectorpack) execution policy
     HPX_CXX_CORE_EXPORT inline constexpr struct to_non_simd_t
-      : hpx::functional::detail::tag_fallback<to_non_simd_t>
     {
-    private:
-        // Bridge: forward to member function if available
+        // Forward to member function if available
         template <typename Target>
             requires requires(Target const& t) { t.to_non_simd(); }
-        friend constexpr decltype(auto) tag_invoke(
-            to_non_simd_t, Target const& target)
+        constexpr decltype(auto) operator()(Target const& target) const
         {
             return target.to_non_simd();
         }
 
         // any non-simd policy just returns itself
         template <execution_policy ExPolicy>
-        friend constexpr decltype(auto) tag_fallback_invoke(
-            to_non_simd_t, ExPolicy&& policy) noexcept
+            requires(!requires(ExPolicy const& t) { t.to_non_simd(); })
+        constexpr decltype(auto) operator()(ExPolicy&& policy) const noexcept
         {
             static_assert(!hpx::is_vectorpack_execution_policy_v<ExPolicy>,
                 "must not be a simd (vectorpack) execution policy");
@@ -54,22 +50,19 @@ namespace hpx::execution::experimental {
 
     // Return the matching simd (vectorpack) execution policy
     HPX_CXX_CORE_EXPORT inline constexpr struct to_simd_t
-      : hpx::functional::detail::tag_fallback<to_simd_t>
     {
-    private:
-        // Bridge: forward to member function if available
+        // Forward to member function if available
         template <typename Target>
             requires requires(Target const& t) { t.to_simd(); }
-        friend constexpr decltype(auto) tag_invoke(
-            to_simd_t, Target const& target)
+        constexpr decltype(auto) operator()(Target const& target) const
         {
             return target.to_simd();
         }
 
         // any simd policy just returns itself
         template <execution_policy ExPolicy>
-        friend constexpr decltype(auto) tag_fallback_invoke(
-            to_simd_t, ExPolicy&& policy) noexcept
+            requires(!requires(ExPolicy const& t) { t.to_simd(); })
+        constexpr decltype(auto) operator()(ExPolicy&& policy) const noexcept
         {
             static_assert(hpx::is_vectorpack_execution_policy_v<ExPolicy>,
                 "must be a simd (vectorpack) execution policy");

--- a/libs/core/executors/include/hpx/executors/execute_on.hpp
+++ b/libs/core/executors/include/hpx/executors/execute_on.hpp
@@ -178,14 +178,12 @@ namespace hpx::execution::experimental {
         // It's up to scheduler customization to check if it can work with the
         // passed execution policy.
         HPX_CXX_CORE_EXPORT inline constexpr struct execute_on_t final
-          : hpx::functional::detail::tag_fallback<execute_on_t>
         {
-        private:
             template <typename Scheduler, execution_policy ExPolicy>
                 requires(hpx::execution::experimental::is_scheduler_v<
                     std::decay_t<Scheduler>>)
-            friend constexpr HPX_FORCEINLINE auto tag_fallback_invoke(
-                execute_on_t, Scheduler&& scheduler, ExPolicy&& policy)
+            constexpr HPX_FORCEINLINE auto operator()(
+                Scheduler&& scheduler, ExPolicy&& policy) const
             {
                 return scheduler_and_policy(HPX_FORWARD(Scheduler, scheduler),
                     HPX_FORWARD(ExPolicy, policy));

--- a/libs/core/executors/include/hpx/executors/execution_policy.hpp
+++ b/libs/core/executors/include/hpx/executors/execution_policy.hpp
@@ -248,8 +248,7 @@ namespace hpx::execution {
                 requires(!std::is_same_v<Tag,
                              hpx::execution::experimental::
                                  with_processing_units_count_t> &&
-                    hpx::functional::is_tag_invocable_v<Tag, executor_type,
-                        Property>)
+                    std::invocable<Tag, executor_type, Property>)
             [[nodiscard]] auto query(Tag tag, Property&& prop) const
             {
                 return hpx::execution::experimental::create_rebound_policy(
@@ -258,8 +257,7 @@ namespace hpx::execution {
             }
 
             template <scheduling_property Tag>
-                requires(
-                    hpx::functional::is_tag_invocable_v<Tag, executor_type>)
+                requires(std::invocable<Tag, executor_type>)
             [[nodiscard]] auto query(Tag tag) const
             {
                 return tag(executor());
@@ -307,7 +305,7 @@ namespace hpx::execution {
             [[nodiscard]] auto query(
                 hpx::execution::experimental::with_processing_units_count_t,
                 std::size_t num_cores) const
-                requires(hpx::functional::is_tag_invocable_v<
+                requires(std::invocable<
                     hpx::execution::experimental::with_processing_units_count_t,
                     executor_type, std::size_t>)
             {
@@ -350,9 +348,8 @@ namespace hpx::execution {
             }
 
             template <executor_parameters Params>
-                requires(hpx::functional::is_tag_invocable_v<
-                             hpx::execution::experimental::
-                                 with_processing_units_count_t,
+                requires(std::invocable<hpx::execution::experimental::
+                                            with_processing_units_count_t,
                              executor_type, std::size_t> &&
                     std::invocable<
                         hpx::execution::experimental::processing_units_count_t,

--- a/libs/core/executors/include/hpx/executors/execution_policy.hpp
+++ b/libs/core/executors/include/hpx/executors/execution_policy.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2007-2025 Hartmut Kaiser
+//  Copyright (c) 2026 Sai Charan Arvapally
 //  Copyright (c) 2016 Marcin Copik
 //
 //  SPDX-License-Identifier: BSL-1.0

--- a/libs/core/executors/include/hpx/executors/execution_policy.hpp
+++ b/libs/core/executors/include/hpx/executors/execution_policy.hpp
@@ -686,6 +686,25 @@ namespace hpx::execution {
 #if defined(HPX_HAVE_DATAPAR)
             constexpr auto to_simd() const;
 #endif
+
+            /// \cond NOINTERNAL
+            // Forward execution operations to wrapped executor (member functions, not tag_invoke)
+            template <typename F, typename... Ts>
+            decltype(auto) async_execute(F&& f, Ts&&... ts) const
+            {
+                return hpx::parallel::execution::async_execute(this->executor(),
+                    HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+            }
+
+            template <typename F, typename Shape, typename... Ts>
+            decltype(auto) bulk_sync_execute(
+                F&& f, Shape const& shape, Ts&&... ts) const
+            {
+                return hpx::parallel::execution::bulk_sync_execute(
+                    this->executor(), HPX_FORWARD(F, f), shape,
+                    HPX_FORWARD(Ts, ts)...);
+            }
+            /// \endcond
         };
     }    // namespace detail
 
@@ -1518,4 +1537,126 @@ namespace hpx::detail {
     {
     };
     /// \endcond
+
+    /// \endcond
 }    // namespace hpx::detail
+
+///////////////////////////////////////////////////////////////////////////////
+namespace hpx::execution::experimental {
+
+    /// \cond NOINTERNAL
+    // Make policy shims satisfy executor traits based on their wrapped executor
+    template <typename Executor, typename Parameters>
+    struct is_two_way_executor<
+        hpx::execution::detail::parallel_policy_shim<Executor, Parameters>>
+      : is_two_way_executor<Executor>
+    {
+    };
+
+    template <typename Executor, typename Parameters>
+    struct is_two_way_executor<hpx::execution::detail::
+            parallel_unsequenced_policy_shim<Executor, Parameters>>
+      : is_two_way_executor<Executor>
+    {
+    };
+
+    template <typename Executor, typename Parameters>
+    struct is_two_way_executor<
+        hpx::execution::detail::parallel_task_policy_shim<Executor, Parameters>>
+      : is_two_way_executor<Executor>
+    {
+    };
+
+    template <typename Executor, typename Parameters>
+    struct is_two_way_executor<hpx::execution::detail::
+            parallel_unsequenced_task_policy_shim<Executor, Parameters>>
+      : is_two_way_executor<Executor>
+    {
+    };
+
+    template <typename Executor, typename Parameters>
+    struct is_two_way_executor<hpx::execution::detail::
+            sequenced_task_policy_shim<Executor, Parameters>>
+      : is_two_way_executor<Executor>
+    {
+    };
+
+    template <typename Executor, typename Parameters>
+    struct is_two_way_executor<
+        hpx::execution::detail::sequenced_policy_shim<Executor, Parameters>>
+      : is_two_way_executor<Executor>
+    {
+    };
+
+    template <typename Executor, typename Parameters>
+    struct is_two_way_executor<
+        hpx::execution::detail::unsequenced_policy_shim<Executor, Parameters>>
+      : is_two_way_executor<Executor>
+    {
+    };
+
+    template <typename Executor, typename Parameters>
+    struct is_two_way_executor<hpx::execution::detail::
+            unsequenced_task_policy_shim<Executor, Parameters>>
+      : is_two_way_executor<Executor>
+    {
+    };
+
+    // Also add bulk_two_way_executor specializations
+    template <typename Executor, typename Parameters>
+    struct is_bulk_two_way_executor<
+        hpx::execution::detail::parallel_policy_shim<Executor, Parameters>>
+      : is_bulk_two_way_executor<Executor>
+    {
+    };
+
+    template <typename Executor, typename Parameters>
+    struct is_bulk_two_way_executor<hpx::execution::detail::
+            parallel_unsequenced_policy_shim<Executor, Parameters>>
+      : is_bulk_two_way_executor<Executor>
+    {
+    };
+
+    template <typename Executor, typename Parameters>
+    struct is_bulk_two_way_executor<
+        hpx::execution::detail::parallel_task_policy_shim<Executor, Parameters>>
+      : is_bulk_two_way_executor<Executor>
+    {
+    };
+
+    template <typename Executor, typename Parameters>
+    struct is_bulk_two_way_executor<hpx::execution::detail::
+            parallel_unsequenced_task_policy_shim<Executor, Parameters>>
+      : is_bulk_two_way_executor<Executor>
+    {
+    };
+
+    template <typename Executor, typename Parameters>
+    struct is_bulk_two_way_executor<hpx::execution::detail::
+            sequenced_task_policy_shim<Executor, Parameters>>
+      : is_bulk_two_way_executor<Executor>
+    {
+    };
+
+    template <typename Executor, typename Parameters>
+    struct is_bulk_two_way_executor<
+        hpx::execution::detail::sequenced_policy_shim<Executor, Parameters>>
+      : is_bulk_two_way_executor<Executor>
+    {
+    };
+
+    template <typename Executor, typename Parameters>
+    struct is_bulk_two_way_executor<
+        hpx::execution::detail::unsequenced_policy_shim<Executor, Parameters>>
+      : is_bulk_two_way_executor<Executor>
+    {
+    };
+
+    template <typename Executor, typename Parameters>
+    struct is_bulk_two_way_executor<hpx::execution::detail::
+            unsequenced_task_policy_shim<Executor, Parameters>>
+      : is_bulk_two_way_executor<Executor>
+    {
+    };
+    /// \endcond
+}    // namespace hpx::execution::experimental

--- a/libs/core/executors/include/hpx/executors/execution_policy.hpp
+++ b/libs/core/executors/include/hpx/executors/execution_policy.hpp
@@ -688,7 +688,8 @@ namespace hpx::execution {
 #endif
 
             /// \cond NOINTERNAL
-            // Forward execution operations to wrapped executor (member functions, not tag_invoke)
+            // Forward execution operations to wrapped executor
+            // (member functions, not tag_invoke)
             template <typename F, typename... Ts>
             decltype(auto) async_execute(F&& f, Ts&&... ts) const
             {

--- a/libs/core/executors/include/hpx/executors/execution_policy_annotation.hpp
+++ b/libs/core/executors/include/hpx/executors/execution_policy_annotation.hpp
@@ -13,7 +13,6 @@
 #include <hpx/modules/concepts.hpp>
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/properties.hpp>
-#include <hpx/modules/tag_invoke.hpp>
 
 #include <concepts>
 #include <string>

--- a/libs/core/executors/include/hpx/executors/execution_policy_mappings.hpp
+++ b/libs/core/executors/include/hpx/executors/execution_policy_mappings.hpp
@@ -11,7 +11,6 @@
 #include <hpx/config.hpp>
 #include <hpx/modules/concepts.hpp>
 #include <hpx/modules/execution.hpp>
-#include <hpx/modules/tag_invoke.hpp>
 
 #include <type_traits>
 #include <utility>
@@ -31,22 +30,19 @@ namespace hpx::execution::experimental {
     ///////////////////////////////////////////////////////////////////////////
     // Return the matching non-parallel (sequenced) execution policy
     HPX_CXX_CORE_EXPORT inline constexpr struct to_non_par_t
-      : hpx::functional::detail::tag_fallback<to_non_par_t>
     {
-    private:
-        // Bridge: forward to member function if available
+        // Forward to member function if available
         template <typename Target>
             requires requires(Target const& t) { t.to_non_par(); }
-        friend constexpr decltype(auto) tag_invoke(
-            to_non_par_t, Target const& target)
+        constexpr decltype(auto) operator()(Target const& target) const
         {
             return target.to_non_par();
         }
 
         // any non-parallel policy just returns itself
         template <execution_policy ExPolicy>
-        friend constexpr decltype(auto) tag_fallback_invoke(
-            to_non_par_t, ExPolicy&& policy) noexcept
+            requires(!requires(ExPolicy const& t) { t.to_non_par(); })
+        constexpr decltype(auto) operator()(ExPolicy&& policy) const noexcept
         {
             static_assert(!hpx::is_parallel_execution_policy_v<ExPolicy>,
                 "must not be a parallel execution policy");
@@ -61,22 +57,19 @@ namespace hpx::execution::experimental {
 
     // Return the matching parallel execution policy
     HPX_CXX_CORE_EXPORT inline constexpr struct to_par_t
-      : hpx::functional::detail::tag_fallback<to_par_t>
     {
-    private:
-        // Bridge: forward to member function if available
+        // Forward to member function if available
         template <typename Target>
             requires requires(Target const& t) { t.to_par(); }
-        friend constexpr decltype(auto) tag_invoke(
-            to_par_t, Target const& target)
+        constexpr decltype(auto) operator()(Target const& target) const
         {
             return target.to_par();
         }
 
         // any parallel policy just returns itself
         template <execution_policy ExPolicy>
-        friend constexpr decltype(auto) tag_fallback_invoke(
-            to_par_t, ExPolicy&& policy) noexcept
+            requires(!requires(ExPolicy const& t) { t.to_par(); })
+        constexpr decltype(auto) operator()(ExPolicy&& policy) const noexcept
         {
             static_assert(hpx::is_parallel_execution_policy_v<ExPolicy>,
                 "must be a parallel execution policy");
@@ -92,22 +85,19 @@ namespace hpx::execution::experimental {
     ///////////////////////////////////////////////////////////////////////////
     // Return the matching non-task (synchronous) execution policy
     HPX_CXX_CORE_EXPORT inline constexpr struct to_non_task_t
-      : hpx::functional::detail::tag_fallback<to_non_task_t>
     {
-    private:
-        // Bridge: forward to member function if available
+        // Forward to member function if available
         template <typename Target>
             requires requires(Target const& t) { t.to_non_task(); }
-        friend constexpr decltype(auto) tag_invoke(
-            to_non_task_t, Target const& target)
+        constexpr decltype(auto) operator()(Target const& target) const
         {
             return target.to_non_task();
         }
 
         // any non-task policy just returns itself
         template <execution_policy ExPolicy>
-        friend constexpr decltype(auto) tag_fallback_invoke(
-            to_non_task_t, ExPolicy&& policy) noexcept
+            requires(!requires(ExPolicy const& t) { t.to_non_task(); })
+        constexpr decltype(auto) operator()(ExPolicy&& policy) const noexcept
         {
             static_assert(!hpx::is_async_execution_policy_v<ExPolicy>,
                 "must not be an asynchronous (task) execution policy");
@@ -122,22 +112,19 @@ namespace hpx::execution::experimental {
 
     // Return the matching task (asynchronous) execution policy
     HPX_CXX_CORE_EXPORT inline constexpr struct to_task_t
-      : hpx::functional::detail::tag_fallback<to_task_t>
     {
-    private:
-        // Bridge: forward to member function if available
+        // Forward to member function if available
         template <typename Target>
             requires requires(Target const& t) { t.to_task(); }
-        friend constexpr decltype(auto) tag_invoke(
-            to_task_t, Target const& target)
+        constexpr decltype(auto) operator()(Target const& target) const
         {
             return target.to_task();
         }
 
         // any task policy just returns itself
         template <execution_policy ExPolicy>
-        friend constexpr decltype(auto) tag_fallback_invoke(
-            to_task_t, ExPolicy&& policy) noexcept
+            requires(!requires(ExPolicy const& t) { t.to_task(); })
+        constexpr decltype(auto) operator()(ExPolicy&& policy) const noexcept
         {
             static_assert(hpx::is_async_execution_policy_v<ExPolicy>,
                 "must be an asynchronous (task) execution policy");
@@ -153,22 +140,19 @@ namespace hpx::execution::experimental {
     ///////////////////////////////////////////////////////////////////////////
     // Return the matching non-unsequenced execution policy
     HPX_CXX_CORE_EXPORT inline constexpr struct to_non_unseq_t
-      : hpx::functional::detail::tag_fallback<to_non_unseq_t>
     {
-    private:
-        // Bridge: forward to member function if available
+        // Forward to member function if available
         template <typename Target>
             requires requires(Target const& t) { t.to_non_unseq(); }
-        friend constexpr decltype(auto) tag_invoke(
-            to_non_unseq_t, Target const& target)
+        constexpr decltype(auto) operator()(Target const& target) const
         {
             return target.to_non_unseq();
         }
 
         // any non-unsequenced policy just returns itself
         template <execution_policy ExPolicy>
-        friend constexpr decltype(auto) tag_fallback_invoke(
-            to_non_unseq_t, ExPolicy&& policy) noexcept
+            requires(!requires(ExPolicy const& t) { t.to_non_unseq(); })
+        constexpr decltype(auto) operator()(ExPolicy&& policy) const noexcept
         {
             static_assert(!hpx::is_unsequenced_execution_policy_v<ExPolicy>,
                 "must not be an unsequenced execution policy");
@@ -183,22 +167,19 @@ namespace hpx::execution::experimental {
 
     // Return the matching unsequenced execution policy
     HPX_CXX_CORE_EXPORT inline constexpr struct to_unseq_t
-      : hpx::functional::detail::tag_fallback<to_unseq_t>
     {
-    private:
-        // Bridge: forward to member function if available
+        // Forward to member function if available
         template <typename Target>
             requires requires(Target const& t) { t.to_unseq(); }
-        friend constexpr decltype(auto) tag_invoke(
-            to_unseq_t, Target const& target)
+        constexpr decltype(auto) operator()(Target const& target) const
         {
             return target.to_unseq();
         }
 
         // any unsequenced policy just returns itself
         template <execution_policy ExPolicy>
-        friend constexpr decltype(auto) tag_fallback_invoke(
-            to_unseq_t, ExPolicy&& policy) noexcept
+            requires(!requires(ExPolicy const& t) { t.to_unseq(); })
+        constexpr decltype(auto) operator()(ExPolicy&& policy) const noexcept
         {
             static_assert(hpx::is_unsequenced_execution_policy_v<ExPolicy>,
                 "must be an unsequenced execution policy");

--- a/libs/core/executors/include/hpx/executors/execution_policy_mappings.hpp
+++ b/libs/core/executors/include/hpx/executors/execution_policy_mappings.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2022-2023 Hartmut Kaiser
+//  Copyright (c) 2026 Sai Charan Arvapally
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/core/executors/include/hpx/executors/execution_policy_parameters.hpp
+++ b/libs/core/executors/include/hpx/executors/execution_policy_parameters.hpp
@@ -5,47 +5,12 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 /// \file hpx/execution/execution_policy_parameters.hpp
+///
+/// Policy forwarding for executor-parameter CPOs now lives on the CPOs
+/// themselves (see execution_parameters_fwd.hpp, e.g. processing_units_count_t
+/// policy overload and detail::forward_to_policy_executor). Parameter attachment
+/// to policies continues to use execution_policy::with() directly.
 
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/concepts.hpp>
-#include <hpx/modules/execution.hpp>
-#include <hpx/modules/tag_invoke.hpp>
-
-#include <concepts>
-#include <cstddef>
-#include <string>
-#include <type_traits>
-#include <utility>
-
-namespace hpx::execution::experimental {
-
-    // with_processing_units_count property implementations for execution
-    // policies that support the embedded executor are provided through the
-    // public query() member functions on execution_policy (see
-    // hpx/executors/execution_policy.hpp).
-
-    // general fallback for parameters types that are not directly supported by
-    // the underlying executor
-    HPX_CXX_CORE_EXPORT template <typename ParametersProperty,
-        execution_policy ExPolicy, executor_parameters Params>
-        requires(!is_scheduling_property_v<ParametersProperty>)
-    constexpr decltype(auto) tag_fallback_invoke(
-        ParametersProperty, ExPolicy&& policy, Params&& params)
-    {
-        return policy.with(HPX_FORWARD(Params, params));
-    }
-
-    HPX_CXX_CORE_EXPORT template <typename ParametersProperty,
-        typename ExPolicy, typename... Ts,
-        HPX_CONCEPT_REQUIRES_(hpx::is_execution_policy_v<ExPolicy>)>
-    constexpr auto tag_fallback_invoke(
-        ParametersProperty prop, ExPolicy&& policy, Ts&&... ts)
-        -> decltype(std::declval<ParametersProperty>()(
-            std::declval<typename std::decay_t<ExPolicy>::executor_type>(),
-            std::declval<Ts>()...))
-    {
-        return prop(policy.executor(), HPX_FORWARD(Ts, ts)...);
-    }
-}    // namespace hpx::execution::experimental

--- a/libs/core/executors/include/hpx/executors/execution_policy_parameters.hpp
+++ b/libs/core/executors/include/hpx/executors/execution_policy_parameters.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2022-2025 Hartmut Kaiser
+//  Copyright (c) 2026 Sai Charan Arvapally
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/core/executors/include/hpx/executors/execution_policy_scheduling_property.hpp
+++ b/libs/core/executors/include/hpx/executors/execution_policy_scheduling_property.hpp
@@ -11,7 +11,6 @@
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/concepts.hpp>
 #include <hpx/modules/execution.hpp>
-#include <hpx/modules/tag_invoke.hpp>
 
 #include <type_traits>
 

--- a/libs/core/executors/include/hpx/executors/executor_scheduler.hpp
+++ b/libs/core/executors/include/hpx/executors/executor_scheduler.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2007-2025 Hartmut Kaiser
+//  Copyright (c) 2026 Sai Charan Arvapally
 //  Copyright (c) 2026 The STE||AR-Group
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -66,10 +67,8 @@ namespace hpx::execution::experimental {
                             hpx::execution::experimental::set_value(
                                 HPX_MOVE(receiver_));
                         }
-                        else if constexpr (hpx::traits::is_one_way_executor_v<
-                                               std::decay_t<Executor>> ||
-                            hpx::traits::is_two_way_executor_v<
-                                std::decay_t<Executor>>)
+                        else if constexpr (hpx::traits::has_post_member_v<
+                                               std::decay_t<Executor>>)
                         {
                             // For executors that support post(), use post
                             hpx::parallel::execution::post(exec_,

--- a/libs/core/executors/include/hpx/executors/executor_scheduler.hpp
+++ b/libs/core/executors/include/hpx/executors/executor_scheduler.hpp
@@ -66,13 +66,24 @@ namespace hpx::execution::experimental {
                             hpx::execution::experimental::set_value(
                                 HPX_MOVE(receiver_));
                         }
-                        else
+                        else if constexpr (hpx::traits::is_one_way_executor_v<
+                                               std::decay_t<Executor>> ||
+                            hpx::traits::is_two_way_executor_v<
+                                std::decay_t<Executor>>)
                         {
+                            // For executors that support post(), use post
                             hpx::parallel::execution::post(exec_,
                                 [receiver = HPX_MOVE(receiver_)]() mutable {
                                     hpx::execution::experimental::set_value(
                                         HPX_MOVE(receiver));
                                 });
+                        }
+                        else
+                        {
+                            // For bulk-only executors (e.g., fork_join_executor),
+                            // invoke inline since they don't support post()
+                            hpx::execution::experimental::set_value(
+                                HPX_MOVE(receiver_));
                         }
                     },
                     [&](std::exception_ptr ep) {

--- a/libs/core/executors/include/hpx/executors/fork_join_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/fork_join_executor.hpp
@@ -1356,8 +1356,8 @@ namespace hpx::execution::experimental {
                               p.processing_units_count(e, d, std::size_t{});
                           })
             {
-                return HPX_FORWARD(Parameters, params).processing_units_count(
-                    *this, iter_dur, num_tasks);
+                return HPX_FORWARD(Parameters, params)
+                    .processing_units_count(*this, iter_dur, num_tasks);
             }
             else
             {

--- a/libs/core/executors/include/hpx/executors/fork_join_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/fork_join_executor.hpp
@@ -1344,11 +1344,25 @@ namespace hpx::execution::experimental {
         template <typename Parameters>
             requires(hpx::executor_parameters<Parameters>)
         [[nodiscard]] std::size_t query(experimental::processing_units_count_t,
-            Parameters&&,
-            hpx::chrono::steady_duration const& = hpx::chrono::null_duration,
-            std::size_t = 0) const noexcept
+            Parameters&& params,
+            hpx::chrono::steady_duration const& iter_dur =
+                hpx::chrono::null_duration,
+            std::size_t num_tasks = 0) const
         {
-            return shared_data_->num_threads_;
+            using exec_type = std::decay_t<decltype(*this)>;
+            if constexpr (requires(std::decay_t<Parameters> const& p,
+                              exec_type const& e,
+                              hpx::chrono::steady_duration const& d) {
+                              p.processing_units_count(e, d, std::size_t{});
+                          })
+            {
+                return HPX_FORWARD(Parameters, params).processing_units_count(
+                    *this, iter_dur, num_tasks);
+            }
+            else
+            {
+                return shared_data_->num_threads_;
+            }
         }
 
         /// \cond NOINTERNAL

--- a/libs/core/executors/include/hpx/executors/parallel_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/parallel_executor.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2019-2020 ETH Zurich
+//  Copyright (c) 2026 Sai Charan Arvapally
 //  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c) 2019 Agustin Berge
 //
@@ -509,8 +510,8 @@ namespace hpx::execution {
         [[nodiscard]] auto query(experimental::with_processing_units_count_t,
             std::size_t num_cores) const
         {
-            using self_type = std::decay_t<decltype(*this)>;
-            return base_type::with_num_cores(self_type(*this), num_cores);
+            return base_type::with_num_cores(
+                parallel_policy_executor(*this), num_cores);
         }
 
         template <typename Parameters>
@@ -521,9 +522,8 @@ namespace hpx::execution {
                 hpx::chrono::null_duration,
             std::size_t num_tasks = 0) const
         {
-            using exec_type = std::decay_t<decltype(*this)>;
             if constexpr (requires(std::decay_t<Parameters> const& p,
-                              exec_type const& e,
+                              parallel_policy_executor const& e,
                               hpx::chrono::steady_duration const& d) {
                               p.processing_units_count(e, d, std::size_t{});
                           })
@@ -540,8 +540,8 @@ namespace hpx::execution {
         [[nodiscard]] auto query(experimental::with_first_core_t,
             std::size_t first_core) const noexcept
         {
-            using self_type = std::decay_t<decltype(*this)>;
-            return base_type::with_first_core(self_type(*this), first_core);
+            return base_type::with_first_core(
+                parallel_policy_executor(*this), first_core);
         }
 
         [[nodiscard]] constexpr std::size_t query(
@@ -837,8 +837,8 @@ namespace hpx::execution {
         [[nodiscard]] auto query(experimental::with_processing_units_count_t,
             std::size_t num_cores) const
         {
-            using self_type = std::decay_t<decltype(*this)>;
-            return base_type::with_num_cores(self_type(*this), num_cores);
+            return base_type::with_num_cores(
+                parallel_policy_executor(*this), num_cores);
         }
 
         template <typename Parameters>
@@ -849,9 +849,8 @@ namespace hpx::execution {
                 hpx::chrono::null_duration,
             std::size_t num_tasks = 0) const
         {
-            using exec_type = std::decay_t<decltype(*this)>;
             if constexpr (requires(std::decay_t<Parameters> const& p,
-                              exec_type const& e,
+                              parallel_policy_executor const& e,
                               hpx::chrono::steady_duration const& d) {
                               p.processing_units_count(e, d, std::size_t{});
                           })
@@ -868,8 +867,8 @@ namespace hpx::execution {
         [[nodiscard]] auto query(experimental::with_first_core_t,
             std::size_t first_core) const noexcept
         {
-            using self_type = std::decay_t<decltype(*this)>;
-            return base_type::with_first_core(self_type(*this), first_core);
+            return base_type::with_first_core(
+                parallel_policy_executor(*this), first_core);
         }
 
         [[nodiscard]] constexpr std::size_t query(

--- a/libs/core/executors/include/hpx/executors/parallel_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/parallel_executor.hpp
@@ -528,8 +528,8 @@ namespace hpx::execution {
                               p.processing_units_count(e, d, std::size_t{});
                           })
             {
-                return HPX_FORWARD(Parameters, params).processing_units_count(
-                    *this, iter_dur, num_tasks);
+                return HPX_FORWARD(Parameters, params)
+                    .processing_units_count(*this, iter_dur, num_tasks);
             }
             else
             {
@@ -856,8 +856,8 @@ namespace hpx::execution {
                               p.processing_units_count(e, d, std::size_t{});
                           })
             {
-                return HPX_FORWARD(Parameters, params).processing_units_count(
-                    *this, iter_dur, num_tasks);
+                return HPX_FORWARD(Parameters, params)
+                    .processing_units_count(*this, iter_dur, num_tasks);
             }
             else
             {

--- a/libs/core/executors/include/hpx/executors/parallel_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/parallel_executor.hpp
@@ -516,11 +516,25 @@ namespace hpx::execution {
         template <typename Parameters>
             requires(hpx::executor_parameters<Parameters>)
         [[nodiscard]] std::size_t query(experimental::processing_units_count_t,
-            Parameters&&,
-            hpx::chrono::steady_duration const& = hpx::chrono::null_duration,
-            std::size_t = 0) const
+            Parameters&& params,
+            hpx::chrono::steady_duration const& iter_dur =
+                hpx::chrono::null_duration,
+            std::size_t num_tasks = 0) const
         {
-            return this->get_num_cores();
+            using exec_type = std::decay_t<decltype(*this)>;
+            if constexpr (requires(std::decay_t<Parameters> const& p,
+                              exec_type const& e,
+                              hpx::chrono::steady_duration const& d) {
+                              p.processing_units_count(e, d, std::size_t{});
+                          })
+            {
+                return HPX_FORWARD(Parameters, params).processing_units_count(
+                    *this, iter_dur, num_tasks);
+            }
+            else
+            {
+                return this->get_num_cores();
+            }
         }
 
         [[nodiscard]] auto query(experimental::with_first_core_t,
@@ -830,11 +844,25 @@ namespace hpx::execution {
         template <typename Parameters>
             requires(hpx::executor_parameters<Parameters>)
         [[nodiscard]] std::size_t query(experimental::processing_units_count_t,
-            Parameters&&,
-            hpx::chrono::steady_duration const& = hpx::chrono::null_duration,
-            std::size_t = 0) const
+            Parameters&& params,
+            hpx::chrono::steady_duration const& iter_dur =
+                hpx::chrono::null_duration,
+            std::size_t num_tasks = 0) const
         {
-            return this->get_num_cores();
+            using exec_type = std::decay_t<decltype(*this)>;
+            if constexpr (requires(std::decay_t<Parameters> const& p,
+                              exec_type const& e,
+                              hpx::chrono::steady_duration const& d) {
+                              p.processing_units_count(e, d, std::size_t{});
+                          })
+            {
+                return HPX_FORWARD(Parameters, params).processing_units_count(
+                    *this, iter_dur, num_tasks);
+            }
+            else
+            {
+                return this->get_num_cores();
+            }
         }
 
         [[nodiscard]] auto query(experimental::with_first_core_t,

--- a/libs/core/executors/include/hpx/executors/parallel_scheduler.hpp
+++ b/libs/core/executors/include/hpx/executors/parallel_scheduler.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Sai Charan Arvapally
+// Copyright (c) 2026 Sai Charan Arvapally
 //
 // SPDX-License-Identifier: BSL-1.0
 // Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/core/executors/include/hpx/executors/parallel_scheduler_backend.hpp
+++ b/libs/core/executors/include/hpx/executors/parallel_scheduler_backend.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Sai Charan Arvapally
+// Copyright (c) 2026 Sai Charan Arvapally
 //
 // SPDX-License-Identifier: BSL-1.0
 // Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/core/executors/include/hpx/executors/sequenced_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/sequenced_executor.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2007-2025 Hartmut Kaiser
+//  Copyright (c) 2026 Sai Charan Arvapally
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -88,9 +89,8 @@ namespace hpx::execution {
                 hpx::chrono::null_duration,
             std::size_t num_tasks = 0) const
         {
-            using exec_type = std::decay_t<decltype(*this)>;
             if constexpr (requires(std::decay_t<Parameters> const& p,
-                              exec_type const& e,
+                              sequenced_executor const& e,
                               hpx::chrono::steady_duration const& d) {
                               p.processing_units_count(e, d, std::size_t{});
                           })

--- a/libs/core/executors/include/hpx/executors/sequenced_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/sequenced_executor.hpp
@@ -82,12 +82,26 @@ namespace hpx::execution {
 
         template <typename Parameters>
             requires(hpx::executor_parameters<Parameters>)
-        [[nodiscard]] constexpr std::size_t query(
-            experimental::processing_units_count_t, Parameters&&,
-            hpx::chrono::steady_duration const& = hpx::chrono::null_duration,
-            std::size_t = 0) const
+        [[nodiscard]] std::size_t query(
+            experimental::processing_units_count_t, Parameters&& params,
+            hpx::chrono::steady_duration const& iter_dur =
+                hpx::chrono::null_duration,
+            std::size_t num_tasks = 0) const
         {
-            return 1;
+            using exec_type = std::decay_t<decltype(*this)>;
+            if constexpr (requires(std::decay_t<Parameters> const& p,
+                              exec_type const& e,
+                              hpx::chrono::steady_duration const& d) {
+                              p.processing_units_count(e, d, std::size_t{});
+                          })
+            {
+                return HPX_FORWARD(Parameters, params).processing_units_count(
+                    *this, iter_dur, num_tasks);
+            }
+            else
+            {
+                return 1;
+            }
         }
 
         [[nodiscard]] auto query(

--- a/libs/core/executors/include/hpx/executors/sequenced_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/sequenced_executor.hpp
@@ -82,8 +82,8 @@ namespace hpx::execution {
 
         template <typename Parameters>
             requires(hpx::executor_parameters<Parameters>)
-        [[nodiscard]] std::size_t query(
-            experimental::processing_units_count_t, Parameters&& params,
+        [[nodiscard]] std::size_t query(experimental::processing_units_count_t,
+            Parameters&& params,
             hpx::chrono::steady_duration const& iter_dur =
                 hpx::chrono::null_duration,
             std::size_t num_tasks = 0) const
@@ -95,8 +95,8 @@ namespace hpx::execution {
                               p.processing_units_count(e, d, std::size_t{});
                           })
             {
-                return HPX_FORWARD(Parameters, params).processing_units_count(
-                    *this, iter_dur, num_tasks);
+                return HPX_FORWARD(Parameters, params)
+                    .processing_units_count(*this, iter_dur, num_tasks);
             }
             else
             {

--- a/libs/core/executors/include/hpx/executors/thread_pool_scheduler.hpp
+++ b/libs/core/executors/include/hpx/executors/thread_pool_scheduler.hpp
@@ -211,11 +211,26 @@ namespace hpx::execution::experimental {
         }
 
         template <executor_parameters Parameters>
-        [[nodiscard]] std::size_t query(processing_units_count_t, Parameters&&,
-            hpx::chrono::steady_duration const& = hpx::chrono::null_duration,
-            std::size_t = 0) const
+        [[nodiscard]] std::size_t query(processing_units_count_t,
+            Parameters&& params,
+            hpx::chrono::steady_duration const& iter_dur =
+                hpx::chrono::null_duration,
+            std::size_t num_tasks = 0) const
         {
-            return get_num_cores();
+            using exec_type = std::decay_t<decltype(*this)>;
+            if constexpr (requires(std::decay_t<Parameters> const& p,
+                              exec_type const& e,
+                              hpx::chrono::steady_duration const& d) {
+                              p.processing_units_count(e, d, std::size_t{});
+                          })
+            {
+                return HPX_FORWARD(Parameters, params)
+                    .processing_units_count(*this, iter_dur, num_tasks);
+            }
+            else
+            {
+                return get_num_cores();
+            }
         }
 
         [[nodiscard]] auto query(

--- a/libs/core/executors/include/hpx/executors/thread_pool_scheduler.hpp
+++ b/libs/core/executors/include/hpx/executors/thread_pool_scheduler.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2020 ETH Zurich
+//  Copyright (c) 2026 Sai Charan Arvapally
 //  Copyright (c) 2022-2025 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0

--- a/libs/core/executors/include/hpx/executors/thread_pool_scheduler.hpp
+++ b/libs/core/executors/include/hpx/executors/thread_pool_scheduler.hpp
@@ -274,7 +274,8 @@ namespace hpx::execution::experimental {
         template <typename Tag, typename Property>
             requires(
                 hpx::execution::experimental::is_scheduling_property_v<Tag> &&
-                hpx::functional::is_tag_invocable_v<Tag, Policy, Property>)
+                hpx::execution::experimental::has_query_v<Policy const&, Tag,
+                    Property>)
         [[nodiscard]] auto query(Tag tag, Property&& prop) const
         {
             auto scheduler_with_prop = *this;
@@ -286,7 +287,7 @@ namespace hpx::execution::experimental {
         template <typename Tag>
             requires(
                 hpx::execution::experimental::is_scheduling_property_v<Tag> &&
-                hpx::functional::is_tag_invocable_v<Tag, Policy>)
+                hpx::execution::experimental::has_query_v<Policy const&, Tag>)
         [[nodiscard]] auto query(Tag tag) const
         {
             return tag(policy());

--- a/libs/core/executors/src/parallel_scheduler.cpp
+++ b/libs/core/executors/src/parallel_scheduler.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Sai Charan Arvapally
+// Copyright (c) 2026 Sai Charan Arvapally
 //
 // SPDX-License-Identifier: BSL-1.0
 // Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/core/executors/tests/regressions/future_then_async_executor.cpp
+++ b/libs/core/executors/tests/regressions/future_then_async_executor.cpp
@@ -17,8 +17,7 @@ struct test_async_executor
     using execution_category = hpx::execution::parallel_execution_tag;
 
     template <typename F, typename... Ts>
-    friend decltype(auto) tag_invoke(hpx::parallel::execution::async_execute_t,
-        test_async_executor const&, F&& f, Ts&&... ts)
+    decltype(auto) async_execute(F&& f, Ts&&... ts) const
     {
         return hpx::dataflow(
             hpx::launch::async, std::forward<F>(f), std::forward<Ts>(ts)...);

--- a/libs/core/executors/tests/regressions/wrapping_executor.cpp
+++ b/libs/core/executors/tests/regressions/wrapping_executor.cpp
@@ -54,74 +54,63 @@ namespace test {
             return *this;
         }
 
-    private:
+    public:
         // OneWayExecutor interface
         template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::sync_execute_t,
-            wrapping_executor const& exec, F&& f, Ts&&... ts)
+        decltype(auto) sync_execute(F&& f, Ts&&... ts) const
         {
             return hpx::parallel::execution::sync_execute(
-                exec.exec_, std::forward<F>(f), std::forward<Ts>(ts)...);
+                exec_, std::forward<F>(f), std::forward<Ts>(ts)...);
         }
 
         // TwoWayExecutor interface
         template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::async_execute_t,
-            wrapping_executor const& exec, F&& f, Ts&&... ts)
+        decltype(auto) async_execute(F&& f, Ts&&... ts) const
         {
             return hpx::parallel::execution::async_execute(
-                exec.exec_, std::forward<F>(f), std::forward<Ts>(ts)...);
+                exec_, std::forward<F>(f), std::forward<Ts>(ts)...);
         }
 
         template <typename F, typename Future, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::then_execute_t,
-            wrapping_executor const& exec, F&& f, Future&& predecessor,
-            Ts&&... ts)
+        decltype(auto) then_execute(
+            F&& f, Future&& predecessor, Ts&&... ts) const
         {
-            return hpx::parallel::execution::then_execute(exec.exec_,
+            return hpx::parallel::execution::then_execute(exec_,
                 std::forward<F>(f), std::forward<Future>(predecessor),
                 std::forward<Ts>(ts)...);
         }
 
         // NonBlockingOneWayExecutor (adapted) interface
         template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(hpx::parallel::execution::post_t,
-            wrapping_executor const& exec, F&& f, Ts&&... ts)
+        decltype(auto) post(F&& f, Ts&&... ts) const
         {
             hpx::parallel::execution::post(
-                exec.exec_, std::forward<F>(f), std::forward<Ts>(ts)...);
+                exec_, std::forward<F>(f), std::forward<Ts>(ts)...);
         }
 
         // BulkOneWayExecutor interface
         template <typename F, typename S, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::bulk_sync_execute_t,
-            wrapping_executor const& exec, F&& f, S const& shape, Ts&&... ts)
+        decltype(auto) bulk_sync_execute(
+            F&& f, S const& shape, Ts&&... ts) const
         {
             return hpx::parallel::execution::bulk_sync_execute(
-                exec.exec_, std::forward<F>(f), shape, std::forward<Ts>(ts)...);
+                exec_, std::forward<F>(f), shape, std::forward<Ts>(ts)...);
         }
 
         // BulkTwoWayExecutor interface
         template <typename F, typename S, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::bulk_async_execute_t,
-            wrapping_executor const& exec, F&& f, S const& shape, Ts&&... ts)
+        decltype(auto) bulk_async_execute(
+            F&& f, S const& shape, Ts&&... ts) const
         {
             return hpx::parallel::execution::bulk_async_execute(
-                exec.exec_, std::forward<F>(f), shape, std::forward<Ts>(ts)...);
+                exec_, std::forward<F>(f), shape, std::forward<Ts>(ts)...);
         }
 
         template <typename F, typename S, typename Future, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::bulk_then_execute_t,
-            wrapping_executor const& exec, F&& f, S const& shape,
-            Future&& predecessor, Ts&&... ts)
+        decltype(auto) bulk_then_execute(
+            F&& f, S const& shape, Future&& predecessor, Ts&&... ts) const
         {
-            return hpx::parallel::execution::bulk_then_execute(exec.exec_,
+            return hpx::parallel::execution::bulk_then_execute(exec_,
                 std::forward<F>(f), shape, std::forward<Future>(predecessor),
                 std::forward<Ts>(ts)...);
         }

--- a/libs/core/executors/tests/regressions/wrapping_executor.cpp
+++ b/libs/core/executors/tests/regressions/wrapping_executor.cpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2020-2024 Hartmut Kaiser
+//  Copyright (c) 2026 Sai Charan Arvapally
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/core/executors/tests/unit/annotating_executor.cpp
+++ b/libs/core/executors/tests/unit/annotating_executor.cpp
@@ -469,8 +469,7 @@ struct test_async_executor
     using execution_category = hpx::execution::parallel_execution_tag;
 
     template <typename F, typename... Ts>
-    friend decltype(auto) tag_invoke(hpx::parallel::execution::async_execute_t,
-        test_async_executor const&, F&& f, Ts&&... ts)
+    decltype(auto) async_execute(F&& f, Ts&&... ts) const
     {
         return hpx::async(std::forward<F>(f), std::forward<Ts>(ts)...);
     }

--- a/libs/core/executors/tests/unit/parallel_scheduler.cpp
+++ b/libs/core/executors/tests/unit/parallel_scheduler.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 Sai Charan Arvapally
+// Copyright (c) 2026 Sai Charan Arvapally
 //
 // SPDX-License-Identifier: BSL-1.0
 // Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/core/executors/tests/unit/shared_parallel_executor.cpp
+++ b/libs/core/executors/tests/unit/shared_parallel_executor.cpp
@@ -20,11 +20,9 @@
 ///////////////////////////////////////////////////////////////////////////////
 struct shared_parallel_executor
 {
-private:
     template <typename F, typename... Ts>
-    friend hpx::shared_future<hpx::util::invoke_result_t<F, Ts...>> tag_invoke(
-        hpx::parallel::execution::async_execute_t,
-        shared_parallel_executor const&, F&& f, Ts&&... ts)
+    hpx::shared_future<hpx::util::invoke_result_t<F, Ts...>> async_execute(
+        F&& f, Ts&&... ts) const
     {
         auto policy = hpx::launch::async;
         auto hint = policy.hint();

--- a/libs/core/lcos_local/tests/unit/local_dataflow_executor_additional_arguments.cpp
+++ b/libs/core/lcos_local/tests/unit/local_dataflow_executor_additional_arguments.cpp
@@ -50,17 +50,15 @@ struct additional_argument
 struct additional_argument_executor
 {
     template <typename F, typename... Ts>
-    friend decltype(auto) tag_invoke(hpx::parallel::execution::async_execute_t,
-        additional_argument_executor const&, F&& f, Ts&&... ts)
+    decltype(auto) async_execute(F&& f, Ts&&... ts) const
     {
         return hpx::async(
             std::forward<F>(f), additional_argument{}, std::forward<Ts>(ts)...);
     }
 
     template <typename A, typename... Ts>
-    friend decltype(auto) tag_invoke(hpx::parallel::execution::post_t,
-        additional_argument_executor const&,
-        hpx::lcos::detail::dataflow_finalization<A>&& f, hpx::tuple<Ts...>&& t)
+    decltype(auto) post(hpx::lcos::detail::dataflow_finalization<A>&& f,
+        hpx::tuple<Ts...>&& t) const
     {
         additional_argument a;
         hpx::post(f, hpx::tuple_cat(hpx::tie(a), std::move(t)));

--- a/libs/core/lcos_local/tests/unit/local_dataflow_external_future.cpp
+++ b/libs/core/lcos_local/tests/unit/local_dataflow_external_future.cpp
@@ -37,8 +37,7 @@ struct external_future_executor
     // type calculation of it. dataflow_finalize has to set the same type to
     // the future state.
     template <typename F, typename... Ts>
-    friend decltype(auto) tag_invoke(hpx::parallel::execution::async_execute_t,
-        external_future_executor const&, F&& f, Ts&&... ts)
+    decltype(auto) async_execute(F&& f, Ts&&... ts) const
     {
         if constexpr (std::is_void_v<hpx::util::invoke_result_t<F, Ts...>>)
         {
@@ -112,8 +111,7 @@ struct external_future_additional_argument_executor
     // type calculation of it. dataflow_finalize has to set the same type to the
     // future state.
     template <typename F, typename... Ts>
-    friend decltype(auto) tag_invoke(hpx::parallel::execution::async_execute_t,
-        external_future_additional_argument_executor const&, F&& f, Ts&&... ts)
+    decltype(auto) async_execute(F&& f, Ts&&... ts) const
     {
         if constexpr (std::is_void_v<hpx::util::invoke_result_t<F,
                           additional_argument, Ts...>>)

--- a/libs/core/resiliency/include/hpx/resiliency/replay_executor.hpp
+++ b/libs/core/resiliency/include/hpx/resiliency/replay_executor.hpp
@@ -66,22 +66,18 @@ namespace hpx::resiliency::experimental {
             return *this;
         }
 
-    private:
         // TwoWayExecutor interface
         template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::async_execute_t,
-            replay_executor const& exec, F&& f, Ts&&... ts)
+        decltype(auto) async_execute(F&& f, Ts&&... ts) const
         {
-            return async_replay_validate(exec.exec_, exec.replay_count_,
-                exec.validator_, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+            return async_replay_validate(exec_, replay_count_, validator_,
+                HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
 
         // BulkTwoWayExecutor interface
         template <typename F, typename S, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::bulk_async_execute_t,
-            replay_executor const& exec, F&& f, S const& shape, Ts&&... ts)
+        decltype(auto) bulk_async_execute(
+            F&& f, S const& shape, Ts&&... ts) const
         {
             std::size_t size = hpx::util::size(shape);
 
@@ -96,7 +92,7 @@ namespace hpx::resiliency::experimental {
 
             hpx::latch l(static_cast<std::ptrdiff_t>(size + 1));
 
-            exec.spawn_hierarchical(results, l, 0, size, num_tasks, f,
+            spawn_hierarchical(results, l, 0, size, num_tasks, f,
                 hpx::util::begin(shape), ts...);
 
             l.arrive_and_wait();
@@ -116,9 +112,7 @@ namespace hpx::resiliency::experimental {
 
             for (std::size_t i = 0; i != size; (void) ++i, ++it)
             {
-                results[base + i] =
-                    tag_invoke(hpx::parallel::execution::async_execute_t{},
-                        *this, func, *it, ts...);
+                results[base + i] = async_execute(func, *it, ts...);
             }
 
             l.count_down(static_cast<std::ptrdiff_t>(size));

--- a/libs/core/resiliency/include/hpx/resiliency/replay_executor.hpp
+++ b/libs/core/resiliency/include/hpx/resiliency/replay_executor.hpp
@@ -162,6 +162,16 @@ namespace hpx::resiliency::experimental {
             return validator_;
         }
 
+        // support scheduling properties via query() for new CPO dispatch
+        template <typename Tag, typename... Args>
+            requires(
+                hpx::execution::experimental::is_scheduling_property_v<Tag>)
+        auto query(Tag tag, Args&&... args) const -> decltype(tag(
+            std::declval<BaseExecutor const&>(), HPX_FORWARD(Args, args)...))
+        {
+            return tag(exec_, HPX_FORWARD(Args, args)...);
+        }
+
     private:
         BaseExecutor exec_;
         std::size_t replay_count_;

--- a/libs/core/resiliency/include/hpx/resiliency/replay_executor.hpp
+++ b/libs/core/resiliency/include/hpx/resiliency/replay_executor.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2020-2025 Hartmut Kaiser
+//  Copyright (c) 2026 Sai Charan Arvapally
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/core/resiliency/include/hpx/resiliency/replay_executor.hpp
+++ b/libs/core/resiliency/include/hpx/resiliency/replay_executor.hpp
@@ -166,10 +166,15 @@ namespace hpx::resiliency::experimental {
         template <typename Tag, typename... Args>
             requires(
                 hpx::execution::experimental::is_scheduling_property_v<Tag>)
-        auto query(Tag tag, Args&&... args) const -> decltype(tag(
-            std::declval<BaseExecutor const&>(), HPX_FORWARD(Args, args)...))
+        auto query(Tag tag, Args&&... args) const
+            -> decltype(replay_executor<BaseExecutor, Validate>(
+                std::declval<Tag>()(
+                    std::declval<BaseExecutor>(), HPX_FORWARD(Args, args)...),
+                std::declval<std::size_t>(), std::declval<Validate>()))
         {
-            return tag(exec_, HPX_FORWARD(Args, args)...);
+            return replay_executor<BaseExecutor, Validate>(
+                tag(exec_, HPX_FORWARD(Args, args)...), replay_count_,
+                validator_);
         }
 
     private:

--- a/libs/core/resiliency/include/hpx/resiliency/replicate_executor.hpp
+++ b/libs/core/resiliency/include/hpx/resiliency/replicate_executor.hpp
@@ -69,23 +69,18 @@ namespace hpx::resiliency::experimental {
             return *this;
         }
 
-    private:
         // TwoWayExecutor interface
         template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::async_execute_t,
-            replicate_executor const& exec, F&& f, Ts&&... ts)
+        decltype(auto) async_execute(F&& f, Ts&&... ts) const
         {
-            return async_replicate_vote_validate(exec.exec_,
-                exec.replicate_count_, exec.voter_, exec.validator_,
-                HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+            return async_replicate_vote_validate(exec_, replicate_count_,
+                voter_, validator_, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
 
         // BulkTwoWayExecutor interface
         template <typename F, typename S, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::bulk_async_execute_t,
-            replicate_executor const& exec, F&& f, S const& shape, Ts&&... ts)
+        decltype(auto) bulk_async_execute(
+            F&& f, S const& shape, Ts&&... ts) const
         {
             std::size_t size = hpx::util::size(shape);
 
@@ -100,7 +95,7 @@ namespace hpx::resiliency::experimental {
 
             hpx::latch l(static_cast<std::ptrdiff_t>(size + 1));
 
-            exec.spawn_hierarchical(results, l, 0, size, num_tasks, f,
+            spawn_hierarchical(results, l, 0, size, num_tasks, f,
                 hpx::util::begin(shape), ts...);
 
             l.arrive_and_wait();
@@ -120,9 +115,7 @@ namespace hpx::resiliency::experimental {
 
             for (std::size_t i = 0; i != size; (void) ++i, ++it)
             {
-                results[base + i] =
-                    tag_invoke(hpx::parallel::execution::async_execute_t{},
-                        *this, func, *it, ts...);
+                results[base + i] = async_execute(func, *it, ts...);
             }
 
             l.count_down(static_cast<std::ptrdiff_t>(size));

--- a/libs/core/resiliency/include/hpx/resiliency/replicate_executor.hpp
+++ b/libs/core/resiliency/include/hpx/resiliency/replicate_executor.hpp
@@ -173,10 +173,16 @@ namespace hpx::resiliency::experimental {
         template <typename Tag, typename... Args>
             requires(
                 hpx::execution::experimental::is_scheduling_property_v<Tag>)
-        auto query(Tag tag, Args&&... args) const -> decltype(tag(
-            std::declval<BaseExecutor const&>(), HPX_FORWARD(Args, args)...))
+        auto query(Tag tag, Args&&... args) const
+            -> decltype(replicate_executor<BaseExecutor, Vote, Validate>(
+                std::declval<Tag>()(
+                    std::declval<BaseExecutor>(), HPX_FORWARD(Args, args)...),
+                std::declval<std::size_t>(), std::declval<Vote>(),
+                std::declval<Validate>()))
         {
-            return tag(exec_, HPX_FORWARD(Args, args)...);
+            return replicate_executor<BaseExecutor, Vote, Validate>(
+                tag(exec_, HPX_FORWARD(Args, args)...), replicate_count_,
+                voter_, validator_);
         }
 
     private:

--- a/libs/core/resiliency/include/hpx/resiliency/replicate_executor.hpp
+++ b/libs/core/resiliency/include/hpx/resiliency/replicate_executor.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2020-2025 Hartmut Kaiser
+//  Copyright (c) 2026 Sai Charan Arvapally
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/core/resiliency/include/hpx/resiliency/replicate_executor.hpp
+++ b/libs/core/resiliency/include/hpx/resiliency/replicate_executor.hpp
@@ -169,6 +169,16 @@ namespace hpx::resiliency::experimental {
             return validator_;
         }
 
+        // support scheduling properties via query() for new CPO dispatch
+        template <typename Tag, typename... Args>
+            requires(
+                hpx::execution::experimental::is_scheduling_property_v<Tag>)
+        auto query(Tag tag, Args&&... args) const -> decltype(tag(
+            std::declval<BaseExecutor const&>(), HPX_FORWARD(Args, args)...))
+        {
+            return tag(exec_, HPX_FORWARD(Args, args)...);
+        }
+
     private:
         BaseExecutor exec_;
         std::size_t replicate_count_;

--- a/libs/core/resource_partitioner/examples/async_customization.cpp
+++ b/libs/core/resource_partitioner/examples/async_customization.cpp
@@ -74,15 +74,14 @@ struct test_async_executor
         }
     };
 
-private:
+public:
     // --------------------------------------------------------------------
     // async execute specialized for simple arguments typical
     // of a normal async call with arbitrary arguments
     // --------------------------------------------------------------------
     template <typename F, typename... Ts>
-    friend future<util::invoke_result_t<F, Ts...>> tag_invoke(
-        hpx::parallel::execution::async_execute_t,
-        test_async_executor const& exec, F&& f, Ts&&... ts)
+    future<util::invoke_result_t<F, Ts...>> async_execute(
+        F&& f, Ts&&... ts) const
     {
         using result_type = util::detail::invoke_deferred_result_t<F, Ts...>;
 
@@ -95,7 +94,7 @@ private:
                   << print_type<result_type>() << "\n";
 
         // forward the task execution on to the real internal executor
-        return hpx::parallel::execution::async_execute(exec.executor_,
+        return hpx::parallel::execution::async_execute(executor_,
             hpx::annotated_function(std::forward<F>(f), "custom"),
             std::forward<Ts>(ts)...);
     }
@@ -107,9 +106,7 @@ private:
     template <typename F, typename Future, typename... Ts,
         typename = std::enable_if_t<
             traits::is_future_v<std::remove_reference_t<Future>>>>
-    friend auto tag_invoke(hpx::parallel::execution::then_execute_t,
-        test_async_executor const& exec, F&& f, Future&& predecessor,
-        Ts&&... ts)
+    auto then_execute(F&& f, Future&& predecessor, Ts&&... ts) const
         -> future<util::detail::invoke_deferred_result_t<F, Future, Ts...>>
     {
         using result_type =
@@ -129,7 +126,7 @@ private:
         std::cout << "then_execute : Result       : "
                   << print_type<result_type>() << "\n";
 
-        return hpx::parallel::execution::then_execute(exec.executor_,
+        return hpx::parallel::execution::then_execute(executor_,
             std::forward<F>(f), std::forward<Future>(predecessor),
             std::forward<Ts>(ts)...);
     }
@@ -145,9 +142,9 @@ private:
             OuterFuture<hpx::tuple<InnerFutures...>>>::value>,
         typename = std::enable_if_t<
             is_tuple_of_futures<hpx::tuple<InnerFutures...>>::value>>
-    friend auto tag_invoke(hpx::parallel::execution::then_execute_t,
-        test_async_executor const& exec, F&& f,
-        OuterFuture<hpx::tuple<InnerFutures...>>&& predecessor, Ts&&... ts)
+    auto then_execute(
+        F&& f,
+        OuterFuture<hpx::tuple<InnerFutures...>>&& predecessor, Ts&&... ts) const
             -> future<util::detail::invoke_deferred_result_t<F,
                         OuterFuture<hpx::tuple<InnerFutures...>>, Ts...>>
     // clang-format on
@@ -181,7 +178,7 @@ private:
             unwrapped_futures_tuple);
 
         // forward the task execution on to the real internal executor
-        return hpx::parallel::execution::then_execute(exec.executor_,
+        return hpx::parallel::execution::then_execute(executor_,
             hpx::annotated_function(std::forward<F>(f), "custom then"),
             std::forward<OuterFuture<hpx::tuple<InnerFutures...>>>(predecessor),
             std::forward<Ts>(ts)...);
@@ -195,9 +192,7 @@ private:
     template <typename F, typename... InnerFutures,
         typename = std::enable_if_t<
             traits::is_future_tuple_v<hpx::tuple<InnerFutures...>>>>
-    friend auto tag_invoke(hpx::parallel::execution::async_execute_t,
-        test_async_executor const& exec, F&& f,
-        hpx::tuple<InnerFutures...>&& predecessor)
+    auto async_execute(F&& f, hpx::tuple<InnerFutures...>&& predecessor) const
         -> future<util::detail::invoke_deferred_result_t<F,
             hpx::tuple<InnerFutures...>>>
     {
@@ -226,7 +221,7 @@ private:
             unwrapped_futures_tuple);
 
         // forward the task execution on to the real internal executor
-        return hpx::parallel::execution::async_execute(exec.executor_,
+        return hpx::parallel::execution::async_execute(executor_,
             hpx::annotated_function(std::forward<F>(f), "custom async"),
             std::forward<hpx::tuple<InnerFutures...>>(predecessor));
     }

--- a/libs/core/timed_execution/include/hpx/timed_execution/timed_execution_fwd.hpp
+++ b/libs/core/timed_execution/include/hpx/timed_execution/timed_execution_fwd.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2017-2025 Hartmut Kaiser
+//  Copyright (c) 2017-2026 Hartmut Kaiser
 //  Copyright (c) 2017 Google
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -10,7 +10,6 @@
 #include <hpx/config.hpp>
 #include <hpx/modules/execution.hpp>
 #include <hpx/modules/execution_base.hpp>
-#include <hpx/modules/tag_invoke.hpp>
 #include <hpx/modules/timing.hpp>
 
 #include <type_traits>
@@ -23,6 +22,29 @@ namespace hpx::parallel::execution {
     namespace detail {
 
         /// \cond NOINTERNAL
+        template <typename Executor, typename Time, typename F, typename... Ts>
+        concept has_post_at_member =
+            requires(Executor&& exec, Time const& time, F&& f, Ts&&... ts) {
+                HPX_FORWARD(Executor, exec)
+                    .post_at(time, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+            };
+
+        template <typename Executor, typename Time, typename F, typename... Ts>
+        concept has_async_execute_at_member =
+            requires(Executor&& exec, Time const& time, F&& f, Ts&&... ts) {
+                HPX_FORWARD(Executor, exec)
+                    .async_execute_at(
+                        time, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+            };
+
+        template <typename Executor, typename Time, typename F, typename... Ts>
+        concept has_sync_execute_at_member =
+            requires(Executor&& exec, Time const& time, F&& f, Ts&&... ts) {
+                HPX_FORWARD(Executor, exec)
+                    .sync_execute_at(
+                        time, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+            };
+
         template <typename Executor, typename Enable = void>
         struct timed_post_fn_helper;
 
@@ -67,13 +89,24 @@ namespace hpx::parallel::execution {
     ///       execution agent.
     ///
     HPX_CXX_CORE_EXPORT inline constexpr struct post_at_t final
-      : hpx::functional::detail::tag_fallback<post_at_t>
     {
-    private:
         template <executor_any Executor, typename F, typename... Ts>
-        friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(post_at_t,
-            Executor&& exec, hpx::chrono::steady_time_point const& abs_time,
-            F&& f, Ts&&... ts)
+            requires(detail::has_post_at_member<Executor,
+                hpx::chrono::steady_time_point const&, F, Ts...>)
+        HPX_FORCEINLINE decltype(auto) operator()(Executor&& exec,
+            hpx::chrono::steady_time_point const& abs_time, F&& f,
+            Ts&&... ts) const
+        {
+            return HPX_FORWARD(Executor, exec)
+                .post_at(abs_time, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+        }
+
+        template <executor_any Executor, typename F, typename... Ts>
+            requires(!detail::has_post_at_member<Executor,
+                hpx::chrono::steady_time_point const&, F, Ts...>)
+        HPX_FORCEINLINE decltype(auto) operator()(Executor&& exec,
+            hpx::chrono::steady_time_point const& abs_time, F&& f,
+            Ts&&... ts) const
         {
             return detail::timed_post_fn_helper<std::decay_t<Executor>>::call(
                 HPX_FORWARD(Executor, exec), abs_time, HPX_FORWARD(F, f),
@@ -102,13 +135,24 @@ namespace hpx::parallel::execution {
     ///       execution agent.
     ///
     HPX_CXX_CORE_EXPORT inline constexpr struct post_after_t final
-      : hpx::functional::detail::tag_fallback<post_after_t>
     {
-    private:
         template <executor_any Executor, typename F, typename... Ts>
-        friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(post_after_t,
-            Executor&& exec, hpx::chrono::steady_duration const& rel_time,
-            F&& f, Ts&&... ts)
+            requires(detail::has_post_at_member<Executor,
+                hpx::chrono::steady_duration const&, F, Ts...>)
+        HPX_FORCEINLINE decltype(auto) operator()(Executor&& exec,
+            hpx::chrono::steady_duration const& rel_time, F&& f,
+            Ts&&... ts) const
+        {
+            return HPX_FORWARD(Executor, exec)
+                .post_at(rel_time, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+        }
+
+        template <executor_any Executor, typename F, typename... Ts>
+            requires(!detail::has_post_at_member<Executor,
+                hpx::chrono::steady_duration const&, F, Ts...>)
+        HPX_FORCEINLINE decltype(auto) operator()(Executor&& exec,
+            hpx::chrono::steady_duration const& rel_time, F&& f,
+            Ts&&... ts) const
         {
             return detail::timed_post_fn_helper<std::decay_t<Executor>>::call(
                 HPX_FORWARD(Executor, exec), rel_time, HPX_FORWARD(F, f),
@@ -143,13 +187,25 @@ namespace hpx::parallel::execution {
     ///       non-time-scheduled execution agent.
     ///
     HPX_CXX_CORE_EXPORT inline constexpr struct async_execute_at_t final
-      : hpx::functional::detail::tag_fallback<async_execute_at_t>
     {
-    private:
         template <executor_any Executor, typename F, typename... Ts>
-        friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            async_execute_at_t, Executor&& exec,
-            hpx::chrono::steady_time_point const& abs_time, F&& f, Ts&&... ts)
+            requires(detail::has_async_execute_at_member<Executor,
+                hpx::chrono::steady_time_point const&, F, Ts...>)
+        HPX_FORCEINLINE decltype(auto) operator()(Executor&& exec,
+            hpx::chrono::steady_time_point const& abs_time, F&& f,
+            Ts&&... ts) const
+        {
+            return HPX_FORWARD(Executor, exec)
+                .async_execute_at(
+                    abs_time, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+        }
+
+        template <executor_any Executor, typename F, typename... Ts>
+            requires(!detail::has_async_execute_at_member<Executor,
+                hpx::chrono::steady_time_point const&, F, Ts...>)
+        HPX_FORCEINLINE decltype(auto) operator()(Executor&& exec,
+            hpx::chrono::steady_time_point const& abs_time, F&& f,
+            Ts&&... ts) const
         {
             return detail::timed_async_execute_fn_helper<
                 std::decay_t<Executor>>::call(HPX_FORWARD(Executor, exec),
@@ -179,13 +235,25 @@ namespace hpx::parallel::execution {
     ///       non-time-scheduled execution agent.
     ///
     HPX_CXX_CORE_EXPORT inline constexpr struct async_execute_after_t final
-      : hpx::functional::detail::tag_fallback<async_execute_after_t>
     {
-    private:
         template <executor_any Executor, typename F, typename... Ts>
-        friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            async_execute_after_t, Executor&& exec,
-            hpx::chrono::steady_duration const& rel_time, F&& f, Ts&&... ts)
+            requires(detail::has_async_execute_at_member<Executor,
+                hpx::chrono::steady_duration const&, F, Ts...>)
+        HPX_FORCEINLINE decltype(auto) operator()(Executor&& exec,
+            hpx::chrono::steady_duration const& rel_time, F&& f,
+            Ts&&... ts) const
+        {
+            return HPX_FORWARD(Executor, exec)
+                .async_execute_at(
+                    rel_time, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+        }
+
+        template <executor_any Executor, typename F, typename... Ts>
+            requires(!detail::has_async_execute_at_member<Executor,
+                hpx::chrono::steady_duration const&, F, Ts...>)
+        HPX_FORCEINLINE decltype(auto) operator()(Executor&& exec,
+            hpx::chrono::steady_duration const& rel_time, F&& f,
+            Ts&&... ts) const
         {
             return detail::timed_async_execute_fn_helper<
                 std::decay_t<Executor>>::call(HPX_FORWARD(Executor, exec),
@@ -215,13 +283,25 @@ namespace hpx::parallel::execution {
     ///       non-time-scheduled execution agent.
     ///
     HPX_CXX_CORE_EXPORT inline constexpr struct sync_execute_at_t final
-      : hpx::functional::detail::tag_fallback<sync_execute_at_t>
     {
-    private:
         template <executor_any Executor, typename F, typename... Ts>
-        friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            sync_execute_at_t, Executor&& exec,
-            hpx::chrono::steady_time_point const& abs_time, F&& f, Ts&&... ts)
+            requires(detail::has_sync_execute_at_member<Executor,
+                hpx::chrono::steady_time_point const&, F, Ts...>)
+        HPX_FORCEINLINE decltype(auto) operator()(Executor&& exec,
+            hpx::chrono::steady_time_point const& abs_time, F&& f,
+            Ts&&... ts) const
+        {
+            return HPX_FORWARD(Executor, exec)
+                .sync_execute_at(
+                    abs_time, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+        }
+
+        template <executor_any Executor, typename F, typename... Ts>
+            requires(!detail::has_sync_execute_at_member<Executor,
+                hpx::chrono::steady_time_point const&, F, Ts...>)
+        HPX_FORCEINLINE decltype(auto) operator()(Executor&& exec,
+            hpx::chrono::steady_time_point const& abs_time, F&& f,
+            Ts&&... ts) const
         {
             return detail::timed_sync_execute_fn_helper<
                 std::decay_t<Executor>>::call(HPX_FORWARD(Executor, exec),
@@ -251,13 +331,25 @@ namespace hpx::parallel::execution {
     ///       non-time-scheduled execution agent.
     ///
     HPX_CXX_CORE_EXPORT inline constexpr struct sync_execute_after_t final
-      : hpx::functional::detail::tag_fallback<sync_execute_after_t>
     {
-    private:
         template <executor_any Executor, typename F, typename... Ts>
-        friend HPX_FORCEINLINE decltype(auto) tag_fallback_invoke(
-            sync_execute_after_t, Executor&& exec,
-            hpx::chrono::steady_duration const& rel_time, F&& f, Ts&&... ts)
+            requires(detail::has_sync_execute_at_member<Executor,
+                hpx::chrono::steady_duration const&, F, Ts...>)
+        HPX_FORCEINLINE decltype(auto) operator()(Executor&& exec,
+            hpx::chrono::steady_duration const& rel_time, F&& f,
+            Ts&&... ts) const
+        {
+            return HPX_FORWARD(Executor, exec)
+                .sync_execute_at(
+                    rel_time, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+        }
+
+        template <executor_any Executor, typename F, typename... Ts>
+            requires(!detail::has_sync_execute_at_member<Executor,
+                hpx::chrono::steady_duration const&, F, Ts...>)
+        HPX_FORCEINLINE decltype(auto) operator()(Executor&& exec,
+            hpx::chrono::steady_duration const& rel_time, F&& f,
+            Ts&&... ts) const
         {
             return detail::timed_sync_execute_fn_helper<
                 std::decay_t<Executor>>::call(HPX_FORWARD(Executor, exec),

--- a/libs/core/timed_execution/include/hpx/timed_execution/timed_execution_fwd.hpp
+++ b/libs/core/timed_execution/include/hpx/timed_execution/timed_execution_fwd.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2017-2026 Hartmut Kaiser
+//  Copyright (c) 2026 Sai Charan Arvapally
 //  Copyright (c) 2017 Google
 //
 //  SPDX-License-Identifier: BSL-1.0

--- a/libs/core/timed_execution/include/hpx/timed_execution/timed_executors.hpp
+++ b/libs/core/timed_execution/include/hpx/timed_execution/timed_executors.hpp
@@ -89,31 +89,7 @@ namespace hpx::parallel::execution {
                     .get();
             }
 
-            template <typename Executor, typename F, typename... Ts,
-                typename Enable =
-                    std::enable_if_t<hpx::functional::is_tag_invocable_v<
-                        hpx::parallel::execution::sync_execute_at_t, Executor&&,
-                        std::chrono::steady_clock::time_point const&, F&&,
-                        Ts&&...>>>
-            static decltype(auto) call(int, Executor&& exec,
-                std::chrono::steady_clock::time_point const& abs_time, F&& f,
-                Ts&&... ts)
-            {
-                return hpx::parallel::execution::sync_execute_at(
-                    HPX_FORWARD(Executor, exec), abs_time, HPX_FORWARD(F, f),
-                    HPX_FORWARD(Ts, ts)...);
-            }
-
-            template <typename Executor, typename F, typename... Ts,
-                typename Enable =
-                    std::enable_if_t<!hpx::functional::is_tag_invocable_v<
-                        hpx::parallel::execution::sync_execute_at_t, Executor&&,
-                        std::chrono::steady_clock::time_point const&, F&&,
-                        Ts&&...>>>
-            HPX_DEPRECATED_V(1, 9,
-                "Exposing sync_execute_at() from an executor is deprecated, "
-                "please expose this functionality through a corresponding "
-                "overload of tag_invoke")
+            template <typename Executor, typename F, typename... Ts>
             static auto call(int, Executor&& exec,
                 std::chrono::steady_clock::time_point const& abs_time, F&& f,
                 Ts&&... ts) -> decltype(exec.sync_execute_at(abs_time,
@@ -139,31 +115,7 @@ namespace hpx::parallel::execution {
                     HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
             }
 
-            template <typename Executor, typename F, typename... Ts,
-                typename Enable =
-                    std::enable_if_t<hpx::functional::is_tag_invocable_v<
-                        hpx::parallel::execution::sync_execute_at_t, Executor&&,
-                        std::chrono::steady_clock::time_point const&, F&&,
-                        Ts&&...>>>
-            static decltype(auto) call(int, Executor&& exec,
-                std::chrono::steady_clock::time_point const& abs_time, F&& f,
-                Ts&&... ts)
-            {
-                return hpx::parallel::execution::sync_execute_at(
-                    HPX_FORWARD(Executor, exec), abs_time, HPX_FORWARD(F, f),
-                    HPX_FORWARD(Ts, ts)...);
-            }
-
-            template <typename Executor, typename F, typename... Ts,
-                typename Enable =
-                    std::enable_if_t<!hpx::functional::is_tag_invocable_v<
-                        hpx::parallel::execution::sync_execute_at_t, Executor&&,
-                        std::chrono::steady_clock::time_point const&, F&&,
-                        Ts&&...>>>
-            HPX_DEPRECATED_V(1, 9,
-                "Exposing sync_execute_at() from an executor is deprecated, "
-                "please expose this functionality through a corresponding "
-                "overload of tag_invoke")
+            template <typename Executor, typename F, typename... Ts>
             static auto call(int, Executor&& exec,
                 std::chrono::steady_clock::time_point const& abs_time, F&& f,
                 Ts&&... ts) -> decltype(exec.sync_execute_at(abs_time,
@@ -218,33 +170,7 @@ namespace hpx::parallel::execution {
                     HPX_MOVE(predecessor));
             }
 
-            template <typename Executor, typename F, typename... Ts,
-                typename Enable =
-                    std::enable_if_t<hpx::functional::is_tag_invocable_v<
-                        hpx::parallel::execution::async_execute_at_t,
-                        Executor&&,
-                        std::chrono::steady_clock::time_point const&, F&&,
-                        Ts&&...>>>
-            static decltype(auto) call(int, Executor&& exec,
-                std::chrono::steady_clock::time_point const& abs_time, F&& f,
-                Ts&&... ts)
-            {
-                return hpx::parallel::execution::async_execute_at(
-                    HPX_FORWARD(Executor, exec), abs_time, HPX_FORWARD(F, f),
-                    HPX_FORWARD(Ts, ts)...);
-            }
-
-            template <typename Executor, typename F, typename... Ts,
-                typename Enable =
-                    std::enable_if_t<!hpx::functional::is_tag_invocable_v<
-                        hpx::parallel::execution::async_execute_at_t,
-                        Executor&&,
-                        std::chrono::steady_clock::time_point const&, F&&,
-                        Ts&&...>>>
-            HPX_DEPRECATED_V(1, 9,
-                "Exposing async_execute_at() from an executor is deprecated, "
-                "please expose this functionality through a corresponding "
-                "overload of tag_invoke")
+            template <typename Executor, typename F, typename... Ts>
             static auto call(int, Executor&& exec,
                 std::chrono::steady_clock::time_point const& abs_time, F&& f,
                 Ts&&... ts) -> decltype(exec.async_execute_at(abs_time,
@@ -271,33 +197,7 @@ namespace hpx::parallel::execution {
                     HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
             }
 
-            template <typename Executor, typename F, typename... Ts,
-                typename Enable =
-                    std::enable_if_t<hpx::functional::is_tag_invocable_v<
-                        hpx::parallel::execution::async_execute_at_t,
-                        Executor&&,
-                        std::chrono::steady_clock::time_point const&, F&&,
-                        Ts&&...>>>
-            static decltype(auto) call(int, Executor&& exec,
-                std::chrono::steady_clock::time_point const& abs_time, F&& f,
-                Ts&&... ts)
-            {
-                return hpx::parallel::execution::async_execute_at(
-                    HPX_FORWARD(Executor, exec), abs_time, HPX_FORWARD(F, f),
-                    HPX_FORWARD(Ts, ts)...);
-            }
-
-            template <typename Executor, typename F, typename... Ts,
-                typename Enable =
-                    std::enable_if_t<!hpx::functional::is_tag_invocable_v<
-                        hpx::parallel::execution::async_execute_at_t,
-                        Executor&&,
-                        std::chrono::steady_clock::time_point const&, F&&,
-                        Ts&&...>>>
-            HPX_DEPRECATED_V(1, 9,
-                "Exposing async_execute_at() from an executor is deprecated, "
-                "please expose this functionality through a corresponding "
-                "overload of tag_invoke")
+            template <typename Executor, typename F, typename... Ts>
             static auto call(int, Executor&& exec,
                 std::chrono::steady_clock::time_point const& abs_time, F&& f,
                 Ts&&... ts) -> decltype(exec.async_execute_at(abs_time,
@@ -347,31 +247,7 @@ namespace hpx::parallel::execution {
                     HPX_MOVE(predecessor));
             }
 
-            template <typename Executor, typename F, typename... Ts,
-                typename Enable =
-                    std::enable_if_t<hpx::functional::is_tag_invocable_v<
-                        hpx::parallel::execution::post_at_t, Executor&&,
-                        std::chrono::steady_clock::time_point const&, F&&,
-                        Ts&&...>>>
-            static decltype(auto) call(int, Executor&& exec,
-                std::chrono::steady_clock::time_point const& abs_time, F&& f,
-                Ts&&... ts)
-            {
-                return hpx::parallel::execution::post_at(
-                    HPX_FORWARD(Executor, exec), abs_time, HPX_FORWARD(F, f),
-                    HPX_FORWARD(Ts, ts)...);
-            }
-
-            template <typename Executor, typename F, typename... Ts,
-                typename Enable =
-                    std::enable_if_t<!hpx::functional::is_tag_invocable_v<
-                        hpx::parallel::execution::post_at_t, Executor&&,
-                        std::chrono::steady_clock::time_point const&, F&&,
-                        Ts&&...>>>
-            HPX_DEPRECATED_V(1, 9,
-                "Exposing post_at() from an executor is deprecated, "
-                "please expose this functionality through a corresponding "
-                "overload of tag_invoke")
+            template <typename Executor, typename F, typename... Ts>
             static auto call(int, Executor&& exec,
                 std::chrono::steady_clock::time_point const& abs_time, F&& f,
                 Ts&&... ts) -> decltype(exec.post_at(abs_time,
@@ -394,30 +270,7 @@ namespace hpx::parallel::execution {
                 execution::post(HPX_FORWARD(Executor, exec), HPX_FORWARD(F, f),
                     HPX_FORWARD(Ts, ts)...);
             }
-
-            template <typename Executor, typename F, typename... Ts,
-                typename Enable =
-                    std::enable_if_t<hpx::functional::is_tag_invocable_v<
-                        hpx::parallel::execution::post_at_t, Executor&&,
-                        std::chrono::steady_clock::time_point const&, F&&,
-                        Ts&&...>>>
-            static decltype(auto) call(int, Executor&& exec,
-                std::chrono::steady_clock::time_point const& abs_time, F&& f,
-                Ts&&... ts)
-            {
-                hpx::parallel::execution::post_at(HPX_FORWARD(Executor, exec),
-                    abs_time, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
-            }
-            template <typename Executor, typename F, typename... Ts,
-                typename Enable =
-                    std::enable_if_t<!hpx::functional::is_tag_invocable_v<
-                        hpx::parallel::execution::post_at_t, Executor&&,
-                        std::chrono::steady_clock::time_point const&, F&&,
-                        Ts&&...>>>
-            HPX_DEPRECATED_V(1, 9,
-                "Exposing post_at() from an executor is deprecated, "
-                "please expose this functionality through a corresponding "
-                "overload of tag_invoke")
+            template <typename Executor, typename F, typename... Ts>
             static auto call(int, Executor&& exec,
                 std::chrono::steady_clock::time_point const& abs_time, F&& f,
                 Ts&&... ts) -> decltype(exec.post_at(abs_time,
@@ -499,54 +352,54 @@ namespace hpx::parallel::execution {
         }
         /// \endcond
 
-    private:
+    public:
         // OneWayExecutor interface
         template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::sync_execute_t,
-            timed_executor const& exec, F&& f, Ts&&... ts)
+        decltype(auto) sync_execute(F&& f, Ts&&... ts) const
         {
-            return detail::call_sync_execute_at(exec.exec_, exec.execute_at_,
-                HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+            return detail::call_sync_execute_at(
+                exec_, execute_at_, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
 
         // TwoWayExecutor interface
         template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::async_execute_t,
-            timed_executor const& exec, F&& f, Ts&&... ts)
+        decltype(auto) async_execute(F&& f, Ts&&... ts) const
         {
-            return detail::call_async_execute_at(exec.exec_, exec.execute_at_,
-                HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+            return detail::call_async_execute_at(
+                exec_, execute_at_, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
 
         // NonBlockingOneWayExecutor (adapted) interface
         template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(hpx::parallel::execution::post_t,
-            timed_executor const& exec, F&& f, Ts&&... ts)
+        decltype(auto) post(F&& f, Ts&&... ts) const
         {
-            detail::call_post_at(exec.exec_, exec.execute_at_,
-                HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+            detail::call_post_at(
+                exec_, execute_at_, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
 
         // support all properties exposed by the wrapped executor
-        template <scheduling_property Tag, typename Property>
-            requires(hpx::functional::is_tag_invocable_v<Tag, BaseExecutor,
-                Property>)
-        friend timed_executor tag_invoke(
-            Tag tag, timed_executor const& exec, Property&& prop)
+        template <typename Tag, typename Property>
+            requires(
+                hpx::execution::experimental::is_scheduling_property_v<Tag> &&
+                requires(Tag tag, BaseExecutor const& exec, Property&& prop) {
+                    tag(exec, HPX_FORWARD(Property, prop));
+                })
+        [[nodiscard]] timed_executor query(Tag, Property&& prop) const
         {
-            return timed_executor(hpx::functional::tag_invoke(
-                tag, exec.exec_, HPX_FORWARD(Property, prop)));
+            return timed_executor(
+                Tag{}(exec_, HPX_FORWARD(Property, prop)), execute_at_);
         }
 
-        template <scheduling_property Tag>
-            requires(hpx::functional::is_tag_invocable_v<Tag, BaseExecutor>)
-        friend decltype(auto) tag_invoke(Tag tag, timed_executor const& exec)
+        template <typename Tag>
+            requires(
+                hpx::execution::experimental::is_scheduling_property_v<Tag> &&
+                requires(Tag tag, BaseExecutor const& exec) { tag(exec); })
+        [[nodiscard]] decltype(auto) query(Tag tag) const
         {
-            return hpx::functional::tag_invoke(tag, exec.exec_);
+            return tag(exec_);
         }
 
+    private:
         BaseExecutor exec_;
         std::chrono::steady_clock::time_point execute_at_;
     };

--- a/libs/core/timed_execution/include/hpx/timed_execution/timed_executors.hpp
+++ b/libs/core/timed_execution/include/hpx/timed_execution/timed_executors.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2017-2024 Hartmut Kaiser
+//  Copyright (c) 2026 Sai Charan Arvapally
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying

--- a/libs/core/timed_execution/tests/unit/minimal_timed_async_executor.cpp
+++ b/libs/core/timed_execution/tests/unit/minimal_timed_async_executor.cpp
@@ -157,8 +157,7 @@ struct test_async_executor1
     using execution_category = hpx::execution::parallel_execution_tag;
 
     template <typename F, typename... Ts>
-    friend decltype(auto) tag_invoke(hpx::parallel::execution::async_execute_t,
-        test_async_executor1 const&, F&& f, Ts&&... ts)
+    decltype(auto) async_execute(F&& f, Ts&&... ts) const
     {
         ++count_async;
 
@@ -174,10 +173,8 @@ struct test_async_executor1
 struct test_timed_async_executor1 : test_async_executor1
 {
     template <typename F, typename... Ts>
-    friend decltype(auto) tag_invoke(
-        hpx::parallel::execution::async_execute_at_t,
-        test_timed_async_executor1 const&,
-        hpx::chrono::steady_time_point const& abs_time, F&& f, Ts&&... ts)
+    decltype(auto) async_execute_at(
+        hpx::chrono::steady_time_point const& abs_time, F&& f, Ts&&... ts) const
     {
         ++count_async_at;
 
@@ -207,8 +204,7 @@ namespace hpx::execution::experimental {
 struct test_timed_async_executor2 : test_async_executor1
 {
     template <typename F, typename... Ts>
-    friend decltype(auto) tag_invoke(hpx::parallel::execution::sync_execute_t,
-        test_timed_async_executor2 const&, F&& f, Ts&&... ts)
+    decltype(auto) sync_execute(F&& f, Ts&&... ts) const
     {
         ++count_sync;
 
@@ -225,10 +221,8 @@ struct test_timed_async_executor2 : test_async_executor1
 struct test_timed_async_executor3 : test_timed_async_executor2
 {
     template <typename F, typename... Ts>
-    friend decltype(auto) tag_invoke(
-        hpx::parallel::execution::sync_execute_at_t,
-        test_timed_async_executor3 const&,
-        hpx::chrono::steady_time_point const& abs_time, F&& f, Ts&&... ts)
+    decltype(auto) sync_execute_at(
+        hpx::chrono::steady_time_point const& abs_time, F&& f, Ts&&... ts) const
     {
         ++count_sync_at;
         hpx::this_thread::sleep_until(abs_time);
@@ -259,8 +253,7 @@ namespace hpx::execution::experimental {
 struct test_timed_async_executor4 : test_async_executor1
 {
     template <typename F, typename... Ts>
-    friend decltype(auto) tag_invoke(hpx::parallel::execution::post_t,
-        test_timed_async_executor4 const&, F&& f, Ts&&... ts)
+    decltype(auto) post(F&& f, Ts&&... ts) const
     {
         ++count_apply;
         hpx::post(std::forward<F>(f), std::forward<Ts>(ts)...);
@@ -270,9 +263,8 @@ struct test_timed_async_executor4 : test_async_executor1
 struct test_timed_async_executor5 : test_timed_async_executor4
 {
     template <typename F, typename... Ts>
-    friend decltype(auto) tag_invoke(hpx::parallel::execution::post_at_t,
-        test_timed_async_executor5 const&,
-        hpx::chrono::steady_time_point const& abs_time, F&& f, Ts&&... ts)
+    void post_at(
+        hpx::chrono::steady_time_point const& abs_time, F&& f, Ts&&... ts) const
     {
         ++count_apply_at;
         hpx::this_thread::sleep_until(abs_time);

--- a/libs/core/timed_execution/tests/unit/minimal_timed_sync_executor.cpp
+++ b/libs/core/timed_execution/tests/unit/minimal_timed_sync_executor.cpp
@@ -151,8 +151,7 @@ struct test_sync_executor1
     typedef hpx::execution::sequenced_execution_tag execution_category;
 
     template <typename F, typename... Ts>
-    friend decltype(auto) tag_invoke(hpx::parallel::execution::sync_execute_t,
-        test_sync_executor1 const&, F&& f, Ts&&... ts)
+    decltype(auto) sync_execute(F&& f, Ts&&... ts) const
     {
         ++count_sync;
         return hpx::invoke(std::forward<F>(f), std::forward<Ts>(ts)...);
@@ -164,10 +163,8 @@ struct test_timed_sync_executor1 : test_sync_executor1
     typedef hpx::execution::sequenced_execution_tag execution_category;
 
     template <typename F, typename... Ts>
-    friend decltype(auto) tag_invoke(
-        hpx::parallel::execution::sync_execute_at_t,
-        test_timed_sync_executor1 const&,
-        hpx::chrono::steady_time_point const& abs_time, F&& f, Ts&&... ts)
+    decltype(auto) sync_execute_at(
+        hpx::chrono::steady_time_point const& abs_time, F&& f, Ts&&... ts) const
     {
         ++count_sync_at;
         hpx::this_thread::sleep_until(abs_time);
@@ -192,8 +189,7 @@ struct test_sync_executor2 : test_sync_executor1
     typedef hpx::execution::sequenced_execution_tag execution_category;
 
     template <typename F, typename... Ts>
-    friend decltype(auto) tag_invoke(hpx::parallel::execution::post_t,
-        test_sync_executor2 const&, F&& f, Ts&&... ts)
+    decltype(auto) post(F&& f, Ts&&... ts) const
     {
         ++count_apply;
         hpx::invoke(std::forward<F>(f), std::forward<Ts>(ts)...);
@@ -203,9 +199,8 @@ struct test_sync_executor2 : test_sync_executor1
 struct test_timed_sync_executor2 : test_sync_executor2
 {
     template <typename F, typename... Ts>
-    friend decltype(auto) tag_invoke(hpx::parallel::execution::post_at_t,
-        test_timed_sync_executor2 const&,
-        hpx::chrono::steady_time_point const& abs_time, F&& f, Ts&&... ts)
+    void post_at(
+        hpx::chrono::steady_time_point const& abs_time, F&& f, Ts&&... ts) const
     {
         ++count_apply_at;
         hpx::this_thread::sleep_until(abs_time);

--- a/libs/full/executors_distributed/include/hpx/executors_distributed/distribution_policy_executor.hpp
+++ b/libs/full/executors_distributed/include/hpx/executors_distributed/distribution_policy_executor.hpp
@@ -147,30 +147,24 @@ namespace hpx::execution::experimental {
         /// \cond NOINTERNAL
         using execution_category = hpx::execution::parallel_execution_tag;
 
-    private:
+        // Executor interface - member functions (not tag_invoke)
         template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(hpx::parallel::execution::post_t,
-            distribution_policy_executor const& exec, F&& f, Ts&&... ts)
+        void post(F&& f, Ts&&... ts) const
         {
-            return exec.post_impl(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+            post_impl(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
 
         template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::async_execute_t,
-            distribution_policy_executor const& exec, F&& f, Ts&&... ts)
+        decltype(auto) async_execute(F&& f, Ts&&... ts) const
         {
-            return exec.async_execute_impl(
+            return async_execute_impl(
                 HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
         }
 
         template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::sync_execute_t,
-            distribution_policy_executor const& exec, F&& f, Ts&&... ts)
+        decltype(auto) sync_execute(F&& f, Ts&&... ts) const
         {
-            return exec
-                .async_execute_impl(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...)
+            return async_execute_impl(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...)
                 .get();
         }
         /// \endcond


### PR DESCRIPTION
Following up on #7301 

migration of executor customization points from
tag_invoke/tag_fallback_invoke to direct member function dispatch
with operator() on CPO structs.