### PR TITLE
Docs: Add troubleshooting note for local runs

### DIFF
--- a/docs/sphinx/examples/hello_world.rst
+++ b/docs/sphinx/examples/hello_world.rst
@@ -68,6 +68,34 @@ Notice how the ordering of the two print statements will change with
 subsequent runs. To run this program on multiple localities please see the
 section :ref:`unix_pbs`.
 
+**Note for Local Runs of Distributed Examples**
+
+If |hpx| is compiled with the MPI parcelport disabled (``HPX_WITH_PARCELPORT_MPI=OFF``),
+running distributed examples out-of-the-box might cause a segmentation
+fault or ``invalid_status`` exception. This happens because the automatic
+runtime initialization macro (``hpx/hpx_main.hpp``) will be bypassed.
+
+The reason for this is the ``#if !defined(HPX_COMPUTE_DEVICE_CODE)`` macro
+guard at the top of the ``hpx/hpx_main.hpp`` header. In specific GPU or device code compilations,
+this guard prevents the header from being included. Without this header,
+the preprocessor does not rename your standard ``main`` to ``hpx_main``,
+leaving the |hpx| environment uninitialized when
+:cpp:func:`hpx::find_all_localities` is called.
+
+**Solution:**
+To fix this without changing the internal logic of the example, you must
+explicitly initialize the runtime. Follow these two steps:
+
+1. Rename your existing ``int main(int argc, char* argv[])`` function to ``int hpx_main(int argc, char* argv[])`` (keeping your original parameters).
+2. Add a manual initialization entry point at the bottom of your file:
+
+.. code-block:: c++
+
+   int main(int argc, char* argv[])
+   {
+       return hpx::init(argc, argv);
+   }
+
 Walkthrough
 ===========
 


### PR DESCRIPTION
Added a warning and a fallback solution for running the hello_world_distributed example locally without MPI. Explained the hpx_main macro bypass issue and provided the manual hpx::init boilerplate.

Fixes # 

## Proposed Changes

- Added a troubleshooting section to the `hello_world` distributed example documentation.
- Explained the `#if !defined(HPX_COMPUTE_DEVICE_CODE)` macro bypass issue when running in local/networkless mode (`HPX_WITH_PARCELPORT_MPI=OFF`).
- Provided the manual `int hpx_main()` and `hpx::init(argc, argv)` boilerplate code to fallback to a single local machine safely without crashing.

## Any background context you want to provide?

While running the `hello_world_distributed` example on a local machine out-of-the-box, I encountered `Segmentation fault` / `invalid_status` exceptions. This happens because the runtime is left uninitialized when `find_all_localities()` is called. This documentation update aims to save time for beginners facing the same issue in networkless environments.

## Checklist

Not all points below apply to all pull requests. *(Note: This is a documentation-only PR, so test requirements are not applicable).*

- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.