### PR TITLE
Harden hierarchical collectives: flat fallback unification, input validation, tree test coverage

### DIFF
--- a/libs/full/collectives/include/hpx/collectives/all_gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_gather.hpp
@@ -392,6 +392,10 @@ namespace hpx::collectives {
     //
     // Key difference from all_reduce: the gather phase produces vector<T>
     // (O(N) data), so the broadcast phase transfers O(N) instead of a scalar.
+    //
+    // An instance may be shared between all_gather and all_reduce (identical
+    // generation scheme), but not with other collectives; see the note on
+    // create_hierarchical_communicator.
 
     // Async overload
     HPX_CXX_EXPORT template <typename T>
@@ -409,7 +413,7 @@ namespace hpx::collectives {
                 HPX_GET_EXCEPTION(hpx::error::bad_parameter,
                     "hpx::collectives::all_gather (hierarchical)",
                     "hierarchical all_gather requires an explicit generation "
-                    "number for the 2k/2k+1 internal mapping"));
+                    "number for the 2k-1/2k internal mapping"));
         }
 
         if (this_site.is_default())
@@ -440,10 +444,12 @@ namespace hpx::collectives {
                     "participating sites"));
         }
 
-        // Flat fast path: when arity >= num_sites, each site is its own
-        // group and the gather+broadcast decomposition collapses to a
-        // single flat all_gather. Dispatch directly to avoid the two
-        // separate gate synchronizations.
+        // Flat fast path: when arity >= num_sites, the tree builder's leaf
+        // condition (right - left < arity) fired at the root call and
+        // produced a single flat communicator spanning all sites. The
+        // gather+broadcast decomposition then collapses to a single flat
+        // all_gather; dispatch directly to avoid the two separate gate
+        // synchronizations.
         if (arity_val >= num_sites_val)
         {
             HPX_ASSERT(communicators.size() == 1);

--- a/libs/full/collectives/include/hpx/collectives/all_gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_gather.hpp
@@ -210,6 +210,7 @@ namespace hpx { namespace collectives {
 #include <hpx/config.hpp>
 
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
+#include <hpx/assert.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/components_base.hpp>

--- a/libs/full/collectives/include/hpx/collectives/all_gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_gather.hpp
@@ -417,6 +417,21 @@ namespace hpx::collectives {
             this_site = agas::get_locality_id();
         }
 
+        // Flat fast path: when arity >= num_sites, each site is its own
+        // group and the gather+broadcast decomposition collapses to a
+        // single flat all_gather. Dispatch directly to avoid the two
+        // separate gate synchronizations.
+        std::size_t const num_sites_val = hpx::get<0>(communicators.get_info());
+        std::size_t const arity_val = communicators.get_arity();
+
+        if (arity_val >= num_sites_val)
+        {
+            HPX_ASSERT(communicators.size() == 1);
+            return all_gather(communicators.get(0),
+                HPX_FORWARD(T, local_result), communicators.site(0),
+                generation);
+        }
+
         generation_arg const gather_gen(2 * generation - 1);
         generation_arg const broadcast_gen(2 * generation);
 

--- a/libs/full/collectives/include/hpx/collectives/all_gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_gather.hpp
@@ -417,13 +417,33 @@ namespace hpx::collectives {
             this_site = agas::get_locality_id();
         }
 
+        std::size_t const num_sites_val = hpx::get<0>(communicators.get_info());
+        std::size_t const arity_val = communicators.get_arity();
+
+        // The hierarchical helpers hardcode site 0 as the local root at
+        // every tree level, so a non-zero root is not supported.
+        if (root_site != 0)
+        {
+            return hpx::make_exceptional_future<std::vector<arg_type>>(
+                HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                    "hpx::collectives::all_gather (hierarchical)",
+                    "hierarchical all_gather currently supports only "
+                    "root_site == 0 (the tree designates site 0 as the root)"));
+        }
+
+        if (this_site >= num_sites_val)
+        {
+            return hpx::make_exceptional_future<std::vector<arg_type>>(
+                HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                    "hpx::collectives::all_gather (hierarchical)",
+                    "this_site must be smaller than the number of "
+                    "participating sites"));
+        }
+
         // Flat fast path: when arity >= num_sites, each site is its own
         // group and the gather+broadcast decomposition collapses to a
         // single flat all_gather. Dispatch directly to avoid the two
         // separate gate synchronizations.
-        std::size_t const num_sites_val = hpx::get<0>(communicators.get_info());
-        std::size_t const arity_val = communicators.get_arity();
-
         if (arity_val >= num_sites_val)
         {
             HPX_ASSERT(communicators.size() == 1);

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -457,13 +457,33 @@ namespace hpx::collectives {
             this_site = agas::get_locality_id();
         }
 
+        std::size_t const num_sites_val = hpx::get<0>(communicators.get_info());
+        std::size_t const arity_val = communicators.get_arity();
+
+        // The hierarchical helpers hardcode site 0 as the local root at
+        // every tree level, so a non-zero root is not supported.
+        if (root_site != 0)
+        {
+            return hpx::make_exceptional_future<arg_type>(
+                HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                    "hpx::collectives::all_reduce (hierarchical)",
+                    "hierarchical all_reduce currently supports only "
+                    "root_site == 0 (the tree designates site 0 as the root)"));
+        }
+
+        if (this_site >= num_sites_val)
+        {
+            return hpx::make_exceptional_future<arg_type>(
+                HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                    "hpx::collectives::all_reduce (hierarchical)",
+                    "this_site must be smaller than the number of "
+                    "participating sites"));
+        }
+
         // Flat fast path: when arity >= num_sites, each site is its own
         // group and the reduce+broadcast decomposition collapses to a
         // single flat all_reduce. Dispatch directly to avoid the two
         // separate gate synchronizations.
-        std::size_t const num_sites_val = hpx::get<0>(communicators.get_info());
-        std::size_t const arity_val = communicators.get_arity();
-
         if (arity_val >= num_sites_val)
         {
             HPX_ASSERT(communicators.size() == 1);

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -434,6 +434,10 @@ namespace hpx::collectives {
     // Hierarchical all_reduce: reduce (bottom-up) + broadcast (top-down)
     // Uses 2k-1/2k generation mapping: user generation k maps to
     // internal generation 2k-1 (reduce phase) and 2k (broadcast phase)
+    //
+    // An instance may be shared between all_reduce and all_gather (identical
+    // generation scheme), but not with other collectives; see the note on
+    // create_hierarchical_communicator.
     HPX_CXX_EXPORT template <typename T, typename F>
     hpx::future<std::decay_t<T>> all_reduce(
         hierarchical_communicator const& communicators, T&& local_result,
@@ -449,7 +453,7 @@ namespace hpx::collectives {
                 HPX_GET_EXCEPTION(hpx::error::bad_parameter,
                     "hpx::collectives::all_reduce (hierarchical)",
                     "hierarchical all_reduce requires an explicit generation "
-                    "number for the 2k/2k+1 internal mapping"));
+                    "number for the 2k-1/2k internal mapping"));
         }
 
         if (this_site.is_default())
@@ -480,10 +484,12 @@ namespace hpx::collectives {
                     "participating sites"));
         }
 
-        // Flat fast path: when arity >= num_sites, each site is its own
-        // group and the reduce+broadcast decomposition collapses to a
-        // single flat all_reduce. Dispatch directly to avoid the two
-        // separate gate synchronizations.
+        // Flat fast path: when arity >= num_sites, the tree builder's leaf
+        // condition (right - left < arity) fired at the root call and
+        // produced a single flat communicator spanning all sites. The
+        // reduce+broadcast decomposition then collapses to a single flat
+        // all_reduce; dispatch directly to avoid the two separate gate
+        // synchronizations.
         if (arity_val >= num_sites_val)
         {
             HPX_ASSERT(communicators.size() == 1);

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -457,6 +457,21 @@ namespace hpx::collectives {
             this_site = agas::get_locality_id();
         }
 
+        // Flat fast path: when arity >= num_sites, each site is its own
+        // group and the reduce+broadcast decomposition collapses to a
+        // single flat all_reduce. Dispatch directly to avoid the two
+        // separate gate synchronizations.
+        std::size_t const num_sites_val = hpx::get<0>(communicators.get_info());
+        std::size_t const arity_val = communicators.get_arity();
+
+        if (arity_val >= num_sites_val)
+        {
+            HPX_ASSERT(communicators.size() == 1);
+            return all_reduce(communicators.get(0),
+                HPX_FORWARD(T, local_result), HPX_FORWARD(F, op),
+                communicators.site(0), generation);
+        }
+
         generation_arg const reduce_gen(2 * generation - 1);
         generation_arg const broadcast_gen(2 * generation);
 

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -457,11 +457,14 @@ namespace hpx::collectives {
         std::size_t const num_sites_val = hpx::get<0>(communicators.get_info());
         std::size_t const arity_val = communicators.get_arity();
 
-        // Flat fallback: created by create_hierarchical_communicator when
-        // num_sites < threshold. All sites share a single flat communicator
-        // spanning all N sites. Delegate to the flat overload.
-        if (communicators.is_flat_fallback())
+        // Flat fast path: when arity >= num_sites (either because the user
+        // chose a large arity or because the factory overrode arity to
+        // num_sites for the flat fallback), each site is its own group and
+        // the 3-phase algorithm collapses to a flat all_to_all. Dispatch
+        // directly to avoid the intermediate allocations.
+        if (arity_val >= num_sites_val)
         {
+            HPX_ASSERT(communicators.size() == 1);
             return all_to_all(communicators.get(0), HPX_MOVE(local_result),
                 communicators.site(0), generation);
         }

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2019-2026 Hartmut Kaiser
+//  Copyright (c) 2026 Anshuman Agrawal
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -456,6 +457,29 @@ namespace hpx::collectives {
 
         std::size_t const num_sites_val = hpx::get<0>(communicators.get_info());
         std::size_t const arity_val = communicators.get_arity();
+
+        // An out-of-range site would classify into no top-level group and
+        // silently take the non-representative branch, hanging the gather.
+        if (this_site >= num_sites_val)
+        {
+            return hpx::make_exceptional_future<std::vector<T>>(
+                HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                    "hpx::collectives::all_to_all (hierarchical)",
+                    "this_site must be smaller than the number of "
+                    "participating sites"));
+        }
+
+        // The phase-2 packing slices each gathered contribution with
+        // unchecked iterator arithmetic, so a wrong-size contribution must
+        // be rejected client-side before any data is sent.
+        if (local_result.size() != num_sites_val)
+        {
+            return hpx::make_exceptional_future<std::vector<T>>(
+                HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                    "hpx::collectives::all_to_all (hierarchical)",
+                    "each participating site must contribute exactly "
+                    "num_sites elements"));
+        }
 
         // Flat fast path: when arity >= num_sites (either because the user
         // chose a large arity or because the factory overrode arity to

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -431,6 +431,10 @@ namespace hpx::collectives {
     //  - Inter-group communicator: k (exchange)
     // Each communicator sees consecutive generations starting at 1,
     // which is required by the and_gate synchronization mechanism.
+    //
+    // A hierarchical_communicator instance used with all_to_all must not be
+    // shared with other collective operations; see the note on
+    // create_hierarchical_communicator.
 
     // Async overload (declared above; default arguments live on that
     // forward declaration).
@@ -483,9 +487,11 @@ namespace hpx::collectives {
 
         // Flat fast path: when arity >= num_sites (either because the user
         // chose a large arity or because the factory overrode arity to
-        // num_sites for the flat fallback), each site is its own group and
-        // the 3-phase algorithm collapses to a flat all_to_all. Dispatch
-        // directly to avoid the intermediate allocations.
+        // num_sites for the flat fallback), the tree builder's leaf condition
+        // (right - left < arity) fired at the root call and produced a single
+        // flat communicator spanning all sites. The 3-phase algorithm then
+        // collapses to a flat all_to_all; dispatch directly to avoid the
+        // intermediate allocations.
         if (arity_val >= num_sites_val)
         {
             HPX_ASSERT(communicators.size() == 1);

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -211,6 +211,7 @@ namespace hpx { namespace collectives {
 
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 
+#include <hpx/assert.hpp>
 #include <hpx/collectives/argument_types.hpp>
 #include <hpx/collectives/create_communicator.hpp>
 #include <hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp>

--- a/libs/full/collectives/include/hpx/collectives/argument_types.hpp
+++ b/libs/full/collectives/include/hpx/collectives/argument_types.hpp
@@ -85,7 +85,7 @@ namespace hpx::collectives {
     HPX_CXX_EXPORT using tag_arg = detail::argument_type<detail::tag_tag, 0>;
 
     /// The number of children each of the communication nodes is connected
-    /// to (default: picked based on num_sites).
+    /// to (default: 2).
     HPX_CXX_EXPORT using arity_arg =
         detail::argument_type<detail::arity_tag, 2>;
 

--- a/libs/full/collectives/include/hpx/collectives/create_communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/create_communicator.hpp
@@ -102,12 +102,13 @@ namespace hpx { namespace collectives {
         generation_arg generation = generation_arg(),
         root_site_arg root_site = root_site_arg());
 
-    /// Create a new communicator object usable with any collective operation
+    /// Create a new hierarchical communicator object usable with collective
+    /// operations
     ///
     /// This functions creates a new hierarchical_communicator object that can
     /// be called in order to pre-allocate a communicator object usable with
-    /// multiple invocations of any of the collective operations (such as \a
-    /// all_gather, \a all_reduce, \a all_to_all, \a broadcast, etc.).
+    /// multiple invocations of a collective operation (such as \a all_gather,
+    /// \a all_reduce, \a all_to_all, \a broadcast, etc.).
     ///
     /// \param  basename    The base name identifying the collective operation
     /// \param  num_sites   The number of participating sites (default: all
@@ -126,6 +127,26 @@ namespace hpx { namespace collectives {
     /// \param  root_site   The site that is responsible for creating the
     ///                     collective support object. This value is optional
     ///                     and defaults to '0' (zero).
+    /// \param  threshold   The site-count threshold below which the
+    ///                     communicator collapses to a single flat
+    ///                     communicator spanning all sites (strict
+    ///                     comparison: num_sites < threshold). The default
+    ///                     is 16; pass 0 to disable the fallback and always
+    ///                     build a tree.
+    ///
+    /// \note   The sub-communicators of a hierarchical_communicator share
+    ///         one generation sequence per registered name, and the
+    ///         hierarchical collectives consume internal generations at
+    ///         different rates: \a broadcast and \a barrier consume one
+    ///         generation per call on every sub-communicator, \a all_gather
+    ///         and \a all_reduce consume two per call, and \a all_to_all
+    ///         consumes two per call on the subtree communicators but one on
+    ///         the inter-group communicator. A single
+    ///         hierarchical_communicator instance must therefore only be
+    ///         used with collective operations sharing one consumption
+    ///         scheme: \a all_gather and \a all_reduce may be mixed on one
+    ///         instance, while \a all_to_all, \a broadcast, and \a barrier
+    ///         each require their own instance.
     ///
     /// \returns    This function returns a new communicator object usable
     ///             with the collective operation.

--- a/libs/full/collectives/include/hpx/collectives/create_communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/create_communicator.hpp
@@ -300,13 +300,12 @@ namespace hpx::collectives {
         hierarchical_communicator(
             std::vector<hpx::tuple<communicator, this_site_arg>>&& comms,
             arity_arg arity, root_site_arg root_site, num_sites_arg num_sites,
-            this_site_arg this_site, bool flat_fallback) noexcept
+            this_site_arg this_site) noexcept
           : communicators(HPX_MOVE(comms))
           , num_sites(num_sites)
           , this_site(this_site)
           , root_site(root_site)
           , arity(arity)
-          , flat_fallback_(flat_fallback)
         {
         }
 
@@ -361,11 +360,6 @@ namespace hpx::collectives {
             return arity;
         }
 
-        [[nodiscard]] constexpr bool is_flat_fallback() const noexcept
-        {
-            return flat_fallback_;
-        }
-
         [[nodiscard]] HPX_EXPORT
             hpx::tuple<num_sites_arg, this_site_arg, root_site_arg>
             get_info_ex() const noexcept;
@@ -379,7 +373,6 @@ namespace hpx::collectives {
         this_site_arg this_site;
         root_site_arg root_site;
         arity_arg arity;
-        bool flat_fallback_ = false;
     };
 
     ///////////////////////////////////////////////////////////////////////////

--- a/libs/full/collectives/src/create_communicator.cpp
+++ b/libs/full/collectives/src/create_communicator.cpp
@@ -455,34 +455,21 @@ namespace hpx::collectives {
         }
 
         // Flat fallback: below the threshold, hierarchical overhead exceeds
-        // its benefit. Produce a single-level communicator spanning all N
-        // sites; the tree walking loops in the hierarchical collective
-        // overloads collapse to a single flat call when size() == 1 (this is
-        // also the code path non-leader sites take in normal tree mode). Pass
+        // its benefit. Override arity to num_sites so that each site becomes
+        // its own group; the tree builder then produces a single flat
+        // communicator and the hierarchical collective algorithms collapse to
+        // a direct flat call (same code path as arity >= num_sites). Pass
         // threshold == 0 to disable this fallback and always build a tree.
         if (num_sites < threshold)
         {
-            // Name the fallback communicator the same way the tree path would
-            // name a single top-level group, to avoid basename collisions with
-            // direct flat communicators using the bare basename.
-            std::string fallback_name(name);
-            fallback_name += "0-" +
-                std::to_string(static_cast<std::size_t>(num_sites) - 1) + "/";
-
-            auto c = create_communicator(fallback_name.c_str(), num_sites,
-                this_site, generation, root_site_arg(0));
-            std::vector<hpx::tuple<communicator, this_site_arg>> communicators;
-            communicators.emplace_back(HPX_MOVE(c), this_site);
-            return hierarchical_communicator(HPX_MOVE(communicators), arity,
-                root_site, num_sites, this_site,
-                /*flat_fallback=*/true);
+            arity = static_cast<std::size_t>(num_sites);
         }
 
         std::vector<hpx::tuple<communicator, this_site_arg>> communicators;
         recursively_fill_communicators(communicators, 0, num_sites - 1, name,
             arity, this_site, num_sites, generation);
-        return hierarchical_communicator(HPX_MOVE(communicators), arity,
-            root_site, num_sites, this_site, /*flat_fallback=*/false);
+        return hierarchical_communicator(
+            HPX_MOVE(communicators), arity, root_site, num_sites, this_site);
     }
 
     hpx::tuple<num_sites_arg, this_site_arg, root_site_arg>

--- a/libs/full/collectives/src/create_communicator.cpp
+++ b/libs/full/collectives/src/create_communicator.cpp
@@ -1,5 +1,6 @@
 //  Copyright (c) 2020-2026 Hartmut Kaiser
 //  Copyright (c) 2025 Lukas Zeil
+//  Copyright (c) 2026 Anshuman Agrawal
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -435,18 +436,27 @@ namespace hpx::collectives {
         if (this_site.is_default())
         {
             this_site = agas::get_locality_id();
-            if (root_site == static_cast<std::size_t>(-1))    //-V1051
-            {
-                root_site = 0;
-            }
+        }
+
+        if (root_site == static_cast<std::size_t>(-1))
+        {
+            root_site = 0;
         }
         if (root_site != 0)
         {
-            this_site = this_site - root_site % num_sites;
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "hpx::collectives::create_hierarchical_communicator",
+                "hierarchical communicators currently support only "
+                "root_site == 0");
         }
-        HPX_ASSERT(this_site < num_sites);
-        HPX_ASSERT(
-            root_site != static_cast<std::size_t>(-1) && root_site < num_sites);
+
+        if (num_sites == 0 || this_site >= num_sites)
+        {
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "hpx::collectives::create_hierarchical_communicator",
+                "num_sites must be non-zero and this_site must be smaller "
+                "than the number of participating sites");
+        }
 
         std::string name(basename);
         if (!generation.is_default())

--- a/libs/full/collectives/src/create_communicator.cpp
+++ b/libs/full/collectives/src/create_communicator.cpp
@@ -25,9 +25,6 @@
 #include <hpx/modules/synchronization.hpp>
 #include <hpx/modules/type_support.hpp>
 
-#include <hpx/collectives/argument_types.hpp>
-#include <hpx/collectives/create_communicator.hpp>
-
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
@@ -465,11 +462,12 @@ namespace hpx::collectives {
         }
 
         // Flat fallback: below the threshold, hierarchical overhead exceeds
-        // its benefit. Override arity to num_sites so that each site becomes
-        // its own group; the tree builder then produces a single flat
-        // communicator and the hierarchical collective algorithms collapse to
-        // a direct flat call (same code path as arity >= num_sites). Pass
-        // threshold == 0 to disable this fallback and always build a tree.
+        // its benefit. Overriding arity to num_sites makes the tree builder's
+        // leaf condition (right - left < arity) fire at the root call, which
+        // produces a single flat communicator spanning all sites; the
+        // hierarchical collectives dispatch on the same arity >= num_sites
+        // condition and collapse to a direct flat call. Pass threshold == 0
+        // to disable this fallback and always build a tree.
         if (num_sites < threshold)
         {
             arity = static_cast<std::size_t>(num_sites);

--- a/libs/full/collectives/tests/performance/benchmark_collectives.cpp
+++ b/libs/full/collectives/tests/performance/benchmark_collectives.cpp
@@ -16,6 +16,8 @@
 #include <hpx/modules/collectives.hpp>
 #include <hpx/modules/testing.hpp>
 
+#include <algorithm>
+#include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -30,6 +32,7 @@ constexpr char const* broadcast_direct_basename = "/test/broadcast_direct/";
 constexpr char const* gather_direct_basename = "/test/gather_direct/";
 constexpr char const* all_reduce_direct_basename = "/test/all_reduce_direct/";
 constexpr char const* all_gather_direct_basename = "/test/all_gather_direct/";
+constexpr char const* all_to_all_direct_basename = "/test/all_to_all_direct/";
 constexpr char const* barrier_bench_basename = "/test/barrier_bench/";
 
 struct vector_adder
@@ -174,7 +177,7 @@ void test_scatter_hierarchical(int arity, int lpn, std::size_t iterations,
     std::size_t const this_locality = hpx::get_locality_id();
     // Ensure at least two localities
     HPX_TEST_LTE(static_cast<std::size_t>(2), num_localities);
-    // Create hierchical communicators
+    // Create hierarchical communicators
     auto communicators =
         create_hierarchical_communicator(scatter_direct_basename,
             num_sites_arg(num_localities), this_site_arg(this_locality),
@@ -1242,6 +1245,76 @@ void test_all_gather_hierarchical(int arity, int lpn, std::size_t iterations,
             test_size, iterations, result);
     }
 }
+
+void test_all_to_all_hierarchical(int arity, int lpn, std::size_t iterations,
+    int test_size, std::string const& operation, int fallback_threshold)
+{
+    // Get parameters
+    std::size_t const num_localities =
+        hpx::get_num_localities(hpx::launch::sync);
+    std::size_t const this_locality = hpx::get_locality_id();
+    // Ensure at least two localities
+    HPX_TEST_LTE(static_cast<std::size_t>(2), num_localities);
+    // Create hierarchical communicators with optional threshold override
+    auto communicators =
+        create_hierarchical_communicator(all_to_all_direct_basename,
+            num_sites_arg(num_localities), this_site_arg(this_locality),
+            arity_arg(arity), generation_arg(1), root_site_arg(0),
+            fallback_threshold < 0 ?
+                flat_fallback_threshold_arg() :
+                flat_fallback_threshold_arg(
+                    static_cast<std::size_t>(fallback_threshold)));
+    // Barrier for synchronization
+    char const* const barrier_test_name = "/test/barrier/hierarchical";
+    hpx::distributed::barrier barrier(barrier_test_name);
+    // Result vector
+    std::vector<double> result(iterations, 0.0);
+    // The all_to_all payload contract requires exactly num_sites elements
+    // per site, so payload scaling happens through the per-destination
+    // block size.
+    std::size_t const block_size = std::max<std::size_t>(
+        1, static_cast<std::size_t>(test_size) / num_localities);
+    // Data
+    std::vector<std::vector<std::uint32_t>> send_data;
+    std::vector<std::vector<std::uint32_t>> recv_data;
+    for (std::size_t i = 0; i != iterations; ++i)
+    {
+        // Each destination block carries the source id
+        send_data.assign(num_localities,
+            std::vector<std::uint32_t>(
+                block_size, static_cast<std::uint32_t>(this_locality)));
+        // Time collective
+        hpx::chrono::high_resolution_timer const timer;
+        hpx::future<std::vector<std::vector<std::uint32_t>>> ft_data =
+            // NOLINTNEXTLINE(bugprone-use-after-move)
+            all_to_all(communicators, std::move(send_data),
+                this_site_arg(this_locality), generation_arg(i + 1));
+        recv_data = ft_data.get();
+        // Synchronize
+        barrier.wait();
+        // Write runtime into vector
+        result[i] = timer.elapsed();
+        // Check for correctness on the first iteration only: result block s
+        // originated at site s. Later iterations are timed unchecked.
+        if (i == 0)
+        {
+            HPX_TEST_EQ(recv_data.size(), num_localities);
+            for (std::size_t s = 0; s != num_localities; ++s)
+            {
+                HPX_TEST_EQ(recv_data[s].size(), block_size);
+                HPX_TEST_EQ(static_cast<std::size_t>(recv_data[s][0]), s);
+            }
+        }
+    }
+    if (this_locality == 0)
+    {
+        std::string const mod_name = fallback_threshold < 0 ?
+            std::string("hierarchical") :
+            "hierarchical_t" + std::to_string(fallback_threshold);
+        write_to_file(operation, mod_name, arity, num_localities, lpn,
+            test_size, iterations, result);
+    }
+}
 ////////////////////////////////////////////////////////////////////////////////////////
 void test_one_shot_use_all_gather(int lpn, std::size_t iterations,
     int test_size, std::string const& operation)
@@ -1436,6 +1509,14 @@ int hpx_main(hpx::program_options::variables_map& vm)
                     operation, fallback_threshold);
             }
         }
+        else if (operation == "all_to_all")
+        {
+            if (arity != -1)
+            {
+                test_all_to_all_hierarchical(arity, lpn, iterations, test_size,
+                    operation, fallback_threshold);
+            }
+        }
         else if (operation == "barrier")
         {
             if (arity == -1)
@@ -1470,7 +1551,7 @@ int main(int argc, char* argv[])
             "Number of Iteration the collective is executed")
         ("operation", value<std::string>()->default_value("scatter"),
             "Collective Operation (scatter, reduce, broadcast, gather, "
-            "all_reduce, all_gather, barrier)")
+            "all_reduce, all_gather, all_to_all, barrier)")
         ("fallback_threshold", value<int>()->default_value(-1),
             "Flat fallback threshold for hierarchical mode. -1 uses library "
             "default (16). Set to 0 to force tree construction. Only meaningful "

--- a/libs/full/collectives/tests/unit/CMakeLists.txt
+++ b/libs/full/collectives/tests/unit/CMakeLists.txt
@@ -17,6 +17,7 @@ set(tests
     broadcast_post
     broadcast_sync
     channel_communicator
+    cross_collective_hierarchical
     fold
     global_spmd_block
     hierarchical_helpers
@@ -51,6 +52,9 @@ if(HPX_WITH_NETWORKING)
   foreach(test ${tests})
     set(${test}_PARAMETERS LOCALITIES 2)
   endforeach()
+
+  # The flat-vs-tree comparison needs a real tree: num_sites > arity (= 2).
+  set(hierarchical_flat_fallback_PARAMETERS LOCALITIES 3)
 endif()
 foreach(test ${tests})
   set(sources ${test}.cpp)

--- a/libs/full/collectives/tests/unit/all_gather_hierarchical.cpp
+++ b/libs/full/collectives/tests/unit/all_gather_hierarchical.cpp
@@ -38,7 +38,8 @@ void test_multiple_use_with_generation(int arity = 2)
 
     auto const all_gather_clients = create_hierarchical_communicator(
         all_gather_direct_basename, num_sites_arg(num_localities),
-        this_site_arg(this_locality), arity_arg(arity));
+        this_site_arg(this_locality), arity_arg(arity), generation_arg(),
+        root_site_arg(), flat_fallback_threshold_arg(0));
 
     hpx::chrono::high_resolution_timer const t;
 
@@ -76,7 +77,8 @@ void test_local_use(std::uint32_t num_sites, int arity = 2)
         sites.push_back(hpx::async([=]() {
             auto const all_gather_clients = create_hierarchical_communicator(
                 all_gather_direct_basename, num_sites_arg(num_sites),
-                this_site_arg(site), arity_arg(arity));
+                this_site_arg(site), arity_arg(arity), generation_arg(),
+                root_site_arg(), flat_fallback_threshold_arg(0));
 
             hpx::chrono::high_resolution_timer const t;
 
@@ -113,6 +115,9 @@ void test_local_use(std::uint32_t num_sites, int arity = 2)
 // division_steps + remainder logic and degenerate single-site leaves.
 // This test exercises site counts that are not clean multiples of the
 // arity, including cases where recursion produces size-1 subgroups.
+// All site counts here are below the default flat-fallback threshold (16),
+// so the communicators must be created with flat_fallback_threshold_arg(0)
+// for these shapes to actually build trees.
 void test_non_power_of_arity()
 {
     // arity=2 with site counts that force uneven splits and odd-sized

--- a/libs/full/collectives/tests/unit/all_reduce_hierarchical.cpp
+++ b/libs/full/collectives/tests/unit/all_reduce_hierarchical.cpp
@@ -38,7 +38,8 @@ void test_multiple_use_with_generation(int arity = 2)
 
     auto const all_reduce_clients = create_hierarchical_communicator(
         all_reduce_direct_basename, num_sites_arg(num_localities),
-        this_site_arg(this_locality), arity_arg(arity));
+        this_site_arg(this_locality), arity_arg(arity), generation_arg(),
+        root_site_arg(), flat_fallback_threshold_arg(0));
 
     hpx::chrono::high_resolution_timer const t;
 
@@ -76,7 +77,8 @@ void test_local_use(std::uint32_t num_sites, int arity = 2)
         sites.push_back(hpx::async([=]() {
             auto const all_reduce_clients = create_hierarchical_communicator(
                 all_reduce_direct_basename, num_sites_arg(num_sites),
-                this_site_arg(site), arity_arg(arity));
+                this_site_arg(site), arity_arg(arity), generation_arg(),
+                root_site_arg(), flat_fallback_threshold_arg(0));
 
             hpx::chrono::high_resolution_timer const t;
 

--- a/libs/full/collectives/tests/unit/broadcast_hierarchical.cpp
+++ b/libs/full/collectives/tests/unit/broadcast_hierarchical.cpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2020-2025 Hartmut Kaiser
+//  Copyright (c) 2026 Anshuman Agrawal
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -37,7 +38,8 @@ void test_multiple_use(int arity = 2)
 
     auto const broadcast_clients = create_hierarchical_communicator(
         broadcast_direct_basename, num_sites_arg(num_localities),
-        this_site_arg(here), arity_arg(arity));
+        this_site_arg(here), arity_arg(arity), generation_arg(),
+        root_site_arg(), flat_fallback_threshold_arg(0));
 
     hpx::chrono::high_resolution_timer const t;
 
@@ -78,7 +80,8 @@ void test_multiple_use_with_generation(int arity = 2)
 
     auto const broadcast_clients = create_hierarchical_communicator(
         broadcast_direct_basename, num_sites_arg(num_localities),
-        this_site_arg(here), arity_arg(arity));
+        this_site_arg(here), arity_arg(arity), generation_arg(),
+        root_site_arg(), flat_fallback_threshold_arg(0));
 
     hpx::chrono::high_resolution_timer const t;
 
@@ -121,7 +124,8 @@ void test_local_use(std::uint32_t num_sites, int arity)
         sites.push_back(hpx::async([=]() {
             auto const broadcast_clients = create_hierarchical_communicator(
                 broadcast_direct_basename, num_sites_arg(num_sites),
-                this_site_arg(site), arity_arg(arity));
+                this_site_arg(site), arity_arg(arity), generation_arg(),
+                root_site_arg(), flat_fallback_threshold_arg(0));
 
             hpx::chrono::high_resolution_timer const t;
 

--- a/libs/full/collectives/tests/unit/cross_collective_hierarchical.cpp
+++ b/libs/full/collectives/tests/unit/cross_collective_hierarchical.cpp
@@ -1,0 +1,179 @@
+//  Copyright (c) 2026 Anshuman Agrawal
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Cross-collective use of hierarchical communicators. A single
+// hierarchical_communicator instance may only be shared by collectives with
+// the same internal generation-consumption scheme (see the note on
+// create_hierarchical_communicator in create_communicator.hpp): all_gather
+// and all_reduce both consume internal generations 2k-1/2k per call on every
+// sub-communicator and may be mixed on one instance, while all_to_all
+// consumes generations at a different rate and needs its own instance.
+//
+// Deliberately not tested: mixing all_to_all with all_reduce on a single
+// instance. That misuse desynchronizes the per-communicator generation
+// sequences, and its failure mode is a deadlock, which cannot be asserted
+// without timeout scaffolding.
+
+#include <hpx/config.hpp>
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/modules/collectives.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace hpx::collectives;
+
+constexpr int ITERATIONS = 4;
+
+// Interleave all_reduce and all_gather on one hierarchical communicator
+// instance, advancing a single shared, strictly consecutive user-generation
+// counter. This is legal because both operations consume the identical
+// 2k-1/2k internal generation scheme on every sub-communicator.
+void test_same_instance_all_reduce_all_gather()
+{
+    constexpr std::uint32_t num_sites = 8;
+
+    std::vector<hpx::future<void>> sites;
+    sites.reserve(num_sites);
+
+    for (std::uint32_t site = 0; site != num_sites; ++site)
+    {
+        sites.push_back(hpx::async([=]() {
+            auto const comms = create_hierarchical_communicator(
+                "/test/cross_collective/same_instance/",
+                num_sites_arg(num_sites), this_site_arg(site), arity_arg(2),
+                generation_arg(), root_site_arg(),
+                flat_fallback_threshold_arg(0));
+
+            std::size_t generation = 0;
+            for (int i = 0; i != ITERATIONS; ++i)
+            {
+                std::uint32_t const value = site + i;
+
+                std::uint32_t const reduced = all_reduce(hpx::launch::sync,
+                    comms, std::uint32_t(value), std::plus<std::uint32_t>{},
+                    this_site_arg(site), generation_arg(++generation));
+
+                std::uint32_t expected_sum = 0;
+                for (std::uint32_t j = 0; j != num_sites; ++j)
+                {
+                    expected_sum += j + i;
+                }
+                HPX_TEST_EQ(reduced, expected_sum);
+
+                std::vector<std::uint32_t> const gathered =
+                    all_gather(hpx::launch::sync, comms, std::uint32_t(value),
+                        this_site_arg(site), generation_arg(++generation));
+
+                HPX_TEST_EQ(
+                    gathered.size(), static_cast<std::size_t>(num_sites));
+                for (std::uint32_t j = 0; j != num_sites; ++j)
+                {
+                    HPX_TEST_EQ(gathered[j], j + i);
+                }
+            }
+        }));
+    }
+
+    hpx::wait_all(std::move(sites));
+}
+
+// Interleave all_to_all and all_reduce, each on its own hierarchical
+// communicator instance with an independent, strictly consecutive
+// user-generation counter. This pins the supported usage pattern under the
+// documented one-consumption-scheme-per-instance restriction.
+void test_separate_instances_all_to_all_all_reduce()
+{
+    constexpr std::uint32_t num_sites = 8;
+
+    std::vector<hpx::future<void>> sites;
+    sites.reserve(num_sites);
+
+    for (std::uint32_t site = 0; site != num_sites; ++site)
+    {
+        sites.push_back(hpx::async([=]() {
+            auto const a2a_comms = create_hierarchical_communicator(
+                "/test/cross_collective/separate_a2a/",
+                num_sites_arg(num_sites), this_site_arg(site), arity_arg(2),
+                generation_arg(), root_site_arg(),
+                flat_fallback_threshold_arg(0));
+
+            auto const reduce_comms = create_hierarchical_communicator(
+                "/test/cross_collective/separate_all_reduce/",
+                num_sites_arg(num_sites), this_site_arg(site), arity_arg(2),
+                generation_arg(), root_site_arg(),
+                flat_fallback_threshold_arg(0));
+
+            std::size_t a2a_generation = 0;
+            std::size_t reduce_generation = 0;
+            for (int i = 0; i != ITERATIONS; ++i)
+            {
+                std::vector<std::uint32_t> values(num_sites);
+                for (std::uint32_t j = 0; j != num_sites; ++j)
+                {
+                    values[j] = site * num_sites + j + i;
+                }
+
+                std::vector<std::uint32_t> const exchanged =
+                    all_to_all(hpx::launch::sync, a2a_comms, std::move(values),
+                        this_site_arg(site), generation_arg(++a2a_generation));
+
+                HPX_TEST_EQ(
+                    exchanged.size(), static_cast<std::size_t>(num_sites));
+                for (std::uint32_t s = 0; s != num_sites; ++s)
+                {
+                    HPX_TEST_EQ(exchanged[s], s * num_sites + site + i);
+                }
+
+                std::uint32_t const reduced = all_reduce(hpx::launch::sync,
+                    reduce_comms, std::uint32_t(site + i),
+                    std::plus<std::uint32_t>{}, this_site_arg(site),
+                    generation_arg(++reduce_generation));
+
+                std::uint32_t expected_sum = 0;
+                for (std::uint32_t j = 0; j != num_sites; ++j)
+                {
+                    expected_sum += j + i;
+                }
+                HPX_TEST_EQ(reduced, expected_sum);
+            }
+        }));
+    }
+
+    hpx::wait_all(std::move(sites));
+}
+
+int hpx_main()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        test_same_instance_all_reduce_all_gather();
+        test_separate_instances_all_to_all_all_reduce();
+    }
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> const cfg = {"hpx.run_hpx_main!=1"};
+
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ(hpx::init(argc, argv, init_args), 0);
+    return hpx::util::report_errors();
+}
+
+#endif

--- a/libs/full/collectives/tests/unit/gather_hierarchical.cpp
+++ b/libs/full/collectives/tests/unit/gather_hierarchical.cpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2020-2025 Hartmut Kaiser
+//  Copyright (c) 2026 Anshuman Agrawal
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -37,7 +38,8 @@ void test_multiple_use(int arity = 2)
     // test functionality based on immediate local result value
     auto const gather_clients = create_hierarchical_communicator(
         gather_direct_basename, num_sites_arg(num_localities),
-        this_site_arg(this_locality), arity_arg(arity));
+        this_site_arg(this_locality), arity_arg(arity), generation_arg(),
+        root_site_arg(), flat_fallback_threshold_arg(0));
 
     hpx::chrono::high_resolution_timer const t;
 
@@ -80,7 +82,8 @@ void test_multiple_use_with_generation(int arity = 2)
     // test functionality based on immediate local result value
     auto const gather_clients = create_hierarchical_communicator(
         gather_direct_basename, num_sites_arg(num_localities),
-        this_site_arg(this_locality), arity_arg(arity));
+        this_site_arg(this_locality), arity_arg(arity), generation_arg(),
+        root_site_arg(), flat_fallback_threshold_arg(0));
 
     hpx::chrono::high_resolution_timer const t;
 
@@ -126,7 +129,8 @@ void test_local_use(std::uint32_t num_sites, int arity = 2)
         sites.push_back(hpx::async([=]() {
             auto const gather_clients = create_hierarchical_communicator(
                 gather_direct_basename, num_sites_arg(num_sites),
-                this_site_arg(site), arity_arg(arity));
+                this_site_arg(site), arity_arg(arity), generation_arg(),
+                root_site_arg(), flat_fallback_threshold_arg(0));
 
             hpx::chrono::high_resolution_timer const t;
 

--- a/libs/full/collectives/tests/unit/hierarchical_flat_fallback.cpp
+++ b/libs/full/collectives/tests/unit/hierarchical_flat_fallback.cpp
@@ -52,17 +52,27 @@ void test_distributed_fallback()
     HPX_TEST_EQ(fb_result, expected);
 
     // Force the tree path by setting threshold to 0; results must match.
-    auto const tree_clients = create_hierarchical_communicator(
-        "/test/hflback_dist_tree/", num_sites_arg(num_localities),
-        this_site_arg(this_locality), arity_arg(2), generation_arg(),
-        root_site_arg(0), flat_fallback_threshold_arg(0));
+    // With 2 localities and arity 2 a tree is structurally impossible
+    // (arity >= num_sites dispatches flat), so this leg needs at least 3.
+    if (num_localities >= 3)
+    {
+        auto const tree_clients = create_hierarchical_communicator(
+            "/test/hflback_dist_tree/", num_sites_arg(num_localities),
+            this_site_arg(this_locality), arity_arg(2), generation_arg(),
+            root_site_arg(0), flat_fallback_threshold_arg(0));
 
-    std::uint32_t const tree_result = all_reduce(tree_clients,
-        std::uint32_t(value), std::plus<std::uint32_t>{},
-        this_site_arg(this_locality), generation_arg(1))
-                                          .get();
+        // Assert the dispatch predicate so the comparison can never
+        // silently degenerate to flat-vs-flat.
+        HPX_TEST_LT(static_cast<std::size_t>(tree_clients.get_arity()),
+            static_cast<std::size_t>(num_localities));
 
-    HPX_TEST_EQ(tree_result, expected);
+        std::uint32_t const tree_result = all_reduce(tree_clients,
+            std::uint32_t(value), std::plus<std::uint32_t>{},
+            this_site_arg(this_locality), generation_arg(1))
+                                              .get();
+
+        HPX_TEST_EQ(tree_result, expected);
+    }
 }
 
 // Distributed test for all_to_all flat fallback: mirrors test_distributed_fallback
@@ -107,28 +117,38 @@ void test_distributed_fallback_all_to_all()
         HPX_TEST_EQ(fb_result[i], expected[i]);
     }
 
-    // Force tree path; results must match.
-    auto const tree_clients = create_hierarchical_communicator(
-        "/test/hflback_dist_a2a_tree/", num_sites_arg(num_localities),
-        this_site_arg(this_locality), arity_arg(2), generation_arg(),
-        root_site_arg(0), flat_fallback_threshold_arg(0));
-
-    auto const tree_result =
-        all_to_all(tree_clients, std::vector<std::uint32_t>(send_data),
-            this_site_arg(this_locality), generation_arg(1))
-            .get();
-
-    HPX_TEST_EQ(tree_result.size(), expected.size());
-    for (std::size_t i = 0; i != expected.size(); ++i)
+    // Force tree path; results must match. With 2 localities and arity 2 a
+    // tree is structurally impossible (arity >= num_sites dispatches flat),
+    // so this leg needs at least 3.
+    if (num_localities >= 3)
     {
-        HPX_TEST_EQ(tree_result[i], expected[i]);
+        auto const tree_clients = create_hierarchical_communicator(
+            "/test/hflback_dist_a2a_tree/", num_sites_arg(num_localities),
+            this_site_arg(this_locality), arity_arg(2), generation_arg(),
+            root_site_arg(0), flat_fallback_threshold_arg(0));
+
+        // Assert the dispatch predicate so the comparison can never
+        // silently degenerate to flat-vs-flat.
+        HPX_TEST_LT(static_cast<std::size_t>(tree_clients.get_arity()),
+            static_cast<std::size_t>(num_localities));
+
+        auto const tree_result =
+            all_to_all(tree_clients, std::vector<std::uint32_t>(send_data),
+                this_site_arg(this_locality), generation_arg(1))
+                .get();
+
+        HPX_TEST_EQ(tree_result.size(), expected.size());
+        for (std::size_t i = 0; i != expected.size(); ++i)
+        {
+            HPX_TEST_EQ(tree_result[i], expected[i]);
+        }
     }
 }
 
-// Local test (single-process, multi-thread sites): verifies that the fallback
-// works for a range of site counts below the default threshold, exercised
-// from locality 0 only.
-void test_local_fallback(std::uint32_t num_sites)
+// Local test (single-process, multi-thread sites), exercised from locality 0
+// only and parameterized over the fallback threshold: 1024 forces the flat
+// path, 0 forces the tree path.
+void test_local_fallback(std::uint32_t num_sites, std::size_t threshold)
 {
     std::vector<hpx::future<void>> sites;
     sites.reserve(num_sites);
@@ -136,12 +156,24 @@ void test_local_fallback(std::uint32_t num_sites)
     for (std::uint32_t site = 0; site != num_sites; ++site)
     {
         sites.push_back(hpx::async([=]() {
+            std::string const basename =
+                "/test/hflback_local_t" + std::to_string(threshold) + "/";
             auto const clients = create_hierarchical_communicator(
-                "/test/hflback_local/", num_sites_arg(num_sites),
-                this_site_arg(site), arity_arg(2), generation_arg(),
-                root_site_arg(0), flat_fallback_threshold_arg(1024));
+                basename.c_str(), num_sites_arg(num_sites), this_site_arg(site),
+                arity_arg(2), generation_arg(), root_site_arg(0),
+                flat_fallback_threshold_arg(threshold));
 
-            HPX_TEST_EQ(clients.size(), static_cast<std::size_t>(1));
+            if (threshold == 0)
+            {
+                // Assert the dispatch predicate so the comparison can never
+                // silently degenerate to flat-vs-flat.
+                HPX_TEST_LT(static_cast<std::size_t>(clients.get_arity()),
+                    static_cast<std::size_t>(num_sites));
+            }
+            else
+            {
+                HPX_TEST_EQ(clients.size(), static_cast<std::size_t>(1));
+            }
 
             std::uint32_t const value = site + 1;
             std::uint32_t const result = all_reduce(clients,
@@ -161,9 +193,11 @@ void test_local_fallback(std::uint32_t num_sites)
     hpx::wait_all(std::move(sites));
 }
 
-// Local all_to_all flat fallback test: exercises the arity_val >= num_sites_val
-// branch in the hierarchical all_to_all overload from a single process.
-void test_local_fallback_all_to_all(std::uint32_t num_sites)
+// Local all_to_all test, parameterized over the fallback threshold like
+// test_local_fallback: 1024 exercises the arity_val >= num_sites_val flat
+// dispatch branch, 0 exercises the 3-phase tree path.
+void test_local_fallback_all_to_all(
+    std::uint32_t num_sites, std::size_t threshold)
 {
     std::vector<hpx::future<void>> sites;
     sites.reserve(num_sites);
@@ -171,12 +205,24 @@ void test_local_fallback_all_to_all(std::uint32_t num_sites)
     for (std::uint32_t site = 0; site != num_sites; ++site)
     {
         sites.push_back(hpx::async([=]() {
+            std::string const basename =
+                "/test/hflback_local_a2a_t" + std::to_string(threshold) + "/";
             auto const clients = create_hierarchical_communicator(
-                "/test/hflback_local_a2a/", num_sites_arg(num_sites),
-                this_site_arg(site), arity_arg(2), generation_arg(),
-                root_site_arg(0), flat_fallback_threshold_arg(1024));
+                basename.c_str(), num_sites_arg(num_sites), this_site_arg(site),
+                arity_arg(2), generation_arg(), root_site_arg(0),
+                flat_fallback_threshold_arg(threshold));
 
-            HPX_TEST_EQ(clients.size(), static_cast<std::size_t>(1));
+            if (threshold == 0)
+            {
+                // Assert the dispatch predicate so the comparison can never
+                // silently degenerate to flat-vs-flat.
+                HPX_TEST_LT(static_cast<std::size_t>(clients.get_arity()),
+                    static_cast<std::size_t>(num_sites));
+            }
+            else
+            {
+                HPX_TEST_EQ(clients.size(), static_cast<std::size_t>(1));
+            }
 
             // Site s sends {s*N+0, ..., s*N+(N-1)}
             std::vector<std::uint32_t> send_data(num_sites);
@@ -213,10 +259,19 @@ int hpx_main()
 
     if (hpx::get_locality_id() == 0)
     {
+        // Flat legs: threshold above all site counts forces the fallback.
         for (std::uint32_t n : {2u, 4u, 8u})
         {
-            test_local_fallback(n);
-            test_local_fallback_all_to_all(n);
+            test_local_fallback(n, 1024);
+            test_local_fallback_all_to_all(n, 1024);
+        }
+
+        // Tree legs: threshold 0 forces real trees (n == 2 cannot tree at
+        // arity 2 because arity >= num_sites dispatches flat).
+        for (std::uint32_t n : {3u, 5u, 8u})
+        {
+            test_local_fallback(n, 0);
+            test_local_fallback_all_to_all(n, 0);
         }
     }
 

--- a/libs/full/collectives/tests/unit/hierarchical_flat_fallback.cpp
+++ b/libs/full/collectives/tests/unit/hierarchical_flat_fallback.cpp
@@ -65,6 +65,66 @@ void test_distributed_fallback()
     HPX_TEST_EQ(tree_result, expected);
 }
 
+// Distributed test for all_to_all flat fallback: mirrors test_distributed_fallback
+// but exercises the all_to_all flat dispatch branch (arity_val >= num_sites_val).
+void test_distributed_fallback_all_to_all()
+{
+    std::uint32_t const this_locality = hpx::get_locality_id();
+    std::uint32_t const num_localities =
+        hpx::get_num_localities(hpx::launch::sync);
+    HPX_TEST_LTE(static_cast<std::uint32_t>(2), num_localities);
+
+    // Site s sends {s*N+0, s*N+1, ..., s*N+(N-1)}
+    std::vector<std::uint32_t> send_data(num_localities);
+    for (std::uint32_t d = 0; d != num_localities; ++d)
+    {
+        send_data[d] = this_locality * num_localities + d;
+    }
+
+    // Expected: result[i] = i * N + this_locality
+    std::vector<std::uint32_t> expected(num_localities);
+    for (std::uint32_t i = 0; i != num_localities; ++i)
+    {
+        expected[i] = i * num_localities + this_locality;
+    }
+
+    // Force flat fallback path.
+    auto const fb_clients = create_hierarchical_communicator(
+        "/test/hflback_dist_a2a_fb/", num_sites_arg(num_localities),
+        this_site_arg(this_locality), arity_arg(2), generation_arg(),
+        root_site_arg(0), flat_fallback_threshold_arg(1024));
+
+    HPX_TEST_EQ(fb_clients.size(), static_cast<std::size_t>(1));
+
+    auto const fb_result =
+        all_to_all(fb_clients, std::vector<std::uint32_t>(send_data),
+            this_site_arg(this_locality), generation_arg(1))
+            .get();
+
+    HPX_TEST_EQ(fb_result.size(), expected.size());
+    for (std::size_t i = 0; i != expected.size(); ++i)
+    {
+        HPX_TEST_EQ(fb_result[i], expected[i]);
+    }
+
+    // Force tree path; results must match.
+    auto const tree_clients = create_hierarchical_communicator(
+        "/test/hflback_dist_a2a_tree/", num_sites_arg(num_localities),
+        this_site_arg(this_locality), arity_arg(2), generation_arg(),
+        root_site_arg(0), flat_fallback_threshold_arg(0));
+
+    auto const tree_result =
+        all_to_all(tree_clients, std::vector<std::uint32_t>(send_data),
+            this_site_arg(this_locality), generation_arg(1))
+            .get();
+
+    HPX_TEST_EQ(tree_result.size(), expected.size());
+    for (std::size_t i = 0; i != expected.size(); ++i)
+    {
+        HPX_TEST_EQ(tree_result[i], expected[i]);
+    }
+}
+
 // Local test (single-process, multi-thread sites): verifies that the fallback
 // works for a range of site counts below the default threshold, exercised
 // from locality 0 only.
@@ -101,12 +161,53 @@ void test_local_fallback(std::uint32_t num_sites)
     hpx::wait_all(std::move(sites));
 }
 
+// Local all_to_all flat fallback test: exercises the arity_val >= num_sites_val
+// branch in the hierarchical all_to_all overload from a single process.
+void test_local_fallback_all_to_all(std::uint32_t num_sites)
+{
+    std::vector<hpx::future<void>> sites;
+    sites.reserve(num_sites);
+
+    for (std::uint32_t site = 0; site != num_sites; ++site)
+    {
+        sites.push_back(hpx::async([=]() {
+            auto const clients = create_hierarchical_communicator(
+                "/test/hflback_local_a2a/", num_sites_arg(num_sites),
+                this_site_arg(site), arity_arg(2), generation_arg(),
+                root_site_arg(0), flat_fallback_threshold_arg(1024));
+
+            HPX_TEST_EQ(clients.size(), static_cast<std::size_t>(1));
+
+            // Site s sends {s*N+0, ..., s*N+(N-1)}
+            std::vector<std::uint32_t> send_data(num_sites);
+            for (std::uint32_t d = 0; d != num_sites; ++d)
+            {
+                send_data[d] = site * num_sites + d;
+            }
+
+            auto const result = all_to_all(clients, HPX_MOVE(send_data),
+                this_site_arg(site), generation_arg(1))
+                                    .get();
+
+            // Expected: result[i] = i * N + site
+            HPX_TEST_EQ(result.size(), static_cast<std::size_t>(num_sites));
+            for (std::uint32_t i = 0; i != num_sites; ++i)
+            {
+                HPX_TEST_EQ(result[i], i * num_sites + site);
+            }
+        }));
+    }
+
+    hpx::wait_all(std::move(sites));
+}
+
 int hpx_main()
 {
 #if defined(HPX_HAVE_NETWORKING)
     if (hpx::get_num_localities(hpx::launch::sync) > 1)
     {
         test_distributed_fallback();
+        test_distributed_fallback_all_to_all();
     }
 #endif
 
@@ -115,6 +216,7 @@ int hpx_main()
         for (std::uint32_t n : {2u, 4u, 8u})
         {
             test_local_fallback(n);
+            test_local_fallback_all_to_all(n);
         }
     }
 

--- a/libs/full/collectives/tests/unit/reduce_hierarchical.cpp
+++ b/libs/full/collectives/tests/unit/reduce_hierarchical.cpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2019-2025 Hartmut Kaiser
+//  Copyright (c) 2026 Anshuman Agrawal
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -36,7 +37,8 @@ void test_multiple_use(int arity = 2)
 
     auto const reduce_clients = create_hierarchical_communicator(
         reduce_direct_basename, num_sites_arg(num_localities),
-        this_site_arg(this_locality), arity_arg(arity));
+        this_site_arg(this_locality), arity_arg(arity), generation_arg(),
+        root_site_arg(), flat_fallback_threshold_arg(0));
 
     hpx::chrono::high_resolution_timer const t;
 
@@ -81,7 +83,8 @@ void test_multiple_use_with_generation(int arity = 2)
 
     auto const reduce_clients = create_hierarchical_communicator(
         reduce_direct_basename, num_sites_arg(num_localities),
-        this_site_arg(this_locality), arity_arg(arity));
+        this_site_arg(this_locality), arity_arg(arity), generation_arg(),
+        root_site_arg(), flat_fallback_threshold_arg(0));
 
     hpx::chrono::high_resolution_timer const t;
 
@@ -130,7 +133,8 @@ void test_local_use(std::uint32_t num_sites, int arity = 2)
         sites.push_back(hpx::async([=]() {
             auto const reduce_clients = create_hierarchical_communicator(
                 reduce_direct_basename, num_sites_arg(num_sites),
-                this_site_arg(site), arity_arg(arity));
+                this_site_arg(site), arity_arg(arity), generation_arg(),
+                root_site_arg(), flat_fallback_threshold_arg(0));
 
             hpx::chrono::high_resolution_timer const t;
 

--- a/libs/full/collectives/tests/unit/scatter_hierarchical.cpp
+++ b/libs/full/collectives/tests/unit/scatter_hierarchical.cpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2020-2025 Hartmut Kaiser
+//  Copyright (c) 2026 Anshuman Agrawal
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -39,7 +40,8 @@ void test_multiple_use(int arity = 2)
 
     auto const scatter_clients = create_hierarchical_communicator(
         scatter_direct_basename, num_sites_arg(num_localities),
-        this_site_arg(this_locality), arity_arg(arity));
+        this_site_arg(this_locality), arity_arg(arity), generation_arg(),
+        root_site_arg(), flat_fallback_threshold_arg(0));
 
     hpx::chrono::high_resolution_timer const t;
 
@@ -83,7 +85,8 @@ void test_multiple_use_with_generation(int arity = 2)
 
     auto const scatter_clients = create_hierarchical_communicator(
         scatter_direct_basename, num_sites_arg(num_localities),
-        this_site_arg(this_locality), arity_arg(arity));
+        this_site_arg(this_locality), arity_arg(arity), generation_arg(),
+        root_site_arg(), flat_fallback_threshold_arg(0));
 
     hpx::chrono::high_resolution_timer const t;
 
@@ -128,7 +131,8 @@ void test_local_use(std::uint32_t num_sites, int arity = 2)
         sites.push_back(hpx::async([=]() {
             auto const scatter_clients = create_hierarchical_communicator(
                 scatter_direct_basename, num_sites_arg(num_sites),
-                this_site_arg(site), arity_arg(arity));
+                this_site_arg(site), arity_arg(arity), generation_arg(),
+                root_site_arg(), flat_fallback_threshold_arg(0));
 
             hpx::chrono::high_resolution_timer const t;
 


### PR DESCRIPTION
## Proposed Changes

- Remove the `flat_fallback_` bool from `hierarchical_communicator` (follow-up to the flat_fallback thread in #7307). The factory overrides arity to num_sites below the threshold, so the tree builder naturally produces a single flat communicator, and all three hierarchical collectives dispatch flat on the same `arity >= num_sites` condition. The flat dispatch in `all_gather`/`all_reduce` is new and saves one gate synchronization per call.
- Validate user input: `all_to_all` rejects an out of range `this_site` (previously hung) and a wrong size `local_result` (previously unchecked iterator arithmetic). `all_gather`/`all_reduce` reject `root_site != 0` and out of range `this_site`. The factory throws on non zero root sites (replacing a broken renumbering), `num_sites == 0`, and `this_site >= num_sites`.
- Restore tree coverage: six older hierarchical tests never passed a threshold, so all local cases below 16 sites silently ran the flat path. They now pass `flat_fallback_threshold_arg(0)`; all newly exercised tree paths pass.
- De-vacuize `hierarchical_flat_fallback`: tree legs assert `arity < num_sites`, the test runs at 3 localities, local tree legs added for 3, 5 and 8 sites.
- Add `cross_collective_hierarchical`, pinning the sharing contract: `all_reduce` and `all_gather` may share one instance, `all_to_all` needs its own.
- Fix documentation: wrong fallback mechanism comments, undocumented `threshold` parameter, 2k/2k+1 error messages (the mapping is 2k-1/2k), wrong `arity_arg` default, and the claim that one hierarchical communicator works with any mix of collectives (replaced by the actual generation consumption contract).
- Add `all_to_all` to `benchmark_collectives`, mirroring the `all_gather` benchmark.

## Any background context you want to provide?

Full collectives test suite (52 tests, including multi locality legs) passes locally.

Questions for reviewers:
1. Keep and validate `root_site` in hierarchical `all_gather`/`all_reduce`, or drop the parameter?
2. Bump the six older hierarchical tests to LOCALITIES 3 (at 2 localities with arity 2 their distributed legs always dispatch flat), or keep CI cost down?

## Checklist

- [x] added a new feature and have added tests to go along with it.
- [x] fixed a bug and have added a regression test.