### PR TITLE
Improve collective benchmark

### DIFF
--- a/libs/full/collectives/tests/performance/benchmark_collectives.cpp
+++ b/libs/full/collectives/tests/performance/benchmark_collectives.cpp
@@ -22,6 +22,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <map>
 #include <numeric>
 #include <string>
 #include <vector>
@@ -1744,6 +1745,17 @@ void test_multiple_use_with_generation_all_gather(int lpn,
             test_size, warmup_iterations, iterations, std::move(result));
     }
 }
+struct benchmarking_functions
+{
+    hpx::function<void(int, std::size_t, std::size_t, int, std::string const&)>
+        one_shot;
+    hpx::function<void(int, std::size_t, std::size_t, int, std::string const&)>
+        multiple_use;
+    hpx::function<void(
+        int, int, std::size_t, std::size_t, int, std::string const&, int)>
+        hierarchical;
+};
+
 int hpx_main(hpx::program_options::variables_map& vm)
 {
     int const arity = vm["arity"].as<int>();
@@ -1763,149 +1775,61 @@ int hpx_main(hpx::program_options::variables_map& vm)
 
     if (hpx::get_num_localities(hpx::launch::sync) > 1)
     {
-        if (operation == "scatter")
+        std::map<std::string, benchmarking_functions> const benchmarking = {
+            {"scatter",
+                {test_one_shot_use_scatter,
+                    test_multiple_use_with_generation_scatter,
+                    test_scatter_hierarchical}},
+            {"reduce",
+                {test_one_shot_use_reduce,
+                    test_multiple_use_with_generation_reduce,
+                    test_reduce_hierarchical}},
+            {"broadcast",
+                {test_one_shot_use_broadcast,
+                    test_multiple_use_with_generation_broadcast,
+                    test_broadcast_hierarchical}},
+            {"gather",
+                {test_one_shot_use_gather,
+                    test_multiple_use_with_generation_gather,
+                    test_gather_hierarchical}},
+            {"all_reduce",
+                {test_one_shot_use_all_reduce,
+                    test_multiple_use_with_generation_all_reduce,
+                    test_all_reduce_hierarchical}},
+            {"all_gather",
+                {test_one_shot_use_all_gather,
+                    test_multiple_use_with_generation_all_gather,
+                    test_all_gather_hierarchical}},
+            {"all_to_all",
+                {test_one_shot_use_all_to_all,
+                    test_multiple_use_with_generation_all_to_all,
+                    test_all_to_all_hierarchical}},
+            {"barrier",
+                {test_one_shot_use_barrier,
+                    test_multiple_use_with_generation_barrier,
+                    test_barrier_hierarchical}},
+        };
+
+        auto it = benchmarking.find(operation);
+        if (it == benchmarking.end())
         {
-            if (arity == -1)
-            {
-                test_one_shot_use_scatter(lpn, iterations,
-                    static_cast<std::size_t>(warmup_iterations), test_size,
-                    operation);
-                test_multiple_use_with_generation_scatter(lpn, iterations,
-                    static_cast<std::size_t>(warmup_iterations), test_size,
-                    operation);
-            }
-            else
-            {
-                test_scatter_hierarchical(arity, lpn, iterations,
-                    static_cast<std::size_t>(warmup_iterations), test_size,
-                    operation, fallback_threshold);
-            }
+            std::cout << "error: unknown operation '" << operation << "'\n";
+            return hpx::finalize();
         }
-        else if (operation == "reduce")
+        if (arity == -1)
         {
-            if (arity == -1)
-            {
-                test_one_shot_use_reduce(lpn, iterations,
-                    static_cast<std::size_t>(warmup_iterations), test_size,
-                    operation);
-                test_multiple_use_with_generation_reduce(lpn, iterations,
-                    static_cast<std::size_t>(warmup_iterations), test_size,
-                    operation);
-            }
-            else
-            {
-                test_reduce_hierarchical(arity, lpn, iterations,
-                    static_cast<std::size_t>(warmup_iterations), test_size,
-                    operation, fallback_threshold);
-            }
+            it->second.one_shot(lpn, iterations,
+                static_cast<std::size_t>(warmup_iterations), test_size,
+                operation);
+            it->second.multiple_use(lpn, iterations,
+                static_cast<std::size_t>(warmup_iterations), test_size,
+                operation);
         }
-        else if (operation == "broadcast")
+        else
         {
-            if (arity == -1)
-            {
-                test_one_shot_use_broadcast(lpn, iterations,
-                    static_cast<std::size_t>(warmup_iterations), test_size,
-                    operation);
-                test_multiple_use_with_generation_broadcast(lpn, iterations,
-                    static_cast<std::size_t>(warmup_iterations), test_size,
-                    operation);
-            }
-            else
-            {
-                test_broadcast_hierarchical(arity, lpn, iterations,
-                    static_cast<std::size_t>(warmup_iterations), test_size,
-                    operation, fallback_threshold);
-            }
-        }
-        else if (operation == "gather")
-        {
-            if (arity == -1)
-            {
-                test_one_shot_use_gather(lpn, iterations,
-                    static_cast<std::size_t>(warmup_iterations), test_size,
-                    operation);
-                test_multiple_use_with_generation_gather(lpn, iterations,
-                    static_cast<std::size_t>(warmup_iterations), test_size,
-                    operation);
-            }
-            else
-            {
-                test_gather_hierarchical(arity, lpn, iterations,
-                    static_cast<std::size_t>(warmup_iterations), test_size,
-                    operation, fallback_threshold);
-            }
-        }
-        else if (operation == "all_reduce")
-        {
-            if (arity == -1)
-            {
-                test_one_shot_use_all_reduce(lpn, iterations,
-                    static_cast<std::size_t>(warmup_iterations), test_size,
-                    operation);
-                test_multiple_use_with_generation_all_reduce(lpn, iterations,
-                    static_cast<std::size_t>(warmup_iterations), test_size,
-                    operation);
-            }
-            else
-            {
-                test_all_reduce_hierarchical(arity, lpn, iterations,
-                    static_cast<std::size_t>(warmup_iterations), test_size,
-                    operation, fallback_threshold);
-            }
-        }
-        else if (operation == "all_gather")
-        {
-            if (arity == -1)
-            {
-                test_one_shot_use_all_gather(lpn, iterations,
-                    static_cast<std::size_t>(warmup_iterations), test_size,
-                    operation);
-                test_multiple_use_with_generation_all_gather(lpn, iterations,
-                    static_cast<std::size_t>(warmup_iterations), test_size,
-                    operation);
-            }
-            else
-            {
-                test_all_gather_hierarchical(arity, lpn, iterations,
-                    static_cast<std::size_t>(warmup_iterations), test_size,
-                    operation, fallback_threshold);
-            }
-        }
-        else if (operation == "all_to_all")
-        {
-            if (arity == -1)
-            {
-                test_one_shot_use_all_to_all(lpn, iterations,
-                    static_cast<std::size_t>(warmup_iterations), test_size,
-                    operation);
-                test_multiple_use_with_generation_all_to_all(lpn, iterations,
-                    static_cast<std::size_t>(warmup_iterations), test_size,
-                    operation);
-            }
-            else
-            {
-                test_all_to_all_hierarchical(arity, lpn, iterations,
-                    static_cast<std::size_t>(warmup_iterations), test_size,
-                    operation, fallback_threshold);
-            }
-        }
-        else if (operation == "barrier")
-        {
-            if (arity == -1)
-            {
-                test_one_shot_use_barrier(lpn, iterations,
-                    static_cast<std::size_t>(warmup_iterations), test_size,
-                    operation);
-                test_multiple_use_with_generation_barrier(lpn, iterations,
-                    static_cast<std::size_t>(warmup_iterations), test_size,
-                    operation);
-            }
-            else
-            {
-                test_barrier_hierarchical(arity, lpn, iterations,
-                    static_cast<std::size_t>(warmup_iterations), test_size,
-                    operation, fallback_threshold);
-            }
+            it->second.hierarchical(arity, lpn, iterations,
+                static_cast<std::size_t>(warmup_iterations), test_size,
+                operation, fallback_threshold);
         }
     }
 

--- a/libs/full/collectives/tests/performance/benchmark_collectives.cpp
+++ b/libs/full/collectives/tests/performance/benchmark_collectives.cpp
@@ -265,19 +265,11 @@ void test_scatter_hierarchical(int arity, int lpn, std::size_t iterations,
         }
         recv_data = ft_data.get();
         // Reduce max elapsed time to root
-        if (this_locality == 0)
-        {
-            double const max_elapsed = reduce_here(hpx::launch::sync,
-                timing_comm, timer.elapsed(), double_max{},
-                generation_arg(i + 1));
-            if (i >= warmup_iterations)
-                result[i - warmup_iterations] = max_elapsed;
-        }
-        else
-        {
-            reduce_there(hpx::launch::sync, timing_comm,
-                timer.elapsed(), generation_arg(i + 1));
-        }
+        double max_elapsed = timer.elapsed();
+        reduce(timing_comm, max_elapsed, double_max{},
+            this_site_arg(this_locality), generation_arg(i + 1));
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
 
         // Check for correctness
         for (int check : recv_data)
@@ -352,19 +344,11 @@ void test_reduce_hierarchical(int arity, int lpn, std::size_t iterations,
             finished.get();
         }
         // Reduce max elapsed time to root
-        if (this_locality == 0)
-        {
-            double const max_elapsed = reduce_here(hpx::launch::sync,
-                timing_comm, timer.elapsed(), double_max{},
-                generation_arg(i + 1));
-            if (i >= warmup_iterations)
-                result[i - warmup_iterations] = max_elapsed;
-        }
-        else
-        {
-            reduce_there(hpx::launch::sync, timing_comm,
-                timer.elapsed(), generation_arg(i + 1));
-        }
+        double max_elapsed = timer.elapsed();
+        reduce(timing_comm, max_elapsed, double_max{},
+            this_site_arg(this_locality), generation_arg(i + 1));
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
 
         // Check for correctness
         if (this_locality == 0)
@@ -434,19 +418,11 @@ void test_broadcast_hierarchical(int arity, int lpn, std::size_t iterations,
         }
         recv_data = ft_data.get();
         // Reduce max elapsed time to root
-        if (this_locality == 0)
-        {
-            double const max_elapsed = reduce_here(hpx::launch::sync,
-                timing_comm, timer.elapsed(), double_max{},
-                generation_arg(i + 1));
-            if (i >= warmup_iterations)
-                result[i - warmup_iterations] = max_elapsed;
-        }
-        else
-        {
-            reduce_there(hpx::launch::sync, timing_comm,
-                timer.elapsed(), generation_arg(i + 1));
-        }
+        double max_elapsed = timer.elapsed();
+        reduce(timing_comm, max_elapsed, double_max{},
+            this_site_arg(this_locality), generation_arg(i + 1));
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
 
         // Check for correctness
         if (this_locality == 0)
@@ -518,19 +494,11 @@ void test_gather_hierarchical(int arity, int lpn, std::size_t iterations,
             finished.get();
         }
         // Reduce max elapsed time to root
-        if (this_locality == 0)
-        {
-            double const max_elapsed = reduce_here(hpx::launch::sync,
-                timing_comm, timer.elapsed(), double_max{},
-                generation_arg(i + 1));
-            if (i >= warmup_iterations)
-                result[i - warmup_iterations] = max_elapsed;
-        }
-        else
-        {
-            reduce_there(hpx::launch::sync, timing_comm,
-                timer.elapsed(), generation_arg(i + 1));
-        }
+        double max_elapsed = timer.elapsed();
+        reduce(timing_comm, max_elapsed, double_max{},
+            this_site_arg(this_locality), generation_arg(i + 1));
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
 
         // Check for correctness
         if (this_locality == 0)
@@ -596,19 +564,11 @@ void test_all_reduce_hierarchical(int arity, int lpn, std::size_t iterations,
         recv_data = ft_data.get();
 
         // Reduce max elapsed time to root
-        if (this_locality == 0)
-        {
-            double const max_elapsed = reduce_here(hpx::launch::sync,
-                timing_comm, timer.elapsed(), double_max{},
-                generation_arg(i + 1));
-            if (i >= warmup_iterations)
-                result[i - warmup_iterations] = max_elapsed;
-        }
-        else
-        {
-            reduce_there(hpx::launch::sync, timing_comm,
-                timer.elapsed(), generation_arg(i + 1));
-        }
+        double max_elapsed = timer.elapsed();
+        reduce(timing_comm, max_elapsed, double_max{},
+            this_site_arg(this_locality), generation_arg(i + 1));
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
 
         // Check for correctness: every site should have the sum
         HPX_TEST_EQ(static_cast<int>(i) * static_cast<int>(num_localities),
@@ -656,19 +616,11 @@ void test_barrier_hierarchical(int arity, int lpn, std::size_t iterations,
             communicators, this_site_arg(this_locality), generation_arg(i + 1))
             .get();
         // Reduce max elapsed time to root
-        if (this_locality == 0)
-        {
-            double const max_elapsed = reduce_here(hpx::launch::sync,
-                timing_comm, timer.elapsed(), double_max{},
-                generation_arg(i + 1));
-            if (i >= warmup_iterations)
-                result[i - warmup_iterations] = max_elapsed;
-        }
-        else
-        {
-            reduce_there(hpx::launch::sync, timing_comm,
-                timer.elapsed(), generation_arg(i + 1));
-        }
+        double max_elapsed = timer.elapsed();
+        reduce(timing_comm, max_elapsed, double_max{},
+            this_site_arg(this_locality), generation_arg(i + 1));
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
     }
 
     if (this_locality == 0)
@@ -738,19 +690,11 @@ void test_one_shot_use_scatter(int lpn, std::size_t iterations,
         }
         recv_data = ft_data.get();
         // Reduce max elapsed time to root
-        if (this_locality == 0)
-        {
-            double const max_elapsed = reduce_here(hpx::launch::sync,
-                timing_comm, timer.elapsed(), double_max{},
-                generation_arg(i + 1));
-            if (i >= warmup_iterations)
-                result[i - warmup_iterations] = max_elapsed;
-        }
-        else
-        {
-            reduce_there(hpx::launch::sync, timing_comm,
-                timer.elapsed(), generation_arg(i + 1));
-        }
+        double max_elapsed = timer.elapsed();
+        reduce(timing_comm, max_elapsed, double_max{},
+            this_site_arg(this_locality), generation_arg(i + 1));
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
 
         // Check for correctness
         for (int check : recv_data)
@@ -812,19 +756,11 @@ void test_one_shot_use_reduce(int lpn, std::size_t iterations,
             finished.get();
         }
         // Reduce max elapsed time to root
-        if (this_locality == 0)
-        {
-            double const max_elapsed = reduce_here(hpx::launch::sync,
-                timing_comm, timer.elapsed(), double_max{},
-                generation_arg(i + 1));
-            if (i >= warmup_iterations)
-                result[i - warmup_iterations] = max_elapsed;
-        }
-        else
-        {
-            reduce_there(hpx::launch::sync, timing_comm,
-                timer.elapsed(), generation_arg(i + 1));
-        }
+        double max_elapsed = timer.elapsed();
+        reduce(timing_comm, max_elapsed, double_max{},
+            this_site_arg(this_locality), generation_arg(i + 1));
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
 
         // Check for correctness
         if (this_locality == 0)
@@ -883,19 +819,11 @@ void test_one_shot_use_broadcast(int lpn, std::size_t iterations,
         }
         recv_data = ft_data.get();
         // Reduce max elapsed time to root
-        if (this_locality == 0)
-        {
-            double const max_elapsed = reduce_here(hpx::launch::sync,
-                timing_comm, timer.elapsed(), double_max{},
-                generation_arg(i + 1));
-            if (i >= warmup_iterations)
-                result[i - warmup_iterations] = max_elapsed;
-        }
-        else
-        {
-            reduce_there(hpx::launch::sync, timing_comm,
-                timer.elapsed(), generation_arg(i + 1));
-        }
+        double max_elapsed = timer.elapsed();
+        reduce(timing_comm, max_elapsed, double_max{},
+            this_site_arg(this_locality), generation_arg(i + 1));
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
 
         // Check for correctness
         if (this_locality == 0)
@@ -955,19 +883,11 @@ void test_one_shot_use_gather(int lpn, std::size_t iterations,
             finished.get();
         }
         // Reduce max elapsed time to root
-        if (this_locality == 0)
-        {
-            double const max_elapsed = reduce_here(hpx::launch::sync,
-                timing_comm, timer.elapsed(), double_max{},
-                generation_arg(i + 1));
-            if (i >= warmup_iterations)
-                result[i - warmup_iterations] = max_elapsed;
-        }
-        else
-        {
-            reduce_there(hpx::launch::sync, timing_comm,
-                timer.elapsed(), generation_arg(i + 1));
-        }
+        double max_elapsed = timer.elapsed();
+        reduce(timing_comm, max_elapsed, double_max{},
+            this_site_arg(this_locality), generation_arg(i + 1));
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
 
         // Check for correctness
         if (this_locality == 0)
@@ -1020,19 +940,11 @@ void test_one_shot_use_all_reduce(int lpn, std::size_t iterations,
                 this_site_arg(this_locality), generation_arg(i + 1));
         recv_data = ft_data.get();
         // Reduce max elapsed time to root
-        if (this_locality == 0)
-        {
-            double const max_elapsed = reduce_here(hpx::launch::sync,
-                timing_comm, timer.elapsed(), double_max{},
-                generation_arg(i + 1));
-            if (i >= warmup_iterations)
-                result[i - warmup_iterations] = max_elapsed;
-        }
-        else
-        {
-            reduce_there(hpx::launch::sync, timing_comm,
-                timer.elapsed(), generation_arg(i + 1));
-        }
+        double max_elapsed = timer.elapsed();
+        reduce(timing_comm, max_elapsed, double_max{},
+            this_site_arg(this_locality), generation_arg(i + 1));
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
 
         // Check for correctness
         HPX_TEST_EQ(static_cast<int>(i) * static_cast<int>(num_localities),
@@ -1106,19 +1018,11 @@ void test_multiple_use_with_generation_scatter(int lpn, std::size_t iterations,
         }
         recv_data = ft_data.get();
         // Reduce max elapsed time to root
-        if (this_locality == 0)
-        {
-            double const max_elapsed = reduce_here(hpx::launch::sync,
-                timing_comm, timer.elapsed(), double_max{},
-                generation_arg(i + 1));
-            if (i >= warmup_iterations)
-                result[i - warmup_iterations] = max_elapsed;
-        }
-        else
-        {
-            reduce_there(hpx::launch::sync, timing_comm,
-                timer.elapsed(), generation_arg(i + 1));
-        }
+        double max_elapsed = timer.elapsed();
+        reduce(timing_comm, max_elapsed, double_max{},
+            this_site_arg(this_locality), generation_arg(i + 1));
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
 
         // Check for correctness
         for (int check : recv_data)
@@ -1182,19 +1086,11 @@ void test_multiple_use_with_generation_reduce(int lpn, std::size_t iterations,
             finished.get();
         }
         // Reduce max elapsed time to root
-        if (this_locality == 0)
-        {
-            double const max_elapsed = reduce_here(hpx::launch::sync,
-                timing_comm, timer.elapsed(), double_max{},
-                generation_arg(i + 1));
-            if (i >= warmup_iterations)
-                result[i - warmup_iterations] = max_elapsed;
-        }
-        else
-        {
-            reduce_there(hpx::launch::sync, timing_comm,
-                timer.elapsed(), generation_arg(i + 1));
-        }
+        double max_elapsed = timer.elapsed();
+        reduce(timing_comm, max_elapsed, double_max{},
+            this_site_arg(this_locality), generation_arg(i + 1));
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
 
         // Check for correctness
         if (this_locality == 0)
@@ -1256,19 +1152,11 @@ void test_multiple_use_with_generation_broadcast(int lpn,
         }
         recv_data = ft_data.get();
         // Reduce max elapsed time to root
-        if (this_locality == 0)
-        {
-            double const max_elapsed = reduce_here(hpx::launch::sync,
-                timing_comm, timer.elapsed(), double_max{},
-                generation_arg(i + 1));
-            if (i >= warmup_iterations)
-                result[i - warmup_iterations] = max_elapsed;
-        }
-        else
-        {
-            reduce_there(hpx::launch::sync, timing_comm,
-                timer.elapsed(), generation_arg(i + 1));
-        }
+        double max_elapsed = timer.elapsed();
+        reduce(timing_comm, max_elapsed, double_max{},
+            this_site_arg(this_locality), generation_arg(i + 1));
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
 
         // Check for correctness
         if (this_locality == 0)
@@ -1330,19 +1218,11 @@ void test_multiple_use_with_generation_gather(int lpn, std::size_t iterations,
             finished.get();
         }
         // Reduce max elapsed time to root
-        if (this_locality == 0)
-        {
-            double const max_elapsed = reduce_here(hpx::launch::sync,
-                timing_comm, timer.elapsed(), double_max{},
-                generation_arg(i + 1));
-            if (i >= warmup_iterations)
-                result[i - warmup_iterations] = max_elapsed;
-        }
-        else
-        {
-            reduce_there(hpx::launch::sync, timing_comm,
-                timer.elapsed(), generation_arg(i + 1));
-        }
+        double max_elapsed = timer.elapsed();
+        reduce(timing_comm, max_elapsed, double_max{},
+            this_site_arg(this_locality), generation_arg(i + 1));
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
 
         // Check for correctness
         if (this_locality == 0)
@@ -1399,19 +1279,11 @@ void test_multiple_use_with_generation_all_reduce(int lpn,
                 vector_adder{}, generation_arg(i + 1));
         recv_data = ft_data.get();
         // Reduce max elapsed time to root
-        if (this_locality == 0)
-        {
-            double const max_elapsed = reduce_here(hpx::launch::sync,
-                timing_comm, timer.elapsed(), double_max{},
-                generation_arg(i + 1));
-            if (i >= warmup_iterations)
-                result[i - warmup_iterations] = max_elapsed;
-        }
-        else
-        {
-            reduce_there(hpx::launch::sync, timing_comm,
-                timer.elapsed(), generation_arg(i + 1));
-        }
+        double max_elapsed = timer.elapsed();
+        reduce(timing_comm, max_elapsed, double_max{},
+            this_site_arg(this_locality), generation_arg(i + 1));
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
 
         // Check for correctness
         HPX_TEST_EQ(static_cast<int>(i) * static_cast<int>(num_localities),
@@ -1449,19 +1321,11 @@ void test_multiple_use_with_generation_barrier(int lpn, std::size_t iterations,
             barrier_client, this_site_arg(this_locality), generation_arg(i + 1))
             .get();
         // Reduce max elapsed time to root
-        if (this_locality == 0)
-        {
-            double const max_elapsed = reduce_here(hpx::launch::sync,
-                timing_comm, timer.elapsed(), double_max{},
-                generation_arg(i + 1));
-            if (i >= warmup_iterations)
-                result[i - warmup_iterations] = max_elapsed;
-        }
-        else
-        {
-            reduce_there(hpx::launch::sync, timing_comm,
-                timer.elapsed(), generation_arg(i + 1));
-        }
+        double max_elapsed = timer.elapsed();
+        reduce(timing_comm, max_elapsed, double_max{},
+            this_site_arg(this_locality), generation_arg(i + 1));
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
     }
 
     if (this_locality == 0)
@@ -1512,19 +1376,11 @@ void test_all_gather_hierarchical(int arity, int lpn, std::size_t iterations,
                 this_site_arg(this_locality), generation_arg(i + 1));
         recv_data = ft_data.get();
         // Reduce max elapsed time to root
-        if (this_locality == 0)
-        {
-            double const max_elapsed = reduce_here(hpx::launch::sync,
-                timing_comm, timer.elapsed(), double_max{},
-                generation_arg(i + 1));
-            if (i >= warmup_iterations)
-                result[i - warmup_iterations] = max_elapsed;
-        }
-        else
-        {
-            reduce_there(hpx::launch::sync, timing_comm,
-                timer.elapsed(), generation_arg(i + 1));
-        }
+        double max_elapsed = timer.elapsed();
+        reduce(timing_comm, max_elapsed, double_max{},
+            this_site_arg(this_locality), generation_arg(i + 1));
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
         // Check for correctness: every site contributed (i + site), so
         // recv_data[j][0] must equal (i + j) at every site.
         for (int j = 0; j < static_cast<int>(num_localities); ++j)
@@ -1596,19 +1452,11 @@ void test_all_to_all_hierarchical(int arity, int lpn, std::size_t iterations,
                 this_site_arg(this_locality), generation_arg(i + 1));
         recv_data = ft_data.get();
         // Reduce max elapsed time to root
-        if (this_locality == 0)
-        {
-            double const max_elapsed = reduce_here(hpx::launch::sync,
-                timing_comm, timer.elapsed(), double_max{},
-                generation_arg(i + 1));
-            if (i >= warmup_iterations)
-                result[i - warmup_iterations] = max_elapsed;
-        }
-        else
-        {
-            reduce_there(hpx::launch::sync, timing_comm,
-                timer.elapsed(), generation_arg(i + 1));
-        }
+        double max_elapsed = timer.elapsed();
+        reduce(timing_comm, max_elapsed, double_max{},
+            this_site_arg(this_locality), generation_arg(i + 1));
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
         // Correctness: recv_data[s][*] == s + this_locality + i
         HPX_TEST_EQ(recv_data.size(), num_localities);
         for (std::size_t s = 0; s != num_localities; ++s)
@@ -1660,19 +1508,11 @@ void test_one_shot_use_all_gather(int lpn, std::size_t iterations,
                 generation_arg(i + 1));
         recv_data = ft_data.get();
         // Reduce max elapsed time to root
-        if (this_locality == 0)
-        {
-            double const max_elapsed = reduce_here(hpx::launch::sync,
-                timing_comm, timer.elapsed(), double_max{},
-                generation_arg(i + 1));
-            if (i >= warmup_iterations)
-                result[i - warmup_iterations] = max_elapsed;
-        }
-        else
-        {
-            reduce_there(hpx::launch::sync, timing_comm,
-                timer.elapsed(), generation_arg(i + 1));
-        }
+        double max_elapsed = timer.elapsed();
+        reduce(timing_comm, max_elapsed, double_max{},
+            this_site_arg(this_locality), generation_arg(i + 1));
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
         // Check for correctness
         for (int j = 0; j < static_cast<int>(num_localities); ++j)
         {
@@ -1722,19 +1562,11 @@ void test_multiple_use_with_generation_all_gather(int lpn,
                 generation_arg(i + 1));
         recv_data = ft_data.get();
         // Reduce max elapsed time to root
-        if (this_locality == 0)
-        {
-            double const max_elapsed = reduce_here(hpx::launch::sync,
-                timing_comm, timer.elapsed(), double_max{},
-                generation_arg(i + 1));
-            if (i >= warmup_iterations)
-                result[i - warmup_iterations] = max_elapsed;
-        }
-        else
-        {
-            reduce_there(hpx::launch::sync, timing_comm,
-                timer.elapsed(), generation_arg(i + 1));
-        }
+        double max_elapsed = timer.elapsed();
+        reduce(timing_comm, max_elapsed, double_max{},
+            this_site_arg(this_locality), generation_arg(i + 1));
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
         // Check for correctness
         for (int j = 0; j < static_cast<int>(num_localities); ++j)
         {

--- a/libs/full/collectives/tests/performance/benchmark_collectives.cpp
+++ b/libs/full/collectives/tests/performance/benchmark_collectives.cpp
@@ -1297,6 +1297,46 @@ void test_multiple_use_with_generation_all_reduce(int lpn,
     }
 }
 
+void test_one_shot_use_barrier(int lpn, std::size_t iterations,
+    std::size_t warmup_iterations, int test_size, std::string const& operation)
+{
+    std::size_t const num_localities =
+        hpx::get_num_localities(hpx::launch::sync);
+    std::size_t const this_locality = hpx::get_locality_id();
+    HPX_TEST_LTE(static_cast<std::size_t>(2), num_localities);
+    char const* const barrier_sync_name = "/test/barrier/single";
+    hpx::distributed::barrier sync(barrier_sync_name);
+    auto const timing_comm =
+        create_communicator("/test/timing_reduce/barrier/one_shot/",
+            num_sites_arg(num_localities), this_site_arg(this_locality));
+    std::vector<double> result(iterations, 0.0);
+
+    for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
+    {
+        // Create a new communicator per iteration (one-shot semantics)
+        auto const barrier_comm = create_communicator(barrier_bench_basename,
+            num_sites_arg(num_localities), this_site_arg(this_locality),
+            generation_arg(i + 1));
+        sync.wait();
+        hpx::chrono::high_resolution_timer const timer;
+        hpx::collectives::barrier(
+            barrier_comm, this_site_arg(this_locality), generation_arg(1))
+            .get();
+        // Reduce max elapsed time to root
+        double max_elapsed = timer.elapsed();
+        reduce(timing_comm, max_elapsed, double_max{},
+            this_site_arg(this_locality), generation_arg(i + 1));
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
+    }
+
+    if (this_locality == 0)
+    {
+        write_to_file(operation, "single_use", -1, num_localities, lpn,
+            test_size, warmup_iterations, iterations, std::move(result));
+    }
+}
+
 void test_multiple_use_with_generation_barrier(int lpn, std::size_t iterations,
     std::size_t warmup_iterations, int test_size, std::string const& operation)
 {
@@ -1853,6 +1893,9 @@ int hpx_main(hpx::program_options::variables_map& vm)
         {
             if (arity == -1)
             {
+                test_one_shot_use_barrier(lpn, iterations,
+                    static_cast<std::size_t>(warmup_iterations), test_size,
+                    operation);
                 test_multiple_use_with_generation_barrier(lpn, iterations,
                     static_cast<std::size_t>(warmup_iterations), test_size,
                     operation);

--- a/libs/full/collectives/tests/performance/benchmark_collectives.cpp
+++ b/libs/full/collectives/tests/performance/benchmark_collectives.cpp
@@ -232,7 +232,7 @@ void test_scatter_hierarchical(int arity, int lpn, std::size_t iterations, std::
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
     auto const timing_comm =
-        create_communicator("/test/timing_reduce/scatter/",
+        create_communicator("/test/timing_reduce/scatter/hierarchical/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
@@ -275,13 +275,22 @@ void test_scatter_hierarchical(int arity, int lpn, std::size_t iterations, std::
                 this_site_arg(this_locality), generation_arg(i + 1));
         }
         recv_data = ft_data.get();
-        // Reduce max elapsed time across all localities
-        double const max_elapsed =
-            all_reduce(timing_comm, timer.elapsed(), double_max{},
-                this_site_arg(this_locality), generation_arg(i + 1))
+        // Reduce max elapsed time to root
+        if (this_locality == 0)
+        {
+            double const max_elapsed =
+                reduce_here(timing_comm, timer.elapsed(), double_max{},
+                    generation_arg(i + 1))
+                    .get();
+            if (i >= warmup_iterations)
+                result[i - warmup_iterations] = max_elapsed;
+        }
+        else
+        {
+            reduce_there(timing_comm, timer.elapsed(),
+                generation_arg(i + 1))
                 .get();
-        if (i >= warmup_iterations)
-            result[i - warmup_iterations] = max_elapsed;
+        }
 
         // Check for correctness
         for (int check : recv_data)
@@ -323,7 +332,7 @@ void test_reduce_hierarchical(int arity, int lpn, std::size_t iterations, std::s
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
     auto const timing_comm =
-        create_communicator("/test/timing_reduce/reduce/",
+        create_communicator("/test/timing_reduce/reduce/hierarchical/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
@@ -354,13 +363,22 @@ void test_reduce_hierarchical(int arity, int lpn, std::size_t iterations, std::s
                 this_site_arg(this_locality), generation_arg(i + 1));
             finished.get();
         }
-        // Reduce max elapsed time across all localities
-        double const max_elapsed =
-            all_reduce(timing_comm, timer.elapsed(), double_max{},
-                this_site_arg(this_locality), generation_arg(i + 1))
+        // Reduce max elapsed time to root
+        if (this_locality == 0)
+        {
+            double const max_elapsed =
+                reduce_here(timing_comm, timer.elapsed(), double_max{},
+                    generation_arg(i + 1))
+                    .get();
+            if (i >= warmup_iterations)
+                result[i - warmup_iterations] = max_elapsed;
+        }
+        else
+        {
+            reduce_there(timing_comm, timer.elapsed(),
+                generation_arg(i + 1))
                 .get();
-        if (i >= warmup_iterations)
-            result[i - warmup_iterations] = max_elapsed;
+        }
 
         // Check for correctness
         if (this_locality == 0)
@@ -403,7 +421,7 @@ void test_broadcast_hierarchical(int arity, int lpn, std::size_t iterations, std
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
     auto const timing_comm =
-        create_communicator("/test/timing_reduce/broadcast/",
+        create_communicator("/test/timing_reduce/broadcast/hierarchical/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
@@ -433,13 +451,22 @@ void test_broadcast_hierarchical(int arity, int lpn, std::size_t iterations, std
                 this_site_arg(this_locality), generation_arg(i + 1));
         }
         recv_data = ft_data.get();
-        // Reduce max elapsed time across all localities
-        double const max_elapsed =
-            all_reduce(timing_comm, timer.elapsed(), double_max{},
-                this_site_arg(this_locality), generation_arg(i + 1))
+        // Reduce max elapsed time to root
+        if (this_locality == 0)
+        {
+            double const max_elapsed =
+                reduce_here(timing_comm, timer.elapsed(), double_max{},
+                    generation_arg(i + 1))
+                    .get();
+            if (i >= warmup_iterations)
+                result[i - warmup_iterations] = max_elapsed;
+        }
+        else
+        {
+            reduce_there(timing_comm, timer.elapsed(),
+                generation_arg(i + 1))
                 .get();
-        if (i >= warmup_iterations)
-            result[i - warmup_iterations] = max_elapsed;
+        }
 
         // Check for correctness
         if (this_locality == 0)
@@ -481,7 +508,7 @@ void test_gather_hierarchical(int arity, int lpn, std::size_t iterations, std::s
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
     auto const timing_comm =
-        create_communicator("/test/timing_reduce/gather/",
+        create_communicator("/test/timing_reduce/gather/hierarchical/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
@@ -512,13 +539,22 @@ void test_gather_hierarchical(int arity, int lpn, std::size_t iterations, std::s
                     this_site_arg(this_locality), generation_arg(i + 1));
             finished.get();
         }
-        // Reduce max elapsed time across all localities
-        double const max_elapsed =
-            all_reduce(timing_comm, timer.elapsed(), double_max{},
-                this_site_arg(this_locality), generation_arg(i + 1))
+        // Reduce max elapsed time to root
+        if (this_locality == 0)
+        {
+            double const max_elapsed =
+                reduce_here(timing_comm, timer.elapsed(), double_max{},
+                    generation_arg(i + 1))
+                    .get();
+            if (i >= warmup_iterations)
+                result[i - warmup_iterations] = max_elapsed;
+        }
+        else
+        {
+            reduce_there(timing_comm, timer.elapsed(),
+                generation_arg(i + 1))
                 .get();
-        if (i >= warmup_iterations)
-            result[i - warmup_iterations] = max_elapsed;
+        }
 
         // Check for correctness
         if (this_locality == 0)
@@ -563,7 +599,7 @@ void test_all_reduce_hierarchical(int arity, int lpn, std::size_t iterations, st
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
     auto const timing_comm =
-        create_communicator("/test/timing_reduce/all_reduce/",
+        create_communicator("/test/timing_reduce/all_reduce/hierarchical/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
@@ -583,13 +619,22 @@ void test_all_reduce_hierarchical(int arity, int lpn, std::size_t iterations, st
                 this_site_arg(this_locality), generation_arg(i + 1));
         recv_data = ft_data.get();
 
-        // Reduce max elapsed time across all localities
-        double const max_elapsed =
-            all_reduce(timing_comm, timer.elapsed(), double_max{},
-                this_site_arg(this_locality), generation_arg(i + 1))
+        // Reduce max elapsed time to root
+        if (this_locality == 0)
+        {
+            double const max_elapsed =
+                reduce_here(timing_comm, timer.elapsed(), double_max{},
+                    generation_arg(i + 1))
+                    .get();
+            if (i >= warmup_iterations)
+                result[i - warmup_iterations] = max_elapsed;
+        }
+        else
+        {
+            reduce_there(timing_comm, timer.elapsed(),
+                generation_arg(i + 1))
                 .get();
-        if (i >= warmup_iterations)
-            result[i - warmup_iterations] = max_elapsed;
+        }
 
         // Check for correctness: every site should have the sum
         HPX_TEST_EQ(static_cast<int>(i) * static_cast<int>(num_localities), recv_data[0]);
@@ -623,7 +668,7 @@ void test_barrier_hierarchical(int arity, int lpn, std::size_t iterations, std::
     char const* const barrier_sync_name = "/test/barrier/hierarchical";
     hpx::distributed::barrier sync(barrier_sync_name);
     auto const timing_comm =
-        create_communicator("/test/timing_reduce/barrier/",
+        create_communicator("/test/timing_reduce/barrier/hierarchical/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
 
@@ -634,13 +679,22 @@ void test_barrier_hierarchical(int arity, int lpn, std::size_t iterations, std::
         hpx::collectives::barrier(
             communicators, this_site_arg(this_locality), generation_arg(i + 1))
             .get();
-        // Reduce max elapsed time across all localities
-        double const max_elapsed =
-            all_reduce(timing_comm, timer.elapsed(), double_max{},
-                this_site_arg(this_locality), generation_arg(i + 1))
+        // Reduce max elapsed time to root
+        if (this_locality == 0)
+        {
+            double const max_elapsed =
+                reduce_here(timing_comm, timer.elapsed(), double_max{},
+                    generation_arg(i + 1))
+                    .get();
+            if (i >= warmup_iterations)
+                result[i - warmup_iterations] = max_elapsed;
+        }
+        else
+        {
+            reduce_there(timing_comm, timer.elapsed(),
+                generation_arg(i + 1))
                 .get();
-        if (i >= warmup_iterations)
-            result[i - warmup_iterations] = max_elapsed;
+        }
     }
 
     if (this_locality == 0)
@@ -669,7 +723,7 @@ void test_one_shot_use_scatter(int lpn, std::size_t iterations, std::size_t warm
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
     auto const timing_comm =
-        create_communicator("/test/timing_reduce/scatter/",
+        create_communicator("/test/timing_reduce/scatter/one_shot/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
@@ -713,13 +767,22 @@ void test_one_shot_use_scatter(int lpn, std::size_t iterations, std::size_t warm
                 this_site_arg(this_locality), generation_arg(i + 1));
         }
         recv_data = ft_data.get();
-        // Reduce max elapsed time across all localities
-        double const max_elapsed =
-            all_reduce(timing_comm, timer.elapsed(), double_max{},
-                this_site_arg(this_locality), generation_arg(i + 1))
+        // Reduce max elapsed time to root
+        if (this_locality == 0)
+        {
+            double const max_elapsed =
+                reduce_here(timing_comm, timer.elapsed(), double_max{},
+                    generation_arg(i + 1))
+                    .get();
+            if (i >= warmup_iterations)
+                result[i - warmup_iterations] = max_elapsed;
+        }
+        else
+        {
+            reduce_there(timing_comm, timer.elapsed(),
+                generation_arg(i + 1))
                 .get();
-        if (i >= warmup_iterations)
-            result[i - warmup_iterations] = max_elapsed;
+        }
 
         // Check for correctness
         for (int check : recv_data)
@@ -749,7 +812,7 @@ void test_one_shot_use_reduce(int lpn, std::size_t iterations, std::size_t warmu
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
     auto const timing_comm =
-        create_communicator("/test/timing_reduce/reduce/",
+        create_communicator("/test/timing_reduce/reduce/one_shot/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
@@ -780,13 +843,22 @@ void test_one_shot_use_reduce(int lpn, std::size_t iterations, std::size_t warmu
                     this_site_arg(this_locality), generation_arg(i + 1));
             finished.get();
         }
-        // Reduce max elapsed time across all localities
-        double const max_elapsed =
-            all_reduce(timing_comm, timer.elapsed(), double_max{},
-                this_site_arg(this_locality), generation_arg(i + 1))
+        // Reduce max elapsed time to root
+        if (this_locality == 0)
+        {
+            double const max_elapsed =
+                reduce_here(timing_comm, timer.elapsed(), double_max{},
+                    generation_arg(i + 1))
+                    .get();
+            if (i >= warmup_iterations)
+                result[i - warmup_iterations] = max_elapsed;
+        }
+        else
+        {
+            reduce_there(timing_comm, timer.elapsed(),
+                generation_arg(i + 1))
                 .get();
-        if (i >= warmup_iterations)
-            result[i - warmup_iterations] = max_elapsed;
+        }
 
         // Check for correctness
         if (this_locality == 0)
@@ -817,7 +889,7 @@ void test_one_shot_use_broadcast(int lpn, std::size_t iterations, std::size_t wa
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
     auto const timing_comm =
-        create_communicator("/test/timing_reduce/broadcast/",
+        create_communicator("/test/timing_reduce/broadcast/one_shot/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
@@ -849,13 +921,22 @@ void test_one_shot_use_broadcast(int lpn, std::size_t iterations, std::size_t wa
                     this_site_arg(this_locality), generation_arg(i + 1));
         }
         recv_data = ft_data.get();
-        // Reduce max elapsed time across all localities
-        double const max_elapsed =
-            all_reduce(timing_comm, timer.elapsed(), double_max{},
-                this_site_arg(this_locality), generation_arg(i + 1))
+        // Reduce max elapsed time to root
+        if (this_locality == 0)
+        {
+            double const max_elapsed =
+                reduce_here(timing_comm, timer.elapsed(), double_max{},
+                    generation_arg(i + 1))
+                    .get();
+            if (i >= warmup_iterations)
+                result[i - warmup_iterations] = max_elapsed;
+        }
+        else
+        {
+            reduce_there(timing_comm, timer.elapsed(),
+                generation_arg(i + 1))
                 .get();
-        if (i >= warmup_iterations)
-            result[i - warmup_iterations] = max_elapsed;
+        }
 
         // Check for correctness
         if (this_locality == 0)
@@ -885,7 +966,7 @@ void test_one_shot_use_gather(int lpn, std::size_t iterations, std::size_t warmu
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
     auto const timing_comm =
-        create_communicator("/test/timing_reduce/gather/",
+        create_communicator("/test/timing_reduce/gather/one_shot/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
@@ -917,13 +998,22 @@ void test_one_shot_use_gather(int lpn, std::size_t iterations, std::size_t warmu
                     this_site_arg(this_locality), generation_arg(i + 1));
             finished.get();
         }
-        // Reduce max elapsed time across all localities
-        double const max_elapsed =
-            all_reduce(timing_comm, timer.elapsed(), double_max{},
-                this_site_arg(this_locality), generation_arg(i + 1))
+        // Reduce max elapsed time to root
+        if (this_locality == 0)
+        {
+            double const max_elapsed =
+                reduce_here(timing_comm, timer.elapsed(), double_max{},
+                    generation_arg(i + 1))
+                    .get();
+            if (i >= warmup_iterations)
+                result[i - warmup_iterations] = max_elapsed;
+        }
+        else
+        {
+            reduce_there(timing_comm, timer.elapsed(),
+                generation_arg(i + 1))
                 .get();
-        if (i >= warmup_iterations)
-            result[i - warmup_iterations] = max_elapsed;
+        }
 
         // Check for correctness
         if (this_locality == 0)
@@ -956,7 +1046,7 @@ void test_one_shot_use_all_reduce(int lpn, std::size_t iterations, std::size_t w
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
     auto const timing_comm =
-        create_communicator("/test/timing_reduce/all_reduce/",
+        create_communicator("/test/timing_reduce/all_reduce/one_shot/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
@@ -976,13 +1066,22 @@ void test_one_shot_use_all_reduce(int lpn, std::size_t iterations, std::size_t w
                 vector_adder{}, num_sites_arg(num_localities),
                 this_site_arg(this_locality), generation_arg(i + 1));
         recv_data = ft_data.get();
-        // Reduce max elapsed time across all localities
-        double const max_elapsed =
-            all_reduce(timing_comm, timer.elapsed(), double_max{},
-                this_site_arg(this_locality), generation_arg(i + 1))
+        // Reduce max elapsed time to root
+        if (this_locality == 0)
+        {
+            double const max_elapsed =
+                reduce_here(timing_comm, timer.elapsed(), double_max{},
+                    generation_arg(i + 1))
+                    .get();
+            if (i >= warmup_iterations)
+                result[i - warmup_iterations] = max_elapsed;
+        }
+        else
+        {
+            reduce_there(timing_comm, timer.elapsed(),
+                generation_arg(i + 1))
                 .get();
-        if (i >= warmup_iterations)
-            result[i - warmup_iterations] = max_elapsed;
+        }
 
         // Check for correctness
         HPX_TEST_EQ(static_cast<int>(i) * static_cast<int>(num_localities), recv_data[0]);
@@ -1015,7 +1114,7 @@ void test_multiple_use_with_generation_scatter(int lpn, std::size_t iterations, 
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
     auto const timing_comm =
-        create_communicator("/test/timing_reduce/scatter/",
+        create_communicator("/test/timing_reduce/scatter/multi_use/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
@@ -1058,13 +1157,22 @@ void test_multiple_use_with_generation_scatter(int lpn, std::size_t iterations, 
                 scatter_direct_client, generation_arg(i + 1));
         }
         recv_data = ft_data.get();
-        // Reduce max elapsed time across all localities
-        double const max_elapsed =
-            all_reduce(timing_comm, timer.elapsed(), double_max{},
-                this_site_arg(this_locality), generation_arg(i + 1))
+        // Reduce max elapsed time to root
+        if (this_locality == 0)
+        {
+            double const max_elapsed =
+                reduce_here(timing_comm, timer.elapsed(), double_max{},
+                    generation_arg(i + 1))
+                    .get();
+            if (i >= warmup_iterations)
+                result[i - warmup_iterations] = max_elapsed;
+        }
+        else
+        {
+            reduce_there(timing_comm, timer.elapsed(),
+                generation_arg(i + 1))
                 .get();
-        if (i >= warmup_iterations)
-            result[i - warmup_iterations] = max_elapsed;
+        }
 
         // Check for correctness
         for (int check : recv_data)
@@ -1098,7 +1206,7 @@ void test_multiple_use_with_generation_reduce(int lpn, std::size_t iterations, s
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
     auto const timing_comm =
-        create_communicator("/test/timing_reduce/reduce/",
+        create_communicator("/test/timing_reduce/reduce/multi_use/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
@@ -1127,13 +1235,22 @@ void test_multiple_use_with_generation_reduce(int lpn, std::size_t iterations, s
                 std::move(send_data), generation_arg(i + 1));
             finished.get();
         }
-        // Reduce max elapsed time across all localities
-        double const max_elapsed =
-            all_reduce(timing_comm, timer.elapsed(), double_max{},
-                this_site_arg(this_locality), generation_arg(i + 1))
+        // Reduce max elapsed time to root
+        if (this_locality == 0)
+        {
+            double const max_elapsed =
+                reduce_here(timing_comm, timer.elapsed(), double_max{},
+                    generation_arg(i + 1))
+                    .get();
+            if (i >= warmup_iterations)
+                result[i - warmup_iterations] = max_elapsed;
+        }
+        else
+        {
+            reduce_there(timing_comm, timer.elapsed(),
+                generation_arg(i + 1))
                 .get();
-        if (i >= warmup_iterations)
-            result[i - warmup_iterations] = max_elapsed;
+        }
 
         // Check for correctness
         if (this_locality == 0)
@@ -1168,7 +1285,7 @@ void test_multiple_use_with_generation_broadcast(int lpn,
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
     auto const timing_comm =
-        create_communicator("/test/timing_reduce/broadcast/",
+        create_communicator("/test/timing_reduce/broadcast/multi_use/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
@@ -1198,13 +1315,22 @@ void test_multiple_use_with_generation_broadcast(int lpn,
                 broadcast_direct_client, generation_arg(i + 1));
         }
         recv_data = ft_data.get();
-        // Reduce max elapsed time across all localities
-        double const max_elapsed =
-            all_reduce(timing_comm, timer.elapsed(), double_max{},
-                this_site_arg(this_locality), generation_arg(i + 1))
+        // Reduce max elapsed time to root
+        if (this_locality == 0)
+        {
+            double const max_elapsed =
+                reduce_here(timing_comm, timer.elapsed(), double_max{},
+                    generation_arg(i + 1))
+                    .get();
+            if (i >= warmup_iterations)
+                result[i - warmup_iterations] = max_elapsed;
+        }
+        else
+        {
+            reduce_there(timing_comm, timer.elapsed(),
+                generation_arg(i + 1))
                 .get();
-        if (i >= warmup_iterations)
-            result[i - warmup_iterations] = max_elapsed;
+        }
 
         // Check for correctness
         if (this_locality == 0)
@@ -1238,7 +1364,7 @@ void test_multiple_use_with_generation_gather(
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
     auto const timing_comm =
-        create_communicator("/test/timing_reduce/gather/",
+        create_communicator("/test/timing_reduce/gather/multi_use/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
@@ -1268,13 +1394,22 @@ void test_multiple_use_with_generation_gather(
                 std::move(send_data), generation_arg(i + 1));
             finished.get();
         }
-        // Reduce max elapsed time across all localities
-        double const max_elapsed =
-            all_reduce(timing_comm, timer.elapsed(), double_max{},
-                this_site_arg(this_locality), generation_arg(i + 1))
+        // Reduce max elapsed time to root
+        if (this_locality == 0)
+        {
+            double const max_elapsed =
+                reduce_here(timing_comm, timer.elapsed(), double_max{},
+                    generation_arg(i + 1))
+                    .get();
+            if (i >= warmup_iterations)
+                result[i - warmup_iterations] = max_elapsed;
+        }
+        else
+        {
+            reduce_there(timing_comm, timer.elapsed(),
+                generation_arg(i + 1))
                 .get();
-        if (i >= warmup_iterations)
-            result[i - warmup_iterations] = max_elapsed;
+        }
 
         // Check for correctness
         if (this_locality == 0)
@@ -1311,7 +1446,7 @@ void test_multiple_use_with_generation_all_reduce(int lpn,
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
     auto const timing_comm =
-        create_communicator("/test/timing_reduce/all_reduce/",
+        create_communicator("/test/timing_reduce/all_reduce/multi_use/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
@@ -1330,13 +1465,22 @@ void test_multiple_use_with_generation_all_reduce(int lpn,
             all_reduce(all_reduce_direct_client, std::move(send_data),
                 vector_adder{}, generation_arg(i + 1));
         recv_data = ft_data.get();
-        // Reduce max elapsed time across all localities
-        double const max_elapsed =
-            all_reduce(timing_comm, timer.elapsed(), double_max{},
-                this_site_arg(this_locality), generation_arg(i + 1))
+        // Reduce max elapsed time to root
+        if (this_locality == 0)
+        {
+            double const max_elapsed =
+                reduce_here(timing_comm, timer.elapsed(), double_max{},
+                    generation_arg(i + 1))
+                    .get();
+            if (i >= warmup_iterations)
+                result[i - warmup_iterations] = max_elapsed;
+        }
+        else
+        {
+            reduce_there(timing_comm, timer.elapsed(),
+                generation_arg(i + 1))
                 .get();
-        if (i >= warmup_iterations)
-            result[i - warmup_iterations] = max_elapsed;
+        }
 
         // Check for correctness
         HPX_TEST_EQ(static_cast<int>(i) * static_cast<int>(num_localities), recv_data[0]);
@@ -1361,7 +1505,7 @@ void test_multiple_use_with_generation_barrier(int lpn, std::size_t iterations, 
     char const* const barrier_sync_name = "/test/barrier/generation";
     hpx::distributed::barrier sync(barrier_sync_name);
     auto const timing_comm =
-        create_communicator("/test/timing_reduce/barrier/",
+        create_communicator("/test/timing_reduce/barrier/multi_use/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
 
@@ -1372,13 +1516,22 @@ void test_multiple_use_with_generation_barrier(int lpn, std::size_t iterations, 
         hpx::collectives::barrier(
             barrier_client, this_site_arg(this_locality), generation_arg(i + 1))
             .get();
-        // Reduce max elapsed time across all localities
-        double const max_elapsed =
-            all_reduce(timing_comm, timer.elapsed(), double_max{},
-                this_site_arg(this_locality), generation_arg(i + 1))
+        // Reduce max elapsed time to root
+        if (this_locality == 0)
+        {
+            double const max_elapsed =
+                reduce_here(timing_comm, timer.elapsed(), double_max{},
+                    generation_arg(i + 1))
+                    .get();
+            if (i >= warmup_iterations)
+                result[i - warmup_iterations] = max_elapsed;
+        }
+        else
+        {
+            reduce_there(timing_comm, timer.elapsed(),
+                generation_arg(i + 1))
                 .get();
-        if (i >= warmup_iterations)
-            result[i - warmup_iterations] = max_elapsed;
+        }
     }
 
     if (this_locality == 0)
@@ -1411,7 +1564,7 @@ void test_all_gather_hierarchical(int arity, int lpn, std::size_t iterations, st
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
     auto const timing_comm =
-        create_communicator("/test/timing_reduce/all_gather/",
+        create_communicator("/test/timing_reduce/all_gather/hierarchical/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
@@ -1429,13 +1582,22 @@ void test_all_gather_hierarchical(int arity, int lpn, std::size_t iterations, st
             all_gather(communicators, std::move(send_data),
                 this_site_arg(this_locality), generation_arg(i + 1));
         recv_data = ft_data.get();
-        // Reduce max elapsed time across all localities
-        double const max_elapsed =
-            all_reduce(timing_comm, timer.elapsed(), double_max{},
-                this_site_arg(this_locality), generation_arg(i + 1))
+        // Reduce max elapsed time to root
+        if (this_locality == 0)
+        {
+            double const max_elapsed =
+                reduce_here(timing_comm, timer.elapsed(), double_max{},
+                    generation_arg(i + 1))
+                    .get();
+            if (i >= warmup_iterations)
+                result[i - warmup_iterations] = max_elapsed;
+        }
+        else
+        {
+            reduce_there(timing_comm, timer.elapsed(),
+                generation_arg(i + 1))
                 .get();
-        if (i >= warmup_iterations)
-            result[i - warmup_iterations] = max_elapsed;
+        }
         // Check for correctness: every site contributed (i + site), so
         // recv_data[j][0] must equal (i + j) at every site.
         for (int j = 0; j < static_cast<int>(num_localities); ++j)
@@ -1476,7 +1638,7 @@ void test_all_to_all_hierarchical(int arity, int lpn, std::size_t iterations, st
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
     auto const timing_comm =
-        create_communicator("/test/timing_reduce/all_to_all/",
+        create_communicator("/test/timing_reduce/all_to_all/hierarchical/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Each destination block carries test_size ints, matching MPI's
@@ -1509,13 +1671,22 @@ void test_all_to_all_hierarchical(int arity, int lpn, std::size_t iterations, st
             all_to_all(communicators, std::move(iter_data),
                 this_site_arg(this_locality), generation_arg(i + 1));
         recv_data = ft_data.get();
-        // Reduce max elapsed time across all localities
-        double const max_elapsed =
-            all_reduce(timing_comm, timer.elapsed(), double_max{},
-                this_site_arg(this_locality), generation_arg(i + 1))
+        // Reduce max elapsed time to root
+        if (this_locality == 0)
+        {
+            double const max_elapsed =
+                reduce_here(timing_comm, timer.elapsed(), double_max{},
+                    generation_arg(i + 1))
+                    .get();
+            if (i >= warmup_iterations)
+                result[i - warmup_iterations] = max_elapsed;
+        }
+        else
+        {
+            reduce_there(timing_comm, timer.elapsed(),
+                generation_arg(i + 1))
                 .get();
-        if (i >= warmup_iterations)
-            result[i - warmup_iterations] = max_elapsed;
+        }
         // Correctness: recv_data[s][*] == s + this_locality + i
         HPX_TEST_EQ(recv_data.size(), num_localities);
         for (std::size_t s = 0; s != num_localities; ++s)
@@ -1549,7 +1720,7 @@ void test_one_shot_use_all_gather(int lpn, std::size_t iterations, std::size_t w
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
     auto const timing_comm =
-        create_communicator("/test/timing_reduce/all_gather/",
+        create_communicator("/test/timing_reduce/all_gather/one_shot/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
@@ -1568,13 +1739,22 @@ void test_one_shot_use_all_gather(int lpn, std::size_t iterations, std::size_t w
                 num_sites_arg(num_localities), this_site_arg(this_locality),
                 generation_arg(i + 1));
         recv_data = ft_data.get();
-        // Reduce max elapsed time across all localities
-        double const max_elapsed =
-            all_reduce(timing_comm, timer.elapsed(), double_max{},
-                this_site_arg(this_locality), generation_arg(i + 1))
+        // Reduce max elapsed time to root
+        if (this_locality == 0)
+        {
+            double const max_elapsed =
+                reduce_here(timing_comm, timer.elapsed(), double_max{},
+                    generation_arg(i + 1))
+                    .get();
+            if (i >= warmup_iterations)
+                result[i - warmup_iterations] = max_elapsed;
+        }
+        else
+        {
+            reduce_there(timing_comm, timer.elapsed(),
+                generation_arg(i + 1))
                 .get();
-        if (i >= warmup_iterations)
-            result[i - warmup_iterations] = max_elapsed;
+        }
         // Check for correctness
         for (int j = 0; j < static_cast<int>(num_localities); ++j)
         {
@@ -1606,7 +1786,7 @@ void test_multiple_use_with_generation_all_gather(int lpn,
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
     auto const timing_comm =
-        create_communicator("/test/timing_reduce/all_gather/",
+        create_communicator("/test/timing_reduce/all_gather/multi_use/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
@@ -1624,13 +1804,22 @@ void test_multiple_use_with_generation_all_gather(int lpn,
             all_gather(all_gather_direct_client, std::move(send_data),
                 generation_arg(i + 1));
         recv_data = ft_data.get();
-        // Reduce max elapsed time across all localities
-        double const max_elapsed =
-            all_reduce(timing_comm, timer.elapsed(), double_max{},
-                this_site_arg(this_locality), generation_arg(i + 1))
+        // Reduce max elapsed time to root
+        if (this_locality == 0)
+        {
+            double const max_elapsed =
+                reduce_here(timing_comm, timer.elapsed(), double_max{},
+                    generation_arg(i + 1))
+                    .get();
+            if (i >= warmup_iterations)
+                result[i - warmup_iterations] = max_elapsed;
+        }
+        else
+        {
+            reduce_there(timing_comm, timer.elapsed(),
+                generation_arg(i + 1))
                 .get();
-        if (i >= warmup_iterations)
-            result[i - warmup_iterations] = max_elapsed;
+        }
         // Check for correctness
         for (int j = 0; j < static_cast<int>(num_localities); ++j)
         {

--- a/libs/full/collectives/tests/performance/benchmark_collectives.cpp
+++ b/libs/full/collectives/tests/performance/benchmark_collectives.cpp
@@ -17,6 +17,8 @@
 #include <hpx/modules/testing.hpp>
 
 #include <algorithm>
+#include <cmath>
+#include <numeric>
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
@@ -92,33 +94,53 @@ void create_parent_dir(std::filesystem::path const& file_path)
     }
 }
 
-std::pair<double, double> compute_moments(std::vector<double> const& data)
+struct Stats
 {
-    // Compute mean
-    double sum = 0.0;
-    for (double x : data)
-    {
-        sum += x;
-    }
-    double mean = sum / static_cast<double>(data.size());
+    double mean;
+    double variance;
+    double stddev;
+    double min;
+    double max;
+    double median;
+};
 
-    // Compute variance (population variance)
+Stats compute_moments(std::vector<double> const& data)
+{
+    double const n = static_cast<double>(data.size());
+
+    // Mean
+    double const sum = std::accumulate(data.begin(), data.end(), 0.0);
+    double const mean = sum / n;
+
+    // Variance (population)
     double varianceSum = 0.0;
     for (double x : data)
-    {
         varianceSum += (x - mean) * (x - mean);
-    }
-    double variance = varianceSum / static_cast<double>(data.size());
+    double const variance = varianceSum / n;
+    double const stddev = std::sqrt(variance);
 
-    return std::make_pair(mean, variance);
+    // Min / max
+    double const min_val = *std::min_element(data.begin(), data.end());
+    double const max_val = *std::max_element(data.begin(), data.end());
+
+    // Median (sorted copy)
+    std::vector<double> sorted(data);
+    std::sort(sorted.begin(), sorted.end());
+    std::size_t const mid = sorted.size() / 2;
+    double const median = (sorted.size() % 2 == 0)
+        ? 0.5 * (sorted[mid - 1] + sorted[mid])
+        : sorted[mid];
+
+    return Stats{mean, variance, stddev, min_val, max_val, median};
 }
 
 void write_to_file(std::string const& collective, std::string const& type,
-    int arity, std::size_t num_l, int lpn, int size, std::size_t iterations,
+    int arity, std::size_t num_l, int lpn, int size,
+    std::size_t warmup_iterations, std::size_t iterations,
     std::vector<double> const& result)
 {
-    // Compute mean and variance
-    auto moments = compute_moments(result);
+    // Compute statistics
+    Stats const stats = compute_moments(result);
     // Compute nodes
     std::size_t nodes = num_l / static_cast<std::size_t>(lpn);
     auto threads = hpx::get_os_thread_count();
@@ -131,11 +153,17 @@ void write_to_file(std::string const& collective, std::string const& type,
                       "Localities/Node:   {6}\n"
                       "HPX threads:       {7}\n"
                       "Size/Locality:     {8}\n"
-                      "Iterations:        {9}\n"
-                      "Mean runtime:      {10}\n"
-                      "Variance:          {11}\n";
+                      "Warmup iterations: {9}\n"
+                      "Iterations:        {10}\n"
+                      "Mean runtime:      {11}\n"
+                      "Variance:          {12}\n"
+                      "Stddev:            {13}\n"
+                      "Min:               {14}\n"
+                      "Max:               {15}\n"
+                      "Median:            {16}\n";
     hpx::util::format_to(std::cout, msg, collective, type, arity, nodes, num_l,
-        lpn, threads, size, iterations, moments.first, moments.second)
+        lpn, threads, size, warmup_iterations, iterations, stats.mean,
+        stats.variance, stats.stddev, stats.min, stats.max, stats.median)
         << std::flush;
 
     // Create directory
@@ -149,8 +177,9 @@ void write_to_file(std::string const& collective, std::string const& type,
     create_parent_dir(runtime_file_path);
 
     // Add header if necessary
-    std::string const header = "collective;type;arity;nodes;localities;lpn;"
-                               "threads;size;iterations;mean;variance\n";
+    std::string const header =
+        "collective;type;arity;nodes;localities;lpn;"
+        "threads;size;warmup;iterations;mean;variance;stddev;min;max;median\n";
     // Read existing content
     std::ifstream infile(runtime_file_path);
     std::stringstream buffer;
@@ -170,7 +199,9 @@ void write_to_file(std::string const& collective, std::string const& type,
     outfile.open(runtime_file_path, std::ios_base::app);
     outfile << collective << ";" << type << ";" << arity << ";" << nodes << ";"
             << num_l << ";" << lpn << ";" << threads << ";" << size << ";"
-            << iterations << ";" << moments.first << ";" << moments.second
+            << warmup_iterations << ";" << iterations << ";"
+            << stats.mean << ";" << stats.variance << ";" << stats.stddev
+            << ";" << stats.min << ";" << stats.max << ";" << stats.median
             << "\n";
     outfile.close();
 }
@@ -252,7 +283,7 @@ void test_scatter_hierarchical(int arity, int lpn, std::size_t iterations, std::
             std::string("hierarchical") :
             "hierarchical_t" + std::to_string(fallback_threshold);
         write_to_file(operation, mod_name, arity, num_localities, lpn,
-            test_size, iterations, result);
+            test_size, warmup_iterations, iterations, result);
     }
 }
 
@@ -332,7 +363,7 @@ void test_reduce_hierarchical(int arity, int lpn, std::size_t iterations, std::s
             std::string("hierarchical") :
             "hierarchical_t" + std::to_string(fallback_threshold);
         write_to_file(operation, mod_name, arity, num_localities, lpn,
-            test_size, iterations, result);
+            test_size, warmup_iterations, iterations, result);
     }
 }
 
@@ -410,7 +441,7 @@ void test_broadcast_hierarchical(int arity, int lpn, std::size_t iterations, std
             std::string("hierarchical") :
             "hierarchical_t" + std::to_string(fallback_threshold);
         write_to_file(operation, mod_name, arity, num_localities, lpn,
-            test_size, iterations, result);
+            test_size, warmup_iterations, iterations, result);
     }
 }
 
@@ -492,7 +523,7 @@ void test_gather_hierarchical(int arity, int lpn, std::size_t iterations, std::s
             std::string("hierarchical") :
             "hierarchical_t" + std::to_string(fallback_threshold);
         write_to_file(operation, mod_name, arity, num_localities, lpn,
-            test_size, iterations, result);
+            test_size, warmup_iterations, iterations, result);
     }
 }
 
@@ -557,7 +588,7 @@ void test_all_reduce_hierarchical(int arity, int lpn, std::size_t iterations, st
             std::string("hierarchical") :
             "hierarchical_t" + std::to_string(fallback_threshold);
         write_to_file(operation, mod_name, arity, num_localities, lpn,
-            test_size, iterations, result);
+            test_size, warmup_iterations, iterations, result);
     }
 }
 
@@ -605,7 +636,7 @@ void test_barrier_hierarchical(int arity, int lpn, std::size_t iterations, std::
             std::string("hierarchical") :
             "hierarchical_t" + std::to_string(fallback_threshold);
         write_to_file(operation, mod_name, arity, num_localities, lpn,
-            test_size, iterations, result);
+            test_size, warmup_iterations, iterations, result);
     }
 }
 
@@ -675,7 +706,7 @@ void test_one_shot_use_scatter(int lpn, std::size_t iterations, std::size_t warm
     if (this_locality == 0)
     {
         write_to_file(operation, "single_use", -1, num_localities, lpn,
-            test_size, iterations, result);
+            test_size, warmup_iterations, iterations, result);
     }
 }
 
@@ -743,7 +774,7 @@ void test_one_shot_use_reduce(int lpn, std::size_t iterations, std::size_t warmu
     if (this_locality == 0)
     {
         write_to_file(operation, "single_use", -1, num_localities, lpn,
-            test_size, iterations, result);
+            test_size, warmup_iterations, iterations, result);
     }
 }
 
@@ -811,7 +842,7 @@ void test_one_shot_use_broadcast(int lpn, std::size_t iterations, std::size_t wa
     if (this_locality == 0)
     {
         write_to_file(operation, "single_use", -1, num_localities, lpn,
-            test_size, iterations, result);
+            test_size, warmup_iterations, iterations, result);
     }
 }
 
@@ -882,7 +913,7 @@ void test_one_shot_use_gather(int lpn, std::size_t iterations, std::size_t warmu
     if (this_locality == 0)
     {
         write_to_file(operation, "single_use", -1, num_localities, lpn,
-            test_size, iterations, result);
+            test_size, warmup_iterations, iterations, result);
     }
 }
 
@@ -935,7 +966,7 @@ void test_one_shot_use_all_reduce(int lpn, std::size_t iterations, std::size_t w
     if (this_locality == 0)
     {
         write_to_file(operation, "single_use", -1, num_localities, lpn,
-            test_size, iterations, result);
+            test_size, warmup_iterations, iterations, result);
     }
 }
 
@@ -1008,7 +1039,7 @@ void test_multiple_use_with_generation_scatter(int lpn, std::size_t iterations, 
     if (this_locality == 0)
     {
         write_to_file(operation, "multi_use", -1, num_localities, lpn,
-            test_size, iterations, result);
+            test_size, warmup_iterations, iterations, result);
     }
 }
 
@@ -1078,7 +1109,7 @@ void test_multiple_use_with_generation_reduce(int lpn, std::size_t iterations, s
     if (this_locality == 0)
     {
         write_to_file(operation, "multi_use", -1, num_localities, lpn,
-            test_size, iterations, result);
+            test_size, warmup_iterations, iterations, result);
     }
 }
 
@@ -1148,7 +1179,7 @@ void test_multiple_use_with_generation_broadcast(int lpn,
     if (this_locality == 0)
     {
         write_to_file(operation, "multi_use", -1, num_localities, lpn,
-            test_size, iterations, result);
+            test_size, warmup_iterations, iterations, result);
     }
 }
 
@@ -1221,7 +1252,7 @@ void test_multiple_use_with_generation_gather(
     if (this_locality == 0)
     {
         write_to_file(operation, "multi_use", -1, num_localities, lpn,
-            test_size, iterations, result);
+            test_size, warmup_iterations, iterations, result);
     }
 }
 
@@ -1277,7 +1308,7 @@ void test_multiple_use_with_generation_all_reduce(int lpn,
     if (this_locality == 0)
     {
         write_to_file(operation, "multi_use", -1, num_localities, lpn,
-            test_size, iterations, result);
+            test_size, warmup_iterations, iterations, result);
     }
 }
 
@@ -1316,7 +1347,7 @@ void test_multiple_use_with_generation_barrier(int lpn, std::size_t iterations, 
     if (this_locality == 0)
     {
         write_to_file(operation, "multi_use", -1, num_localities, lpn,
-            test_size, iterations, result);
+            test_size, warmup_iterations, iterations, result);
     }
 }
 
@@ -1381,7 +1412,7 @@ void test_all_gather_hierarchical(int arity, int lpn, std::size_t iterations, st
             std::string("hierarchical") :
             "hierarchical_t" + std::to_string(fallback_threshold);
         write_to_file(operation, mod_name, arity, num_localities, lpn,
-            test_size, iterations, result);
+            test_size, warmup_iterations, iterations, result);
     }
 }
 
@@ -1458,7 +1489,7 @@ void test_all_to_all_hierarchical(int arity, int lpn, std::size_t iterations, st
             std::string("hierarchical") :
             "hierarchical_t" + std::to_string(fallback_threshold);
         write_to_file(operation, mod_name, arity, num_localities, lpn,
-            test_size, iterations, result);
+            test_size, warmup_iterations, iterations, result);
     }
 }
 ////////////////////////////////////////////////////////////////////////////////////////
@@ -1511,7 +1542,7 @@ void test_one_shot_use_all_gather(int lpn, std::size_t iterations, std::size_t w
     if (this_locality == 0)
     {
         write_to_file(operation, "single_use", -1, num_localities, lpn,
-            test_size, iterations, result);
+            test_size, warmup_iterations, iterations, result);
     }
 }
 ////////////////////////////////////////////////////////////////////////////////////////
@@ -1567,7 +1598,7 @@ void test_multiple_use_with_generation_all_gather(int lpn,
     if (this_locality == 0)
     {
         write_to_file(operation, "multi_use", -1, num_localities, lpn,
-            test_size, iterations, result);
+            test_size, warmup_iterations, iterations, result);
     }
 }
 int hpx_main(hpx::program_options::variables_map& vm)

--- a/libs/full/collectives/tests/performance/benchmark_collectives.cpp
+++ b/libs/full/collectives/tests/performance/benchmark_collectives.cpp
@@ -18,11 +18,11 @@
 
 #include <algorithm>
 #include <cmath>
-#include <numeric>
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <numeric>
 #include <string>
 #include <vector>
 
@@ -117,9 +117,9 @@ Stats compute_moments(std::vector<double> const& data)
     std::vector<double> sorted(data);
     std::sort(sorted.begin(), sorted.end());
     std::size_t const mid = sorted.size() / 2;
-    double const median = (sorted.size() % 2 == 0)
-        ? 0.5 * (sorted[mid - 1] + sorted[mid])
-        : sorted[mid];
+    double const median = (sorted.size() % 2 == 0) ?
+        0.5 * (sorted[mid - 1] + sorted[mid]) :
+        sorted[mid];
 
     return Stats{mean, variance, stddev, min_val, max_val, median};
 }
@@ -167,10 +167,9 @@ void write_to_file(std::string const& collective, std::string const& type,
     }
 
     // Create directory: result/hpx/<parcelport>/<num_localities>/<collective>/
-    std::string runtime_file_path =
-        "result/hpx/" + pp_type + "/" + std::to_string(num_l) + "/" +
-        collective + "/runtimes_" +
-        collective + "_" + type;
+    std::string runtime_file_path = "result/hpx/" + pp_type + "/" +
+        std::to_string(num_l) + "/" + collective + "/runtimes_" + collective +
+        "_" + type;
     if (arity != -1 && type == "hierarchical")
     {
         runtime_file_path = runtime_file_path + "_" + std::to_string(arity);
@@ -201,17 +200,17 @@ void write_to_file(std::string const& collective, std::string const& type,
     outfile.open(runtime_file_path, std::ios_base::app);
     outfile << collective << ";" << type << ";" << arity << ";" << nodes << ";"
             << num_l << ";" << lpn << ";" << threads << ";" << size << ";"
-            << warmup_iterations << ";" << iterations << ";"
-            << stats.mean << ";" << stats.variance << ";" << stats.stddev
-            << ";" << stats.min << ";" << stats.max << ";" << stats.median
-            << "\n";
+            << warmup_iterations << ";" << iterations << ";" << stats.mean
+            << ";" << stats.variance << ";" << stats.stddev << ";" << stats.min
+            << ";" << stats.max << ";" << stats.median << "\n";
     outfile.close();
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////
 // Hierarchical collectives
-void test_scatter_hierarchical(int arity, int lpn, std::size_t iterations, std::size_t warmup_iterations,
-    int test_size, std::string const& operation, int fallback_threshold)
+void test_scatter_hierarchical(int arity, int lpn, std::size_t iterations,
+    std::size_t warmup_iterations, int test_size, std::string const& operation,
+    int fallback_threshold)
 {
     // Get parameters
     std::size_t const num_localities =
@@ -251,10 +250,9 @@ void test_scatter_hierarchical(int arity, int lpn, std::size_t iterations, std::
         if (this_locality == 0)
         {
             for (std::ptrdiff_t j = 0;
-                 j < static_cast<std::ptrdiff_t>(num_localities); ++j)
+                j < static_cast<std::ptrdiff_t>(num_localities); ++j)
             {
-                std::fill(
-                    send_data[static_cast<std::size_t>(j)].begin(),
+                std::fill(send_data[static_cast<std::size_t>(j)].begin(),
                     send_data[static_cast<std::size_t>(j)].end(),
                     static_cast<int>(42 + i) + static_cast<int>(j));
             }
@@ -278,24 +276,24 @@ void test_scatter_hierarchical(int arity, int lpn, std::size_t iterations, std::
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed =
-                reduce_here(timing_comm, timer.elapsed(), double_max{},
-                    generation_arg(i + 1))
-                    .get();
+            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
+                double_max{}, generation_arg(i + 1))
+                                           .get();
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(),
-                generation_arg(i + 1))
+            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
                 .get();
         }
 
         // Check for correctness
         for (int check : recv_data)
         {
-            HPX_TEST_EQ(static_cast<int>(42 + i) + static_cast<int>(this_locality), check);
+            HPX_TEST_EQ(
+                static_cast<int>(42 + i) + static_cast<int>(this_locality),
+                check);
         }
     }
 
@@ -309,8 +307,9 @@ void test_scatter_hierarchical(int arity, int lpn, std::size_t iterations, std::
     }
 }
 
-void test_reduce_hierarchical(int arity, int lpn, std::size_t iterations, std::size_t warmup_iterations,
-    int test_size, std::string const& operation, int fallback_threshold)
+void test_reduce_hierarchical(int arity, int lpn, std::size_t iterations,
+    std::size_t warmup_iterations, int test_size, std::string const& operation,
+    int fallback_threshold)
 {
     // Get parameters
     std::size_t const num_localities =
@@ -350,39 +349,37 @@ void test_reduce_hierarchical(int arity, int lpn, std::size_t iterations, std::s
         if (this_locality == 0)
         {
             ft_data =
-                    reduce_here(communicators, std::move(iter_data), vector_adder{},
+                reduce_here(communicators, std::move(iter_data), vector_adder{},
                     this_site_arg(this_locality), generation_arg(i + 1));
             recv_data = ft_data.get();
         }
         else
         {
             hpx::future<void> finished = reduce_there(communicators,
-                    std::move(iter_data), vector_adder{},
+                std::move(iter_data), vector_adder{},
                 this_site_arg(this_locality), generation_arg(i + 1));
             finished.get();
         }
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed =
-                reduce_here(timing_comm, timer.elapsed(), double_max{},
-                    generation_arg(i + 1))
-                    .get();
+            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
+                double_max{}, generation_arg(i + 1))
+                                           .get();
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(),
-                generation_arg(i + 1))
+            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
                 .get();
         }
 
         // Check for correctness
         if (this_locality == 0)
         {
-            HPX_TEST_EQ(
-                static_cast<int>(i) * static_cast<int>(num_localities), recv_data[0]);
+            HPX_TEST_EQ(static_cast<int>(i) * static_cast<int>(num_localities),
+                recv_data[0]);
         }
     }
 
@@ -396,8 +393,9 @@ void test_reduce_hierarchical(int arity, int lpn, std::size_t iterations, std::s
     }
 }
 
-void test_broadcast_hierarchical(int arity, int lpn, std::size_t iterations, std::size_t warmup_iterations,
-    int test_size, std::string const& operation, int fallback_threshold)
+void test_broadcast_hierarchical(int arity, int lpn, std::size_t iterations,
+    std::size_t warmup_iterations, int test_size, std::string const& operation,
+    int fallback_threshold)
 {
     // Get parameters
     std::size_t const num_localities =
@@ -434,7 +432,8 @@ void test_broadcast_hierarchical(int arity, int lpn, std::size_t iterations, std
         if (this_locality == 0)
         {
             ft_data = broadcast_to(communicators,
-                std::vector<int>(static_cast<std::size_t>(test_size), static_cast<int>(i)),
+                std::vector<int>(
+                    static_cast<std::size_t>(test_size), static_cast<int>(i)),
                 this_site_arg(this_locality), generation_arg(i + 1));
         }
         else
@@ -446,17 +445,15 @@ void test_broadcast_hierarchical(int arity, int lpn, std::size_t iterations, std
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed =
-                reduce_here(timing_comm, timer.elapsed(), double_max{},
-                    generation_arg(i + 1))
-                    .get();
+            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
+                double_max{}, generation_arg(i + 1))
+                                           .get();
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(),
-                generation_arg(i + 1))
+            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
                 .get();
         }
 
@@ -477,8 +474,9 @@ void test_broadcast_hierarchical(int arity, int lpn, std::size_t iterations, std
     }
 }
 
-void test_gather_hierarchical(int arity, int lpn, std::size_t iterations, std::size_t warmup_iterations,
-    int test_size, std::string const& operation, int fallback_threshold)
+void test_gather_hierarchical(int arity, int lpn, std::size_t iterations,
+    std::size_t warmup_iterations, int test_size, std::string const& operation,
+    int fallback_threshold)
 {
     // Get parameters
     std::size_t const num_localities =
@@ -524,24 +522,22 @@ void test_gather_hierarchical(int arity, int lpn, std::size_t iterations, std::s
         else
         {
             hpx::future<void> finished =
-                    gather_there(communicators, std::move(iter_data),
+                gather_there(communicators, std::move(iter_data),
                     this_site_arg(this_locality), generation_arg(i + 1));
             finished.get();
         }
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed =
-                reduce_here(timing_comm, timer.elapsed(), double_max{},
-                    generation_arg(i + 1))
-                    .get();
+            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
+                double_max{}, generation_arg(i + 1))
+                                           .get();
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(),
-                generation_arg(i + 1))
+            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
                 .get();
         }
 
@@ -565,8 +561,9 @@ void test_gather_hierarchical(int arity, int lpn, std::size_t iterations, std::s
     }
 }
 
-void test_all_reduce_hierarchical(int arity, int lpn, std::size_t iterations, std::size_t warmup_iterations,
-    int test_size, std::string const& operation, int fallback_threshold)
+void test_all_reduce_hierarchical(int arity, int lpn, std::size_t iterations,
+    std::size_t warmup_iterations, int test_size, std::string const& operation,
+    int fallback_threshold)
 {
     // Get parameters
     std::size_t const num_localities =
@@ -610,22 +607,21 @@ void test_all_reduce_hierarchical(int arity, int lpn, std::size_t iterations, st
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed =
-                reduce_here(timing_comm, timer.elapsed(), double_max{},
-                    generation_arg(i + 1))
-                    .get();
+            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
+                double_max{}, generation_arg(i + 1))
+                                           .get();
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(),
-                generation_arg(i + 1))
+            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
                 .get();
         }
 
         // Check for correctness: every site should have the sum
-        HPX_TEST_EQ(static_cast<int>(i) * static_cast<int>(num_localities), recv_data[0]);
+        HPX_TEST_EQ(static_cast<int>(i) * static_cast<int>(num_localities),
+            recv_data[0]);
     }
 
     if (this_locality == 0)
@@ -638,8 +634,9 @@ void test_all_reduce_hierarchical(int arity, int lpn, std::size_t iterations, st
     }
 }
 
-void test_barrier_hierarchical(int arity, int lpn, std::size_t iterations, std::size_t warmup_iterations,
-    int test_size, std::string const& operation, int fallback_threshold)
+void test_barrier_hierarchical(int arity, int lpn, std::size_t iterations,
+    std::size_t warmup_iterations, int test_size, std::string const& operation,
+    int fallback_threshold)
 {
     std::size_t const num_localities =
         hpx::get_num_localities(hpx::launch::sync);
@@ -670,17 +667,15 @@ void test_barrier_hierarchical(int arity, int lpn, std::size_t iterations, std::
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed =
-                reduce_here(timing_comm, timer.elapsed(), double_max{},
-                    generation_arg(i + 1))
-                    .get();
+            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
+                double_max{}, generation_arg(i + 1))
+                                           .get();
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(),
-                generation_arg(i + 1))
+            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
                 .get();
         }
     }
@@ -697,8 +692,8 @@ void test_barrier_hierarchical(int arity, int lpn, std::size_t iterations, std::
 
 ////////////////////////////////////////////////////////////////////////////////////////
 // One shot collectives
-void test_one_shot_use_scatter(int lpn, std::size_t iterations, std::size_t warmup_iterations, int test_size,
-    std::string const& operation)
+void test_one_shot_use_scatter(int lpn, std::size_t iterations,
+    std::size_t warmup_iterations, int test_size, std::string const& operation)
 {
     // Get parameters
     std::size_t const num_localities =
@@ -729,10 +724,9 @@ void test_one_shot_use_scatter(int lpn, std::size_t iterations, std::size_t warm
         if (this_locality == 0)
         {
             for (std::ptrdiff_t j = 0;
-                 j < static_cast<std::ptrdiff_t>(num_localities); ++j)
+                j < static_cast<std::ptrdiff_t>(num_localities); ++j)
             {
-                std::fill(
-                    send_data[static_cast<std::size_t>(j)].begin(),
+                std::fill(send_data[static_cast<std::size_t>(j)].begin(),
                     send_data[static_cast<std::size_t>(j)].end(),
                     static_cast<int>(42 + i) + static_cast<int>(j));
             }
@@ -757,24 +751,24 @@ void test_one_shot_use_scatter(int lpn, std::size_t iterations, std::size_t warm
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed =
-                reduce_here(timing_comm, timer.elapsed(), double_max{},
-                    generation_arg(i + 1))
-                    .get();
+            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
+                double_max{}, generation_arg(i + 1))
+                                           .get();
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(),
-                generation_arg(i + 1))
+            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
                 .get();
         }
 
         // Check for correctness
         for (int check : recv_data)
         {
-            HPX_TEST_EQ(static_cast<int>(42 + i) + static_cast<int>(this_locality), check);
+            HPX_TEST_EQ(
+                static_cast<int>(42 + i) + static_cast<int>(this_locality),
+                check);
         }
     }
 
@@ -785,8 +779,8 @@ void test_one_shot_use_scatter(int lpn, std::size_t iterations, std::size_t warm
     }
 }
 
-void test_one_shot_use_reduce(int lpn, std::size_t iterations, std::size_t warmup_iterations, int test_size,
-    std::string const& operation)
+void test_one_shot_use_reduce(int lpn, std::size_t iterations,
+    std::size_t warmup_iterations, int test_size, std::string const& operation)
 {
     // Get parameters
     std::size_t const num_localities =
@@ -824,32 +818,30 @@ void test_one_shot_use_reduce(int lpn, std::size_t iterations, std::size_t warmu
         else
         {
             hpx::future<void> finished =
-                    reduce_there(reduce_direct_basename, std::move(iter_data),
+                reduce_there(reduce_direct_basename, std::move(iter_data),
                     this_site_arg(this_locality), generation_arg(i + 1));
             finished.get();
         }
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed =
-                reduce_here(timing_comm, timer.elapsed(), double_max{},
-                    generation_arg(i + 1))
-                    .get();
+            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
+                double_max{}, generation_arg(i + 1))
+                                           .get();
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(),
-                generation_arg(i + 1))
+            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
                 .get();
         }
 
         // Check for correctness
         if (this_locality == 0)
         {
-            HPX_TEST_EQ(
-                static_cast<int>(i) * static_cast<int>(num_localities), recv_data[0]);
+            HPX_TEST_EQ(static_cast<int>(i) * static_cast<int>(num_localities),
+                recv_data[0]);
         }
     }
 
@@ -860,8 +852,8 @@ void test_one_shot_use_reduce(int lpn, std::size_t iterations, std::size_t warmu
     }
 }
 
-void test_one_shot_use_broadcast(int lpn, std::size_t iterations, std::size_t warmup_iterations, int test_size,
-    std::string const& operation)
+void test_one_shot_use_broadcast(int lpn, std::size_t iterations,
+    std::size_t warmup_iterations, int test_size, std::string const& operation)
 {
     // Get parameters
     std::size_t const num_localities =
@@ -889,9 +881,10 @@ void test_one_shot_use_broadcast(int lpn, std::size_t iterations, std::size_t wa
         if (this_locality == 0)
         {
             ft_data = broadcast_to(broadcast_direct_basename,
-                std::vector<int>(static_cast<std::size_t>(test_size), static_cast<int>(i)),
-                num_sites_arg(num_localities),
-                this_site_arg(this_locality), generation_arg(i + 1));
+                std::vector<int>(
+                    static_cast<std::size_t>(test_size), static_cast<int>(i)),
+                num_sites_arg(num_localities), this_site_arg(this_locality),
+                generation_arg(i + 1));
         }
         else
         {
@@ -903,17 +896,15 @@ void test_one_shot_use_broadcast(int lpn, std::size_t iterations, std::size_t wa
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed =
-                reduce_here(timing_comm, timer.elapsed(), double_max{},
-                    generation_arg(i + 1))
-                    .get();
+            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
+                double_max{}, generation_arg(i + 1))
+                                           .get();
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(),
-                generation_arg(i + 1))
+            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
                 .get();
         }
 
@@ -931,8 +922,8 @@ void test_one_shot_use_broadcast(int lpn, std::size_t iterations, std::size_t wa
     }
 }
 
-void test_one_shot_use_gather(int lpn, std::size_t iterations, std::size_t warmup_iterations, int test_size,
-    std::string const& operation)
+void test_one_shot_use_gather(int lpn, std::size_t iterations,
+    std::size_t warmup_iterations, int test_size, std::string const& operation)
 {
     // Get parameters
     std::size_t const num_localities =
@@ -970,24 +961,22 @@ void test_one_shot_use_gather(int lpn, std::size_t iterations, std::size_t warmu
         else
         {
             hpx::future<void> finished =
-                    gather_there(gather_direct_basename, std::move(iter_data),
+                gather_there(gather_direct_basename, std::move(iter_data),
                     this_site_arg(this_locality), generation_arg(i + 1));
             finished.get();
         }
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed =
-                reduce_here(timing_comm, timer.elapsed(), double_max{},
-                    generation_arg(i + 1))
-                    .get();
+            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
+                double_max{}, generation_arg(i + 1))
+                                           .get();
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(),
-                generation_arg(i + 1))
+            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
                 .get();
         }
 
@@ -1008,8 +997,8 @@ void test_one_shot_use_gather(int lpn, std::size_t iterations, std::size_t warmu
     }
 }
 
-void test_one_shot_use_all_reduce(int lpn, std::size_t iterations, std::size_t warmup_iterations,
-    int test_size, std::string const& operation)
+void test_one_shot_use_all_reduce(int lpn, std::size_t iterations,
+    std::size_t warmup_iterations, int test_size, std::string const& operation)
 {
     // Get parameters
     std::size_t const num_localities =
@@ -1044,22 +1033,21 @@ void test_one_shot_use_all_reduce(int lpn, std::size_t iterations, std::size_t w
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed =
-                reduce_here(timing_comm, timer.elapsed(), double_max{},
-                    generation_arg(i + 1))
-                    .get();
+            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
+                double_max{}, generation_arg(i + 1))
+                                           .get();
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(),
-                generation_arg(i + 1))
+            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
                 .get();
         }
 
         // Check for correctness
-        HPX_TEST_EQ(static_cast<int>(i) * static_cast<int>(num_localities), recv_data[0]);
+        HPX_TEST_EQ(static_cast<int>(i) * static_cast<int>(num_localities),
+            recv_data[0]);
     }
 
     if (this_locality == 0)
@@ -1071,8 +1059,8 @@ void test_one_shot_use_all_reduce(int lpn, std::size_t iterations, std::size_t w
 
 ////////////////////////////////////////////////////////////////////////////////////////
 // Multi-use shot collectives
-void test_multiple_use_with_generation_scatter(int lpn, std::size_t iterations, std::size_t warmup_iterations,
-    int test_size, std::string const& operation)
+void test_multiple_use_with_generation_scatter(int lpn, std::size_t iterations,
+    std::size_t warmup_iterations, int test_size, std::string const& operation)
 {
     // Get parameters
     std::size_t const num_localities =
@@ -1107,10 +1095,9 @@ void test_multiple_use_with_generation_scatter(int lpn, std::size_t iterations, 
         if (this_locality == 0)
         {
             for (std::ptrdiff_t j = 0;
-                 j < static_cast<std::ptrdiff_t>(num_localities); ++j)
+                j < static_cast<std::ptrdiff_t>(num_localities); ++j)
             {
-                std::fill(
-                    send_data[static_cast<std::size_t>(j)].begin(),
+                std::fill(send_data[static_cast<std::size_t>(j)].begin(),
                     send_data[static_cast<std::size_t>(j)].end(),
                     static_cast<int>(42 + i) + static_cast<int>(j));
             }
@@ -1134,24 +1121,24 @@ void test_multiple_use_with_generation_scatter(int lpn, std::size_t iterations, 
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed =
-                reduce_here(timing_comm, timer.elapsed(), double_max{},
-                    generation_arg(i + 1))
-                    .get();
+            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
+                double_max{}, generation_arg(i + 1))
+                                           .get();
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(),
-                generation_arg(i + 1))
+            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
                 .get();
         }
 
         // Check for correctness
         for (int check : recv_data)
         {
-            HPX_TEST_EQ(static_cast<int>(42 + i) + static_cast<int>(this_locality), check);
+            HPX_TEST_EQ(
+                static_cast<int>(42 + i) + static_cast<int>(this_locality),
+                check);
         }
     }
 
@@ -1162,8 +1149,8 @@ void test_multiple_use_with_generation_scatter(int lpn, std::size_t iterations, 
     }
 }
 
-void test_multiple_use_with_generation_reduce(int lpn, std::size_t iterations, std::size_t warmup_iterations,
-    int test_size, std::string const& operation)
+void test_multiple_use_with_generation_reduce(int lpn, std::size_t iterations,
+    std::size_t warmup_iterations, int test_size, std::string const& operation)
 {
     // Get parameters
     std::size_t const num_localities =
@@ -1204,31 +1191,29 @@ void test_multiple_use_with_generation_reduce(int lpn, std::size_t iterations, s
         else
         {
             hpx::future<void> finished = reduce_there(reduce_direct_client,
-                    std::move(iter_data), generation_arg(i + 1));
+                std::move(iter_data), generation_arg(i + 1));
             finished.get();
         }
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed =
-                reduce_here(timing_comm, timer.elapsed(), double_max{},
-                    generation_arg(i + 1))
-                    .get();
+            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
+                double_max{}, generation_arg(i + 1))
+                                           .get();
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(),
-                generation_arg(i + 1))
+            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
                 .get();
         }
 
         // Check for correctness
         if (this_locality == 0)
         {
-            HPX_TEST_EQ(
-                static_cast<int>(i) * static_cast<int>(num_localities), recv_data[0]);
+            HPX_TEST_EQ(static_cast<int>(i) * static_cast<int>(num_localities),
+                recv_data[0]);
         }
     }
 
@@ -1240,7 +1225,8 @@ void test_multiple_use_with_generation_reduce(int lpn, std::size_t iterations, s
 }
 
 void test_multiple_use_with_generation_broadcast(int lpn,
-    std::size_t iterations, std::size_t warmup_iterations, int test_size, std::string const& operation)
+    std::size_t iterations, std::size_t warmup_iterations, int test_size,
+    std::string const& operation)
 {
     // Get parameters
     std::size_t const num_localities =
@@ -1272,7 +1258,8 @@ void test_multiple_use_with_generation_broadcast(int lpn,
         if (this_locality == 0)
         {
             ft_data = broadcast_to(broadcast_direct_client,
-                std::vector<int>(static_cast<std::size_t>(test_size), static_cast<int>(i)),
+                std::vector<int>(
+                    static_cast<std::size_t>(test_size), static_cast<int>(i)),
                 generation_arg(i + 1));
         }
         else
@@ -1284,17 +1271,15 @@ void test_multiple_use_with_generation_broadcast(int lpn,
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed =
-                reduce_here(timing_comm, timer.elapsed(), double_max{},
-                    generation_arg(i + 1))
-                    .get();
+            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
+                double_max{}, generation_arg(i + 1))
+                                           .get();
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(),
-                generation_arg(i + 1))
+            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
                 .get();
         }
 
@@ -1312,8 +1297,8 @@ void test_multiple_use_with_generation_broadcast(int lpn,
     }
 }
 
-void test_multiple_use_with_generation_gather(
-    int lpn, std::size_t iterations, std::size_t warmup_iterations, int test_size, std::string const& operation)
+void test_multiple_use_with_generation_gather(int lpn, std::size_t iterations,
+    std::size_t warmup_iterations, int test_size, std::string const& operation)
 {
     // Get parameters
     std::size_t const num_localities =
@@ -1354,23 +1339,21 @@ void test_multiple_use_with_generation_gather(
         else
         {
             hpx::future<void> finished = gather_there(gather_direct_client,
-                    std::move(iter_data), generation_arg(i + 1));
+                std::move(iter_data), generation_arg(i + 1));
             finished.get();
         }
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed =
-                reduce_here(timing_comm, timer.elapsed(), double_max{},
-                    generation_arg(i + 1))
-                    .get();
+            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
+                double_max{}, generation_arg(i + 1))
+                                           .get();
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(),
-                generation_arg(i + 1))
+            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
                 .get();
         }
 
@@ -1392,7 +1375,8 @@ void test_multiple_use_with_generation_gather(
 }
 
 void test_multiple_use_with_generation_all_reduce(int lpn,
-    std::size_t iterations, std::size_t warmup_iterations, int test_size, std::string const& operation)
+    std::size_t iterations, std::size_t warmup_iterations, int test_size,
+    std::string const& operation)
 {
     // Get parameters
     std::size_t const num_localities =
@@ -1430,22 +1414,21 @@ void test_multiple_use_with_generation_all_reduce(int lpn,
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed =
-                reduce_here(timing_comm, timer.elapsed(), double_max{},
-                    generation_arg(i + 1))
-                    .get();
+            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
+                double_max{}, generation_arg(i + 1))
+                                           .get();
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(),
-                generation_arg(i + 1))
+            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
                 .get();
         }
 
         // Check for correctness
-        HPX_TEST_EQ(static_cast<int>(i) * static_cast<int>(num_localities), recv_data[0]);
+        HPX_TEST_EQ(static_cast<int>(i) * static_cast<int>(num_localities),
+            recv_data[0]);
     }
 
     if (this_locality == 0)
@@ -1455,8 +1438,8 @@ void test_multiple_use_with_generation_all_reduce(int lpn,
     }
 }
 
-void test_multiple_use_with_generation_barrier(int lpn, std::size_t iterations, std::size_t warmup_iterations,
-    int test_size, std::string const& operation)
+void test_multiple_use_with_generation_barrier(int lpn, std::size_t iterations,
+    std::size_t warmup_iterations, int test_size, std::string const& operation)
 {
     std::size_t const num_localities =
         hpx::get_num_localities(hpx::launch::sync);
@@ -1481,17 +1464,15 @@ void test_multiple_use_with_generation_barrier(int lpn, std::size_t iterations, 
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed =
-                reduce_here(timing_comm, timer.elapsed(), double_max{},
-                    generation_arg(i + 1))
-                    .get();
+            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
+                double_max{}, generation_arg(i + 1))
+                                           .get();
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(),
-                generation_arg(i + 1))
+            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
                 .get();
         }
     }
@@ -1503,8 +1484,9 @@ void test_multiple_use_with_generation_barrier(int lpn, std::size_t iterations, 
     }
 }
 
-void test_all_gather_hierarchical(int arity, int lpn, std::size_t iterations, std::size_t warmup_iterations,
-    int test_size, std::string const& operation, int fallback_threshold)
+void test_all_gather_hierarchical(int arity, int lpn, std::size_t iterations,
+    std::size_t warmup_iterations, int test_size, std::string const& operation,
+    int fallback_threshold)
 {
     // Get parameters
     std::size_t const num_localities =
@@ -1545,17 +1527,15 @@ void test_all_gather_hierarchical(int arity, int lpn, std::size_t iterations, st
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed =
-                reduce_here(timing_comm, timer.elapsed(), double_max{},
-                    generation_arg(i + 1))
-                    .get();
+            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
+                double_max{}, generation_arg(i + 1))
+                                           .get();
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(),
-                generation_arg(i + 1))
+            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
                 .get();
         }
         // Check for correctness: every site contributed (i + site), so
@@ -1575,8 +1555,9 @@ void test_all_gather_hierarchical(int arity, int lpn, std::size_t iterations, st
     }
 }
 
-void test_all_to_all_hierarchical(int arity, int lpn, std::size_t iterations, std::size_t warmup_iterations,
-    int test_size, std::string const& operation, int fallback_threshold)
+void test_all_to_all_hierarchical(int arity, int lpn, std::size_t iterations,
+    std::size_t warmup_iterations, int test_size, std::string const& operation,
+    int fallback_threshold)
 {
     // Get parameters
     std::size_t const num_localities =
@@ -1613,10 +1594,9 @@ void test_all_to_all_hierarchical(int arity, int lpn, std::size_t iterations, st
     {
         // Refill: block j carries (this_locality + j + i)
         for (std::ptrdiff_t j = 0;
-             j < static_cast<std::ptrdiff_t>(num_localities); ++j)
+            j < static_cast<std::ptrdiff_t>(num_localities); ++j)
         {
-            std::fill(
-                send_data[static_cast<std::size_t>(j)].begin(),
+            std::fill(send_data[static_cast<std::size_t>(j)].begin(),
                 send_data[static_cast<std::size_t>(j)].end(),
                 static_cast<int>(
                     this_locality + static_cast<std::size_t>(j) + i));
@@ -1634,17 +1614,15 @@ void test_all_to_all_hierarchical(int arity, int lpn, std::size_t iterations, st
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed =
-                reduce_here(timing_comm, timer.elapsed(), double_max{},
-                    generation_arg(i + 1))
-                    .get();
+            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
+                double_max{}, generation_arg(i + 1))
+                                           .get();
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(),
-                generation_arg(i + 1))
+            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
                 .get();
         }
         // Correctness: recv_data[s][*] == s + this_locality + i
@@ -1652,8 +1630,8 @@ void test_all_to_all_hierarchical(int arity, int lpn, std::size_t iterations, st
         for (std::size_t s = 0; s != num_localities; ++s)
         {
             HPX_TEST_EQ(recv_data[s].size(), block_size);
-            HPX_TEST_EQ(recv_data[s][0],
-                static_cast<int>(s + this_locality + i));
+            HPX_TEST_EQ(
+                recv_data[s][0], static_cast<int>(s + this_locality + i));
         }
     }
     if (this_locality == 0)
@@ -1666,8 +1644,8 @@ void test_all_to_all_hierarchical(int arity, int lpn, std::size_t iterations, st
     }
 }
 ////////////////////////////////////////////////////////////////////////////////////////
-void test_one_shot_use_all_gather(int lpn, std::size_t iterations, std::size_t warmup_iterations,
-    int test_size, std::string const& operation)
+void test_one_shot_use_all_gather(int lpn, std::size_t iterations,
+    std::size_t warmup_iterations, int test_size, std::string const& operation)
 {
     // Get parameters
     std::size_t const num_localities =
@@ -1700,17 +1678,15 @@ void test_one_shot_use_all_gather(int lpn, std::size_t iterations, std::size_t w
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed =
-                reduce_here(timing_comm, timer.elapsed(), double_max{},
-                    generation_arg(i + 1))
-                    .get();
+            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
+                double_max{}, generation_arg(i + 1))
+                                           .get();
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(),
-                generation_arg(i + 1))
+            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
                 .get();
         }
         // Check for correctness
@@ -1727,7 +1703,8 @@ void test_one_shot_use_all_gather(int lpn, std::size_t iterations, std::size_t w
 }
 ////////////////////////////////////////////////////////////////////////////////////////
 void test_multiple_use_with_generation_all_gather(int lpn,
-    std::size_t iterations, std::size_t warmup_iterations, int test_size, std::string const& operation)
+    std::size_t iterations, std::size_t warmup_iterations, int test_size,
+    std::string const& operation)
 {
     // Get parameters
     std::size_t const num_localities =
@@ -1763,17 +1740,15 @@ void test_multiple_use_with_generation_all_gather(int lpn,
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed =
-                reduce_here(timing_comm, timer.elapsed(), double_max{},
-                    generation_arg(i + 1))
-                    .get();
+            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
+                double_max{}, generation_arg(i + 1))
+                                           .get();
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(),
-                generation_arg(i + 1))
+            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
                 .get();
         }
         // Check for correctness
@@ -1811,14 +1786,17 @@ int hpx_main(hpx::program_options::variables_map& vm)
         {
             if (arity == -1)
             {
-                test_one_shot_use_scatter(
-                    lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size, operation);
-                test_multiple_use_with_generation_scatter(
-                    lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size, operation);
+                test_one_shot_use_scatter(lpn, iterations,
+                    static_cast<std::size_t>(warmup_iterations), test_size,
+                    operation);
+                test_multiple_use_with_generation_scatter(lpn, iterations,
+                    static_cast<std::size_t>(warmup_iterations), test_size,
+                    operation);
             }
             else
             {
-                test_scatter_hierarchical(arity, lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size,
+                test_scatter_hierarchical(arity, lpn, iterations,
+                    static_cast<std::size_t>(warmup_iterations), test_size,
                     operation, fallback_threshold);
             }
         }
@@ -1826,13 +1804,17 @@ int hpx_main(hpx::program_options::variables_map& vm)
         {
             if (arity == -1)
             {
-                test_one_shot_use_reduce(lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size, operation);
-                test_multiple_use_with_generation_reduce(
-                    lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size, operation);
+                test_one_shot_use_reduce(lpn, iterations,
+                    static_cast<std::size_t>(warmup_iterations), test_size,
+                    operation);
+                test_multiple_use_with_generation_reduce(lpn, iterations,
+                    static_cast<std::size_t>(warmup_iterations), test_size,
+                    operation);
             }
             else
             {
-                test_reduce_hierarchical(arity, lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size,
+                test_reduce_hierarchical(arity, lpn, iterations,
+                    static_cast<std::size_t>(warmup_iterations), test_size,
                     operation, fallback_threshold);
             }
         }
@@ -1840,14 +1822,17 @@ int hpx_main(hpx::program_options::variables_map& vm)
         {
             if (arity == -1)
             {
-                test_one_shot_use_broadcast(
-                    lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size, operation);
-                test_multiple_use_with_generation_broadcast(
-                    lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size, operation);
+                test_one_shot_use_broadcast(lpn, iterations,
+                    static_cast<std::size_t>(warmup_iterations), test_size,
+                    operation);
+                test_multiple_use_with_generation_broadcast(lpn, iterations,
+                    static_cast<std::size_t>(warmup_iterations), test_size,
+                    operation);
             }
             else
             {
-                test_broadcast_hierarchical(arity, lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size,
+                test_broadcast_hierarchical(arity, lpn, iterations,
+                    static_cast<std::size_t>(warmup_iterations), test_size,
                     operation, fallback_threshold);
             }
         }
@@ -1855,13 +1840,17 @@ int hpx_main(hpx::program_options::variables_map& vm)
         {
             if (arity == -1)
             {
-                test_one_shot_use_gather(lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size, operation);
-                test_multiple_use_with_generation_gather(
-                    lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size, operation);
+                test_one_shot_use_gather(lpn, iterations,
+                    static_cast<std::size_t>(warmup_iterations), test_size,
+                    operation);
+                test_multiple_use_with_generation_gather(lpn, iterations,
+                    static_cast<std::size_t>(warmup_iterations), test_size,
+                    operation);
             }
             else
             {
-                test_gather_hierarchical(arity, lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size,
+                test_gather_hierarchical(arity, lpn, iterations,
+                    static_cast<std::size_t>(warmup_iterations), test_size,
                     operation, fallback_threshold);
             }
         }
@@ -1869,14 +1858,17 @@ int hpx_main(hpx::program_options::variables_map& vm)
         {
             if (arity == -1)
             {
-                test_one_shot_use_all_reduce(
-                    lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size, operation);
-                test_multiple_use_with_generation_all_reduce(
-                    lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size, operation);
+                test_one_shot_use_all_reduce(lpn, iterations,
+                    static_cast<std::size_t>(warmup_iterations), test_size,
+                    operation);
+                test_multiple_use_with_generation_all_reduce(lpn, iterations,
+                    static_cast<std::size_t>(warmup_iterations), test_size,
+                    operation);
             }
             else
             {
-                test_all_reduce_hierarchical(arity, lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size,
+                test_all_reduce_hierarchical(arity, lpn, iterations,
+                    static_cast<std::size_t>(warmup_iterations), test_size,
                     operation, fallback_threshold);
             }
         }
@@ -1884,14 +1876,17 @@ int hpx_main(hpx::program_options::variables_map& vm)
         {
             if (arity == -1)
             {
-                test_one_shot_use_all_gather(
-                    lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size, operation);
-                test_multiple_use_with_generation_all_gather(
-                    lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size, operation);
+                test_one_shot_use_all_gather(lpn, iterations,
+                    static_cast<std::size_t>(warmup_iterations), test_size,
+                    operation);
+                test_multiple_use_with_generation_all_gather(lpn, iterations,
+                    static_cast<std::size_t>(warmup_iterations), test_size,
+                    operation);
             }
             else
             {
-                test_all_gather_hierarchical(arity, lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size,
+                test_all_gather_hierarchical(arity, lpn, iterations,
+                    static_cast<std::size_t>(warmup_iterations), test_size,
                     operation, fallback_threshold);
             }
         }
@@ -1899,7 +1894,8 @@ int hpx_main(hpx::program_options::variables_map& vm)
         {
             if (arity != -1)
             {
-                test_all_to_all_hierarchical(arity, lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size,
+                test_all_to_all_hierarchical(arity, lpn, iterations,
+                    static_cast<std::size_t>(warmup_iterations), test_size,
                     operation, fallback_threshold);
             }
             else
@@ -1912,12 +1908,14 @@ int hpx_main(hpx::program_options::variables_map& vm)
         {
             if (arity == -1)
             {
-                test_multiple_use_with_generation_barrier(
-                    lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size, operation);
+                test_multiple_use_with_generation_barrier(lpn, iterations,
+                    static_cast<std::size_t>(warmup_iterations), test_size,
+                    operation);
             }
             else
             {
-                test_barrier_hierarchical(arity, lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size,
+                test_barrier_hierarchical(arity, lpn, iterations,
+                    static_cast<std::size_t>(warmup_iterations), test_size,
                     operation, fallback_threshold);
             }
         }

--- a/libs/full/collectives/tests/performance/benchmark_collectives.cpp
+++ b/libs/full/collectives/tests/performance/benchmark_collectives.cpp
@@ -336,17 +336,16 @@ void test_reduce_hierarchical(int arity, int lpn, std::size_t iterations, std::s
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
-    std::vector<int> send_data(static_cast<std::size_t>(test_size), 0);
     std::vector<int> recv_data;
     hpx::future<std::vector<int>> ft_data;
 
     for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
-        std::fill(send_data.begin(), send_data.end(), static_cast<int>(i));
+        std::vector<int> iter_data(
+            static_cast<std::size_t>(test_size), static_cast<int>(i));
 
         barrier.wait();
         // Time collective
-        auto iter_data = send_data;
         hpx::chrono::high_resolution_timer const timer;
         if (this_locality == 0)
         {
@@ -424,24 +423,18 @@ void test_broadcast_hierarchical(int arity, int lpn, std::size_t iterations, std
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
-    std::vector<int> send_data(static_cast<std::size_t>(test_size), 0);
     std::vector<int> recv_data;
     hpx::future<std::vector<int>> ft_data;
 
     for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
-        if (this_locality == 0)
-        {
-            std::fill(send_data.begin(), send_data.end(), static_cast<int>(i));
-        }
-
         barrier.wait();
         // Time collective
-        auto iter_data = send_data;
         hpx::chrono::high_resolution_timer const timer;
         if (this_locality == 0)
         {
-            ft_data = broadcast_to(communicators, std::move(iter_data),
+            ft_data = broadcast_to(communicators,
+                std::vector<int>(static_cast<std::size_t>(test_size), static_cast<int>(i)),
                 this_site_arg(this_locality), generation_arg(i + 1));
         }
         else
@@ -511,18 +504,16 @@ void test_gather_hierarchical(int arity, int lpn, std::size_t iterations, std::s
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
-    std::vector<int> send_data(static_cast<std::size_t>(test_size), 0);
     std::vector<std::vector<int>> recv_data;
     hpx::future<std::vector<std::vector<int>>> ft_data;
 
     for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
-        std::fill(send_data.begin(), send_data.end(),
+        std::vector<int> iter_data(static_cast<std::size_t>(test_size),
             static_cast<int>(i + this_locality));
 
         barrier.wait();
         // Time collective
-        auto iter_data = send_data;
         hpx::chrono::high_resolution_timer const timer;
         if (this_locality == 0)
         {
@@ -601,16 +592,15 @@ void test_all_reduce_hierarchical(int arity, int lpn, std::size_t iterations, st
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
-    std::vector<int> send_data(static_cast<std::size_t>(test_size), 0);
     std::vector<int> recv_data;
 
     for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
-        std::fill(send_data.begin(), send_data.end(), static_cast<int>(i));
+        std::vector<int> iter_data(
+            static_cast<std::size_t>(test_size), static_cast<int>(i));
 
         barrier.wait();
         // Time collective
-        auto iter_data = send_data;
         hpx::chrono::high_resolution_timer const timer;
         hpx::future<std::vector<int>> ft_data =
             all_reduce(communicators, std::move(iter_data), vector_adder{},
@@ -813,17 +803,16 @@ void test_one_shot_use_reduce(int lpn, std::size_t iterations, std::size_t warmu
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
-    std::vector<int> send_data(static_cast<std::size_t>(test_size), 0);
     std::vector<int> recv_data;
     hpx::future<std::vector<int>> ft_data;
 
     for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
-        std::fill(send_data.begin(), send_data.end(), static_cast<int>(i));
+        std::vector<int> iter_data(
+            static_cast<std::size_t>(test_size), static_cast<int>(i));
 
         barrier.wait();
         // Time collective
-        auto iter_data = send_data;
         hpx::chrono::high_resolution_timer const timer;
         if (this_locality == 0)
         {
@@ -889,25 +878,19 @@ void test_one_shot_use_broadcast(int lpn, std::size_t iterations, std::size_t wa
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
-    std::vector<int> send_data(static_cast<std::size_t>(test_size), 0);
     std::vector<int> recv_data;
     hpx::future<std::vector<int>> ft_data;
 
     for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
-        if (this_locality == 0)
-        {
-            std::fill(send_data.begin(), send_data.end(), static_cast<int>(i));
-        }
-
         barrier.wait();
         // Time collective
-        auto iter_data = send_data;
         hpx::chrono::high_resolution_timer const timer;
         if (this_locality == 0)
         {
             ft_data = broadcast_to(broadcast_direct_basename,
-                    std::move(iter_data), num_sites_arg(num_localities),
+                std::vector<int>(static_cast<std::size_t>(test_size), static_cast<int>(i)),
+                num_sites_arg(num_localities),
                 this_site_arg(this_locality), generation_arg(i + 1));
         }
         else
@@ -966,18 +949,16 @@ void test_one_shot_use_gather(int lpn, std::size_t iterations, std::size_t warmu
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
-    std::vector<int> send_data(static_cast<std::size_t>(test_size), 0);
     std::vector<std::vector<int>> recv_data;
     hpx::future<std::vector<std::vector<int>>> ft_data;
 
     for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
-        std::fill(send_data.begin(), send_data.end(),
+        std::vector<int> iter_data(static_cast<std::size_t>(test_size),
             static_cast<int>(i + this_locality));
 
         barrier.wait();
         // Time collective
-        auto iter_data = send_data;
         hpx::chrono::high_resolution_timer const timer;
         if (this_locality == 0)
         {
@@ -1045,16 +1026,15 @@ void test_one_shot_use_all_reduce(int lpn, std::size_t iterations, std::size_t w
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
-    std::vector<int> send_data(static_cast<std::size_t>(test_size), 0);
     std::vector<int> recv_data;
 
     for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
-        std::fill(send_data.begin(), send_data.end(), static_cast<int>(i));
+        std::vector<int> iter_data(
+            static_cast<std::size_t>(test_size), static_cast<int>(i));
 
         barrier.wait();
         // Time collective
-        auto iter_data = send_data;
         hpx::chrono::high_resolution_timer const timer;
         hpx::future<std::vector<int>> ft_data =
             all_reduce(all_reduce_direct_basename, std::move(iter_data),
@@ -1204,17 +1184,16 @@ void test_multiple_use_with_generation_reduce(int lpn, std::size_t iterations, s
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
-    std::vector<int> send_data(static_cast<std::size_t>(test_size), 0);
     std::vector<int> recv_data;
     hpx::future<std::vector<int>> ft_data;
 
     for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
-        std::fill(send_data.begin(), send_data.end(), static_cast<int>(i));
+        std::vector<int> iter_data(
+            static_cast<std::size_t>(test_size), static_cast<int>(i));
 
         barrier.wait();
         // Time collective
-        auto iter_data = send_data;
         hpx::chrono::high_resolution_timer const timer;
         if (this_locality == 0)
         {
@@ -1282,25 +1261,19 @@ void test_multiple_use_with_generation_broadcast(int lpn,
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
-    std::vector<int> send_data(static_cast<std::size_t>(test_size), 0);
     std::vector<int> recv_data;
     hpx::future<std::vector<int>> ft_data;
 
     for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
-        if (this_locality == 0)
-        {
-            std::fill(send_data.begin(), send_data.end(), static_cast<int>(i));
-        }
-
         barrier.wait();
         // Time collective
-        auto iter_data = send_data;
         hpx::chrono::high_resolution_timer const timer;
         if (this_locality == 0)
         {
             ft_data = broadcast_to(broadcast_direct_client,
-                    std::move(iter_data), generation_arg(i + 1));
+                std::vector<int>(static_cast<std::size_t>(test_size), static_cast<int>(i)),
+                generation_arg(i + 1));
         }
         else
         {
@@ -1361,18 +1334,16 @@ void test_multiple_use_with_generation_gather(
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
-    std::vector<int> send_data(static_cast<std::size_t>(test_size), 0);
     std::vector<std::vector<int>> recv_data;
     hpx::future<std::vector<std::vector<int>>> ft_data;
 
     for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
-        std::fill(send_data.begin(), send_data.end(),
+        std::vector<int> iter_data(static_cast<std::size_t>(test_size),
             static_cast<int>(i + this_locality));
 
         barrier.wait();
         // Time collective
-        auto iter_data = send_data;
         hpx::chrono::high_resolution_timer const timer;
         if (this_locality == 0)
         {
@@ -1442,16 +1413,15 @@ void test_multiple_use_with_generation_all_reduce(int lpn,
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
-    std::vector<int> send_data(static_cast<std::size_t>(test_size), 0);
     std::vector<int> recv_data;
 
     for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
-        std::fill(send_data.begin(), send_data.end(), static_cast<int>(i));
+        std::vector<int> iter_data(
+            static_cast<std::size_t>(test_size), static_cast<int>(i));
 
         barrier.wait();
         // Time collective
-        auto iter_data = send_data;
         hpx::chrono::high_resolution_timer const timer;
         hpx::future<std::vector<int>> ft_data =
             all_reduce(all_reduce_direct_client, std::move(iter_data),
@@ -1560,15 +1530,13 @@ void test_all_gather_hierarchical(int arity, int lpn, std::size_t iterations, st
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
-    std::vector<int> send_data(static_cast<std::size_t>(test_size), 0);
     std::vector<std::vector<int>> recv_data;
     for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
-        std::fill(send_data.begin(), send_data.end(),
+        std::vector<int> iter_data(static_cast<std::size_t>(test_size),
             static_cast<int>(i + this_locality));
         barrier.wait();
         // Time collective
-        auto iter_data = send_data;
         hpx::chrono::high_resolution_timer const timer;
         hpx::future<std::vector<std::vector<int>>> ft_data =
             all_gather(communicators, std::move(iter_data),
@@ -1716,15 +1684,13 @@ void test_one_shot_use_all_gather(int lpn, std::size_t iterations, std::size_t w
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
-    std::vector<int> send_data(static_cast<std::size_t>(test_size), 0);
     std::vector<std::vector<int>> recv_data;
     for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
-        std::fill(send_data.begin(), send_data.end(),
+        std::vector<int> iter_data(static_cast<std::size_t>(test_size),
             static_cast<int>(i + this_locality));
         barrier.wait();
         // Time collective
-        auto iter_data = send_data;
         hpx::chrono::high_resolution_timer const timer;
         hpx::future<std::vector<std::vector<int>>> ft_data =
             all_gather(all_gather_direct_basename, std::move(iter_data),
@@ -1782,15 +1748,13 @@ void test_multiple_use_with_generation_all_gather(int lpn,
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
-    std::vector<int> send_data(static_cast<std::size_t>(test_size), 0);
     std::vector<std::vector<int>> recv_data;
     for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
-        std::fill(send_data.begin(), send_data.end(),
+        std::vector<int> iter_data(static_cast<std::size_t>(test_size),
             static_cast<int>(i + this_locality));
         barrier.wait();
         // Time collective
-        auto iter_data = send_data;
         hpx::chrono::high_resolution_timer const timer;
         hpx::future<std::vector<std::vector<int>>> ft_data =
             all_gather(all_gather_direct_client, std::move(iter_data),

--- a/libs/full/collectives/tests/performance/benchmark_collectives.cpp
+++ b/libs/full/collectives/tests/performance/benchmark_collectives.cpp
@@ -34,6 +34,15 @@ constexpr char const* all_reduce_direct_basename = "/test/all_reduce_direct/";
 constexpr char const* all_gather_direct_basename = "/test/all_gather_direct/";
 constexpr char const* all_to_all_direct_basename = "/test/all_to_all_direct/";
 constexpr char const* barrier_bench_basename = "/test/barrier_bench/";
+constexpr char const* timing_reduce_basename = "/test/timing_reduce/";
+
+struct double_max
+{
+    double operator()(double a, double b) const
+    {
+        return std::max(a, b);
+    }
+};
 
 struct vector_adder
 {
@@ -168,7 +177,7 @@ void write_to_file(std::string const& collective, std::string const& type,
 
 ////////////////////////////////////////////////////////////////////////////////////////
 // Hierarchical collectives
-void test_scatter_hierarchical(int arity, int lpn, std::size_t iterations,
+void test_scatter_hierarchical(int arity, int lpn, std::size_t iterations, std::size_t warmup_iterations,
     int test_size, std::string const& operation, int fallback_threshold)
 {
     // Get parameters
@@ -190,13 +199,16 @@ void test_scatter_hierarchical(int arity, int lpn, std::size_t iterations,
     char const* const barrier_test_name = "/test/barrier/hierarchical";
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
+    auto const timing_comm =
+        create_communicator(timing_reduce_basename,
+            num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
     std::vector<std::vector<int>> send_data;
     std::vector<int> recv_data;
     hpx::future<std::vector<int>> ft_data;
 
-    for (std::size_t i = 0; i != iterations; ++i)
+    for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
         if (this_locality == 0)
         {
@@ -204,6 +216,7 @@ void test_scatter_hierarchical(int arity, int lpn, std::size_t iterations,
                 test_size, static_cast<int>(42 + i));
         }
 
+        barrier.wait();
         // Time collective
         hpx::chrono::high_resolution_timer const timer;
         if (this_locality == 0)
@@ -218,10 +231,13 @@ void test_scatter_hierarchical(int arity, int lpn, std::size_t iterations,
                 this_site_arg(this_locality), generation_arg(i + 1));
         }
         recv_data = ft_data.get();
-        // Synchronize
-        barrier.wait();
-        // Write runtime into vector
-        result[i] = timer.elapsed();
+        // Reduce max elapsed time across all localities
+        double const max_elapsed =
+            all_reduce(timing_comm, timer.elapsed(), double_max{},
+                this_site_arg(this_locality), generation_arg(i + 1))
+                .get();
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
 
         // Check for correctness
         for (std::size_t check : recv_data)
@@ -240,7 +256,7 @@ void test_scatter_hierarchical(int arity, int lpn, std::size_t iterations,
     }
 }
 
-void test_reduce_hierarchical(int arity, int lpn, std::size_t iterations,
+void test_reduce_hierarchical(int arity, int lpn, std::size_t iterations, std::size_t warmup_iterations,
     int test_size, std::string const& operation, int fallback_threshold)
 {
     // Get parameters
@@ -262,16 +278,20 @@ void test_reduce_hierarchical(int arity, int lpn, std::size_t iterations,
     char const* const barrier_test_name = "/test/barrier/hierarchical";
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
+    auto const timing_comm =
+        create_communicator(timing_reduce_basename,
+            num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
     std::vector<int> send_data;
     std::vector<int> recv_data;
     hpx::future<std::vector<int>> ft_data;
 
-    for (std::size_t i = 0; i != iterations; ++i)
+    for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
         send_data = std::vector<int>(test_size, static_cast<int>(i));
 
+        barrier.wait();
         // Time collective
         hpx::chrono::high_resolution_timer const timer;
         if (this_locality == 0)
@@ -290,10 +310,13 @@ void test_reduce_hierarchical(int arity, int lpn, std::size_t iterations,
                 this_site_arg(this_locality), generation_arg(i + 1));
             finished.get();
         }
-        // Synchronize
-        barrier.wait();
-        // Write runtime into vector
-        result[i] = timer.elapsed();
+        // Reduce max elapsed time across all localities
+        double const max_elapsed =
+            all_reduce(timing_comm, timer.elapsed(), double_max{},
+                this_site_arg(this_locality), generation_arg(i + 1))
+                .get();
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
 
         // Check for correctness
         if (this_locality == 0)
@@ -313,7 +336,7 @@ void test_reduce_hierarchical(int arity, int lpn, std::size_t iterations,
     }
 }
 
-void test_broadcast_hierarchical(int arity, int lpn, std::size_t iterations,
+void test_broadcast_hierarchical(int arity, int lpn, std::size_t iterations, std::size_t warmup_iterations,
     int test_size, std::string const& operation, int fallback_threshold)
 {
     // Get parameters
@@ -335,19 +358,23 @@ void test_broadcast_hierarchical(int arity, int lpn, std::size_t iterations,
     char const* const barrier_test_name = "/test/barrier/hierarchical";
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
+    auto const timing_comm =
+        create_communicator(timing_reduce_basename,
+            num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
     std::vector<int> send_data;
     std::vector<int> recv_data;
     hpx::future<std::vector<int>> ft_data;
 
-    for (std::size_t i = 0; i != iterations; ++i)
+    for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
         if (this_locality == 0)
         {
             send_data = std::vector<int>(test_size, static_cast<int>(i));
         }
 
+        barrier.wait();
         // Time collective
         hpx::chrono::high_resolution_timer const timer;
         if (this_locality == 0)
@@ -362,10 +389,13 @@ void test_broadcast_hierarchical(int arity, int lpn, std::size_t iterations,
                 this_site_arg(this_locality), generation_arg(i + 1));
         }
         recv_data = ft_data.get();
-        // Synchronize
-        barrier.wait();
-        // Write runtime into vector
-        result[i] = timer.elapsed();
+        // Reduce max elapsed time across all localities
+        double const max_elapsed =
+            all_reduce(timing_comm, timer.elapsed(), double_max{},
+                this_site_arg(this_locality), generation_arg(i + 1))
+                .get();
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
 
         // Check for correctness
         if (this_locality == 0)
@@ -384,7 +414,7 @@ void test_broadcast_hierarchical(int arity, int lpn, std::size_t iterations,
     }
 }
 
-void test_gather_hierarchical(int arity, int lpn, std::size_t iterations,
+void test_gather_hierarchical(int arity, int lpn, std::size_t iterations, std::size_t warmup_iterations,
     int test_size, std::string const& operation, int fallback_threshold)
 {
     // Get parameters
@@ -406,17 +436,21 @@ void test_gather_hierarchical(int arity, int lpn, std::size_t iterations,
     char const* const barrier_test_name = "/test/barrier/hierarchical";
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
+    auto const timing_comm =
+        create_communicator(timing_reduce_basename,
+            num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
     std::vector<int> send_data;
     std::vector<std::vector<int>> recv_data;
     hpx::future<std::vector<std::vector<int>>> ft_data;
 
-    for (std::size_t i = 0; i != iterations; ++i)
+    for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
         send_data =
             std::vector<int>(test_size, static_cast<int>(i + this_locality));
 
+        barrier.wait();
         // Time collective
         hpx::chrono::high_resolution_timer const timer;
         if (this_locality == 0)
@@ -434,10 +468,13 @@ void test_gather_hierarchical(int arity, int lpn, std::size_t iterations,
                     this_site_arg(this_locality), generation_arg(i + 1));
             finished.get();
         }
-        // Synchronize
-        barrier.wait();
-        // Write runtime into vector
-        result[i] = timer.elapsed();
+        // Reduce max elapsed time across all localities
+        double const max_elapsed =
+            all_reduce(timing_comm, timer.elapsed(), double_max{},
+                this_site_arg(this_locality), generation_arg(i + 1))
+                .get();
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
 
         // Check for correctness
         if (this_locality == 0)
@@ -459,7 +496,7 @@ void test_gather_hierarchical(int arity, int lpn, std::size_t iterations,
     }
 }
 
-void test_all_reduce_hierarchical(int arity, int lpn, std::size_t iterations,
+void test_all_reduce_hierarchical(int arity, int lpn, std::size_t iterations, std::size_t warmup_iterations,
     int test_size, std::string const& operation, int fallback_threshold)
 {
     // Get parameters
@@ -481,15 +518,19 @@ void test_all_reduce_hierarchical(int arity, int lpn, std::size_t iterations,
     char const* const barrier_test_name = "/test/barrier/hierarchical";
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
+    auto const timing_comm =
+        create_communicator(timing_reduce_basename,
+            num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
     std::vector<int> send_data;
     std::vector<int> recv_data;
 
-    for (std::size_t i = 0; i != iterations; ++i)
+    for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
         send_data = std::vector<int>(test_size, static_cast<int>(i));
 
+        barrier.wait();
         // Time collective
         hpx::chrono::high_resolution_timer const timer;
         // NOLINTNEXTLINE(bugprone-use-after-move)
@@ -498,10 +539,13 @@ void test_all_reduce_hierarchical(int arity, int lpn, std::size_t iterations,
                 this_site_arg(this_locality), generation_arg(i + 1));
         recv_data = ft_data.get();
 
-        // Synchronize
-        barrier.wait();
-        // Write runtime into vector
-        result[i] = timer.elapsed();
+        // Reduce max elapsed time across all localities
+        double const max_elapsed =
+            all_reduce(timing_comm, timer.elapsed(), double_max{},
+                this_site_arg(this_locality), generation_arg(i + 1))
+                .get();
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
 
         // Check for correctness: every site should have the sum
         HPX_TEST_EQ(i * num_localities, static_cast<std::size_t>(recv_data[0]));
@@ -517,7 +561,7 @@ void test_all_reduce_hierarchical(int arity, int lpn, std::size_t iterations,
     }
 }
 
-void test_barrier_hierarchical(int arity, int lpn, std::size_t iterations,
+void test_barrier_hierarchical(int arity, int lpn, std::size_t iterations, std::size_t warmup_iterations,
     int test_size, std::string const& operation, int fallback_threshold)
 {
     std::size_t const num_localities =
@@ -534,16 +578,25 @@ void test_barrier_hierarchical(int arity, int lpn, std::size_t iterations,
                     static_cast<std::size_t>(fallback_threshold)));
     char const* const barrier_sync_name = "/test/barrier/hierarchical";
     hpx::distributed::barrier sync(barrier_sync_name);
+    auto const timing_comm =
+        create_communicator(timing_reduce_basename,
+            num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
 
-    for (std::size_t i = 0; i != iterations; ++i)
+    for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
+        sync.wait();
         hpx::chrono::high_resolution_timer const timer;
         hpx::collectives::barrier(
             communicators, this_site_arg(this_locality), generation_arg(i + 1))
             .get();
-        sync.wait();
-        result[i] = timer.elapsed();
+        // Reduce max elapsed time across all localities
+        double const max_elapsed =
+            all_reduce(timing_comm, timer.elapsed(), double_max{},
+                this_site_arg(this_locality), generation_arg(i + 1))
+                .get();
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
     }
 
     if (this_locality == 0)
@@ -558,7 +611,7 @@ void test_barrier_hierarchical(int arity, int lpn, std::size_t iterations,
 
 ////////////////////////////////////////////////////////////////////////////////////////
 // One shot collectives
-void test_one_shot_use_scatter(int lpn, std::size_t iterations, int test_size,
+void test_one_shot_use_scatter(int lpn, std::size_t iterations, std::size_t warmup_iterations, int test_size,
     std::string const& operation)
 {
     // Get parameters
@@ -571,13 +624,16 @@ void test_one_shot_use_scatter(int lpn, std::size_t iterations, int test_size,
     char const* const barrier_test_name = "/test/barrier/single";
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
+    auto const timing_comm =
+        create_communicator(timing_reduce_basename,
+            num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
     std::vector<std::vector<int>> send_data;
     std::vector<int> recv_data;
     hpx::future<std::vector<int>> ft_data;
 
-    for (std::size_t i = 0; i != iterations; ++i)
+    for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
         if (this_locality == 0)
         {
@@ -585,6 +641,7 @@ void test_one_shot_use_scatter(int lpn, std::size_t iterations, int test_size,
                 test_size, static_cast<int>(42 + i));
         }
 
+        barrier.wait();
         // Time collective
         hpx::chrono::high_resolution_timer const timer;
         if (this_locality == 0)
@@ -600,10 +657,13 @@ void test_one_shot_use_scatter(int lpn, std::size_t iterations, int test_size,
                 this_site_arg(this_locality), generation_arg(i + 1));
         }
         recv_data = ft_data.get();
-        // Synchronize
-        barrier.wait();
-        // Write runtime into vector
-        result[i] = timer.elapsed();
+        // Reduce max elapsed time across all localities
+        double const max_elapsed =
+            all_reduce(timing_comm, timer.elapsed(), double_max{},
+                this_site_arg(this_locality), generation_arg(i + 1))
+                .get();
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
 
         // Check for correctness
         for (std::size_t check : recv_data)
@@ -619,7 +679,7 @@ void test_one_shot_use_scatter(int lpn, std::size_t iterations, int test_size,
     }
 }
 
-void test_one_shot_use_reduce(int lpn, std::size_t iterations, int test_size,
+void test_one_shot_use_reduce(int lpn, std::size_t iterations, std::size_t warmup_iterations, int test_size,
     std::string const& operation)
 {
     // Get parameters
@@ -632,16 +692,20 @@ void test_one_shot_use_reduce(int lpn, std::size_t iterations, int test_size,
     char const* const barrier_test_name = "/test/barrier/single";
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
+    auto const timing_comm =
+        create_communicator(timing_reduce_basename,
+            num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
     std::vector<int> send_data;
     std::vector<int> recv_data;
     hpx::future<std::vector<int>> ft_data;
 
-    for (std::size_t i = 0; i != iterations; ++i)
+    for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
         send_data = std::vector<int>(test_size, static_cast<int>(i));
 
+        barrier.wait();
         // Time collective
         hpx::chrono::high_resolution_timer const timer;
         if (this_locality == 0)
@@ -660,10 +724,13 @@ void test_one_shot_use_reduce(int lpn, std::size_t iterations, int test_size,
                     this_site_arg(this_locality), generation_arg(i + 1));
             finished.get();
         }
-        // Synchronize
-        barrier.wait();
-        // Write runtime into vector
-        result[i] = timer.elapsed();
+        // Reduce max elapsed time across all localities
+        double const max_elapsed =
+            all_reduce(timing_comm, timer.elapsed(), double_max{},
+                this_site_arg(this_locality), generation_arg(i + 1))
+                .get();
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
 
         // Check for correctness
         if (this_locality == 0)
@@ -680,7 +747,7 @@ void test_one_shot_use_reduce(int lpn, std::size_t iterations, int test_size,
     }
 }
 
-void test_one_shot_use_broadcast(int lpn, std::size_t iterations, int test_size,
+void test_one_shot_use_broadcast(int lpn, std::size_t iterations, std::size_t warmup_iterations, int test_size,
     std::string const& operation)
 {
     // Get parameters
@@ -693,19 +760,23 @@ void test_one_shot_use_broadcast(int lpn, std::size_t iterations, int test_size,
     char const* const barrier_test_name = "/test/barrier/single";
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
+    auto const timing_comm =
+        create_communicator(timing_reduce_basename,
+            num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
     std::vector<int> send_data;
     std::vector<int> recv_data;
     hpx::future<std::vector<int>> ft_data;
 
-    for (std::size_t i = 0; i != iterations; ++i)
+    for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
         if (this_locality == 0)
         {
             send_data = std::vector<int>(test_size, static_cast<int>(i));
         }
 
+        barrier.wait();
         // Time collective
         hpx::chrono::high_resolution_timer const timer;
         if (this_locality == 0)
@@ -722,10 +793,13 @@ void test_one_shot_use_broadcast(int lpn, std::size_t iterations, int test_size,
                     this_site_arg(this_locality), generation_arg(i + 1));
         }
         recv_data = ft_data.get();
-        // Synchronize
-        barrier.wait();
-        // Write runtime into vector
-        result[i] = timer.elapsed();
+        // Reduce max elapsed time across all localities
+        double const max_elapsed =
+            all_reduce(timing_comm, timer.elapsed(), double_max{},
+                this_site_arg(this_locality), generation_arg(i + 1))
+                .get();
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
 
         // Check for correctness
         if (this_locality == 0)
@@ -741,7 +815,7 @@ void test_one_shot_use_broadcast(int lpn, std::size_t iterations, int test_size,
     }
 }
 
-void test_one_shot_use_gather(int lpn, std::size_t iterations, int test_size,
+void test_one_shot_use_gather(int lpn, std::size_t iterations, std::size_t warmup_iterations, int test_size,
     std::string const& operation)
 {
     // Get parameters
@@ -754,17 +828,21 @@ void test_one_shot_use_gather(int lpn, std::size_t iterations, int test_size,
     char const* const barrier_test_name = "/test/barrier/single";
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
+    auto const timing_comm =
+        create_communicator(timing_reduce_basename,
+            num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
     std::vector<int> send_data;
     std::vector<std::vector<int>> recv_data;
     hpx::future<std::vector<std::vector<int>>> ft_data;
 
-    for (std::size_t i = 0; i != iterations; ++i)
+    for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
         send_data =
             std::vector<int>(test_size, static_cast<int>(i + this_locality));
 
+        barrier.wait();
         // Time collective
         hpx::chrono::high_resolution_timer const timer;
         if (this_locality == 0)
@@ -783,10 +861,13 @@ void test_one_shot_use_gather(int lpn, std::size_t iterations, int test_size,
                     this_site_arg(this_locality), generation_arg(i + 1));
             finished.get();
         }
-        // Synchronize
-        barrier.wait();
-        // Write runtime into vector
-        result[i] = timer.elapsed();
+        // Reduce max elapsed time across all localities
+        double const max_elapsed =
+            all_reduce(timing_comm, timer.elapsed(), double_max{},
+                this_site_arg(this_locality), generation_arg(i + 1))
+                .get();
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
 
         // Check for correctness
         if (this_locality == 0)
@@ -805,7 +886,7 @@ void test_one_shot_use_gather(int lpn, std::size_t iterations, int test_size,
     }
 }
 
-void test_one_shot_use_all_reduce(int lpn, std::size_t iterations,
+void test_one_shot_use_all_reduce(int lpn, std::size_t iterations, std::size_t warmup_iterations,
     int test_size, std::string const& operation)
 {
     // Get parameters
@@ -818,15 +899,19 @@ void test_one_shot_use_all_reduce(int lpn, std::size_t iterations,
     char const* const barrier_test_name = "/test/barrier/single";
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
+    auto const timing_comm =
+        create_communicator(timing_reduce_basename,
+            num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
     std::vector<int> send_data;
     std::vector<int> recv_data;
 
-    for (std::size_t i = 0; i != iterations; ++i)
+    for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
         send_data = std::vector<int>(test_size, static_cast<int>(i));
 
+        barrier.wait();
         // Time collective
         hpx::chrono::high_resolution_timer const timer;
         hpx::future<std::vector<int>> ft_data =
@@ -835,10 +920,13 @@ void test_one_shot_use_all_reduce(int lpn, std::size_t iterations,
                 vector_adder{}, num_sites_arg(num_localities),
                 this_site_arg(this_locality), generation_arg(i + 1));
         recv_data = ft_data.get();
-        // Synchronize
-        barrier.wait();
-        // Write runtime into vector
-        result[i] = timer.elapsed();
+        // Reduce max elapsed time across all localities
+        double const max_elapsed =
+            all_reduce(timing_comm, timer.elapsed(), double_max{},
+                this_site_arg(this_locality), generation_arg(i + 1))
+                .get();
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
 
         // Check for correctness
         HPX_TEST_EQ(i * num_localities, static_cast<std::size_t>(recv_data[0]));
@@ -853,7 +941,7 @@ void test_one_shot_use_all_reduce(int lpn, std::size_t iterations,
 
 ////////////////////////////////////////////////////////////////////////////////////////
 // Multi-use shot collectives
-void test_multiple_use_with_generation_scatter(int lpn, std::size_t iterations,
+void test_multiple_use_with_generation_scatter(int lpn, std::size_t iterations, std::size_t warmup_iterations,
     int test_size, std::string const& operation)
 {
     // Get parameters
@@ -870,13 +958,16 @@ void test_multiple_use_with_generation_scatter(int lpn, std::size_t iterations,
     char const* const barrier_test_name = "/test/barrier/generation";
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
+    auto const timing_comm =
+        create_communicator(timing_reduce_basename,
+            num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
     std::vector<std::vector<int>> send_data;
     std::vector<int> recv_data;
     hpx::future<std::vector<int>> ft_data;
 
-    for (std::size_t i = 0; i != iterations; ++i)
+    for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
         if (this_locality == 0)
         {
@@ -884,6 +975,7 @@ void test_multiple_use_with_generation_scatter(int lpn, std::size_t iterations,
                 test_size, static_cast<int>(42 + i));
         }
 
+        barrier.wait();
         // Time collective
         hpx::chrono::high_resolution_timer const timer;
         if (this_locality == 0)
@@ -898,10 +990,13 @@ void test_multiple_use_with_generation_scatter(int lpn, std::size_t iterations,
                 scatter_direct_client, generation_arg(i + 1));
         }
         recv_data = ft_data.get();
-        // Synchronize
-        barrier.wait();
-        // Write runtime into vector
-        result[i] = timer.elapsed();
+        // Reduce max elapsed time across all localities
+        double const max_elapsed =
+            all_reduce(timing_comm, timer.elapsed(), double_max{},
+                this_site_arg(this_locality), generation_arg(i + 1))
+                .get();
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
 
         // Check for correctness
         for (std::size_t check : recv_data)
@@ -917,7 +1012,7 @@ void test_multiple_use_with_generation_scatter(int lpn, std::size_t iterations,
     }
 }
 
-void test_multiple_use_with_generation_reduce(int lpn, std::size_t iterations,
+void test_multiple_use_with_generation_reduce(int lpn, std::size_t iterations, std::size_t warmup_iterations,
     int test_size, std::string const& operation)
 {
     // Get parameters
@@ -934,16 +1029,20 @@ void test_multiple_use_with_generation_reduce(int lpn, std::size_t iterations,
     char const* const barrier_test_name = "/test/barrier/generation";
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
+    auto const timing_comm =
+        create_communicator(timing_reduce_basename,
+            num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
     std::vector<int> send_data;
     std::vector<int> recv_data;
     hpx::future<std::vector<int>> ft_data;
 
-    for (std::size_t i = 0; i != iterations; ++i)
+    for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
         send_data = std::vector<int>(test_size, static_cast<int>(i));
 
+        barrier.wait();
         // Time collective
         hpx::chrono::high_resolution_timer const timer;
         if (this_locality == 0)
@@ -960,10 +1059,13 @@ void test_multiple_use_with_generation_reduce(int lpn, std::size_t iterations,
                 std::move(send_data), generation_arg(i + 1));
             finished.get();
         }
-        // Synchronize
-        barrier.wait();
-        // Write runtime into vector
-        result[i] = timer.elapsed();
+        // Reduce max elapsed time across all localities
+        double const max_elapsed =
+            all_reduce(timing_comm, timer.elapsed(), double_max{},
+                this_site_arg(this_locality), generation_arg(i + 1))
+                .get();
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
 
         // Check for correctness
         if (this_locality == 0)
@@ -981,7 +1083,7 @@ void test_multiple_use_with_generation_reduce(int lpn, std::size_t iterations,
 }
 
 void test_multiple_use_with_generation_broadcast(int lpn,
-    std::size_t iterations, int test_size, std::string const& operation)
+    std::size_t iterations, std::size_t warmup_iterations, int test_size, std::string const& operation)
 {
     // Get parameters
     std::size_t const num_localities =
@@ -997,19 +1099,23 @@ void test_multiple_use_with_generation_broadcast(int lpn,
     char const* const barrier_test_name = "/test/barrier/generation";
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
+    auto const timing_comm =
+        create_communicator(timing_reduce_basename,
+            num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
     std::vector<int> send_data;
     std::vector<int> recv_data;
     hpx::future<std::vector<int>> ft_data;
 
-    for (std::size_t i = 0; i != iterations; ++i)
+    for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
         if (this_locality == 0)
         {
             send_data = std::vector<int>(test_size, static_cast<int>(i));
         }
 
+        barrier.wait();
         // Time collective
         hpx::chrono::high_resolution_timer const timer;
         if (this_locality == 0)
@@ -1024,10 +1130,13 @@ void test_multiple_use_with_generation_broadcast(int lpn,
                 broadcast_direct_client, generation_arg(i + 1));
         }
         recv_data = ft_data.get();
-        // Synchronize
-        barrier.wait();
-        // Write runtime into vector
-        result[i] = timer.elapsed();
+        // Reduce max elapsed time across all localities
+        double const max_elapsed =
+            all_reduce(timing_comm, timer.elapsed(), double_max{},
+                this_site_arg(this_locality), generation_arg(i + 1))
+                .get();
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
 
         // Check for correctness
         if (this_locality == 0)
@@ -1044,7 +1153,7 @@ void test_multiple_use_with_generation_broadcast(int lpn,
 }
 
 void test_multiple_use_with_generation_gather(
-    int lpn, std::size_t iterations, int test_size, std::string operation)
+    int lpn, std::size_t iterations, std::size_t warmup_iterations, int test_size, std::string operation)
 {
     // Get parameters
     std::size_t const num_localities =
@@ -1060,17 +1169,21 @@ void test_multiple_use_with_generation_gather(
     char const* const barrier_test_name = "/test/barrier/generation";
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
+    auto const timing_comm =
+        create_communicator(timing_reduce_basename,
+            num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
     std::vector<int> send_data;
     std::vector<std::vector<int>> recv_data;
     hpx::future<std::vector<std::vector<int>>> ft_data;
 
-    for (std::size_t i = 0; i != iterations; ++i)
+    for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
         send_data =
             std::vector<int>(test_size, static_cast<int>(i + this_locality));
 
+        barrier.wait();
         // Time collective
         hpx::chrono::high_resolution_timer const timer;
         if (this_locality == 0)
@@ -1087,10 +1200,13 @@ void test_multiple_use_with_generation_gather(
                 std::move(send_data), generation_arg(i + 1));
             finished.get();
         }
-        // Synchronize
-        barrier.wait();
-        // Write runtime into vector
-        result[i] = timer.elapsed();
+        // Reduce max elapsed time across all localities
+        double const max_elapsed =
+            all_reduce(timing_comm, timer.elapsed(), double_max{},
+                this_site_arg(this_locality), generation_arg(i + 1))
+                .get();
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
 
         // Check for correctness
         if (this_locality == 0)
@@ -1110,7 +1226,7 @@ void test_multiple_use_with_generation_gather(
 }
 
 void test_multiple_use_with_generation_all_reduce(int lpn,
-    std::size_t iterations, int test_size, std::string const& operation)
+    std::size_t iterations, std::size_t warmup_iterations, int test_size, std::string const& operation)
 {
     // Get parameters
     std::size_t const num_localities =
@@ -1126,15 +1242,19 @@ void test_multiple_use_with_generation_all_reduce(int lpn,
     char const* const barrier_test_name = "/test/barrier/generation";
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
+    auto const timing_comm =
+        create_communicator(timing_reduce_basename,
+            num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
     std::vector<int> send_data;
     std::vector<int> recv_data;
 
-    for (std::size_t i = 0; i != iterations; ++i)
+    for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
         send_data = std::vector<int>(test_size, static_cast<int>(i));
 
+        barrier.wait();
         // Time collective
         hpx::chrono::high_resolution_timer const timer;
         hpx::future<std::vector<int>> ft_data =
@@ -1142,10 +1262,13 @@ void test_multiple_use_with_generation_all_reduce(int lpn,
             all_reduce(all_reduce_direct_client, std::move(send_data),
                 vector_adder{}, generation_arg(i + 1));
         recv_data = ft_data.get();
-        // Synchronize
-        barrier.wait();
-        // Write runtime into vector
-        result[i] = timer.elapsed();
+        // Reduce max elapsed time across all localities
+        double const max_elapsed =
+            all_reduce(timing_comm, timer.elapsed(), double_max{},
+                this_site_arg(this_locality), generation_arg(i + 1))
+                .get();
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
 
         // Check for correctness
         HPX_TEST_EQ(i * num_localities, static_cast<std::size_t>(recv_data[0]));
@@ -1158,7 +1281,7 @@ void test_multiple_use_with_generation_all_reduce(int lpn,
     }
 }
 
-void test_multiple_use_with_generation_barrier(int lpn, std::size_t iterations,
+void test_multiple_use_with_generation_barrier(int lpn, std::size_t iterations, std::size_t warmup_iterations,
     int test_size, std::string const& operation)
 {
     std::size_t const num_localities =
@@ -1169,16 +1292,25 @@ void test_multiple_use_with_generation_barrier(int lpn, std::size_t iterations,
         num_sites_arg(num_localities), this_site_arg(this_locality));
     char const* const barrier_sync_name = "/test/barrier/generation";
     hpx::distributed::barrier sync(barrier_sync_name);
+    auto const timing_comm =
+        create_communicator(timing_reduce_basename,
+            num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
 
-    for (std::size_t i = 0; i != iterations; ++i)
+    for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
+        sync.wait();
         hpx::chrono::high_resolution_timer const timer;
         hpx::collectives::barrier(
             barrier_client, this_site_arg(), generation_arg(i + 1))
             .get();
-        sync.wait();
-        result[i] = timer.elapsed();
+        // Reduce max elapsed time across all localities
+        double const max_elapsed =
+            all_reduce(timing_comm, timer.elapsed(), double_max{},
+                this_site_arg(this_locality), generation_arg(i + 1))
+                .get();
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
     }
 
     if (this_locality == 0)
@@ -1188,7 +1320,7 @@ void test_multiple_use_with_generation_barrier(int lpn, std::size_t iterations,
     }
 }
 
-void test_all_gather_hierarchical(int arity, int lpn, std::size_t iterations,
+void test_all_gather_hierarchical(int arity, int lpn, std::size_t iterations, std::size_t warmup_iterations,
     int test_size, std::string const& operation, int fallback_threshold)
 {
     // Get parameters
@@ -1210,14 +1342,18 @@ void test_all_gather_hierarchical(int arity, int lpn, std::size_t iterations,
     char const* const barrier_test_name = "/test/barrier/hierarchical";
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
+    auto const timing_comm =
+        create_communicator(timing_reduce_basename,
+            num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
     std::vector<int> send_data;
     std::vector<std::vector<int>> recv_data;
-    for (std::size_t i = 0; i != iterations; ++i)
+    for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
         send_data =
             std::vector<int>(test_size, static_cast<int>(i + this_locality));
+        barrier.wait();
         // Time collective
         hpx::chrono::high_resolution_timer const timer;
         // NOLINTNEXTLINE(bugprone-use-after-move)
@@ -1225,10 +1361,13 @@ void test_all_gather_hierarchical(int arity, int lpn, std::size_t iterations,
             all_gather(communicators, std::move(send_data),
                 this_site_arg(this_locality), generation_arg(i + 1));
         recv_data = ft_data.get();
-        // Synchronize
-        barrier.wait();
-        // Write runtime into vector
-        result[i] = timer.elapsed();
+        // Reduce max elapsed time across all localities
+        double const max_elapsed =
+            all_reduce(timing_comm, timer.elapsed(), double_max{},
+                this_site_arg(this_locality), generation_arg(i + 1))
+                .get();
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
         // Check for correctness: every site contributed (i + site), so
         // recv_data[j][0] must equal (i + j) at every site.
         for (int j = 0; j < static_cast<int>(num_localities); ++j)
@@ -1246,7 +1385,7 @@ void test_all_gather_hierarchical(int arity, int lpn, std::size_t iterations,
     }
 }
 
-void test_all_to_all_hierarchical(int arity, int lpn, std::size_t iterations,
+void test_all_to_all_hierarchical(int arity, int lpn, std::size_t iterations, std::size_t warmup_iterations,
     int test_size, std::string const& operation, int fallback_threshold)
 {
     // Get parameters
@@ -1268,6 +1407,9 @@ void test_all_to_all_hierarchical(int arity, int lpn, std::size_t iterations,
     char const* const barrier_test_name = "/test/barrier/hierarchical";
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
+    auto const timing_comm =
+        create_communicator(timing_reduce_basename,
+            num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // The all_to_all payload contract requires exactly num_sites elements
     // per site, so payload scaling happens through the per-destination
@@ -1277,12 +1419,13 @@ void test_all_to_all_hierarchical(int arity, int lpn, std::size_t iterations,
     // Data
     std::vector<std::vector<std::uint32_t>> send_data;
     std::vector<std::vector<std::uint32_t>> recv_data;
-    for (std::size_t i = 0; i != iterations; ++i)
+    for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
         // Each destination block carries the source id
         send_data.assign(num_localities,
             std::vector<std::uint32_t>(
                 block_size, static_cast<std::uint32_t>(this_locality)));
+        barrier.wait();
         // Time collective
         hpx::chrono::high_resolution_timer const timer;
         hpx::future<std::vector<std::vector<std::uint32_t>>> ft_data =
@@ -1290,10 +1433,13 @@ void test_all_to_all_hierarchical(int arity, int lpn, std::size_t iterations,
             all_to_all(communicators, std::move(send_data),
                 this_site_arg(this_locality), generation_arg(i + 1));
         recv_data = ft_data.get();
-        // Synchronize
-        barrier.wait();
-        // Write runtime into vector
-        result[i] = timer.elapsed();
+        // Reduce max elapsed time across all localities
+        double const max_elapsed =
+            all_reduce(timing_comm, timer.elapsed(), double_max{},
+                this_site_arg(this_locality), generation_arg(i + 1))
+                .get();
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
         // Check for correctness on the first iteration only: result block s
         // originated at site s. Later iterations are timed unchecked.
         if (i == 0)
@@ -1316,7 +1462,7 @@ void test_all_to_all_hierarchical(int arity, int lpn, std::size_t iterations,
     }
 }
 ////////////////////////////////////////////////////////////////////////////////////////
-void test_one_shot_use_all_gather(int lpn, std::size_t iterations,
+void test_one_shot_use_all_gather(int lpn, std::size_t iterations, std::size_t warmup_iterations,
     int test_size, std::string const& operation)
 {
     // Get parameters
@@ -1329,14 +1475,18 @@ void test_one_shot_use_all_gather(int lpn, std::size_t iterations,
     char const* const barrier_test_name = "/test/barrier/single";
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
+    auto const timing_comm =
+        create_communicator(timing_reduce_basename,
+            num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
     std::vector<int> send_data;
     std::vector<std::vector<int>> recv_data;
-    for (std::size_t i = 0; i != iterations; ++i)
+    for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
         send_data =
             std::vector<int>(test_size, static_cast<int>(i + this_locality));
+        barrier.wait();
         // Time collective
         hpx::chrono::high_resolution_timer const timer;
         hpx::future<std::vector<std::vector<int>>> ft_data =
@@ -1345,10 +1495,13 @@ void test_one_shot_use_all_gather(int lpn, std::size_t iterations,
                 num_sites_arg(num_localities), this_site_arg(this_locality),
                 generation_arg(i + 1));
         recv_data = ft_data.get();
-        // Synchronize
-        barrier.wait();
-        // Write runtime into vector
-        result[i] = timer.elapsed();
+        // Reduce max elapsed time across all localities
+        double const max_elapsed =
+            all_reduce(timing_comm, timer.elapsed(), double_max{},
+                this_site_arg(this_locality), generation_arg(i + 1))
+                .get();
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
         // Check for correctness
         for (int j = 0; j < static_cast<int>(num_localities); ++j)
         {
@@ -1363,7 +1516,7 @@ void test_one_shot_use_all_gather(int lpn, std::size_t iterations,
 }
 ////////////////////////////////////////////////////////////////////////////////////////
 void test_multiple_use_with_generation_all_gather(int lpn,
-    std::size_t iterations, int test_size, std::string const& operation)
+    std::size_t iterations, std::size_t warmup_iterations, int test_size, std::string const& operation)
 {
     // Get parameters
     std::size_t const num_localities =
@@ -1379,14 +1532,18 @@ void test_multiple_use_with_generation_all_gather(int lpn,
     char const* const barrier_test_name = "/test/barrier/generation";
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
+    auto const timing_comm =
+        create_communicator(timing_reduce_basename,
+            num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
     std::vector<int> send_data;
     std::vector<std::vector<int>> recv_data;
-    for (std::size_t i = 0; i != iterations; ++i)
+    for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
         send_data =
             std::vector<int>(test_size, static_cast<int>(i + this_locality));
+        barrier.wait();
         // Time collective
         hpx::chrono::high_resolution_timer const timer;
         hpx::future<std::vector<std::vector<int>>> ft_data =
@@ -1394,10 +1551,13 @@ void test_multiple_use_with_generation_all_gather(int lpn,
             all_gather(all_gather_direct_client, std::move(send_data),
                 generation_arg(i + 1));
         recv_data = ft_data.get();
-        // Synchronize
-        barrier.wait();
-        // Write runtime into vector
-        result[i] = timer.elapsed();
+        // Reduce max elapsed time across all localities
+        double const max_elapsed =
+            all_reduce(timing_comm, timer.elapsed(), double_max{},
+                this_site_arg(this_locality), generation_arg(i + 1))
+                .get();
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
         // Check for correctness
         for (int j = 0; j < static_cast<int>(num_localities); ++j)
         {
@@ -1418,6 +1578,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
     std::string const operation = vm["operation"].as<std::string>();
     int const iterations = vm["iterations"].as<int>();
     int const fallback_threshold = vm["fallback_threshold"].as<int>();
+    int const warmup_iterations = vm["warmup_iterations"].as<int>();
 
     if (hpx::get_num_localities(hpx::launch::sync) > 1)
     {
@@ -1426,13 +1587,13 @@ int hpx_main(hpx::program_options::variables_map& vm)
             if (arity == -1)
             {
                 test_one_shot_use_scatter(
-                    lpn, iterations, test_size, operation);
+                    lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size, operation);
                 test_multiple_use_with_generation_scatter(
-                    lpn, iterations, test_size, operation);
+                    lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size, operation);
             }
             else
             {
-                test_scatter_hierarchical(arity, lpn, iterations, test_size,
+                test_scatter_hierarchical(arity, lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size,
                     operation, fallback_threshold);
             }
         }
@@ -1440,13 +1601,13 @@ int hpx_main(hpx::program_options::variables_map& vm)
         {
             if (arity == -1)
             {
-                test_one_shot_use_reduce(lpn, iterations, test_size, operation);
+                test_one_shot_use_reduce(lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size, operation);
                 test_multiple_use_with_generation_reduce(
-                    lpn, iterations, test_size, operation);
+                    lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size, operation);
             }
             else
             {
-                test_reduce_hierarchical(arity, lpn, iterations, test_size,
+                test_reduce_hierarchical(arity, lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size,
                     operation, fallback_threshold);
             }
         }
@@ -1455,13 +1616,13 @@ int hpx_main(hpx::program_options::variables_map& vm)
             if (arity == -1)
             {
                 test_one_shot_use_broadcast(
-                    lpn, iterations, test_size, operation);
+                    lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size, operation);
                 test_multiple_use_with_generation_broadcast(
-                    lpn, iterations, test_size, operation);
+                    lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size, operation);
             }
             else
             {
-                test_broadcast_hierarchical(arity, lpn, iterations, test_size,
+                test_broadcast_hierarchical(arity, lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size,
                     operation, fallback_threshold);
             }
         }
@@ -1469,13 +1630,13 @@ int hpx_main(hpx::program_options::variables_map& vm)
         {
             if (arity == -1)
             {
-                test_one_shot_use_gather(lpn, iterations, test_size, operation);
+                test_one_shot_use_gather(lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size, operation);
                 test_multiple_use_with_generation_gather(
-                    lpn, iterations, test_size, operation);
+                    lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size, operation);
             }
             else
             {
-                test_gather_hierarchical(arity, lpn, iterations, test_size,
+                test_gather_hierarchical(arity, lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size,
                     operation, fallback_threshold);
             }
         }
@@ -1484,13 +1645,13 @@ int hpx_main(hpx::program_options::variables_map& vm)
             if (arity == -1)
             {
                 test_one_shot_use_all_reduce(
-                    lpn, iterations, test_size, operation);
+                    lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size, operation);
                 test_multiple_use_with_generation_all_reduce(
-                    lpn, iterations, test_size, operation);
+                    lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size, operation);
             }
             else
             {
-                test_all_reduce_hierarchical(arity, lpn, iterations, test_size,
+                test_all_reduce_hierarchical(arity, lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size,
                     operation, fallback_threshold);
             }
         }
@@ -1499,13 +1660,13 @@ int hpx_main(hpx::program_options::variables_map& vm)
             if (arity == -1)
             {
                 test_one_shot_use_all_gather(
-                    lpn, iterations, test_size, operation);
+                    lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size, operation);
                 test_multiple_use_with_generation_all_gather(
-                    lpn, iterations, test_size, operation);
+                    lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size, operation);
             }
             else
             {
-                test_all_gather_hierarchical(arity, lpn, iterations, test_size,
+                test_all_gather_hierarchical(arity, lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size,
                     operation, fallback_threshold);
             }
         }
@@ -1513,7 +1674,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
         {
             if (arity != -1)
             {
-                test_all_to_all_hierarchical(arity, lpn, iterations, test_size,
+                test_all_to_all_hierarchical(arity, lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size,
                     operation, fallback_threshold);
             }
         }
@@ -1522,11 +1683,11 @@ int hpx_main(hpx::program_options::variables_map& vm)
             if (arity == -1)
             {
                 test_multiple_use_with_generation_barrier(
-                    lpn, iterations, test_size, operation);
+                    lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size, operation);
             }
             else
             {
-                test_barrier_hierarchical(arity, lpn, iterations, test_size,
+                test_barrier_hierarchical(arity, lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size,
                     operation, fallback_threshold);
             }
         }
@@ -1555,7 +1716,9 @@ int main(int argc, char* argv[])
         ("fallback_threshold", value<int>()->default_value(-1),
             "Flat fallback threshold for hierarchical mode. -1 uses library "
             "default (16). Set to 0 to force tree construction. Only meaningful "
-            "with hierarchical mode.");
+            "with hierarchical mode.")
+        ("warmup_iterations", value<int>()->default_value(3),
+            "Number of warmup iterations before the timed loop (default 3)");
     // clang-format on
 
     std::vector<std::string> const cfg = {"hpx.run_hpx_main!=1"};

--- a/libs/full/collectives/tests/performance/benchmark_collectives.cpp
+++ b/libs/full/collectives/tests/performance/benchmark_collectives.cpp
@@ -67,6 +67,7 @@ struct vector_adder
     }
 };
 
+
 void create_parent_dir(std::filesystem::path const& file_path)
 {
     // Create parent directory if does not exist
@@ -1764,17 +1765,18 @@ void test_one_shot_use_exclusive_scan(int lpn, std::size_t iterations,
     auto const timing_comm =
         create_communicator("/test/timing_reduce/exclusive_scan/one_shot/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
+    std::size_t const block_size = static_cast<std::size_t>(test_size);
     std::vector<double> result(iterations, 0.0);
-    std::uint32_t recv_data = 0;
+    std::vector<int> recv_data;
     for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
-        auto const value =
-            static_cast<std::uint32_t>(this_locality + 1 + i);
+        std::vector<int> value(
+            block_size, static_cast<int>(this_locality + 1 + i));
         barrier.wait();
         // Time collective
         hpx::chrono::high_resolution_timer const timer;
-        recv_data = exclusive_scan(exclusive_scan_basename, value,
-            static_cast<std::uint32_t>(0), std::plus<std::uint32_t>{},
+        recv_data = exclusive_scan(exclusive_scan_basename, std::move(value),
+            std::vector<int>(block_size, 0), vector_adder{},
             num_sites_arg(num_localities), this_site_arg(this_locality),
             generation_arg(i + 1))
                         .get();
@@ -1784,10 +1786,11 @@ void test_one_shot_use_exclusive_scan(int lpn, std::size_t iterations,
             this_site_arg(this_locality), generation_arg(i + 1));
         if (i >= warmup_iterations)
             result[i - warmup_iterations] = max_elapsed;
-        std::uint32_t expected = 0;
+        int expected = 0;
         for (std::size_t j = 0; j < this_locality; ++j)
-            expected += static_cast<std::uint32_t>(j + 1 + i);
-        HPX_TEST_EQ(recv_data, expected);
+            expected += static_cast<int>(j + 1 + i);
+        HPX_TEST_EQ(recv_data.size(), block_size);
+        HPX_TEST_EQ(recv_data[0], expected);
     }
     if (this_locality == 0)
     {
@@ -1817,17 +1820,18 @@ void test_multiple_use_with_generation_exclusive_scan(int lpn,
     auto const timing_comm =
         create_communicator("/test/timing_reduce/exclusive_scan/multi_use/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
+    std::size_t const block_size = static_cast<std::size_t>(test_size);
     std::vector<double> result(iterations, 0.0);
-    std::uint32_t recv_data = 0;
+    std::vector<int> recv_data;
     for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
-        auto const value =
-            static_cast<std::uint32_t>(this_locality + 1 + i);
+        std::vector<int> value(
+            block_size, static_cast<int>(this_locality + 1 + i));
         barrier.wait();
         // Time collective
         hpx::chrono::high_resolution_timer const timer;
-        recv_data = exclusive_scan(exclusive_scan_client, value,
-            static_cast<std::uint32_t>(0), std::plus<std::uint32_t>{},
+        recv_data = exclusive_scan(exclusive_scan_client, std::move(value),
+            std::vector<int>(block_size, 0), vector_adder{},
             generation_arg(i + 1))
                         .get();
         // Reduce max elapsed time to root
@@ -1836,10 +1840,11 @@ void test_multiple_use_with_generation_exclusive_scan(int lpn,
             this_site_arg(this_locality), generation_arg(i + 1));
         if (i >= warmup_iterations)
             result[i - warmup_iterations] = max_elapsed;
-        std::uint32_t expected = 0;
+        int expected = 0;
         for (std::size_t j = 0; j < this_locality; ++j)
-            expected += static_cast<std::uint32_t>(j + 1 + i);
-        HPX_TEST_EQ(recv_data, expected);
+            expected += static_cast<int>(j + 1 + i);
+        HPX_TEST_EQ(recv_data.size(), block_size);
+        HPX_TEST_EQ(recv_data[0], expected);
     }
     if (this_locality == 0)
     {
@@ -1873,17 +1878,18 @@ void test_one_shot_use_inclusive_scan(int lpn, std::size_t iterations,
     auto const timing_comm =
         create_communicator("/test/timing_reduce/inclusive_scan/one_shot/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
+    std::size_t const block_size = static_cast<std::size_t>(test_size);
     std::vector<double> result(iterations, 0.0);
-    std::uint32_t recv_data = 0;
+    std::vector<int> recv_data;
     for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
-        auto const value =
-            static_cast<std::uint32_t>(this_locality + 1 + i);
+        std::vector<int> value(
+            block_size, static_cast<int>(this_locality + 1 + i));
         barrier.wait();
         // Time collective
         hpx::chrono::high_resolution_timer const timer;
-        recv_data = inclusive_scan(inclusive_scan_basename, value,
-            std::plus<std::uint32_t>{}, num_sites_arg(num_localities),
+        recv_data = inclusive_scan(inclusive_scan_basename, std::move(value),
+            vector_adder{}, num_sites_arg(num_localities),
             this_site_arg(this_locality), generation_arg(i + 1))
                         .get();
         // Reduce max elapsed time to root
@@ -1892,10 +1898,11 @@ void test_one_shot_use_inclusive_scan(int lpn, std::size_t iterations,
             this_site_arg(this_locality), generation_arg(i + 1));
         if (i >= warmup_iterations)
             result[i - warmup_iterations] = max_elapsed;
-        std::uint32_t expected = 0;
+        int expected = 0;
         for (std::size_t j = 0; j <= this_locality; ++j)
-            expected += static_cast<std::uint32_t>(j + 1 + i);
-        HPX_TEST_EQ(recv_data, expected);
+            expected += static_cast<int>(j + 1 + i);
+        HPX_TEST_EQ(recv_data.size(), block_size);
+        HPX_TEST_EQ(recv_data[0], expected);
     }
     if (this_locality == 0)
     {
@@ -1925,18 +1932,19 @@ void test_multiple_use_with_generation_inclusive_scan(int lpn,
     auto const timing_comm =
         create_communicator("/test/timing_reduce/inclusive_scan/multi_use/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
+    std::size_t const block_size = static_cast<std::size_t>(test_size);
     std::vector<double> result(iterations, 0.0);
-    std::uint32_t recv_data = 0;
+    std::vector<int> recv_data;
     for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
-        auto const value =
-            static_cast<std::uint32_t>(this_locality + 1 + i);
+        std::vector<int> value(
+            block_size, static_cast<int>(this_locality + 1 + i));
         barrier.wait();
         // Time collective
         hpx::chrono::high_resolution_timer const timer;
         recv_data =
-            inclusive_scan(inclusive_scan_client, value,
-                std::plus<std::uint32_t>{}, generation_arg(i + 1))
+            inclusive_scan(inclusive_scan_client, std::move(value),
+                vector_adder{}, generation_arg(i + 1))
                 .get();
         // Reduce max elapsed time to root
         double max_elapsed = timer.elapsed();
@@ -1944,10 +1952,11 @@ void test_multiple_use_with_generation_inclusive_scan(int lpn,
             this_site_arg(this_locality), generation_arg(i + 1));
         if (i >= warmup_iterations)
             result[i - warmup_iterations] = max_elapsed;
-        std::uint32_t expected = 0;
+        int expected = 0;
         for (std::size_t j = 0; j <= this_locality; ++j)
-            expected += static_cast<std::uint32_t>(j + 1 + i);
-        HPX_TEST_EQ(recv_data, expected);
+            expected += static_cast<int>(j + 1 + i);
+        HPX_TEST_EQ(recv_data.size(), block_size);
+        HPX_TEST_EQ(recv_data[0], expected);
     }
     if (this_locality == 0)
     {

--- a/libs/full/collectives/tests/performance/benchmark_collectives.cpp
+++ b/libs/full/collectives/tests/performance/benchmark_collectives.cpp
@@ -37,6 +37,7 @@ constexpr char const* all_reduce_direct_basename = "/test/all_reduce_direct/";
 constexpr char const* all_gather_direct_basename = "/test/all_gather_direct/";
 constexpr char const* all_to_all_direct_basename = "/test/all_to_all_direct/";
 constexpr char const* barrier_bench_basename = "/test/barrier_bench/";
+constexpr char const* exclusive_scan_basename = "/test/exclusive_scan_direct/";
 
 struct double_max
 {
@@ -1745,7 +1746,116 @@ void test_multiple_use_with_generation_all_gather(int lpn,
             test_size, warmup_iterations, iterations, std::move(result));
     }
 }
-struct benchmarking_functions
+////////////////////////////////////////////////////////////////////////////////////////
+void test_one_shot_use_exclusive_scan(int lpn, std::size_t iterations,
+    std::size_t warmup_iterations, int test_size, std::string const& operation)
+{
+    // Get parameters
+    std::size_t const num_localities =
+        hpx::get_num_localities(hpx::launch::sync);
+    std::size_t const this_locality = hpx::get_locality_id();
+    // Ensure at least two localities
+    HPX_TEST_LTE(static_cast<std::size_t>(2), num_localities);
+    // Barrier for synchronization
+    char const* const barrier_test_name = "/test/barrier/single";
+    hpx::distributed::barrier barrier(barrier_test_name);
+    // Timing communicator
+    auto const timing_comm =
+        create_communicator("/test/timing_reduce/exclusive_scan/one_shot/",
+            num_sites_arg(num_localities), this_site_arg(this_locality));
+    std::vector<double> result(iterations, 0.0);
+    std::uint32_t recv_data = 0;
+    for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
+    {
+        auto const value =
+            static_cast<std::uint32_t>(this_locality + 1 + i);
+        barrier.wait();
+        // Time collective
+        hpx::chrono::high_resolution_timer const timer;
+        recv_data = exclusive_scan(exclusive_scan_basename, value,
+            static_cast<std::uint32_t>(0), std::plus<std::uint32_t>{},
+            num_sites_arg(num_localities), this_site_arg(this_locality),
+            generation_arg(i + 1))
+                        .get();
+        // Reduce max elapsed time to root
+        double max_elapsed = timer.elapsed();
+        reduce(timing_comm, max_elapsed, double_max{},
+            this_site_arg(this_locality), generation_arg(i + 1));
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
+        std::uint32_t expected = 0;
+        for (std::size_t j = 0; j < this_locality; ++j)
+            expected += static_cast<std::uint32_t>(j + 1 + i);
+        HPX_TEST_EQ(recv_data, expected);
+    }
+    if (this_locality == 0)
+    {
+        write_to_file(operation, "single_use", -1, num_localities, lpn,
+            test_size, warmup_iterations, iterations, std::move(result));
+    }
+}
+////////////////////////////////////////////////////////////////////////////////////////
+void test_multiple_use_with_generation_exclusive_scan(int lpn,
+    std::size_t iterations, std::size_t warmup_iterations, int test_size,
+    std::string const& operation)
+{
+    // Get parameters
+    std::size_t const num_localities =
+        hpx::get_num_localities(hpx::launch::sync);
+    std::size_t const this_locality = hpx::get_locality_id();
+    // Ensure at least two localities
+    HPX_TEST_LTE(static_cast<std::size_t>(2), num_localities);
+    // Create communicator
+    auto const exclusive_scan_client =
+        create_communicator(exclusive_scan_basename,
+            num_sites_arg(num_localities), this_site_arg(this_locality));
+    // Barrier for synchronization
+    char const* const barrier_test_name = "/test/barrier/generation";
+    hpx::distributed::barrier barrier(barrier_test_name);
+    // Timing communicator
+    auto const timing_comm =
+        create_communicator("/test/timing_reduce/exclusive_scan/multi_use/",
+            num_sites_arg(num_localities), this_site_arg(this_locality));
+    std::vector<double> result(iterations, 0.0);
+    std::uint32_t recv_data = 0;
+    for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
+    {
+        auto const value =
+            static_cast<std::uint32_t>(this_locality + 1 + i);
+        barrier.wait();
+        // Time collective
+        hpx::chrono::high_resolution_timer const timer;
+        recv_data = exclusive_scan(exclusive_scan_client, value,
+            static_cast<std::uint32_t>(0), std::plus<std::uint32_t>{},
+            generation_arg(i + 1))
+                        .get();
+        // Reduce max elapsed time to root
+        double max_elapsed = timer.elapsed();
+        reduce(timing_comm, max_elapsed, double_max{},
+            this_site_arg(this_locality), generation_arg(i + 1));
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
+        std::uint32_t expected = 0;
+        for (std::size_t j = 0; j < this_locality; ++j)
+            expected += static_cast<std::uint32_t>(j + 1 + i);
+        HPX_TEST_EQ(recv_data, expected);
+    }
+    if (this_locality == 0)
+    {
+        write_to_file(operation, "multi_use", -1, num_localities, lpn,
+            test_size, warmup_iterations, iterations, std::move(result));
+    }
+}
+////////////////////////////////////////////////////////////////////////////////////////
+void test_exclusive_scan_hierarchical(int /*arity*/, int /*lpn*/,
+    std::size_t /*iterations*/, std::size_t /*warmup_iterations*/,
+    int /*test_size*/, std::string const& /*operation*/,
+    int /*fallback_threshold*/)
+{
+    std::cout << "error: exclusive_scan does not support hierarchical "
+                 "communicators\n";
+}
+////////////////////////////////////////////////////////////////struct benchmarking_functions
 {
     hpx::function<void(int, std::size_t, std::size_t, int, std::string const&)>
         one_shot;
@@ -1808,6 +1918,10 @@ int hpx_main(hpx::program_options::variables_map& vm)
                 {test_one_shot_use_barrier,
                     test_multiple_use_with_generation_barrier,
                     test_barrier_hierarchical}},
+            {"exclusive_scan",
+                {test_one_shot_use_exclusive_scan,
+                    test_multiple_use_with_generation_exclusive_scan,
+                    test_exclusive_scan_hierarchical}},
         };
 
         auto it = benchmarking.find(operation);
@@ -1852,7 +1966,7 @@ int main(int argc, char* argv[])
             "Number of Iteration the collective is executed")
         ("operation", value<std::string>()->default_value("scatter"),
             "Collective Operation (scatter, reduce, broadcast, gather, "
-            "all_reduce, all_gather, all_to_all, barrier)")
+            "all_reduce, all_gather, all_to_all, barrier, exclusive_scan)")
         ("fallback_threshold", value<int>()->default_value(-1),
             "Flat fallback threshold for hierarchical mode. -1 uses library "
             "default (16). Set to 0 to force tree construction. Only meaningful "

--- a/libs/full/collectives/tests/performance/benchmark_collectives.cpp
+++ b/libs/full/collectives/tests/performance/benchmark_collectives.cpp
@@ -41,7 +41,7 @@ struct double_max
 {
     double operator()(double a, double b) const
     {
-        return std::max(a, b);
+        return (std::max)(a, b);
     }
 };
 
@@ -84,53 +84,46 @@ void create_parent_dir(std::filesystem::path const& file_path)
 
 struct Stats
 {
-    double mean;
-    double variance;
-    double stddev;
-    double min;
-    double max;
-    double median;
+    double mean = 0.0;
+    double variance = 0.0;
+    double stddev = 0.0;
+    double min = 0.0;
+    double max = 0.0;
+    double median = 0.0;
 };
 
-Stats compute_moments(std::vector<double> const& data)
+Stats compute_moments(std::vector<double> data)
 {
     if (data.empty())
-        return Stats{0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+        return {};
     double const n = static_cast<double>(data.size());
 
-    // Mean
     double const sum = std::accumulate(data.begin(), data.end(), 0.0);
     double const mean = sum / n;
 
-    // Variance (population)
     double varianceSum = 0.0;
     for (double x : data)
         varianceSum += (x - mean) * (x - mean);
     double const variance = varianceSum / n;
     double const stddev = std::sqrt(variance);
 
-    // Min / max
-    double const min_val = *std::min_element(data.begin(), data.end());
-    double const max_val = *std::max_element(data.begin(), data.end());
+    // Median and min/max: sort in place (data is a local copy)
+    std::sort(data.begin(), data.end());
+    std::size_t const mid = data.size() / 2;
+    double const median = (data.size() % 2 == 0) ?
+        0.5 * (data[mid - 1] + data[mid]) :
+        data[mid];
 
-    // Median (sorted copy)
-    std::vector<double> sorted(data);
-    std::sort(sorted.begin(), sorted.end());
-    std::size_t const mid = sorted.size() / 2;
-    double const median = (sorted.size() % 2 == 0) ?
-        0.5 * (sorted[mid - 1] + sorted[mid]) :
-        sorted[mid];
-
-    return Stats{mean, variance, stddev, min_val, max_val, median};
+    return Stats{mean, variance, stddev, data.front(), data.back(), median};
 }
 
 void write_to_file(std::string const& collective, std::string const& type,
     int arity, std::size_t num_l, int lpn, int size,
     std::size_t warmup_iterations, std::size_t iterations,
-    std::vector<double> const& result)
+    std::vector<double>&& result)
 {
     // Compute statistics
-    Stats const stats = compute_moments(result);
+    Stats const stats = compute_moments(std::move(result));
     // Compute nodes
     std::size_t nodes = num_l / static_cast<std::size_t>(lpn);
     auto threads = hpx::get_os_thread_count();
@@ -198,11 +191,11 @@ void write_to_file(std::string const& collective, std::string const& type,
     // Add runtimes
     std::ofstream outfile;
     outfile.open(runtime_file_path, std::ios_base::app);
-    outfile << collective << ";" << type << ";" << arity << ";" << nodes << ";"
-            << num_l << ";" << lpn << ";" << threads << ";" << size << ";"
-            << warmup_iterations << ";" << iterations << ";" << stats.mean
-            << ";" << stats.variance << ";" << stats.stddev << ";" << stats.min
-            << ";" << stats.max << ";" << stats.median << "\n";
+    hpx::util::format_to(outfile,
+        "{1};{2};{3};{4};{5};{6};{7};{8};{9};{10};{11};{12};{13};{14};{15};{16}\n",
+        collective, type, arity, nodes, num_l, lpn, threads, size,
+        warmup_iterations, iterations, stats.mean, stats.variance, stats.stddev,
+        stats.min, stats.max, stats.median);
     outfile.close();
 }
 
@@ -249,11 +242,9 @@ void test_scatter_hierarchical(int arity, int lpn, std::size_t iterations,
     {
         if (this_locality == 0)
         {
-            for (std::ptrdiff_t j = 0;
-                j < static_cast<std::ptrdiff_t>(num_localities); ++j)
+            for (std::size_t j = 0; j < num_localities; ++j)
             {
-                std::fill(send_data[static_cast<std::size_t>(j)].begin(),
-                    send_data[static_cast<std::size_t>(j)].end(),
+                std::fill(send_data[j].begin(), send_data[j].end(),
                     static_cast<int>(42 + i) + static_cast<int>(j));
             }
         }
@@ -276,16 +267,16 @@ void test_scatter_hierarchical(int arity, int lpn, std::size_t iterations,
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
-                double_max{}, generation_arg(i + 1))
-                                           .get();
+            double const max_elapsed = reduce_here(hpx::launch::sync,
+                timing_comm, timer.elapsed(), double_max{},
+                generation_arg(i + 1));
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
-                .get();
+            reduce_there(hpx::launch::sync, timing_comm,
+                timer.elapsed(), generation_arg(i + 1));
         }
 
         // Check for correctness
@@ -303,7 +294,7 @@ void test_scatter_hierarchical(int arity, int lpn, std::size_t iterations,
             std::string("hierarchical") :
             "hierarchical_t" + std::to_string(fallback_threshold);
         write_to_file(operation, mod_name, arity, num_localities, lpn,
-            test_size, warmup_iterations, iterations, result);
+            test_size, warmup_iterations, iterations, std::move(result));
     }
 }
 
@@ -363,16 +354,16 @@ void test_reduce_hierarchical(int arity, int lpn, std::size_t iterations,
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
-                double_max{}, generation_arg(i + 1))
-                                           .get();
+            double const max_elapsed = reduce_here(hpx::launch::sync,
+                timing_comm, timer.elapsed(), double_max{},
+                generation_arg(i + 1));
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
-                .get();
+            reduce_there(hpx::launch::sync, timing_comm,
+                timer.elapsed(), generation_arg(i + 1));
         }
 
         // Check for correctness
@@ -389,7 +380,7 @@ void test_reduce_hierarchical(int arity, int lpn, std::size_t iterations,
             std::string("hierarchical") :
             "hierarchical_t" + std::to_string(fallback_threshold);
         write_to_file(operation, mod_name, arity, num_localities, lpn,
-            test_size, warmup_iterations, iterations, result);
+            test_size, warmup_iterations, iterations, std::move(result));
     }
 }
 
@@ -445,16 +436,16 @@ void test_broadcast_hierarchical(int arity, int lpn, std::size_t iterations,
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
-                double_max{}, generation_arg(i + 1))
-                                           .get();
+            double const max_elapsed = reduce_here(hpx::launch::sync,
+                timing_comm, timer.elapsed(), double_max{},
+                generation_arg(i + 1));
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
-                .get();
+            reduce_there(hpx::launch::sync, timing_comm,
+                timer.elapsed(), generation_arg(i + 1));
         }
 
         // Check for correctness
@@ -470,7 +461,7 @@ void test_broadcast_hierarchical(int arity, int lpn, std::size_t iterations,
             std::string("hierarchical") :
             "hierarchical_t" + std::to_string(fallback_threshold);
         write_to_file(operation, mod_name, arity, num_localities, lpn,
-            test_size, warmup_iterations, iterations, result);
+            test_size, warmup_iterations, iterations, std::move(result));
     }
 }
 
@@ -529,16 +520,16 @@ void test_gather_hierarchical(int arity, int lpn, std::size_t iterations,
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
-                double_max{}, generation_arg(i + 1))
-                                           .get();
+            double const max_elapsed = reduce_here(hpx::launch::sync,
+                timing_comm, timer.elapsed(), double_max{},
+                generation_arg(i + 1));
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
-                .get();
+            reduce_there(hpx::launch::sync, timing_comm,
+                timer.elapsed(), generation_arg(i + 1));
         }
 
         // Check for correctness
@@ -557,7 +548,7 @@ void test_gather_hierarchical(int arity, int lpn, std::size_t iterations,
             std::string("hierarchical") :
             "hierarchical_t" + std::to_string(fallback_threshold);
         write_to_file(operation, mod_name, arity, num_localities, lpn,
-            test_size, warmup_iterations, iterations, result);
+            test_size, warmup_iterations, iterations, std::move(result));
     }
 }
 
@@ -607,16 +598,16 @@ void test_all_reduce_hierarchical(int arity, int lpn, std::size_t iterations,
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
-                double_max{}, generation_arg(i + 1))
-                                           .get();
+            double const max_elapsed = reduce_here(hpx::launch::sync,
+                timing_comm, timer.elapsed(), double_max{},
+                generation_arg(i + 1));
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
-                .get();
+            reduce_there(hpx::launch::sync, timing_comm,
+                timer.elapsed(), generation_arg(i + 1));
         }
 
         // Check for correctness: every site should have the sum
@@ -630,7 +621,7 @@ void test_all_reduce_hierarchical(int arity, int lpn, std::size_t iterations,
             std::string("hierarchical") :
             "hierarchical_t" + std::to_string(fallback_threshold);
         write_to_file(operation, mod_name, arity, num_localities, lpn,
-            test_size, warmup_iterations, iterations, result);
+            test_size, warmup_iterations, iterations, std::move(result));
     }
 }
 
@@ -667,16 +658,16 @@ void test_barrier_hierarchical(int arity, int lpn, std::size_t iterations,
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
-                double_max{}, generation_arg(i + 1))
-                                           .get();
+            double const max_elapsed = reduce_here(hpx::launch::sync,
+                timing_comm, timer.elapsed(), double_max{},
+                generation_arg(i + 1));
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
-                .get();
+            reduce_there(hpx::launch::sync, timing_comm,
+                timer.elapsed(), generation_arg(i + 1));
         }
     }
 
@@ -686,7 +677,7 @@ void test_barrier_hierarchical(int arity, int lpn, std::size_t iterations,
             std::string("hierarchical") :
             "hierarchical_t" + std::to_string(fallback_threshold);
         write_to_file(operation, mod_name, arity, num_localities, lpn,
-            test_size, warmup_iterations, iterations, result);
+            test_size, warmup_iterations, iterations, std::move(result));
     }
 }
 
@@ -723,11 +714,9 @@ void test_one_shot_use_scatter(int lpn, std::size_t iterations,
     {
         if (this_locality == 0)
         {
-            for (std::ptrdiff_t j = 0;
-                j < static_cast<std::ptrdiff_t>(num_localities); ++j)
+            for (std::size_t j = 0; j < num_localities; ++j)
             {
-                std::fill(send_data[static_cast<std::size_t>(j)].begin(),
-                    send_data[static_cast<std::size_t>(j)].end(),
+                std::fill(send_data[j].begin(), send_data[j].end(),
                     static_cast<int>(42 + i) + static_cast<int>(j));
             }
         }
@@ -751,16 +740,16 @@ void test_one_shot_use_scatter(int lpn, std::size_t iterations,
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
-                double_max{}, generation_arg(i + 1))
-                                           .get();
+            double const max_elapsed = reduce_here(hpx::launch::sync,
+                timing_comm, timer.elapsed(), double_max{},
+                generation_arg(i + 1));
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
-                .get();
+            reduce_there(hpx::launch::sync, timing_comm,
+                timer.elapsed(), generation_arg(i + 1));
         }
 
         // Check for correctness
@@ -775,7 +764,7 @@ void test_one_shot_use_scatter(int lpn, std::size_t iterations,
     if (this_locality == 0)
     {
         write_to_file(operation, "single_use", -1, num_localities, lpn,
-            test_size, warmup_iterations, iterations, result);
+            test_size, warmup_iterations, iterations, std::move(result));
     }
 }
 
@@ -825,16 +814,16 @@ void test_one_shot_use_reduce(int lpn, std::size_t iterations,
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
-                double_max{}, generation_arg(i + 1))
-                                           .get();
+            double const max_elapsed = reduce_here(hpx::launch::sync,
+                timing_comm, timer.elapsed(), double_max{},
+                generation_arg(i + 1));
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
-                .get();
+            reduce_there(hpx::launch::sync, timing_comm,
+                timer.elapsed(), generation_arg(i + 1));
         }
 
         // Check for correctness
@@ -848,7 +837,7 @@ void test_one_shot_use_reduce(int lpn, std::size_t iterations,
     if (this_locality == 0)
     {
         write_to_file(operation, "single_use", -1, num_localities, lpn,
-            test_size, warmup_iterations, iterations, result);
+            test_size, warmup_iterations, iterations, std::move(result));
     }
 }
 
@@ -896,16 +885,16 @@ void test_one_shot_use_broadcast(int lpn, std::size_t iterations,
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
-                double_max{}, generation_arg(i + 1))
-                                           .get();
+            double const max_elapsed = reduce_here(hpx::launch::sync,
+                timing_comm, timer.elapsed(), double_max{},
+                generation_arg(i + 1));
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
-                .get();
+            reduce_there(hpx::launch::sync, timing_comm,
+                timer.elapsed(), generation_arg(i + 1));
         }
 
         // Check for correctness
@@ -918,7 +907,7 @@ void test_one_shot_use_broadcast(int lpn, std::size_t iterations,
     if (this_locality == 0)
     {
         write_to_file(operation, "single_use", -1, num_localities, lpn,
-            test_size, warmup_iterations, iterations, result);
+            test_size, warmup_iterations, iterations, std::move(result));
     }
 }
 
@@ -968,16 +957,16 @@ void test_one_shot_use_gather(int lpn, std::size_t iterations,
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
-                double_max{}, generation_arg(i + 1))
-                                           .get();
+            double const max_elapsed = reduce_here(hpx::launch::sync,
+                timing_comm, timer.elapsed(), double_max{},
+                generation_arg(i + 1));
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
-                .get();
+            reduce_there(hpx::launch::sync, timing_comm,
+                timer.elapsed(), generation_arg(i + 1));
         }
 
         // Check for correctness
@@ -993,7 +982,7 @@ void test_one_shot_use_gather(int lpn, std::size_t iterations,
     if (this_locality == 0)
     {
         write_to_file(operation, "single_use", -1, num_localities, lpn,
-            test_size, warmup_iterations, iterations, result);
+            test_size, warmup_iterations, iterations, std::move(result));
     }
 }
 
@@ -1033,16 +1022,16 @@ void test_one_shot_use_all_reduce(int lpn, std::size_t iterations,
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
-                double_max{}, generation_arg(i + 1))
-                                           .get();
+            double const max_elapsed = reduce_here(hpx::launch::sync,
+                timing_comm, timer.elapsed(), double_max{},
+                generation_arg(i + 1));
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
-                .get();
+            reduce_there(hpx::launch::sync, timing_comm,
+                timer.elapsed(), generation_arg(i + 1));
         }
 
         // Check for correctness
@@ -1053,7 +1042,7 @@ void test_one_shot_use_all_reduce(int lpn, std::size_t iterations,
     if (this_locality == 0)
     {
         write_to_file(operation, "single_use", -1, num_localities, lpn,
-            test_size, warmup_iterations, iterations, result);
+            test_size, warmup_iterations, iterations, std::move(result));
     }
 }
 
@@ -1094,11 +1083,9 @@ void test_multiple_use_with_generation_scatter(int lpn, std::size_t iterations,
     {
         if (this_locality == 0)
         {
-            for (std::ptrdiff_t j = 0;
-                j < static_cast<std::ptrdiff_t>(num_localities); ++j)
+            for (std::size_t j = 0; j < num_localities; ++j)
             {
-                std::fill(send_data[static_cast<std::size_t>(j)].begin(),
-                    send_data[static_cast<std::size_t>(j)].end(),
+                std::fill(send_data[j].begin(), send_data[j].end(),
                     static_cast<int>(42 + i) + static_cast<int>(j));
             }
         }
@@ -1121,16 +1108,16 @@ void test_multiple_use_with_generation_scatter(int lpn, std::size_t iterations,
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
-                double_max{}, generation_arg(i + 1))
-                                           .get();
+            double const max_elapsed = reduce_here(hpx::launch::sync,
+                timing_comm, timer.elapsed(), double_max{},
+                generation_arg(i + 1));
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
-                .get();
+            reduce_there(hpx::launch::sync, timing_comm,
+                timer.elapsed(), generation_arg(i + 1));
         }
 
         // Check for correctness
@@ -1145,7 +1132,7 @@ void test_multiple_use_with_generation_scatter(int lpn, std::size_t iterations,
     if (this_locality == 0)
     {
         write_to_file(operation, "multi_use", -1, num_localities, lpn,
-            test_size, warmup_iterations, iterations, result);
+            test_size, warmup_iterations, iterations, std::move(result));
     }
 }
 
@@ -1197,16 +1184,16 @@ void test_multiple_use_with_generation_reduce(int lpn, std::size_t iterations,
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
-                double_max{}, generation_arg(i + 1))
-                                           .get();
+            double const max_elapsed = reduce_here(hpx::launch::sync,
+                timing_comm, timer.elapsed(), double_max{},
+                generation_arg(i + 1));
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
-                .get();
+            reduce_there(hpx::launch::sync, timing_comm,
+                timer.elapsed(), generation_arg(i + 1));
         }
 
         // Check for correctness
@@ -1220,7 +1207,7 @@ void test_multiple_use_with_generation_reduce(int lpn, std::size_t iterations,
     if (this_locality == 0)
     {
         write_to_file(operation, "multi_use", -1, num_localities, lpn,
-            test_size, warmup_iterations, iterations, result);
+            test_size, warmup_iterations, iterations, std::move(result));
     }
 }
 
@@ -1271,16 +1258,16 @@ void test_multiple_use_with_generation_broadcast(int lpn,
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
-                double_max{}, generation_arg(i + 1))
-                                           .get();
+            double const max_elapsed = reduce_here(hpx::launch::sync,
+                timing_comm, timer.elapsed(), double_max{},
+                generation_arg(i + 1));
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
-                .get();
+            reduce_there(hpx::launch::sync, timing_comm,
+                timer.elapsed(), generation_arg(i + 1));
         }
 
         // Check for correctness
@@ -1293,7 +1280,7 @@ void test_multiple_use_with_generation_broadcast(int lpn,
     if (this_locality == 0)
     {
         write_to_file(operation, "multi_use", -1, num_localities, lpn,
-            test_size, warmup_iterations, iterations, result);
+            test_size, warmup_iterations, iterations, std::move(result));
     }
 }
 
@@ -1345,16 +1332,16 @@ void test_multiple_use_with_generation_gather(int lpn, std::size_t iterations,
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
-                double_max{}, generation_arg(i + 1))
-                                           .get();
+            double const max_elapsed = reduce_here(hpx::launch::sync,
+                timing_comm, timer.elapsed(), double_max{},
+                generation_arg(i + 1));
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
-                .get();
+            reduce_there(hpx::launch::sync, timing_comm,
+                timer.elapsed(), generation_arg(i + 1));
         }
 
         // Check for correctness
@@ -1370,7 +1357,7 @@ void test_multiple_use_with_generation_gather(int lpn, std::size_t iterations,
     if (this_locality == 0)
     {
         write_to_file(operation, "multi_use", -1, num_localities, lpn,
-            test_size, warmup_iterations, iterations, result);
+            test_size, warmup_iterations, iterations, std::move(result));
     }
 }
 
@@ -1414,16 +1401,16 @@ void test_multiple_use_with_generation_all_reduce(int lpn,
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
-                double_max{}, generation_arg(i + 1))
-                                           .get();
+            double const max_elapsed = reduce_here(hpx::launch::sync,
+                timing_comm, timer.elapsed(), double_max{},
+                generation_arg(i + 1));
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
-                .get();
+            reduce_there(hpx::launch::sync, timing_comm,
+                timer.elapsed(), generation_arg(i + 1));
         }
 
         // Check for correctness
@@ -1434,7 +1421,7 @@ void test_multiple_use_with_generation_all_reduce(int lpn,
     if (this_locality == 0)
     {
         write_to_file(operation, "multi_use", -1, num_localities, lpn,
-            test_size, warmup_iterations, iterations, result);
+            test_size, warmup_iterations, iterations, std::move(result));
     }
 }
 
@@ -1464,23 +1451,23 @@ void test_multiple_use_with_generation_barrier(int lpn, std::size_t iterations,
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
-                double_max{}, generation_arg(i + 1))
-                                           .get();
+            double const max_elapsed = reduce_here(hpx::launch::sync,
+                timing_comm, timer.elapsed(), double_max{},
+                generation_arg(i + 1));
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
-                .get();
+            reduce_there(hpx::launch::sync, timing_comm,
+                timer.elapsed(), generation_arg(i + 1));
         }
     }
 
     if (this_locality == 0)
     {
         write_to_file(operation, "multi_use", -1, num_localities, lpn,
-            test_size, warmup_iterations, iterations, result);
+            test_size, warmup_iterations, iterations, std::move(result));
     }
 }
 
@@ -1527,16 +1514,16 @@ void test_all_gather_hierarchical(int arity, int lpn, std::size_t iterations,
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
-                double_max{}, generation_arg(i + 1))
-                                           .get();
+            double const max_elapsed = reduce_here(hpx::launch::sync,
+                timing_comm, timer.elapsed(), double_max{},
+                generation_arg(i + 1));
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
-                .get();
+            reduce_there(hpx::launch::sync, timing_comm,
+                timer.elapsed(), generation_arg(i + 1));
         }
         // Check for correctness: every site contributed (i + site), so
         // recv_data[j][0] must equal (i + j) at every site.
@@ -1551,7 +1538,7 @@ void test_all_gather_hierarchical(int arity, int lpn, std::size_t iterations,
             std::string("hierarchical") :
             "hierarchical_t" + std::to_string(fallback_threshold);
         write_to_file(operation, mod_name, arity, num_localities, lpn,
-            test_size, warmup_iterations, iterations, result);
+            test_size, warmup_iterations, iterations, std::move(result));
     }
 }
 
@@ -1593,13 +1580,10 @@ void test_all_to_all_hierarchical(int arity, int lpn, std::size_t iterations,
     for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
         // Refill: block j carries (this_locality + j + i)
-        for (std::ptrdiff_t j = 0;
-            j < static_cast<std::ptrdiff_t>(num_localities); ++j)
+        for (std::size_t j = 0; j < num_localities; ++j)
         {
-            std::fill(send_data[static_cast<std::size_t>(j)].begin(),
-                send_data[static_cast<std::size_t>(j)].end(),
-                static_cast<int>(
-                    this_locality + static_cast<std::size_t>(j) + i));
+            std::fill(send_data[j].begin(), send_data[j].end(),
+                static_cast<int>(this_locality + j + i));
         }
         barrier.wait();
         // Time collective
@@ -1614,16 +1598,16 @@ void test_all_to_all_hierarchical(int arity, int lpn, std::size_t iterations,
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
-                double_max{}, generation_arg(i + 1))
-                                           .get();
+            double const max_elapsed = reduce_here(hpx::launch::sync,
+                timing_comm, timer.elapsed(), double_max{},
+                generation_arg(i + 1));
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
-                .get();
+            reduce_there(hpx::launch::sync, timing_comm,
+                timer.elapsed(), generation_arg(i + 1));
         }
         // Correctness: recv_data[s][*] == s + this_locality + i
         HPX_TEST_EQ(recv_data.size(), num_localities);
@@ -1640,7 +1624,7 @@ void test_all_to_all_hierarchical(int arity, int lpn, std::size_t iterations,
             std::string("hierarchical") :
             "hierarchical_t" + std::to_string(fallback_threshold);
         write_to_file(operation, mod_name, arity, num_localities, lpn,
-            test_size, warmup_iterations, iterations, result);
+            test_size, warmup_iterations, iterations, std::move(result));
     }
 }
 ////////////////////////////////////////////////////////////////////////////////////////
@@ -1678,16 +1662,16 @@ void test_one_shot_use_all_gather(int lpn, std::size_t iterations,
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
-                double_max{}, generation_arg(i + 1))
-                                           .get();
+            double const max_elapsed = reduce_here(hpx::launch::sync,
+                timing_comm, timer.elapsed(), double_max{},
+                generation_arg(i + 1));
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
-                .get();
+            reduce_there(hpx::launch::sync, timing_comm,
+                timer.elapsed(), generation_arg(i + 1));
         }
         // Check for correctness
         for (int j = 0; j < static_cast<int>(num_localities); ++j)
@@ -1698,7 +1682,7 @@ void test_one_shot_use_all_gather(int lpn, std::size_t iterations,
     if (this_locality == 0)
     {
         write_to_file(operation, "single_use", -1, num_localities, lpn,
-            test_size, warmup_iterations, iterations, result);
+            test_size, warmup_iterations, iterations, std::move(result));
     }
 }
 ////////////////////////////////////////////////////////////////////////////////////////
@@ -1740,16 +1724,16 @@ void test_multiple_use_with_generation_all_gather(int lpn,
         // Reduce max elapsed time to root
         if (this_locality == 0)
         {
-            double const max_elapsed = reduce_here(timing_comm, timer.elapsed(),
-                double_max{}, generation_arg(i + 1))
-                                           .get();
+            double const max_elapsed = reduce_here(hpx::launch::sync,
+                timing_comm, timer.elapsed(), double_max{},
+                generation_arg(i + 1));
             if (i >= warmup_iterations)
                 result[i - warmup_iterations] = max_elapsed;
         }
         else
         {
-            reduce_there(timing_comm, timer.elapsed(), generation_arg(i + 1))
-                .get();
+            reduce_there(hpx::launch::sync, timing_comm,
+                timer.elapsed(), generation_arg(i + 1));
         }
         // Check for correctness
         for (int j = 0; j < static_cast<int>(num_localities); ++j)
@@ -1760,7 +1744,7 @@ void test_multiple_use_with_generation_all_gather(int lpn,
     if (this_locality == 0)
     {
         write_to_file(operation, "multi_use", -1, num_localities, lpn,
-            test_size, warmup_iterations, iterations, result);
+            test_size, warmup_iterations, iterations, std::move(result));
     }
 }
 int hpx_main(hpx::program_options::variables_map& vm)

--- a/libs/full/collectives/tests/performance/benchmark_collectives.cpp
+++ b/libs/full/collectives/tests/performance/benchmark_collectives.cpp
@@ -44,7 +44,7 @@ struct double_max
 {
     double operator()(double a, double b) const
     {
-        return (std::max)(a, b);
+        return (std::max) (a, b);
     }
 };
 
@@ -66,7 +66,6 @@ struct vector_adder
         return result;
     }
 };
-
 
 void create_parent_dir(std::filesystem::path const& file_path)
 {
@@ -114,9 +113,8 @@ Stats compute_moments(std::vector<double> data)
     // Median and min/max: sort in place (data is a local copy)
     std::sort(data.begin(), data.end());
     std::size_t const mid = data.size() / 2;
-    double const median = (data.size() % 2 == 0) ?
-        0.5 * (data[mid - 1] + data[mid]) :
-        data[mid];
+    double const median =
+        (data.size() % 2 == 0) ? 0.5 * (data[mid - 1] + data[mid]) : data[mid];
 
     return Stats{mean, variance, stddev, data.front(), data.back(), median};
 }
@@ -196,7 +194,8 @@ void write_to_file(std::string const& collective, std::string const& type,
     std::ofstream outfile;
     outfile.open(runtime_file_path, std::ios_base::app);
     hpx::util::format_to(outfile,
-        "{1};{2};{3};{4};{5};{6};{7};{8};{9};{10};{11};{12};{13};{14};{15};{16}\n",
+        "{1};{2};{3};{4};{5};{6};{7};{8};{9};{10};{11};{12};{13};{14};{15};{16}"
+        "\n",
         collective, type, arity, nodes, num_l, lpn, threads, size,
         warmup_iterations, iterations, stats.mean, stats.variance, stats.stddev,
         stats.min, stats.max, stats.median);
@@ -1475,11 +1474,10 @@ void test_one_shot_use_all_to_all(int lpn, std::size_t iterations,
         // Time collective
         auto iter_data = send_data;
         hpx::chrono::high_resolution_timer const timer;
-        recv_data =
-            all_to_all(all_to_all_direct_basename, std::move(iter_data),
-                num_sites_arg(num_localities), this_site_arg(this_locality),
-                generation_arg(i + 1))
-                .get();
+        recv_data = all_to_all(all_to_all_direct_basename, std::move(iter_data),
+            num_sites_arg(num_localities), this_site_arg(this_locality),
+            generation_arg(i + 1))
+                        .get();
         // Reduce max elapsed time to root
         double max_elapsed = timer.elapsed();
         reduce(timing_comm, max_elapsed, double_max{},
@@ -1514,9 +1512,8 @@ void test_multiple_use_with_generation_all_to_all(int lpn,
     // Ensure at least two localities
     HPX_TEST_LTE(static_cast<std::size_t>(2), num_localities);
     // Create communicator once for all iterations
-    auto const comm =
-        create_communicator(all_to_all_direct_basename,
-            num_sites_arg(num_localities), this_site_arg(this_locality));
+    auto const comm = create_communicator(all_to_all_direct_basename,
+        num_sites_arg(num_localities), this_site_arg(this_locality));
     // Barrier for synchronization
     char const* const barrier_test_name = "/test/barrier/generation";
     hpx::distributed::barrier barrier(barrier_test_name);
@@ -1594,11 +1591,8 @@ void test_all_to_all_hierarchical(int arity, int lpn, std::size_t iterations,
         create_communicator("/test/timing_reduce/all_to_all/hierarchical/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
-    // Each destination block carries test_size ints, matching MPI's
-    // MPI_Alltoall with sendcount=test_size per rank.
+    // Each destination block carries test_size ints
     std::size_t const block_size = static_cast<std::size_t>(test_size);
-    // Data – pre-allocate shape; refill each iteration so payload varies
-    // with i (matching the MPI benchmark: block j carries this_locality+j+i).
     std::vector<std::vector<int>> send_data(
         num_localities, std::vector<int>(block_size, 0));
     std::vector<std::vector<int>> recv_data;
@@ -1942,10 +1936,9 @@ void test_multiple_use_with_generation_inclusive_scan(int lpn,
         barrier.wait();
         // Time collective
         hpx::chrono::high_resolution_timer const timer;
-        recv_data =
-            inclusive_scan(inclusive_scan_client, std::move(value),
-                vector_adder{}, generation_arg(i + 1))
-                .get();
+        recv_data = inclusive_scan(inclusive_scan_client, std::move(value),
+            vector_adder{}, generation_arg(i + 1))
+                        .get();
         // Reduce max elapsed time to root
         double max_elapsed = timer.elapsed();
         reduce(timing_comm, max_elapsed, double_max{},

--- a/libs/full/collectives/tests/performance/benchmark_collectives.cpp
+++ b/libs/full/collectives/tests/performance/benchmark_collectives.cpp
@@ -1398,6 +1398,131 @@ void test_all_gather_hierarchical(int arity, int lpn, std::size_t iterations,
     }
 }
 
+void test_one_shot_use_all_to_all(int lpn, std::size_t iterations,
+    std::size_t warmup_iterations, int test_size, std::string const& operation)
+{
+    // Get parameters
+    std::size_t const num_localities =
+        hpx::get_num_localities(hpx::launch::sync);
+    std::size_t const this_locality = hpx::get_locality_id();
+    // Ensure at least two localities
+    HPX_TEST_LTE(static_cast<std::size_t>(2), num_localities);
+    // Barrier for synchronization
+    char const* const barrier_test_name = "/test/barrier/single";
+    hpx::distributed::barrier barrier(barrier_test_name);
+    // Result vector
+    auto const timing_comm =
+        create_communicator("/test/timing_reduce/all_to_all/one_shot/",
+            num_sites_arg(num_localities), this_site_arg(this_locality));
+    std::vector<double> result(iterations, 0.0);
+    std::size_t const block_size = static_cast<std::size_t>(test_size);
+    std::vector<std::vector<int>> send_data(
+        num_localities, std::vector<int>(block_size, 0));
+    std::vector<std::vector<int>> recv_data;
+
+    for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
+    {
+        for (std::size_t j = 0; j < num_localities; ++j)
+        {
+            std::fill(send_data[j].begin(), send_data[j].end(),
+                static_cast<int>(this_locality + j + i));
+        }
+        barrier.wait();
+        // Time collective
+        auto iter_data = send_data;
+        hpx::chrono::high_resolution_timer const timer;
+        recv_data =
+            all_to_all(all_to_all_direct_basename, std::move(iter_data),
+                num_sites_arg(num_localities), this_site_arg(this_locality),
+                generation_arg(i + 1))
+                .get();
+        // Reduce max elapsed time to root
+        double max_elapsed = timer.elapsed();
+        reduce(timing_comm, max_elapsed, double_max{},
+            this_site_arg(this_locality), generation_arg(i + 1));
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
+        // Correctness: recv_data[s][*] == s + this_locality + i
+        HPX_TEST_EQ(recv_data.size(), num_localities);
+        for (std::size_t s = 0; s != num_localities; ++s)
+        {
+            HPX_TEST_EQ(recv_data[s].size(), block_size);
+            HPX_TEST_EQ(
+                recv_data[s][0], static_cast<int>(s + this_locality + i));
+        }
+    }
+
+    if (this_locality == 0)
+    {
+        write_to_file(operation, "single_use", -1, num_localities, lpn,
+            test_size, warmup_iterations, iterations, std::move(result));
+    }
+}
+
+void test_multiple_use_with_generation_all_to_all(int lpn,
+    std::size_t iterations, std::size_t warmup_iterations, int test_size,
+    std::string const& operation)
+{
+    // Get parameters
+    std::size_t const num_localities =
+        hpx::get_num_localities(hpx::launch::sync);
+    std::size_t const this_locality = hpx::get_locality_id();
+    // Ensure at least two localities
+    HPX_TEST_LTE(static_cast<std::size_t>(2), num_localities);
+    // Create communicator once for all iterations
+    auto const comm =
+        create_communicator(all_to_all_direct_basename,
+            num_sites_arg(num_localities), this_site_arg(this_locality));
+    // Barrier for synchronization
+    char const* const barrier_test_name = "/test/barrier/generation";
+    hpx::distributed::barrier barrier(barrier_test_name);
+    // Result vector
+    auto const timing_comm =
+        create_communicator("/test/timing_reduce/all_to_all/multi_use/",
+            num_sites_arg(num_localities), this_site_arg(this_locality));
+    std::vector<double> result(iterations, 0.0);
+    std::size_t const block_size = static_cast<std::size_t>(test_size);
+    std::vector<std::vector<int>> send_data(
+        num_localities, std::vector<int>(block_size, 0));
+    std::vector<std::vector<int>> recv_data;
+
+    for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
+    {
+        for (std::size_t j = 0; j < num_localities; ++j)
+        {
+            std::fill(send_data[j].begin(), send_data[j].end(),
+                static_cast<int>(this_locality + j + i));
+        }
+        barrier.wait();
+        // Time collective
+        auto iter_data = send_data;
+        hpx::chrono::high_resolution_timer const timer;
+        recv_data = all_to_all(comm, std::move(iter_data),
+            this_site_arg(this_locality), generation_arg(i + 1))
+                        .get();
+        // Reduce max elapsed time to root
+        double max_elapsed = timer.elapsed();
+        reduce(timing_comm, max_elapsed, double_max{},
+            this_site_arg(this_locality), generation_arg(i + 1));
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
+        // Correctness: recv_data[s][*] == s + this_locality + i
+        HPX_TEST_EQ(recv_data.size(), num_localities);
+        for (std::size_t s = 0; s != num_localities; ++s)
+        {
+            HPX_TEST_EQ(recv_data[s].size(), block_size);
+            HPX_TEST_EQ(
+                recv_data[s][0], static_cast<int>(s + this_locality + i));
+        }
+    }
+
+    if (this_locality == 0)
+    {
+        write_to_file(operation, "multi_use", -1, num_localities, lpn,
+            test_size, warmup_iterations, iterations, std::move(result));
+    }
+}
+
 void test_all_to_all_hierarchical(int arity, int lpn, std::size_t iterations,
     std::size_t warmup_iterations, int test_size, std::string const& operation,
     int fallback_threshold)
@@ -1708,16 +1833,20 @@ int hpx_main(hpx::program_options::variables_map& vm)
         }
         else if (operation == "all_to_all")
         {
-            if (arity != -1)
+            if (arity == -1)
+            {
+                test_one_shot_use_all_to_all(lpn, iterations,
+                    static_cast<std::size_t>(warmup_iterations), test_size,
+                    operation);
+                test_multiple_use_with_generation_all_to_all(lpn, iterations,
+                    static_cast<std::size_t>(warmup_iterations), test_size,
+                    operation);
+            }
+            else
             {
                 test_all_to_all_hierarchical(arity, lpn, iterations,
                     static_cast<std::size_t>(warmup_iterations), test_size,
                     operation, fallback_threshold);
-            }
-            else
-            {
-                std::cout << "warning: all_to_all requires --arity to select "
-                             "an algorithm; no flat variant is implemented\n";
             }
         }
         else if (operation == "barrier")

--- a/libs/full/collectives/tests/performance/benchmark_collectives.cpp
+++ b/libs/full/collectives/tests/performance/benchmark_collectives.cpp
@@ -507,7 +507,7 @@ void test_gather_hierarchical(int arity, int lpn, std::size_t iterations,
         // Check for correctness
         if (this_locality == 0)
         {
-            for (int j = 0; j < static_cast<int>(num_localities); ++j)
+            for (std::size_t j = 0; j < num_localities; ++j)
             {
                 HPX_TEST_EQ(static_cast<int>(i + j), recv_data[j][0]);
             }
@@ -896,7 +896,7 @@ void test_one_shot_use_gather(int lpn, std::size_t iterations,
         // Check for correctness
         if (this_locality == 0)
         {
-            for (int j = 0; j < static_cast<int>(num_localities); ++j)
+            for (std::size_t j = 0; j < num_localities; ++j)
             {
                 HPX_TEST_EQ(static_cast<int>(i + j), recv_data[j][0]);
             }
@@ -1231,7 +1231,7 @@ void test_multiple_use_with_generation_gather(int lpn, std::size_t iterations,
         // Check for correctness
         if (this_locality == 0)
         {
-            for (int j = 0; j < static_cast<int>(num_localities); ++j)
+            for (std::size_t j = 0; j < num_localities; ++j)
             {
                 HPX_TEST_EQ(static_cast<int>(i + j), recv_data[j][0]);
             }
@@ -1427,7 +1427,7 @@ void test_all_gather_hierarchical(int arity, int lpn, std::size_t iterations,
             result[i - warmup_iterations] = max_elapsed;
         // Check for correctness: every site contributed (i + site), so
         // recv_data[j][0] must equal (i + j) at every site.
-        for (int j = 0; j < static_cast<int>(num_localities); ++j)
+        for (std::size_t j = 0; j < num_localities; ++j)
         {
             HPX_TEST_EQ(static_cast<int>(i + j), recv_data[j][0]);
         }
@@ -1683,7 +1683,7 @@ void test_one_shot_use_all_gather(int lpn, std::size_t iterations,
         if (i >= warmup_iterations)
             result[i - warmup_iterations] = max_elapsed;
         // Check for correctness
-        for (int j = 0; j < static_cast<int>(num_localities); ++j)
+        for (std::size_t j = 0; j < num_localities; ++j)
         {
             HPX_TEST_EQ(static_cast<int>(i + j), recv_data[j][0]);
         }
@@ -1737,7 +1737,7 @@ void test_multiple_use_with_generation_all_gather(int lpn,
         if (i >= warmup_iterations)
             result[i - warmup_iterations] = max_elapsed;
         // Check for correctness
-        for (int j = 0; j < static_cast<int>(num_localities); ++j)
+        for (std::size_t j = 0; j < num_localities; ++j)
         {
             HPX_TEST_EQ(static_cast<int>(i + j), recv_data[j][0]);
         }

--- a/libs/full/collectives/tests/performance/benchmark_collectives.cpp
+++ b/libs/full/collectives/tests/performance/benchmark_collectives.cpp
@@ -166,9 +166,10 @@ void write_to_file(std::string const& collective, std::string const& type,
             pp_type = pp->type();
     }
 
-    // Create directory: result/hpx/<parcelport>/<collective>/
+    // Create directory: result/hpx/<parcelport>/<num_localities>/<collective>/
     std::string runtime_file_path =
-        "result/hpx/" + pp_type + "/" + collective + "/runtimes_" +
+        "result/hpx/" + pp_type + "/" + std::to_string(num_l) + "/" +
+        collective + "/runtimes_" +
         collective + "_" + type;
     if (arity != -1 && type == "hierarchical")
     {
@@ -237,7 +238,6 @@ void test_scatter_hierarchical(int arity, int lpn, std::size_t iterations, std::
     std::vector<double> result(iterations, 0.0);
     // Data
     std::vector<std::vector<int>> send_data;
-    // Pre-allocate scatter send buffer once (root only); refill each iteration
     if (this_locality == 0)
     {
         send_data.assign(num_localities,
@@ -262,11 +262,11 @@ void test_scatter_hierarchical(int arity, int lpn, std::size_t iterations, std::
 
         barrier.wait();
         // Time collective
+        auto iter_data = send_data;
         hpx::chrono::high_resolution_timer const timer;
         if (this_locality == 0)
         {
-            // NOLINTNEXTLINE(bugprone-use-after-move)
-            ft_data = scatter_to(communicators, std::move(send_data),
+            ft_data = scatter_to(communicators, std::move(iter_data),
                 this_site_arg(this_locality), generation_arg(i + 1));
         }
         else
@@ -346,20 +346,19 @@ void test_reduce_hierarchical(int arity, int lpn, std::size_t iterations, std::s
 
         barrier.wait();
         // Time collective
+        auto iter_data = send_data;
         hpx::chrono::high_resolution_timer const timer;
         if (this_locality == 0)
         {
             ft_data =
-                // NOLINTNEXTLINE(bugprone-use-after-move)
-                reduce_here(communicators, std::move(send_data), vector_adder{},
+                    reduce_here(communicators, std::move(iter_data), vector_adder{},
                     this_site_arg(this_locality), generation_arg(i + 1));
             recv_data = ft_data.get();
         }
         else
         {
             hpx::future<void> finished = reduce_there(communicators,
-                // NOLINTNEXTLINE(bugprone-use-after-move)
-                std::move(send_data), vector_adder{},
+                    std::move(iter_data), vector_adder{},
                 this_site_arg(this_locality), generation_arg(i + 1));
             finished.get();
         }
@@ -438,11 +437,11 @@ void test_broadcast_hierarchical(int arity, int lpn, std::size_t iterations, std
 
         barrier.wait();
         // Time collective
+        auto iter_data = send_data;
         hpx::chrono::high_resolution_timer const timer;
         if (this_locality == 0)
         {
-            // NOLINTNEXTLINE(bugprone-use-after-move)
-            ft_data = broadcast_to(communicators, std::move(send_data),
+            ft_data = broadcast_to(communicators, std::move(iter_data),
                 this_site_arg(this_locality), generation_arg(i + 1));
         }
         else
@@ -523,19 +522,18 @@ void test_gather_hierarchical(int arity, int lpn, std::size_t iterations, std::s
 
         barrier.wait();
         // Time collective
+        auto iter_data = send_data;
         hpx::chrono::high_resolution_timer const timer;
         if (this_locality == 0)
         {
-            // NOLINTNEXTLINE(bugprone-use-after-move)
-            ft_data = gather_here(communicators, std::move(send_data),
+            ft_data = gather_here(communicators, std::move(iter_data),
                 this_site_arg(this_locality), generation_arg(i + 1));
             recv_data = ft_data.get();
         }
         else
         {
             hpx::future<void> finished =
-                // NOLINTNEXTLINE(bugprone-use-after-move)
-                gather_there(communicators, std::move(send_data),
+                    gather_there(communicators, std::move(iter_data),
                     this_site_arg(this_locality), generation_arg(i + 1));
             finished.get();
         }
@@ -612,10 +610,10 @@ void test_all_reduce_hierarchical(int arity, int lpn, std::size_t iterations, st
 
         barrier.wait();
         // Time collective
+        auto iter_data = send_data;
         hpx::chrono::high_resolution_timer const timer;
-        // NOLINTNEXTLINE(bugprone-use-after-move)
         hpx::future<std::vector<int>> ft_data =
-            all_reduce(communicators, std::move(send_data), vector_adder{},
+            all_reduce(communicators, std::move(iter_data), vector_adder{},
                 this_site_arg(this_locality), generation_arg(i + 1));
         recv_data = ft_data.get();
 
@@ -728,7 +726,6 @@ void test_one_shot_use_scatter(int lpn, std::size_t iterations, std::size_t warm
     std::vector<double> result(iterations, 0.0);
     // Data
     std::vector<std::vector<int>> send_data;
-    // Pre-allocate scatter send buffer once (root only); refill each iteration
     if (this_locality == 0)
     {
         send_data.assign(num_localities,
@@ -753,11 +750,11 @@ void test_one_shot_use_scatter(int lpn, std::size_t iterations, std::size_t warm
 
         barrier.wait();
         // Time collective
+        auto iter_data = send_data;
         hpx::chrono::high_resolution_timer const timer;
         if (this_locality == 0)
         {
-            // NOLINTNEXTLINE(bugprone-use-after-move)
-            ft_data = scatter_to(scatter_direct_basename, std::move(send_data),
+            ft_data = scatter_to(scatter_direct_basename, std::move(iter_data),
                 num_sites_arg(num_localities), this_site_arg(this_locality),
                 generation_arg(i + 1));
         }
@@ -826,11 +823,11 @@ void test_one_shot_use_reduce(int lpn, std::size_t iterations, std::size_t warmu
 
         barrier.wait();
         // Time collective
+        auto iter_data = send_data;
         hpx::chrono::high_resolution_timer const timer;
         if (this_locality == 0)
         {
-            // NOLINTNEXTLINE(bugprone-use-after-move)
-            ft_data = reduce_here(reduce_direct_basename, std::move(send_data),
+            ft_data = reduce_here(reduce_direct_basename, std::move(iter_data),
                 vector_adder{}, num_sites_arg(num_localities),
                 this_site_arg(this_locality), generation_arg(i + 1));
             recv_data = ft_data.get();
@@ -838,8 +835,7 @@ void test_one_shot_use_reduce(int lpn, std::size_t iterations, std::size_t warmu
         else
         {
             hpx::future<void> finished =
-                // NOLINTNEXTLINE(bugprone-use-after-move)
-                reduce_there(reduce_direct_basename, std::move(send_data),
+                    reduce_there(reduce_direct_basename, std::move(iter_data),
                     this_site_arg(this_locality), generation_arg(i + 1));
             finished.get();
         }
@@ -906,12 +902,12 @@ void test_one_shot_use_broadcast(int lpn, std::size_t iterations, std::size_t wa
 
         barrier.wait();
         // Time collective
+        auto iter_data = send_data;
         hpx::chrono::high_resolution_timer const timer;
         if (this_locality == 0)
         {
             ft_data = broadcast_to(broadcast_direct_basename,
-                // NOLINTNEXTLINE(bugprone-use-after-move)
-                std::move(send_data), num_sites_arg(num_localities),
+                    std::move(iter_data), num_sites_arg(num_localities),
                 this_site_arg(this_locality), generation_arg(i + 1));
         }
         else
@@ -981,11 +977,11 @@ void test_one_shot_use_gather(int lpn, std::size_t iterations, std::size_t warmu
 
         barrier.wait();
         // Time collective
+        auto iter_data = send_data;
         hpx::chrono::high_resolution_timer const timer;
         if (this_locality == 0)
         {
-            // NOLINTNEXTLINE(bugprone-use-after-move)
-            ft_data = gather_here(gather_direct_basename, std::move(send_data),
+            ft_data = gather_here(gather_direct_basename, std::move(iter_data),
                 num_sites_arg(num_localities), this_site_arg(this_locality),
                 generation_arg(i + 1));
             recv_data = ft_data.get();
@@ -993,8 +989,7 @@ void test_one_shot_use_gather(int lpn, std::size_t iterations, std::size_t warmu
         else
         {
             hpx::future<void> finished =
-                // NOLINTNEXTLINE(bugprone-use-after-move)
-                gather_there(gather_direct_basename, std::move(send_data),
+                    gather_there(gather_direct_basename, std::move(iter_data),
                     this_site_arg(this_locality), generation_arg(i + 1));
             finished.get();
         }
@@ -1059,10 +1054,10 @@ void test_one_shot_use_all_reduce(int lpn, std::size_t iterations, std::size_t w
 
         barrier.wait();
         // Time collective
+        auto iter_data = send_data;
         hpx::chrono::high_resolution_timer const timer;
         hpx::future<std::vector<int>> ft_data =
-            // NOLINTNEXTLINE(bugprone-use-after-move)
-            all_reduce(all_reduce_direct_basename, std::move(send_data),
+            all_reduce(all_reduce_direct_basename, std::move(iter_data),
                 vector_adder{}, num_sites_arg(num_localities),
                 this_site_arg(this_locality), generation_arg(i + 1));
         recv_data = ft_data.get();
@@ -1119,7 +1114,6 @@ void test_multiple_use_with_generation_scatter(int lpn, std::size_t iterations, 
     std::vector<double> result(iterations, 0.0);
     // Data
     std::vector<std::vector<int>> send_data;
-    // Pre-allocate scatter send buffer once (root only); refill each iteration
     if (this_locality == 0)
     {
         send_data.assign(num_localities,
@@ -1144,11 +1138,11 @@ void test_multiple_use_with_generation_scatter(int lpn, std::size_t iterations, 
 
         barrier.wait();
         // Time collective
+        auto iter_data = send_data;
         hpx::chrono::high_resolution_timer const timer;
         if (this_locality == 0)
         {
-            // NOLINTNEXTLINE(bugprone-use-after-move)
-            ft_data = scatter_to(scatter_direct_client, std::move(send_data),
+            ft_data = scatter_to(scatter_direct_client, std::move(iter_data),
                 generation_arg(i + 1));
         }
         else
@@ -1220,19 +1214,18 @@ void test_multiple_use_with_generation_reduce(int lpn, std::size_t iterations, s
 
         barrier.wait();
         // Time collective
+        auto iter_data = send_data;
         hpx::chrono::high_resolution_timer const timer;
         if (this_locality == 0)
         {
-            // NOLINTNEXTLINE(bugprone-use-after-move)
-            ft_data = reduce_here(reduce_direct_client, std::move(send_data),
+            ft_data = reduce_here(reduce_direct_client, std::move(iter_data),
                 vector_adder{}, generation_arg(i + 1));
             recv_data = ft_data.get();
         }
         else
         {
             hpx::future<void> finished = reduce_there(reduce_direct_client,
-                // NOLINTNEXTLINE(bugprone-use-after-move)
-                std::move(send_data), generation_arg(i + 1));
+                    std::move(iter_data), generation_arg(i + 1));
             finished.get();
         }
         // Reduce max elapsed time to root
@@ -1302,12 +1295,12 @@ void test_multiple_use_with_generation_broadcast(int lpn,
 
         barrier.wait();
         // Time collective
+        auto iter_data = send_data;
         hpx::chrono::high_resolution_timer const timer;
         if (this_locality == 0)
         {
             ft_data = broadcast_to(broadcast_direct_client,
-                // NOLINTNEXTLINE(bugprone-use-after-move)
-                std::move(send_data), generation_arg(i + 1));
+                    std::move(iter_data), generation_arg(i + 1));
         }
         else
         {
@@ -1379,19 +1372,18 @@ void test_multiple_use_with_generation_gather(
 
         barrier.wait();
         // Time collective
+        auto iter_data = send_data;
         hpx::chrono::high_resolution_timer const timer;
         if (this_locality == 0)
         {
-            // NOLINTNEXTLINE(bugprone-use-after-move)
-            ft_data = gather_here(gather_direct_client, std::move(send_data),
+            ft_data = gather_here(gather_direct_client, std::move(iter_data),
                 generation_arg(i + 1));
             recv_data = ft_data.get();
         }
         else
         {
             hpx::future<void> finished = gather_there(gather_direct_client,
-                // NOLINTNEXTLINE(bugprone-use-after-move)
-                std::move(send_data), generation_arg(i + 1));
+                    std::move(iter_data), generation_arg(i + 1));
             finished.get();
         }
         // Reduce max elapsed time to root
@@ -1459,10 +1451,10 @@ void test_multiple_use_with_generation_all_reduce(int lpn,
 
         barrier.wait();
         // Time collective
+        auto iter_data = send_data;
         hpx::chrono::high_resolution_timer const timer;
         hpx::future<std::vector<int>> ft_data =
-            // NOLINTNEXTLINE(bugprone-use-after-move)
-            all_reduce(all_reduce_direct_client, std::move(send_data),
+            all_reduce(all_reduce_direct_client, std::move(iter_data),
                 vector_adder{}, generation_arg(i + 1));
         recv_data = ft_data.get();
         // Reduce max elapsed time to root
@@ -1576,10 +1568,10 @@ void test_all_gather_hierarchical(int arity, int lpn, std::size_t iterations, st
             static_cast<int>(i + this_locality));
         barrier.wait();
         // Time collective
+        auto iter_data = send_data;
         hpx::chrono::high_resolution_timer const timer;
-        // NOLINTNEXTLINE(bugprone-use-after-move)
         hpx::future<std::vector<std::vector<int>>> ft_data =
-            all_gather(communicators, std::move(send_data),
+            all_gather(communicators, std::move(iter_data),
                 this_site_arg(this_locality), generation_arg(i + 1));
         recv_data = ft_data.get();
         // Reduce max elapsed time to root
@@ -1732,10 +1724,10 @@ void test_one_shot_use_all_gather(int lpn, std::size_t iterations, std::size_t w
             static_cast<int>(i + this_locality));
         barrier.wait();
         // Time collective
+        auto iter_data = send_data;
         hpx::chrono::high_resolution_timer const timer;
         hpx::future<std::vector<std::vector<int>>> ft_data =
-            // NOLINTNEXTLINE(bugprone-use-after-move)
-            all_gather(all_gather_direct_basename, std::move(send_data),
+            all_gather(all_gather_direct_basename, std::move(iter_data),
                 num_sites_arg(num_localities), this_site_arg(this_locality),
                 generation_arg(i + 1));
         recv_data = ft_data.get();
@@ -1798,10 +1790,10 @@ void test_multiple_use_with_generation_all_gather(int lpn,
             static_cast<int>(i + this_locality));
         barrier.wait();
         // Time collective
+        auto iter_data = send_data;
         hpx::chrono::high_resolution_timer const timer;
         hpx::future<std::vector<std::vector<int>>> ft_data =
-            // NOLINTNEXTLINE(bugprone-use-after-move)
-            all_gather(all_gather_direct_client, std::move(send_data),
+            all_gather(all_gather_direct_client, std::move(iter_data),
                 generation_arg(i + 1));
         recv_data = ft_data.get();
         // Reduce max elapsed time to root
@@ -1844,7 +1836,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
 
     if (iterations <= 0 || warmup_iterations < 0 || test_size <= 0 || lpn <= 0)
     {
-        hpx::cout << "error: iterations and test_size and lpn must be > 0; "
+        std::cout << "error: iterations and test_size and lpn must be > 0; "
                      "warmup_iterations must be >= 0\n";
         return hpx::finalize();
     }
@@ -1948,7 +1940,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
             }
             else
             {
-                hpx::cout << "warning: all_to_all requires --arity to select "
+                std::cout << "warning: all_to_all requires --arity to select "
                              "an algorithm; no flat variant is implemented\n";
             }
         }

--- a/libs/full/collectives/tests/performance/benchmark_collectives.cpp
+++ b/libs/full/collectives/tests/performance/benchmark_collectives.cpp
@@ -36,7 +36,6 @@ constexpr char const* all_reduce_direct_basename = "/test/all_reduce_direct/";
 constexpr char const* all_gather_direct_basename = "/test/all_gather_direct/";
 constexpr char const* all_to_all_direct_basename = "/test/all_to_all_direct/";
 constexpr char const* barrier_bench_basename = "/test/barrier_bench/";
-constexpr char const* timing_reduce_basename = "/test/timing_reduce/";
 
 struct double_max
 {
@@ -64,17 +63,6 @@ struct vector_adder
         return result;
     }
 };
-
-std::vector<std::vector<int>> generate_matrix(
-    int localities, int test_size, int start_val)
-{
-    std::vector<std::vector<int>> result;
-    for (int i = 0; i < localities; ++i)
-    {
-        result.push_back(std::vector<int>(test_size, start_val + i));
-    }
-    return result;
-}
 
 void create_parent_dir(std::filesystem::path const& file_path)
 {
@@ -106,6 +94,8 @@ struct Stats
 
 Stats compute_moments(std::vector<double> const& data)
 {
+    if (data.empty())
+        return Stats{0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
     double const n = static_cast<double>(data.size());
 
     // Mean
@@ -166,9 +156,20 @@ void write_to_file(std::string const& collective, std::string const& type,
         stats.variance, stats.stddev, stats.min, stats.max, stats.median)
         << std::flush;
 
-    // Create directory
+    // Determine active parcelport (bootstrap port = highest-priority enabled port).
+    // Guard on num_l > 1: single-locality runs have no distributed runtime/parcelport.
+    std::string pp_type = "local";
+    if (num_l > 1)
+    {
+        auto& ph = hpx::get_runtime_distributed().get_parcel_handler();
+        if (auto pp = ph.get_bootstrap_parcelport())
+            pp_type = pp->type();
+    }
+
+    // Create directory: result/hpx/<parcelport>/<collective>/
     std::string runtime_file_path =
-        "result/hpx/" + collective + "/runtimes_" + collective + "_" + type;
+        "result/hpx/" + pp_type + "/" + collective + "/runtimes_" +
+        collective + "_" + type;
     if (arity != -1 && type == "hierarchical")
     {
         runtime_file_path = runtime_file_path + "_" + std::to_string(arity);
@@ -231,11 +232,17 @@ void test_scatter_hierarchical(int arity, int lpn, std::size_t iterations, std::
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
     auto const timing_comm =
-        create_communicator(timing_reduce_basename,
+        create_communicator("/test/timing_reduce/scatter/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
     std::vector<std::vector<int>> send_data;
+    // Pre-allocate scatter send buffer once (root only); refill each iteration
+    if (this_locality == 0)
+    {
+        send_data.assign(num_localities,
+            std::vector<int>(static_cast<std::size_t>(test_size), 0));
+    }
     std::vector<int> recv_data;
     hpx::future<std::vector<int>> ft_data;
 
@@ -243,8 +250,14 @@ void test_scatter_hierarchical(int arity, int lpn, std::size_t iterations, std::
     {
         if (this_locality == 0)
         {
-            send_data = generate_matrix(static_cast<int>(num_localities),
-                test_size, static_cast<int>(42 + i));
+            for (std::ptrdiff_t j = 0;
+                 j < static_cast<std::ptrdiff_t>(num_localities); ++j)
+            {
+                std::fill(
+                    send_data[static_cast<std::size_t>(j)].begin(),
+                    send_data[static_cast<std::size_t>(j)].end(),
+                    static_cast<int>(42 + i) + static_cast<int>(j));
+            }
         }
 
         barrier.wait();
@@ -271,9 +284,9 @@ void test_scatter_hierarchical(int arity, int lpn, std::size_t iterations, std::
             result[i - warmup_iterations] = max_elapsed;
 
         // Check for correctness
-        for (std::size_t check : recv_data)
+        for (int check : recv_data)
         {
-            HPX_TEST_EQ(42 + i + this_locality, check);
+            HPX_TEST_EQ(static_cast<int>(42 + i) + static_cast<int>(this_locality), check);
         }
     }
 
@@ -310,17 +323,17 @@ void test_reduce_hierarchical(int arity, int lpn, std::size_t iterations, std::s
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
     auto const timing_comm =
-        create_communicator(timing_reduce_basename,
+        create_communicator("/test/timing_reduce/reduce/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
-    std::vector<int> send_data;
+    std::vector<int> send_data(static_cast<std::size_t>(test_size), 0);
     std::vector<int> recv_data;
     hpx::future<std::vector<int>> ft_data;
 
     for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
-        send_data = std::vector<int>(test_size, static_cast<int>(i));
+        std::fill(send_data.begin(), send_data.end(), static_cast<int>(i));
 
         barrier.wait();
         // Time collective
@@ -353,7 +366,7 @@ void test_reduce_hierarchical(int arity, int lpn, std::size_t iterations, std::s
         if (this_locality == 0)
         {
             HPX_TEST_EQ(
-                i * num_localities, static_cast<std::size_t>(recv_data[0]));
+                static_cast<int>(i) * static_cast<int>(num_localities), recv_data[0]);
         }
     }
 
@@ -390,11 +403,11 @@ void test_broadcast_hierarchical(int arity, int lpn, std::size_t iterations, std
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
     auto const timing_comm =
-        create_communicator(timing_reduce_basename,
+        create_communicator("/test/timing_reduce/broadcast/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
-    std::vector<int> send_data;
+    std::vector<int> send_data(static_cast<std::size_t>(test_size), 0);
     std::vector<int> recv_data;
     hpx::future<std::vector<int>> ft_data;
 
@@ -402,7 +415,7 @@ void test_broadcast_hierarchical(int arity, int lpn, std::size_t iterations, std
     {
         if (this_locality == 0)
         {
-            send_data = std::vector<int>(test_size, static_cast<int>(i));
+            std::fill(send_data.begin(), send_data.end(), static_cast<int>(i));
         }
 
         barrier.wait();
@@ -431,7 +444,7 @@ void test_broadcast_hierarchical(int arity, int lpn, std::size_t iterations, std
         // Check for correctness
         if (this_locality == 0)
         {
-            HPX_TEST_EQ(i, static_cast<std::size_t>(recv_data[0]));
+            HPX_TEST_EQ(static_cast<int>(i), recv_data[0]);
         }
     }
 
@@ -468,18 +481,18 @@ void test_gather_hierarchical(int arity, int lpn, std::size_t iterations, std::s
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
     auto const timing_comm =
-        create_communicator(timing_reduce_basename,
+        create_communicator("/test/timing_reduce/gather/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
-    std::vector<int> send_data;
+    std::vector<int> send_data(static_cast<std::size_t>(test_size), 0);
     std::vector<std::vector<int>> recv_data;
     hpx::future<std::vector<std::vector<int>>> ft_data;
 
     for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
-        send_data =
-            std::vector<int>(test_size, static_cast<int>(i + this_locality));
+        std::fill(send_data.begin(), send_data.end(),
+            static_cast<int>(i + this_locality));
 
         barrier.wait();
         // Time collective
@@ -512,7 +525,7 @@ void test_gather_hierarchical(int arity, int lpn, std::size_t iterations, std::s
         {
             for (int j = 0; j < static_cast<int>(num_localities); ++j)
             {
-                HPX_TEST_EQ(i + j, static_cast<std::size_t>(recv_data[j][0]));
+                HPX_TEST_EQ(static_cast<int>(i + j), recv_data[j][0]);
             }
         }
     }
@@ -550,16 +563,16 @@ void test_all_reduce_hierarchical(int arity, int lpn, std::size_t iterations, st
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
     auto const timing_comm =
-        create_communicator(timing_reduce_basename,
+        create_communicator("/test/timing_reduce/all_reduce/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
-    std::vector<int> send_data;
+    std::vector<int> send_data(static_cast<std::size_t>(test_size), 0);
     std::vector<int> recv_data;
 
     for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
-        send_data = std::vector<int>(test_size, static_cast<int>(i));
+        std::fill(send_data.begin(), send_data.end(), static_cast<int>(i));
 
         barrier.wait();
         // Time collective
@@ -579,7 +592,7 @@ void test_all_reduce_hierarchical(int arity, int lpn, std::size_t iterations, st
             result[i - warmup_iterations] = max_elapsed;
 
         // Check for correctness: every site should have the sum
-        HPX_TEST_EQ(i * num_localities, static_cast<std::size_t>(recv_data[0]));
+        HPX_TEST_EQ(static_cast<int>(i) * static_cast<int>(num_localities), recv_data[0]);
     }
 
     if (this_locality == 0)
@@ -610,7 +623,7 @@ void test_barrier_hierarchical(int arity, int lpn, std::size_t iterations, std::
     char const* const barrier_sync_name = "/test/barrier/hierarchical";
     hpx::distributed::barrier sync(barrier_sync_name);
     auto const timing_comm =
-        create_communicator(timing_reduce_basename,
+        create_communicator("/test/timing_reduce/barrier/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
 
@@ -656,11 +669,17 @@ void test_one_shot_use_scatter(int lpn, std::size_t iterations, std::size_t warm
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
     auto const timing_comm =
-        create_communicator(timing_reduce_basename,
+        create_communicator("/test/timing_reduce/scatter/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
     std::vector<std::vector<int>> send_data;
+    // Pre-allocate scatter send buffer once (root only); refill each iteration
+    if (this_locality == 0)
+    {
+        send_data.assign(num_localities,
+            std::vector<int>(static_cast<std::size_t>(test_size), 0));
+    }
     std::vector<int> recv_data;
     hpx::future<std::vector<int>> ft_data;
 
@@ -668,8 +687,14 @@ void test_one_shot_use_scatter(int lpn, std::size_t iterations, std::size_t warm
     {
         if (this_locality == 0)
         {
-            send_data = generate_matrix(static_cast<int>(num_localities),
-                test_size, static_cast<int>(42 + i));
+            for (std::ptrdiff_t j = 0;
+                 j < static_cast<std::ptrdiff_t>(num_localities); ++j)
+            {
+                std::fill(
+                    send_data[static_cast<std::size_t>(j)].begin(),
+                    send_data[static_cast<std::size_t>(j)].end(),
+                    static_cast<int>(42 + i) + static_cast<int>(j));
+            }
         }
 
         barrier.wait();
@@ -697,9 +722,9 @@ void test_one_shot_use_scatter(int lpn, std::size_t iterations, std::size_t warm
             result[i - warmup_iterations] = max_elapsed;
 
         // Check for correctness
-        for (std::size_t check : recv_data)
+        for (int check : recv_data)
         {
-            HPX_TEST_EQ(42 + i + this_locality, check);
+            HPX_TEST_EQ(static_cast<int>(42 + i) + static_cast<int>(this_locality), check);
         }
     }
 
@@ -724,17 +749,17 @@ void test_one_shot_use_reduce(int lpn, std::size_t iterations, std::size_t warmu
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
     auto const timing_comm =
-        create_communicator(timing_reduce_basename,
+        create_communicator("/test/timing_reduce/reduce/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
-    std::vector<int> send_data;
+    std::vector<int> send_data(static_cast<std::size_t>(test_size), 0);
     std::vector<int> recv_data;
     hpx::future<std::vector<int>> ft_data;
 
     for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
-        send_data = std::vector<int>(test_size, static_cast<int>(i));
+        std::fill(send_data.begin(), send_data.end(), static_cast<int>(i));
 
         barrier.wait();
         // Time collective
@@ -767,7 +792,7 @@ void test_one_shot_use_reduce(int lpn, std::size_t iterations, std::size_t warmu
         if (this_locality == 0)
         {
             HPX_TEST_EQ(
-                i * num_localities, static_cast<std::size_t>(recv_data[0]));
+                static_cast<int>(i) * static_cast<int>(num_localities), recv_data[0]);
         }
     }
 
@@ -792,11 +817,11 @@ void test_one_shot_use_broadcast(int lpn, std::size_t iterations, std::size_t wa
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
     auto const timing_comm =
-        create_communicator(timing_reduce_basename,
+        create_communicator("/test/timing_reduce/broadcast/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
-    std::vector<int> send_data;
+    std::vector<int> send_data(static_cast<std::size_t>(test_size), 0);
     std::vector<int> recv_data;
     hpx::future<std::vector<int>> ft_data;
 
@@ -804,7 +829,7 @@ void test_one_shot_use_broadcast(int lpn, std::size_t iterations, std::size_t wa
     {
         if (this_locality == 0)
         {
-            send_data = std::vector<int>(test_size, static_cast<int>(i));
+            std::fill(send_data.begin(), send_data.end(), static_cast<int>(i));
         }
 
         barrier.wait();
@@ -835,7 +860,7 @@ void test_one_shot_use_broadcast(int lpn, std::size_t iterations, std::size_t wa
         // Check for correctness
         if (this_locality == 0)
         {
-            HPX_TEST_EQ(i, static_cast<std::size_t>(recv_data[0]));
+            HPX_TEST_EQ(static_cast<int>(i), recv_data[0]);
         }
     }
 
@@ -860,18 +885,18 @@ void test_one_shot_use_gather(int lpn, std::size_t iterations, std::size_t warmu
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
     auto const timing_comm =
-        create_communicator(timing_reduce_basename,
+        create_communicator("/test/timing_reduce/gather/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
-    std::vector<int> send_data;
+    std::vector<int> send_data(static_cast<std::size_t>(test_size), 0);
     std::vector<std::vector<int>> recv_data;
     hpx::future<std::vector<std::vector<int>>> ft_data;
 
     for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
-        send_data =
-            std::vector<int>(test_size, static_cast<int>(i + this_locality));
+        std::fill(send_data.begin(), send_data.end(),
+            static_cast<int>(i + this_locality));
 
         barrier.wait();
         // Time collective
@@ -905,7 +930,7 @@ void test_one_shot_use_gather(int lpn, std::size_t iterations, std::size_t warmu
         {
             for (int j = 0; j < static_cast<int>(num_localities); ++j)
             {
-                HPX_TEST_EQ(i + j, static_cast<std::size_t>(recv_data[j][0]));
+                HPX_TEST_EQ(static_cast<int>(i + j), recv_data[j][0]);
             }
         }
     }
@@ -931,16 +956,16 @@ void test_one_shot_use_all_reduce(int lpn, std::size_t iterations, std::size_t w
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
     auto const timing_comm =
-        create_communicator(timing_reduce_basename,
+        create_communicator("/test/timing_reduce/all_reduce/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
-    std::vector<int> send_data;
+    std::vector<int> send_data(static_cast<std::size_t>(test_size), 0);
     std::vector<int> recv_data;
 
     for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
-        send_data = std::vector<int>(test_size, static_cast<int>(i));
+        std::fill(send_data.begin(), send_data.end(), static_cast<int>(i));
 
         barrier.wait();
         // Time collective
@@ -960,7 +985,7 @@ void test_one_shot_use_all_reduce(int lpn, std::size_t iterations, std::size_t w
             result[i - warmup_iterations] = max_elapsed;
 
         // Check for correctness
-        HPX_TEST_EQ(i * num_localities, static_cast<std::size_t>(recv_data[0]));
+        HPX_TEST_EQ(static_cast<int>(i) * static_cast<int>(num_localities), recv_data[0]);
     }
 
     if (this_locality == 0)
@@ -990,11 +1015,17 @@ void test_multiple_use_with_generation_scatter(int lpn, std::size_t iterations, 
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
     auto const timing_comm =
-        create_communicator(timing_reduce_basename,
+        create_communicator("/test/timing_reduce/scatter/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
     std::vector<std::vector<int>> send_data;
+    // Pre-allocate scatter send buffer once (root only); refill each iteration
+    if (this_locality == 0)
+    {
+        send_data.assign(num_localities,
+            std::vector<int>(static_cast<std::size_t>(test_size), 0));
+    }
     std::vector<int> recv_data;
     hpx::future<std::vector<int>> ft_data;
 
@@ -1002,8 +1033,14 @@ void test_multiple_use_with_generation_scatter(int lpn, std::size_t iterations, 
     {
         if (this_locality == 0)
         {
-            send_data = generate_matrix(static_cast<int>(num_localities),
-                test_size, static_cast<int>(42 + i));
+            for (std::ptrdiff_t j = 0;
+                 j < static_cast<std::ptrdiff_t>(num_localities); ++j)
+            {
+                std::fill(
+                    send_data[static_cast<std::size_t>(j)].begin(),
+                    send_data[static_cast<std::size_t>(j)].end(),
+                    static_cast<int>(42 + i) + static_cast<int>(j));
+            }
         }
 
         barrier.wait();
@@ -1030,9 +1067,9 @@ void test_multiple_use_with_generation_scatter(int lpn, std::size_t iterations, 
             result[i - warmup_iterations] = max_elapsed;
 
         // Check for correctness
-        for (std::size_t check : recv_data)
+        for (int check : recv_data)
         {
-            HPX_TEST_EQ(42 + i + this_locality, check);
+            HPX_TEST_EQ(static_cast<int>(42 + i) + static_cast<int>(this_locality), check);
         }
     }
 
@@ -1061,17 +1098,17 @@ void test_multiple_use_with_generation_reduce(int lpn, std::size_t iterations, s
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
     auto const timing_comm =
-        create_communicator(timing_reduce_basename,
+        create_communicator("/test/timing_reduce/reduce/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
-    std::vector<int> send_data;
+    std::vector<int> send_data(static_cast<std::size_t>(test_size), 0);
     std::vector<int> recv_data;
     hpx::future<std::vector<int>> ft_data;
 
     for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
-        send_data = std::vector<int>(test_size, static_cast<int>(i));
+        std::fill(send_data.begin(), send_data.end(), static_cast<int>(i));
 
         barrier.wait();
         // Time collective
@@ -1102,7 +1139,7 @@ void test_multiple_use_with_generation_reduce(int lpn, std::size_t iterations, s
         if (this_locality == 0)
         {
             HPX_TEST_EQ(
-                i * num_localities, static_cast<std::size_t>(recv_data[0]));
+                static_cast<int>(i) * static_cast<int>(num_localities), recv_data[0]);
         }
     }
 
@@ -1131,11 +1168,11 @@ void test_multiple_use_with_generation_broadcast(int lpn,
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
     auto const timing_comm =
-        create_communicator(timing_reduce_basename,
+        create_communicator("/test/timing_reduce/broadcast/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
-    std::vector<int> send_data;
+    std::vector<int> send_data(static_cast<std::size_t>(test_size), 0);
     std::vector<int> recv_data;
     hpx::future<std::vector<int>> ft_data;
 
@@ -1143,7 +1180,7 @@ void test_multiple_use_with_generation_broadcast(int lpn,
     {
         if (this_locality == 0)
         {
-            send_data = std::vector<int>(test_size, static_cast<int>(i));
+            std::fill(send_data.begin(), send_data.end(), static_cast<int>(i));
         }
 
         barrier.wait();
@@ -1172,7 +1209,7 @@ void test_multiple_use_with_generation_broadcast(int lpn,
         // Check for correctness
         if (this_locality == 0)
         {
-            HPX_TEST_EQ(i, static_cast<std::size_t>(recv_data[0]));
+            HPX_TEST_EQ(static_cast<int>(i), recv_data[0]);
         }
     }
 
@@ -1184,7 +1221,7 @@ void test_multiple_use_with_generation_broadcast(int lpn,
 }
 
 void test_multiple_use_with_generation_gather(
-    int lpn, std::size_t iterations, std::size_t warmup_iterations, int test_size, std::string operation)
+    int lpn, std::size_t iterations, std::size_t warmup_iterations, int test_size, std::string const& operation)
 {
     // Get parameters
     std::size_t const num_localities =
@@ -1201,18 +1238,18 @@ void test_multiple_use_with_generation_gather(
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
     auto const timing_comm =
-        create_communicator(timing_reduce_basename,
+        create_communicator("/test/timing_reduce/gather/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
-    std::vector<int> send_data;
+    std::vector<int> send_data(static_cast<std::size_t>(test_size), 0);
     std::vector<std::vector<int>> recv_data;
     hpx::future<std::vector<std::vector<int>>> ft_data;
 
     for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
-        send_data =
-            std::vector<int>(test_size, static_cast<int>(i + this_locality));
+        std::fill(send_data.begin(), send_data.end(),
+            static_cast<int>(i + this_locality));
 
         barrier.wait();
         // Time collective
@@ -1244,7 +1281,7 @@ void test_multiple_use_with_generation_gather(
         {
             for (int j = 0; j < static_cast<int>(num_localities); ++j)
             {
-                HPX_TEST_EQ(i + j, static_cast<std::size_t>(recv_data[j][0]));
+                HPX_TEST_EQ(static_cast<int>(i + j), recv_data[j][0]);
             }
         }
     }
@@ -1274,16 +1311,16 @@ void test_multiple_use_with_generation_all_reduce(int lpn,
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
     auto const timing_comm =
-        create_communicator(timing_reduce_basename,
+        create_communicator("/test/timing_reduce/all_reduce/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
-    std::vector<int> send_data;
+    std::vector<int> send_data(static_cast<std::size_t>(test_size), 0);
     std::vector<int> recv_data;
 
     for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
-        send_data = std::vector<int>(test_size, static_cast<int>(i));
+        std::fill(send_data.begin(), send_data.end(), static_cast<int>(i));
 
         barrier.wait();
         // Time collective
@@ -1302,7 +1339,7 @@ void test_multiple_use_with_generation_all_reduce(int lpn,
             result[i - warmup_iterations] = max_elapsed;
 
         // Check for correctness
-        HPX_TEST_EQ(i * num_localities, static_cast<std::size_t>(recv_data[0]));
+        HPX_TEST_EQ(static_cast<int>(i) * static_cast<int>(num_localities), recv_data[0]);
     }
 
     if (this_locality == 0)
@@ -1324,7 +1361,7 @@ void test_multiple_use_with_generation_barrier(int lpn, std::size_t iterations, 
     char const* const barrier_sync_name = "/test/barrier/generation";
     hpx::distributed::barrier sync(barrier_sync_name);
     auto const timing_comm =
-        create_communicator(timing_reduce_basename,
+        create_communicator("/test/timing_reduce/barrier/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
 
@@ -1333,7 +1370,7 @@ void test_multiple_use_with_generation_barrier(int lpn, std::size_t iterations, 
         sync.wait();
         hpx::chrono::high_resolution_timer const timer;
         hpx::collectives::barrier(
-            barrier_client, this_site_arg(), generation_arg(i + 1))
+            barrier_client, this_site_arg(this_locality), generation_arg(i + 1))
             .get();
         // Reduce max elapsed time across all localities
         double const max_elapsed =
@@ -1374,16 +1411,16 @@ void test_all_gather_hierarchical(int arity, int lpn, std::size_t iterations, st
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
     auto const timing_comm =
-        create_communicator(timing_reduce_basename,
+        create_communicator("/test/timing_reduce/all_gather/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
-    std::vector<int> send_data;
+    std::vector<int> send_data(static_cast<std::size_t>(test_size), 0);
     std::vector<std::vector<int>> recv_data;
     for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
-        send_data =
-            std::vector<int>(test_size, static_cast<int>(i + this_locality));
+        std::fill(send_data.begin(), send_data.end(),
+            static_cast<int>(i + this_locality));
         barrier.wait();
         // Time collective
         hpx::chrono::high_resolution_timer const timer;
@@ -1403,7 +1440,7 @@ void test_all_gather_hierarchical(int arity, int lpn, std::size_t iterations, st
         // recv_data[j][0] must equal (i + j) at every site.
         for (int j = 0; j < static_cast<int>(num_localities); ++j)
         {
-            HPX_TEST_EQ(i + j, static_cast<std::size_t>(recv_data[j][0]));
+            HPX_TEST_EQ(static_cast<int>(i + j), recv_data[j][0]);
         }
     }
     if (this_locality == 0)
@@ -1439,29 +1476,37 @@ void test_all_to_all_hierarchical(int arity, int lpn, std::size_t iterations, st
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
     auto const timing_comm =
-        create_communicator(timing_reduce_basename,
+        create_communicator("/test/timing_reduce/all_to_all/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
-    // The all_to_all payload contract requires exactly num_sites elements
-    // per site, so payload scaling happens through the per-destination
-    // block size.
-    std::size_t const block_size = std::max<std::size_t>(
-        1, static_cast<std::size_t>(test_size) / num_localities);
-    // Data
-    std::vector<std::vector<std::uint32_t>> send_data;
-    std::vector<std::vector<std::uint32_t>> recv_data;
+    // Each destination block carries test_size ints, matching MPI's
+    // MPI_Alltoall with sendcount=test_size per rank.
+    std::size_t const block_size = static_cast<std::size_t>(test_size);
+    // Data – pre-allocate shape; refill each iteration so payload varies
+    // with i (matching the MPI benchmark: block j carries this_locality+j+i).
+    std::vector<std::vector<int>> send_data(
+        num_localities, std::vector<int>(block_size, 0));
+    std::vector<std::vector<int>> recv_data;
     for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
-        // Each destination block carries the source id
-        send_data.assign(num_localities,
-            std::vector<std::uint32_t>(
-                block_size, static_cast<std::uint32_t>(this_locality)));
+        // Refill: block j carries (this_locality + j + i)
+        for (std::ptrdiff_t j = 0;
+             j < static_cast<std::ptrdiff_t>(num_localities); ++j)
+        {
+            std::fill(
+                send_data[static_cast<std::size_t>(j)].begin(),
+                send_data[static_cast<std::size_t>(j)].end(),
+                static_cast<int>(
+                    this_locality + static_cast<std::size_t>(j) + i));
+        }
         barrier.wait();
         // Time collective
+        // all_to_all consumes its payload via &&; copy the pre-filled buffer
+        // so the pre-allocated shape survives for the next iteration.
+        auto iter_data = send_data;
         hpx::chrono::high_resolution_timer const timer;
-        hpx::future<std::vector<std::vector<std::uint32_t>>> ft_data =
-            // NOLINTNEXTLINE(bugprone-use-after-move)
-            all_to_all(communicators, std::move(send_data),
+        hpx::future<std::vector<std::vector<int>>> ft_data =
+            all_to_all(communicators, std::move(iter_data),
                 this_site_arg(this_locality), generation_arg(i + 1));
         recv_data = ft_data.get();
         // Reduce max elapsed time across all localities
@@ -1471,16 +1516,13 @@ void test_all_to_all_hierarchical(int arity, int lpn, std::size_t iterations, st
                 .get();
         if (i >= warmup_iterations)
             result[i - warmup_iterations] = max_elapsed;
-        // Check for correctness on the first iteration only: result block s
-        // originated at site s. Later iterations are timed unchecked.
-        if (i == 0)
+        // Correctness: recv_data[s][*] == s + this_locality + i
+        HPX_TEST_EQ(recv_data.size(), num_localities);
+        for (std::size_t s = 0; s != num_localities; ++s)
         {
-            HPX_TEST_EQ(recv_data.size(), num_localities);
-            for (std::size_t s = 0; s != num_localities; ++s)
-            {
-                HPX_TEST_EQ(recv_data[s].size(), block_size);
-                HPX_TEST_EQ(static_cast<std::size_t>(recv_data[s][0]), s);
-            }
+            HPX_TEST_EQ(recv_data[s].size(), block_size);
+            HPX_TEST_EQ(recv_data[s][0],
+                static_cast<int>(s + this_locality + i));
         }
     }
     if (this_locality == 0)
@@ -1507,16 +1549,16 @@ void test_one_shot_use_all_gather(int lpn, std::size_t iterations, std::size_t w
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
     auto const timing_comm =
-        create_communicator(timing_reduce_basename,
+        create_communicator("/test/timing_reduce/all_gather/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
-    std::vector<int> send_data;
+    std::vector<int> send_data(static_cast<std::size_t>(test_size), 0);
     std::vector<std::vector<int>> recv_data;
     for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
-        send_data =
-            std::vector<int>(test_size, static_cast<int>(i + this_locality));
+        std::fill(send_data.begin(), send_data.end(),
+            static_cast<int>(i + this_locality));
         barrier.wait();
         // Time collective
         hpx::chrono::high_resolution_timer const timer;
@@ -1536,7 +1578,7 @@ void test_one_shot_use_all_gather(int lpn, std::size_t iterations, std::size_t w
         // Check for correctness
         for (int j = 0; j < static_cast<int>(num_localities); ++j)
         {
-            HPX_TEST_EQ(i + j, static_cast<std::size_t>(recv_data[j][0]));
+            HPX_TEST_EQ(static_cast<int>(i + j), recv_data[j][0]);
         }
     }
     if (this_locality == 0)
@@ -1564,16 +1606,16 @@ void test_multiple_use_with_generation_all_gather(int lpn,
     hpx::distributed::barrier barrier(barrier_test_name);
     // Result vector
     auto const timing_comm =
-        create_communicator(timing_reduce_basename,
+        create_communicator("/test/timing_reduce/all_gather/",
             num_sites_arg(num_localities), this_site_arg(this_locality));
     std::vector<double> result(iterations, 0.0);
     // Data
-    std::vector<int> send_data;
+    std::vector<int> send_data(static_cast<std::size_t>(test_size), 0);
     std::vector<std::vector<int>> recv_data;
     for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
     {
-        send_data =
-            std::vector<int>(test_size, static_cast<int>(i + this_locality));
+        std::fill(send_data.begin(), send_data.end(),
+            static_cast<int>(i + this_locality));
         barrier.wait();
         // Time collective
         hpx::chrono::high_resolution_timer const timer;
@@ -1592,7 +1634,7 @@ void test_multiple_use_with_generation_all_gather(int lpn,
         // Check for correctness
         for (int j = 0; j < static_cast<int>(num_localities); ++j)
         {
-            HPX_TEST_EQ(i + j, static_cast<std::size_t>(recv_data[j][0]));
+            HPX_TEST_EQ(static_cast<int>(i + j), recv_data[j][0]);
         }
     }
     if (this_locality == 0)
@@ -1610,6 +1652,13 @@ int hpx_main(hpx::program_options::variables_map& vm)
     int const iterations = vm["iterations"].as<int>();
     int const fallback_threshold = vm["fallback_threshold"].as<int>();
     int const warmup_iterations = vm["warmup_iterations"].as<int>();
+
+    if (iterations <= 0 || warmup_iterations < 0 || test_size <= 0 || lpn <= 0)
+    {
+        hpx::cout << "error: iterations and test_size and lpn must be > 0; "
+                     "warmup_iterations must be >= 0\n";
+        return hpx::finalize();
+    }
 
     if (hpx::get_num_localities(hpx::launch::sync) > 1)
     {
@@ -1707,6 +1756,11 @@ int hpx_main(hpx::program_options::variables_map& vm)
             {
                 test_all_to_all_hierarchical(arity, lpn, iterations, static_cast<std::size_t>(warmup_iterations), test_size,
                     operation, fallback_threshold);
+            }
+            else
+            {
+                hpx::cout << "warning: all_to_all requires --arity to select "
+                             "an algorithm; no flat variant is implemented\n";
             }
         }
         else if (operation == "barrier")

--- a/libs/full/collectives/tests/performance/benchmark_collectives.cpp
+++ b/libs/full/collectives/tests/performance/benchmark_collectives.cpp
@@ -38,6 +38,7 @@ constexpr char const* all_gather_direct_basename = "/test/all_gather_direct/";
 constexpr char const* all_to_all_direct_basename = "/test/all_to_all_direct/";
 constexpr char const* barrier_bench_basename = "/test/barrier_bench/";
 constexpr char const* exclusive_scan_basename = "/test/exclusive_scan_direct/";
+constexpr char const* inclusive_scan_basename = "/test/inclusive_scan_direct/";
 
 struct double_max
 {
@@ -1855,7 +1856,115 @@ void test_exclusive_scan_hierarchical(int /*arity*/, int /*lpn*/,
     std::cout << "error: exclusive_scan does not support hierarchical "
                  "communicators\n";
 }
-////////////////////////////////////////////////////////////////struct benchmarking_functions
+////////////////////////////////////////////////////////////////////////////////////////
+void test_one_shot_use_inclusive_scan(int lpn, std::size_t iterations,
+    std::size_t warmup_iterations, int test_size, std::string const& operation)
+{
+    // Get parameters
+    std::size_t const num_localities =
+        hpx::get_num_localities(hpx::launch::sync);
+    std::size_t const this_locality = hpx::get_locality_id();
+    // Ensure at least two localities
+    HPX_TEST_LTE(static_cast<std::size_t>(2), num_localities);
+    // Barrier for synchronization
+    char const* const barrier_test_name = "/test/barrier/single";
+    hpx::distributed::barrier barrier(barrier_test_name);
+    // Timing communicator
+    auto const timing_comm =
+        create_communicator("/test/timing_reduce/inclusive_scan/one_shot/",
+            num_sites_arg(num_localities), this_site_arg(this_locality));
+    std::vector<double> result(iterations, 0.0);
+    std::uint32_t recv_data = 0;
+    for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
+    {
+        auto const value =
+            static_cast<std::uint32_t>(this_locality + 1 + i);
+        barrier.wait();
+        // Time collective
+        hpx::chrono::high_resolution_timer const timer;
+        recv_data = inclusive_scan(inclusive_scan_basename, value,
+            std::plus<std::uint32_t>{}, num_sites_arg(num_localities),
+            this_site_arg(this_locality), generation_arg(i + 1))
+                        .get();
+        // Reduce max elapsed time to root
+        double max_elapsed = timer.elapsed();
+        reduce(timing_comm, max_elapsed, double_max{},
+            this_site_arg(this_locality), generation_arg(i + 1));
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
+        std::uint32_t expected = 0;
+        for (std::size_t j = 0; j <= this_locality; ++j)
+            expected += static_cast<std::uint32_t>(j + 1 + i);
+        HPX_TEST_EQ(recv_data, expected);
+    }
+    if (this_locality == 0)
+    {
+        write_to_file(operation, "single_use", -1, num_localities, lpn,
+            test_size, warmup_iterations, iterations, std::move(result));
+    }
+}
+////////////////////////////////////////////////////////////////////////////////////////
+void test_multiple_use_with_generation_inclusive_scan(int lpn,
+    std::size_t iterations, std::size_t warmup_iterations, int test_size,
+    std::string const& operation)
+{
+    // Get parameters
+    std::size_t const num_localities =
+        hpx::get_num_localities(hpx::launch::sync);
+    std::size_t const this_locality = hpx::get_locality_id();
+    // Ensure at least two localities
+    HPX_TEST_LTE(static_cast<std::size_t>(2), num_localities);
+    // Create communicator
+    auto const inclusive_scan_client =
+        create_communicator(inclusive_scan_basename,
+            num_sites_arg(num_localities), this_site_arg(this_locality));
+    // Barrier for synchronization
+    char const* const barrier_test_name = "/test/barrier/generation";
+    hpx::distributed::barrier barrier(barrier_test_name);
+    // Timing communicator
+    auto const timing_comm =
+        create_communicator("/test/timing_reduce/inclusive_scan/multi_use/",
+            num_sites_arg(num_localities), this_site_arg(this_locality));
+    std::vector<double> result(iterations, 0.0);
+    std::uint32_t recv_data = 0;
+    for (std::size_t i = 0; i != warmup_iterations + iterations; ++i)
+    {
+        auto const value =
+            static_cast<std::uint32_t>(this_locality + 1 + i);
+        barrier.wait();
+        // Time collective
+        hpx::chrono::high_resolution_timer const timer;
+        recv_data =
+            inclusive_scan(inclusive_scan_client, value,
+                std::plus<std::uint32_t>{}, generation_arg(i + 1))
+                .get();
+        // Reduce max elapsed time to root
+        double max_elapsed = timer.elapsed();
+        reduce(timing_comm, max_elapsed, double_max{},
+            this_site_arg(this_locality), generation_arg(i + 1));
+        if (i >= warmup_iterations)
+            result[i - warmup_iterations] = max_elapsed;
+        std::uint32_t expected = 0;
+        for (std::size_t j = 0; j <= this_locality; ++j)
+            expected += static_cast<std::uint32_t>(j + 1 + i);
+        HPX_TEST_EQ(recv_data, expected);
+    }
+    if (this_locality == 0)
+    {
+        write_to_file(operation, "multi_use", -1, num_localities, lpn,
+            test_size, warmup_iterations, iterations, std::move(result));
+    }
+}
+////////////////////////////////////////////////////////////////////////////////////////
+void test_inclusive_scan_hierarchical(int /*arity*/, int /*lpn*/,
+    std::size_t /*iterations*/, std::size_t /*warmup_iterations*/,
+    int /*test_size*/, std::string const& /*operation*/,
+    int /*fallback_threshold*/)
+{
+    std::cout << "error: inclusive_scan does not support hierarchical "
+                 "communicators\n";
+}
+struct benchmarking_functions
 {
     hpx::function<void(int, std::size_t, std::size_t, int, std::string const&)>
         one_shot;
@@ -1922,6 +2031,10 @@ int hpx_main(hpx::program_options::variables_map& vm)
                 {test_one_shot_use_exclusive_scan,
                     test_multiple_use_with_generation_exclusive_scan,
                     test_exclusive_scan_hierarchical}},
+            {"inclusive_scan",
+                {test_one_shot_use_inclusive_scan,
+                    test_multiple_use_with_generation_inclusive_scan,
+                    test_inclusive_scan_hierarchical}},
         };
 
         auto it = benchmarking.find(operation);
@@ -1966,7 +2079,8 @@ int main(int argc, char* argv[])
             "Number of Iteration the collective is executed")
         ("operation", value<std::string>()->default_value("scatter"),
             "Collective Operation (scatter, reduce, broadcast, gather, "
-            "all_reduce, all_gather, all_to_all, barrier, exclusive_scan)")
+            "all_reduce, all_gather, all_to_all, barrier, "
+            "exclusive_scan, inclusive_scan)")
         ("fallback_threshold", value<int>()->default_value(-1),
             "Flat fallback threshold for hierarchical mode. -1 uses library "
             "default (16). Set to 0 to force tree construction. Only meaningful "


### PR DESCRIPTION
## Proposed Changes
### Collective Additions:
-  Missing all_to_all and barriers
- Inclusive/exclusive scans

### Timing: 
- Add a pre-iteration barrier to sync localities before timing starts
- Add --warmup_iterations flag (default 3)
- Record max elapsed time across ranks (slowest locality, not root's view).

### Statistics: 
- Extend output/CSV with variance, stddev, min, max, median alongside mean.

### Buffer correctness: 
- Align payload size with MPI reference (num_localities * test_size)
- Use-after-move fix across all 21 test functions by copying to iter_data outside the timed region and moving that into the collective, keeping copy cost out of the measurement window. 
- Removes all NOLINTNEXTLINE(bugprone-use-after-move) suppressions.

### Output organization: 
- Write results under result/hpx/<parcelport>/<num_localities>/<collective>/

## Background
This branch benchmarks HPX distributed collectives against an MPI reference across TCP, MPI, and LCI parcelports. The changes fix correctness bugs that previously skewed timing (unsynchronized start, empty payloads from use-after-move, reduction for max time) and add fuller statistical output per run. The new directory layout (<parcelport>/<num_localities>/<collective>/) makes cross-parcelport and cross-scale comparison straightforward without manual file renaming.