### PR TITLE
feat(execution): implement get_allocator query for P2300 schedulers

### DIFF
--- a/libs/core/execution/tests/unit/CMakeLists.txt
+++ b/libs/core/execution/tests/unit/CMakeLists.txt
@@ -39,6 +39,7 @@ set(tests
     minimal_async_executor
     minimal_sync_executor
     persistent_executor_parameters
+    query_get_allocator
     rebind_executor_parameters
 )
 

--- a/libs/core/execution/tests/unit/query_get_allocator.cpp
+++ b/libs/core/execution/tests/unit/query_get_allocator.cpp
@@ -22,7 +22,9 @@ struct custom_allocator
     custom_allocator() = default;
 
     template <typename U>
-    constexpr custom_allocator(custom_allocator const&) noexcept {}
+    constexpr custom_allocator(custom_allocator const&) noexcept
+    {
+    }
 
     [[nodiscard]] std::byte* allocate(std::size_t n)
     {
@@ -34,12 +36,14 @@ struct custom_allocator
         ::operator delete(p);
     }
 
-    friend constexpr bool operator==(custom_allocator const&, custom_allocator const&) noexcept
+    friend constexpr bool operator==(
+        custom_allocator const&, custom_allocator const&) noexcept
     {
         return true;
     }
 
-    friend constexpr bool operator!=(custom_allocator const&, custom_allocator const&) noexcept
+    friend constexpr bool operator!=(
+        custom_allocator const&, custom_allocator const&) noexcept
     {
         return false;
     }
@@ -57,7 +61,7 @@ struct custom_env
 struct custom_sender
 {
     using sender_concept = ex::sender_t;
-    
+
     constexpr custom_env get_env() const noexcept
     {
         return custom_env{};
@@ -67,11 +71,13 @@ struct custom_sender
 // Custom scheduler wrapper that provides the custom environment
 struct custom_scheduler
 {
-    friend constexpr bool operator==(custom_scheduler const&, custom_scheduler const&) noexcept
+    friend constexpr bool operator==(
+        custom_scheduler const&, custom_scheduler const&) noexcept
     {
         return true;
     }
-    friend constexpr bool operator!=(custom_scheduler const&, custom_scheduler const&) noexcept
+    friend constexpr bool operator!=(
+        custom_scheduler const&, custom_scheduler const&) noexcept
     {
         return false;
     }
@@ -98,7 +104,7 @@ int hpx_main()
 
         // The query should return std::allocator<std::byte> for thread_pool_scheduler
         auto alloc = ex::get_allocator(env);
-        HPX_TEST((std::is_same_v<decltype(alloc), std::allocator<std::byte>>));
+        HPX_TEST((std::is_same_v<decltype(alloc), std::allocator<std::byte>>) );
     }
 
     {
@@ -108,7 +114,7 @@ int hpx_main()
         auto env = ex::get_env(sndr);
 
         auto alloc = ex::get_allocator(env);
-        HPX_TEST((std::is_same_v<decltype(alloc), custom_allocator>));
+        HPX_TEST((std::is_same_v<decltype(alloc), custom_allocator>) );
     }
 
     return hpx::local::finalize();

--- a/libs/core/execution/tests/unit/query_get_allocator.cpp
+++ b/libs/core/execution/tests/unit/query_get_allocator.cpp
@@ -9,6 +9,7 @@
 #include <hpx/executors/thread_pool_scheduler.hpp>
 #include <hpx/modules/testing.hpp>
 
+#include <cstddef>
 #include <memory>
 #include <type_traits>
 

--- a/libs/core/execution/tests/unit/query_get_allocator.cpp
+++ b/libs/core/execution/tests/unit/query_get_allocator.cpp
@@ -1,0 +1,123 @@
+//  Copyright (c) 2025 Shivansh Singh
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#include <hpx/execution.hpp>
+#include <hpx/executors/thread_pool_scheduler.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <memory>
+#include <type_traits>
+
+namespace ex = hpx::execution::experimental;
+
+// Dummy allocator for testing custom environment
+struct custom_allocator
+{
+    using value_type = std::byte;
+
+    custom_allocator() = default;
+
+    template <typename U>
+    constexpr custom_allocator(custom_allocator const&) noexcept {}
+
+    [[nodiscard]] std::byte* allocate(std::size_t n)
+    {
+        return static_cast<std::byte*>(::operator new(n));
+    }
+
+    void deallocate(std::byte* p, std::size_t) noexcept
+    {
+        ::operator delete(p);
+    }
+
+    friend constexpr bool operator==(custom_allocator const&, custom_allocator const&) noexcept
+    {
+        return true;
+    }
+
+    friend constexpr bool operator!=(custom_allocator const&, custom_allocator const&) noexcept
+    {
+        return false;
+    }
+};
+
+// Custom environment that overrides get_allocator
+struct custom_env
+{
+    constexpr custom_allocator query(ex::get_allocator_t) const noexcept
+    {
+        return custom_allocator{};
+    }
+};
+
+struct custom_sender
+{
+    using sender_concept = ex::sender_t;
+    
+    constexpr custom_env get_env() const noexcept
+    {
+        return custom_env{};
+    }
+};
+
+// Custom scheduler wrapper that provides the custom environment
+struct custom_scheduler
+{
+    friend constexpr bool operator==(custom_scheduler const&, custom_scheduler const&) noexcept
+    {
+        return true;
+    }
+    friend constexpr bool operator!=(custom_scheduler const&, custom_scheduler const&) noexcept
+    {
+        return false;
+    }
+
+    constexpr custom_sender schedule() const noexcept
+    {
+        return custom_sender{};
+    }
+};
+
+#include <hpx/init.hpp>
+
+int hpx_main()
+{
+    {
+        // Test: hpx::execution::experimental::thread_pool_scheduler
+        ex::thread_pool_scheduler sched{};
+
+        // In P2300, get_allocator is queried on the environment of the sender
+        // produced by the scheduler (or potentially on the environment of the
+        // scheduler itself, if it provides one).
+        auto sndr = ex::schedule(sched);
+        auto env = ex::get_env(sndr);
+
+        // The query should return std::allocator<std::byte> for thread_pool_scheduler
+        auto alloc = ex::get_allocator(env);
+        HPX_TEST((std::is_same_v<decltype(alloc), std::allocator<std::byte>>));
+    }
+
+    {
+        // Test: Custom scheduler wrapper overriding the allocator
+        custom_scheduler sched{};
+        auto sndr = ex::schedule(sched);
+        auto env = ex::get_env(sndr);
+
+        auto alloc = ex::get_allocator(env);
+        HPX_TEST((std::is_same_v<decltype(alloc), custom_allocator>));
+    }
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/executors/include/hpx/executors/executor_scheduler.hpp
+++ b/libs/core/executors/include/hpx/executors/executor_scheduler.hpp
@@ -16,6 +16,7 @@
 #include <hpx/modules/execution_base.hpp>
 
 #include <exception>
+#include <memory>
 #include <type_traits>
 #include <utility>
 
@@ -115,6 +116,14 @@ namespace hpx::execution::experimental {
                         const noexcept
                     {
                         return executor_scheduler<Executor>{exec_};
+                    }
+
+                    // P2300 get_allocator query
+                    constexpr auto query(
+                        hpx::execution::experimental::get_allocator_t)
+                        const noexcept
+                    {
+                        return std::allocator<std::byte>{};
                     }
                 };
                 return env{exec_};

--- a/libs/core/executors/include/hpx/executors/parallel_scheduler.hpp
+++ b/libs/core/executors/include/hpx/executors/parallel_scheduler.hpp
@@ -789,6 +789,12 @@ namespace hpx::execution::experimental {
                 {
                     return {};
                 }
+
+                // P2300 get_allocator query
+                constexpr auto query(get_allocator_t) const noexcept
+                {
+                    return std::allocator<std::byte>{};
+                }
             };
 
             env get_env() const noexcept

--- a/libs/core/executors/include/hpx/executors/thread_pool_scheduler.hpp
+++ b/libs/core/executors/include/hpx/executors/thread_pool_scheduler.hpp
@@ -21,6 +21,7 @@
 #include <concepts>
 #include <cstddef>
 #include <exception>
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <string>
@@ -497,6 +498,14 @@ namespace hpx::execution::experimental {
                     return sched.query(
                         hpx::execution::experimental::get_completion_domain_t<
                             CPO>{});
+                }
+
+                // P2300 get_allocator query
+                constexpr auto query(
+                    hpx::execution::experimental::get_allocator_t)
+                    const noexcept
+                {
+                    return std::allocator<std::byte>{};
                 }
             };
 

--- a/libs/core/executors/include/hpx/executors/thread_pool_scheduler_bulk.hpp
+++ b/libs/core/executors/include/hpx/executors/thread_pool_scheduler_bulk.hpp
@@ -31,6 +31,7 @@
 #include <cstdint>
 #include <exception>
 #include <iterator>
+#include <memory>
 #include <optional>
 #include <ranges>
 #include <string>
@@ -849,6 +850,13 @@ namespace hpx::execution::experimental::detail {
                 return sch.query(
                     hpx::execution::experimental::get_completion_domain_t<
                         CPO>{});
+            }
+
+            // P2300 get_allocator query
+            constexpr auto query(
+                hpx::execution::experimental::get_allocator_t) const noexcept
+            {
+                return std::allocator<std::byte>{};
             }
         };
 


### PR DESCRIPTION
Fixes #

## Proposed Changes

  - Introduced allocator awareness to the P2300 implementation by adding `query(get_allocator_t)` support to scheduler environments.
  - Implemented `query(hpx::execution::experimental::get_allocator_t)` for the sender environment struct within `thread_pool_policy_scheduler`.
  - Implemented `query(hpx::execution::experimental::get_allocator_t)` for the sender environment struct within `executor_scheduler<Executor>`.
  - Configured both overloads to return `std::allocator<std::byte>{}` to safely satisfy the standards-compliant `__simple_allocator` contract while preventing internal infrastructure leaks.

## Any background context you want to provide?

Currently, neither `thread_pool_scheduler` nor `executor_scheduler` expose an allocator query through their respective sender environments. This causes asynchronous P2300 algorithms that require temporary or shared internal state allocation (such as `ex::split` or `ex::ensure_started`) to fail compilation or fall back to unoptimized global heap pathways when running on HPX execution policies.

By explicitly returning `std::allocator<std::byte>`, we fulfill P2300 advisory requirements safely. This ensures optimal structural forwarding across pipelines without exposing jemalloc-specific or HPX-internal runtime implementation details downstream.

## Checklist

Not all points below apply to all pull requests.

- [x] I have added a new feature and have added tests to go along with it. (Core implementation is clean and verified by local builds; unit test coverage to follow).
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.