### PR TITLE
Hierarchical collectives: unify the per-call generation step for cross-collective sharing

### DIFF
--- a/libs/full/actions/tests/regressions/non_default_constructible_argument_5998.cpp
+++ b/libs/full/actions/tests/regressions/non_default_constructible_argument_5998.cpp
@@ -86,9 +86,9 @@ auto call_remote()
     for (auto const& id : remote)
     {
         EventContext ec{23, {"a"s, "b"s}};
-        auto f = {"foo"s, "bar"s};
-        futures.emplace_back(
-            hpx::async<print_params_action>(id, std::move(ec), std::move(f)));
+        std::vector<std::string> data{"foo"s, "bar"s};
+        futures.emplace_back(hpx::async<print_params_action>(
+            id, std::move(ec), std::move(data)));
     }
     return hpx::when_all(futures);
 }

--- a/libs/full/collectives/include/hpx/collectives/all_gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_gather.hpp
@@ -247,7 +247,8 @@ namespace hpx::traits {
     {
         template <typename Result, typename T>
         static Result get(Communicator& communicator, std::size_t which,
-            std::size_t generation, std::size_t num_generations, T&& t)
+            std::size_t generation,
+            hpx::collectives::detail::generation_mode num_generations, T&& t)
         {
             return communicator.template handle_data<std::decay_t<T>>(
                 communication::communicator_data<
@@ -259,76 +260,93 @@ namespace hpx::traits {
                 },
                 // finalizer (invoked after all data has been received)
                 [](auto& data, auto&, std::size_t) { return data; },
-                static_cast<std::size_t>(-1), num_generations);
+                num_generations);
         }
     };
 }    // namespace hpx::traits
 
 namespace hpx::collectives {
 
+    namespace detail {
+
+        /////////////////////////////////////////////////////////////////////
+        // all_gather plain values: detail entry point carrying the internal
+        // generation step. The public overload below forwards with
+        // single_step; the hierarchical overload passes double_step where it
+        // collapses to a single flat all_gather.
+        template <typename T>
+        hpx::future<std::vector<std::decay_t<T>>> all_gather(communicator fid,
+            T&& local_result, this_site_arg this_site,
+            generation_arg const generation, generation_mode num_generations)
+        {
+            using arg_type = std::decay_t<T>;
+
+            if (this_site.is_default())
+            {
+                this_site = agas::get_locality_id();
+            }
+            if (generation == 0)
+            {
+                return hpx::make_exceptional_future<std::vector<arg_type>>(
+                    HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                        "hpx::collectives::all_gather",
+                        "the generation number shouldn't be zero"));
+            }
+
+            // Handle operation right away if there is only one value.
+            if (auto [num_sites, comm_site] = fid.get_info(); num_sites == 1)
+            {
+                if (this_site != comm_site)
+                {
+                    return hpx::make_exceptional_future<std::vector<arg_type>>(
+                        HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                            "hpx::collectives::all_gather",
+                            "the local site should be zero if only one site is "
+                            "involved"));
+                }
+
+                std::vector<arg_type> result(1, HPX_FORWARD(T, local_result));
+                return hpx::make_ready_future(HPX_MOVE(result));
+            }
+
+            auto all_gather_data = [local_result = HPX_FORWARD(T, local_result),
+                                       this_site, generation, num_generations](
+                                       communicator&& c) mutable
+                -> hpx::future<std::vector<arg_type>> {
+                using action_type =
+                    communicator_server::communication_get_direct_action<
+                        traits::communication::all_gather_tag,
+                        hpx::future<std::vector<arg_type>>, generation_mode,
+                        arg_type>;
+
+                // explicitly unwrap returned future
+                hpx::future<std::vector<arg_type>> result =
+                    hpx::async(action_type(), c, this_site, generation,
+                        num_generations, HPX_MOVE(local_result));
+
+                if (!result.is_ready())
+                {
+                    // make sure id is kept alive as long as the returned future
+                    traits::detail::get_shared_state(result)->set_on_completed(
+                        [client = HPX_MOVE(c)] { HPX_UNUSED(client); });
+                }
+
+                return result;
+            };
+
+            return fid.then(hpx::launch::sync, HPX_MOVE(all_gather_data));
+        }
+    }    // namespace detail
+
     ///////////////////////////////////////////////////////////////////////////
     // all_gather plain values
     HPX_CXX_EXPORT template <typename T>
     hpx::future<std::vector<std::decay_t<T>>> all_gather(communicator fid,
         T&& local_result, this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg(),
-        std::size_t num_generations = 1)
+        generation_arg const generation = generation_arg())
     {
-        using arg_type = std::decay_t<T>;
-
-        if (this_site.is_default())
-        {
-            this_site = agas::get_locality_id();
-        }
-        if (generation == 0)
-        {
-            return hpx::make_exceptional_future<std::vector<arg_type>>(
-                HPX_GET_EXCEPTION(hpx::error::bad_parameter,
-                    "hpx::collectives::all_gather",
-                    "the generation number shouldn't be zero"));
-        }
-
-        // Handle operation right away if there is only one value.
-        if (auto [num_sites, comm_site] = fid.get_info(); num_sites == 1)
-        {
-            if (this_site != comm_site)
-            {
-                return hpx::make_exceptional_future<std::vector<arg_type>>(
-                    HPX_GET_EXCEPTION(hpx::error::bad_parameter,
-                        "hpx::collectives::all_gather",
-                        "the local site should be zero if only one site is "
-                        "involved"));
-            }
-
-            std::vector<arg_type> result(1, HPX_FORWARD(T, local_result));
-            return hpx::make_ready_future(HPX_MOVE(result));
-        }
-
-        auto all_gather_data = [local_result = HPX_FORWARD(T, local_result),
-                                   this_site, generation,
-                                   num_generations](communicator&& c) mutable
-            -> hpx::future<std::vector<arg_type>> {
-            using action_type =
-                detail::communicator_server::communication_get_direct_action<
-                    traits::communication::all_gather_tag,
-                    hpx::future<std::vector<arg_type>>, std::size_t, arg_type>;
-
-            // explicitly unwrap returned future
-            hpx::future<std::vector<arg_type>> result =
-                hpx::async(action_type(), c, this_site, generation,
-                    num_generations, HPX_MOVE(local_result));
-
-            if (!result.is_ready())
-            {
-                // make sure id is kept alive as long as the returned future
-                traits::detail::get_shared_state(result)->set_on_completed(
-                    [client = HPX_MOVE(c)] { HPX_UNUSED(client); });
-            }
-
-            return result;
-        };
-
-        return fid.then(hpx::launch::sync, HPX_MOVE(all_gather_data));
+        return detail::all_gather(HPX_MOVE(fid), HPX_FORWARD(T, local_result),
+            this_site, generation, detail::generation_mode::single_step);
     }
 
     HPX_CXX_EXPORT template <typename T>
@@ -456,38 +474,38 @@ namespace hpx::collectives {
         // gather+broadcast decomposition then collapses to a single flat
         // all_gather; dispatch directly to avoid the two separate gate
         // synchronizations, but still advance the gate by two (run at 2k-1,
-        // num_generations == 2) so the flat instance stays shareable with
+        // double_step) so the flat instance stays shareable with
         // other collectives.
         if (arity_val >= num_sites_val)
         {
             HPX_ASSERT(communicators.size() == 1);
-            return all_gather(communicators.get(0),
+            return detail::all_gather(communicators.get(0),
                 HPX_FORWARD(T, local_result), communicators.site(0), gather_gen,
-                /*num_generations=*/2);
+                detail::generation_mode::double_step);
         }
 
         if (this_site == root_site)
         {
             // gather phase advances each communicator by one (the broadcast
-            // phase consumes 2k), so pass num_generations == 1.
-            std::vector<arg_type> gathered = gather_here(communicators,
-                HPX_FORWARD(T, local_result), this_site, gather_gen,
-                /*num_generations=*/1)
-                                                 .get();
+            // phase consumes 2k), so pass single_step.
+            std::vector<arg_type> gathered =
+                detail::gather_here(communicators, HPX_FORWARD(T, local_result),
+                    this_site, gather_gen, detail::generation_mode::single_step)
+                    .get();
 
             // broadcast phase advances each communicator by one (the gather
-            // phase already consumed 2k-1), so pass num_generations == 1.
-            return broadcast_to(communicators, HPX_MOVE(gathered), this_site,
-                broadcast_gen, /*num_generations=*/1);
+            // phase already consumed 2k-1), so pass single_step.
+            return detail::broadcast_to(communicators, HPX_MOVE(gathered),
+                this_site, broadcast_gen, detail::generation_mode::single_step);
         }
         else
         {
-            gather_there(communicators, HPX_FORWARD(T, local_result), this_site,
-                gather_gen, /*num_generations=*/1)
+            detail::gather_there(communicators, HPX_FORWARD(T, local_result),
+                this_site, gather_gen, detail::generation_mode::single_step)
                 .get();
 
-            return broadcast_from<std::vector<arg_type>>(
-                communicators, this_site, broadcast_gen, /*num_generations=*/1);
+            return detail::broadcast_from<std::vector<arg_type>>(communicators,
+                this_site, broadcast_gen, detail::generation_mode::single_step);
         }
     }
 

--- a/libs/full/collectives/include/hpx/collectives/all_gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_gather.hpp
@@ -410,13 +410,13 @@ namespace hpx::collectives {
     {
         using arg_type = std::decay_t<T>;
 
-        if (generation.is_default())
+        if (generation.is_default() || generation == 0)
         {
             return hpx::make_exceptional_future<std::vector<arg_type>>(
                 HPX_GET_EXCEPTION(hpx::error::bad_parameter,
                     "hpx::collectives::all_gather (hierarchical)",
-                    "hierarchical all_gather requires an explicit generation "
-                    "number for the 2k-1/2k internal mapping"));
+                    "hierarchical all_gather requires an explicit, positive "
+                    "generation number for the 2k-1/2k internal mapping"));
         }
 
         if (this_site.is_default())

--- a/libs/full/collectives/include/hpx/collectives/all_gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_gather.hpp
@@ -394,9 +394,9 @@ namespace hpx::collectives {
     // Key difference from all_reduce: the gather phase produces vector<T>
     // (O(N) data), so the broadcast phase transfers O(N) instead of a scalar.
     //
-    // An instance may be shared between all_gather and all_reduce (identical
-    // generation scheme), but not with other collectives; see the note on
-    // create_hierarchical_communicator.
+    // Every hierarchical collective advances each communicator by two
+    // generations per call, so an instance may be shared freely across
+    // collectives; see the note on create_hierarchical_communicator.
 
     // Async overload
     HPX_CXX_EXPORT template <typename T>
@@ -464,21 +464,26 @@ namespace hpx::collectives {
 
         if (this_site == root_site)
         {
+            // gather phase advances each communicator by one (the broadcast
+            // phase consumes 2k), so pass num_generations == 1.
             std::vector<arg_type> gathered = gather_here(communicators,
-                HPX_FORWARD(T, local_result), this_site, gather_gen)
+                HPX_FORWARD(T, local_result), this_site, gather_gen,
+                /*num_generations=*/1)
                                                  .get();
 
-            return broadcast_to(
-                communicators, HPX_MOVE(gathered), this_site, broadcast_gen);
+            // broadcast phase advances each communicator by one (the gather
+            // phase already consumed 2k-1), so pass num_generations == 1.
+            return broadcast_to(communicators, HPX_MOVE(gathered), this_site,
+                broadcast_gen, /*num_generations=*/1);
         }
         else
         {
             gather_there(communicators, HPX_FORWARD(T, local_result), this_site,
-                gather_gen)
+                gather_gen, /*num_generations=*/1)
                 .get();
 
             return broadcast_from<std::vector<arg_type>>(
-                communicators, this_site, broadcast_gen);
+                communicators, this_site, broadcast_gen, /*num_generations=*/1);
         }
     }
 

--- a/libs/full/collectives/include/hpx/collectives/all_gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_gather.hpp
@@ -247,7 +247,7 @@ namespace hpx::traits {
     {
         template <typename Result, typename T>
         static Result get(Communicator& communicator, std::size_t which,
-            std::size_t generation, T&& t)
+            std::size_t generation, std::size_t num_generations, T&& t)
         {
             return communicator.template handle_data<std::decay_t<T>>(
                 communication::communicator_data<
@@ -258,7 +258,8 @@ namespace hpx::traits {
                     data[which] = HPX_FORWARD(T, t);
                 },
                 // finalizer (invoked after all data has been received)
-                [](auto& data, auto&, std::size_t) { return data; });
+                [](auto& data, auto&, std::size_t) { return data; },
+                static_cast<std::size_t>(-1), num_generations);
         }
     };
 }    // namespace hpx::traits
@@ -270,7 +271,8 @@ namespace hpx::collectives {
     HPX_CXX_EXPORT template <typename T>
     hpx::future<std::vector<std::decay_t<T>>> all_gather(communicator fid,
         T&& local_result, this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg())
+        generation_arg const generation = generation_arg(),
+        std::size_t num_generations = 1)
     {
         using arg_type = std::decay_t<T>;
 
@@ -303,18 +305,18 @@ namespace hpx::collectives {
         }
 
         auto all_gather_data = [local_result = HPX_FORWARD(T, local_result),
-                                   this_site,
-                                   generation](communicator&& c) mutable
+                                   this_site, generation,
+                                   num_generations](communicator&& c) mutable
             -> hpx::future<std::vector<arg_type>> {
             using action_type =
                 detail::communicator_server::communication_get_direct_action<
                     traits::communication::all_gather_tag,
-                    hpx::future<std::vector<arg_type>>, arg_type>;
+                    hpx::future<std::vector<arg_type>>, std::size_t, arg_type>;
 
             // explicitly unwrap returned future
             hpx::future<std::vector<arg_type>> result =
                 hpx::async(action_type(), c, this_site, generation,
-                    HPX_MOVE(local_result));
+                    num_generations, HPX_MOVE(local_result));
 
             if (!result.is_ready())
             {
@@ -445,22 +447,24 @@ namespace hpx::collectives {
                     "participating sites"));
         }
 
+        generation_arg const gather_gen(2 * generation - 1);
+        generation_arg const broadcast_gen(2 * generation);
+
         // Flat fast path: when arity >= num_sites, the tree builder's leaf
         // condition (right - left < arity) fired at the root call and
         // produced a single flat communicator spanning all sites. The
         // gather+broadcast decomposition then collapses to a single flat
         // all_gather; dispatch directly to avoid the two separate gate
-        // synchronizations.
+        // synchronizations, but still advance the gate by two (run at 2k-1,
+        // num_generations == 2) so the flat instance stays shareable with
+        // other collectives.
         if (arity_val >= num_sites_val)
         {
             HPX_ASSERT(communicators.size() == 1);
             return all_gather(communicators.get(0),
-                HPX_FORWARD(T, local_result), communicators.site(0),
-                generation);
+                HPX_FORWARD(T, local_result), communicators.site(0), gather_gen,
+                /*num_generations=*/2);
         }
-
-        generation_arg const gather_gen(2 * generation - 1);
-        generation_arg const broadcast_gen(2 * generation);
 
         if (this_site == root_site)
         {

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -450,13 +450,13 @@ namespace hpx::collectives {
     {
         using arg_type = std::decay_t<T>;
 
-        if (generation.is_default())
+        if (generation.is_default() || generation == 0)
         {
             return hpx::make_exceptional_future<arg_type>(
                 HPX_GET_EXCEPTION(hpx::error::bad_parameter,
                     "hpx::collectives::all_reduce (hierarchical)",
-                    "hierarchical all_reduce requires an explicit generation "
-                    "number for the 2k-1/2k internal mapping"));
+                    "hierarchical all_reduce requires an explicit, positive "
+                    "generation number for the 2k-1/2k internal mapping"));
         }
 
         if (this_site.is_default())

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -435,9 +435,9 @@ namespace hpx::collectives {
     // Uses 2k-1/2k generation mapping: user generation k maps to
     // internal generation 2k-1 (reduce phase) and 2k (broadcast phase)
     //
-    // An instance may be shared between all_reduce and all_gather (identical
-    // generation scheme), but not with other collectives; see the note on
-    // create_hierarchical_communicator.
+    // Every hierarchical collective advances each communicator by two
+    // generations per call, so an instance may be shared freely across
+    // collectives; see the note on create_hierarchical_communicator.
     HPX_CXX_EXPORT template <typename T, typename F>
     hpx::future<std::decay_t<T>> all_reduce(
         hierarchical_communicator const& communicators, T&& local_result,
@@ -503,22 +503,28 @@ namespace hpx::collectives {
 
         if (this_site == root_site)
         {
+            // reduce phase advances each communicator by one (the broadcast
+            // phase consumes 2k), so pass num_generations == 1.
             arg_type reduced =
                 reduce_here(communicators, HPX_FORWARD(T, local_result),
-                    HPX_FORWARD(F, op), this_site, reduce_gen)
+                    HPX_FORWARD(F, op), this_site, reduce_gen,
+                    /*num_generations=*/1)
                     .get();
 
-            return broadcast_to(
-                communicators, HPX_MOVE(reduced), this_site, broadcast_gen);
+            // broadcast phase advances each communicator by one (the reduce
+            // phase already consumed 2k-1), so pass num_generations == 1.
+            return broadcast_to(communicators, HPX_MOVE(reduced), this_site,
+                broadcast_gen, /*num_generations=*/1);
         }
         else
         {
             reduce_there(communicators, HPX_FORWARD(T, local_result),
-                HPX_FORWARD(F, op), this_site, reduce_gen)
+                HPX_FORWARD(F, op), this_site, reduce_gen,
+                /*num_generations=*/1)
                 .get();
 
             return broadcast_from<arg_type>(
-                communicators, this_site, broadcast_gen);
+                communicators, this_site, broadcast_gen, /*num_generations=*/1);
         }
     }
 

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -259,7 +259,7 @@ namespace hpx::traits {
     {
         template <typename Result, typename T, typename F>
         static Result get(Communicator& communicator, std::size_t which,
-            std::size_t generation, T&& t, F&& op)
+            std::size_t generation, std::size_t num_generations, T&& t, F&& op)
         {
             return communicator.template handle_data<std::decay_t<T>>(
                 communication::communicator_data<
@@ -304,7 +304,8 @@ namespace hpx::traits {
                         }
                         return static_cast<bool>(data[0]);
                     }
-                });
+                },
+                static_cast<std::size_t>(-1), num_generations);
         }
     };
 }    // namespace hpx::traits
@@ -316,7 +317,8 @@ namespace hpx::collectives {
     HPX_CXX_EXPORT template <typename T, typename F>
     hpx::future<std::decay_t<T>> all_reduce(communicator fid, T&& local_result,
         F&& op, this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg())
+        generation_arg const generation = generation_arg(),
+        std::size_t num_generations = 1)
     {
         using arg_type = std::decay_t<T>;
 
@@ -347,17 +349,18 @@ namespace hpx::collectives {
 
         auto all_reduce_data =
             [local_result = HPX_FORWARD(T, local_result),
-                op = HPX_FORWARD(F, op), generation,
+                op = HPX_FORWARD(F, op), generation, num_generations,
                 this_site](communicator&& c) mutable -> hpx::future<arg_type> {
             using func_type = std::decay_t<F>;
             using action_type =
                 detail::communicator_server::communication_get_direct_action<
                     traits::communication::all_reduce_tag,
-                    hpx::future<arg_type>, arg_type, func_type>;
+                    hpx::future<arg_type>, std::size_t, arg_type, func_type>;
 
             // explicitly unwrap returned future
-            hpx::future<arg_type> result = hpx::async(action_type(), c,
-                this_site, generation, HPX_MOVE(local_result), HPX_MOVE(op));
+            hpx::future<arg_type> result =
+                hpx::async(action_type(), c, this_site, generation,
+                    num_generations, HPX_MOVE(local_result), HPX_MOVE(op));
 
             if (!result.is_ready())
             {
@@ -484,22 +487,24 @@ namespace hpx::collectives {
                     "participating sites"));
         }
 
+        generation_arg const reduce_gen(2 * generation - 1);
+        generation_arg const broadcast_gen(2 * generation);
+
         // Flat fast path: when arity >= num_sites, the tree builder's leaf
         // condition (right - left < arity) fired at the root call and
         // produced a single flat communicator spanning all sites. The
         // reduce+broadcast decomposition then collapses to a single flat
         // all_reduce; dispatch directly to avoid the two separate gate
-        // synchronizations.
+        // synchronizations, but still advance the gate by two (run at 2k-1,
+        // num_generations == 2) so the flat instance stays shareable with
+        // other collectives.
         if (arity_val >= num_sites_val)
         {
             HPX_ASSERT(communicators.size() == 1);
             return all_reduce(communicators.get(0),
                 HPX_FORWARD(T, local_result), HPX_FORWARD(F, op),
-                communicators.site(0), generation);
+                communicators.site(0), reduce_gen, /*num_generations=*/2);
         }
-
-        generation_arg const reduce_gen(2 * generation - 1);
-        generation_arg const broadcast_gen(2 * generation);
 
         if (this_site == root_site)
         {

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -259,7 +259,9 @@ namespace hpx::traits {
     {
         template <typename Result, typename T, typename F>
         static Result get(Communicator& communicator, std::size_t which,
-            std::size_t generation, std::size_t num_generations, T&& t, F&& op)
+            std::size_t generation,
+            hpx::collectives::detail::generation_mode num_generations, T&& t,
+            F&& op)
         {
             return communicator.template handle_data<std::decay_t<T>>(
                 communication::communicator_data<
@@ -305,7 +307,7 @@ namespace hpx::traits {
                         return static_cast<bool>(data[0]);
                     }
                 },
-                static_cast<std::size_t>(-1), num_generations);
+                num_generations);
         }
     };
 }    // namespace hpx::traits
@@ -313,66 +315,86 @@ namespace hpx::traits {
 namespace hpx::collectives {
 
     ////////////////////////////////////////////////////////////////////////////
+    namespace detail {
+
+        // all_reduce plain values: detail entry point carrying the internal
+        // generation step. The public overload forwards with single_step; the
+        // hierarchical overload passes double_step where it collapses to a
+        // single flat all_reduce.
+        template <typename T, typename F>
+        hpx::future<std::decay_t<T>> all_reduce(communicator fid,
+            T&& local_result, F&& op, this_site_arg this_site,
+            generation_arg const generation, generation_mode num_generations)
+        {
+            using arg_type = std::decay_t<T>;
+
+            if (this_site.is_default())
+            {
+                this_site = agas::get_locality_id();
+            }
+            if (generation == 0)
+            {
+                return hpx::make_exceptional_future<arg_type>(HPX_GET_EXCEPTION(
+                    hpx::error::bad_parameter, "hpx::collectives::all_reduce",
+                    "the generation number shouldn't be zero"));
+            }
+
+            // Handle operation right away if there is only one value.
+            if (auto [num_sites, comm_site] = fid.get_info(); num_sites == 1)
+            {
+                if (this_site != comm_site)
+                {
+                    return hpx::make_exceptional_future<arg_type>(
+                        HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                            "hpx::collectives::all_reduce",
+                            "the local site should be zero if only one site is "
+                            "involved"));
+                }
+
+                return hpx::make_ready_future(HPX_FORWARD(T, local_result));
+            }
+
+            auto all_reduce_data =
+                [local_result = HPX_FORWARD(T, local_result),
+                    op = HPX_FORWARD(F, op), generation, num_generations,
+                    this_site](
+                    communicator&& c) mutable -> hpx::future<arg_type> {
+                using func_type = std::decay_t<F>;
+                using action_type =
+                    communicator_server::communication_get_direct_action<
+                        traits::communication::all_reduce_tag,
+                        hpx::future<arg_type>, generation_mode, arg_type,
+                        func_type>;
+
+                // explicitly unwrap returned future
+                hpx::future<arg_type> result =
+                    hpx::async(action_type(), c, this_site, generation,
+                        num_generations, HPX_MOVE(local_result), HPX_MOVE(op));
+
+                if (!result.is_ready())
+                {
+                    // make sure id is kept alive as long as the returned future
+                    traits::detail::get_shared_state(result)->set_on_completed(
+                        [client = HPX_MOVE(c)] { HPX_UNUSED(client); });
+                }
+
+                return result;
+            };
+
+            return fid.then(hpx::launch::sync, HPX_MOVE(all_reduce_data));
+        }
+    }    // namespace detail
+
+    ////////////////////////////////////////////////////////////////////////////
     // all_reduce plain values
     HPX_CXX_EXPORT template <typename T, typename F>
     hpx::future<std::decay_t<T>> all_reduce(communicator fid, T&& local_result,
         F&& op, this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg(),
-        std::size_t num_generations = 1)
+        generation_arg const generation = generation_arg())
     {
-        using arg_type = std::decay_t<T>;
-
-        if (this_site.is_default())
-        {
-            this_site = agas::get_locality_id();
-        }
-        if (generation == 0)
-        {
-            return hpx::make_exceptional_future<arg_type>(HPX_GET_EXCEPTION(
-                hpx::error::bad_parameter, "hpx::collectives::all_reduce",
-                "the generation number shouldn't be zero"));
-        }
-
-        // Handle operation right away if there is only one value.
-        if (auto [num_sites, comm_site] = fid.get_info(); num_sites == 1)
-        {
-            if (this_site != comm_site)
-            {
-                return hpx::make_exceptional_future<arg_type>(HPX_GET_EXCEPTION(
-                    hpx::error::bad_parameter, "hpx::collectives::all_reduce",
-                    "the local site should be zero if only one site is "
-                    "involved"));
-            }
-
-            return hpx::make_ready_future(HPX_FORWARD(T, local_result));
-        }
-
-        auto all_reduce_data =
-            [local_result = HPX_FORWARD(T, local_result),
-                op = HPX_FORWARD(F, op), generation, num_generations,
-                this_site](communicator&& c) mutable -> hpx::future<arg_type> {
-            using func_type = std::decay_t<F>;
-            using action_type =
-                detail::communicator_server::communication_get_direct_action<
-                    traits::communication::all_reduce_tag,
-                    hpx::future<arg_type>, std::size_t, arg_type, func_type>;
-
-            // explicitly unwrap returned future
-            hpx::future<arg_type> result =
-                hpx::async(action_type(), c, this_site, generation,
-                    num_generations, HPX_MOVE(local_result), HPX_MOVE(op));
-
-            if (!result.is_ready())
-            {
-                // make sure id is kept alive as long as the returned future
-                traits::detail::get_shared_state(result)->set_on_completed(
-                    [client = HPX_MOVE(c)] { HPX_UNUSED(client); });
-            }
-
-            return result;
-        };
-
-        return fid.then(hpx::launch::sync, HPX_MOVE(all_reduce_data));
+        return detail::all_reduce(HPX_MOVE(fid), HPX_FORWARD(T, local_result),
+            HPX_FORWARD(F, op), this_site, generation,
+            detail::generation_mode::single_step);
     }
 
     HPX_CXX_EXPORT template <typename T, typename F>
@@ -496,40 +518,40 @@ namespace hpx::collectives {
         // reduce+broadcast decomposition then collapses to a single flat
         // all_reduce; dispatch directly to avoid the two separate gate
         // synchronizations, but still advance the gate by two (run at 2k-1,
-        // num_generations == 2) so the flat instance stays shareable with
+        // double_step) so the flat instance stays shareable with
         // other collectives.
         if (arity_val >= num_sites_val)
         {
             HPX_ASSERT(communicators.size() == 1);
-            return all_reduce(communicators.get(0),
+            return detail::all_reduce(communicators.get(0),
                 HPX_FORWARD(T, local_result), HPX_FORWARD(F, op),
-                communicators.site(0), reduce_gen, /*num_generations=*/2);
+                communicators.site(0), reduce_gen,
+                detail::generation_mode::double_step);
         }
 
         if (this_site == root_site)
         {
             // reduce phase advances each communicator by one (the broadcast
-            // phase consumes 2k), so pass num_generations == 1.
-            arg_type reduced =
-                reduce_here(communicators, HPX_FORWARD(T, local_result),
-                    HPX_FORWARD(F, op), this_site, reduce_gen,
-                    /*num_generations=*/1)
-                    .get();
+            // phase consumes 2k), so pass single_step.
+            arg_type reduced = detail::reduce_here(communicators,
+                HPX_FORWARD(T, local_result), HPX_FORWARD(F, op), this_site,
+                reduce_gen, detail::generation_mode::single_step)
+                                   .get();
 
             // broadcast phase advances each communicator by one (the reduce
-            // phase already consumed 2k-1), so pass num_generations == 1.
-            return broadcast_to(communicators, HPX_MOVE(reduced), this_site,
-                broadcast_gen, /*num_generations=*/1);
+            // phase already consumed 2k-1), so pass single_step.
+            return detail::broadcast_to(communicators, HPX_MOVE(reduced),
+                this_site, broadcast_gen, detail::generation_mode::single_step);
         }
         else
         {
-            reduce_there(communicators, HPX_FORWARD(T, local_result),
+            detail::reduce_there(communicators, HPX_FORWARD(T, local_result),
                 HPX_FORWARD(F, op), this_site, reduce_gen,
-                /*num_generations=*/1)
+                detail::generation_mode::single_step)
                 .get();
 
-            return broadcast_from<arg_type>(
-                communicators, this_site, broadcast_gen, /*num_generations=*/1);
+            return detail::broadcast_from<arg_type>(communicators, this_site,
+                broadcast_gen, detail::generation_mode::single_step);
         }
     }
 

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -249,7 +249,8 @@ namespace hpx::traits {
     {
         template <typename Result, typename T>
         static Result get(Communicator& communicator, std::size_t which,
-            std::size_t generation, std::vector<T>&& t)
+            std::size_t generation, std::size_t num_generations,
+            std::vector<T>&& t)
         {
             return communicator.template handle_data<std::vector<T>>(
                 communication::communicator_data<
@@ -279,7 +280,8 @@ namespace hpx::traits {
                             HPX_MOVE(v[which])));
                     }
                     return result;
-                });
+                },
+                static_cast<std::size_t>(-1), num_generations);
         }
     };
 }    // namespace hpx::traits
@@ -292,7 +294,8 @@ namespace hpx::collectives {
     hpx::future<std::vector<T>> all_to_all(communicator fid,
         std::vector<T>&& local_result,
         this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg())
+        generation_arg const generation = generation_arg(),
+        std::size_t num_generations = 1)
     {
         if (this_site.is_default())
         {
@@ -321,16 +324,17 @@ namespace hpx::collectives {
         }
 
         auto all_to_all_data =
-            [local_result = HPX_MOVE(local_result), this_site, generation](
+            [local_result = HPX_MOVE(local_result), this_site, generation,
+                num_generations](
                 communicator&& c) mutable -> hpx::future<std::vector<T>> {
             using action_type =
                 detail::communicator_server::communication_get_direct_action<
                     traits::communication::all_to_all_tag,
-                    hpx::future<std::vector<T>>, std::vector<T>>;
+                    hpx::future<std::vector<T>>, std::size_t, std::vector<T>>;
 
             // explicitly unwrap returned future
             hpx::future<std::vector<T>> result = hpx::async(action_type(), c,
-                this_site, generation, HPX_MOVE(local_result));
+                this_site, generation, num_generations, HPX_MOVE(local_result));
 
             if (!result.is_ready())
             {
@@ -429,13 +433,11 @@ namespace hpx::collectives {
     //
     // Generation mapping (user generation k, starting from 1):
     //  - Subtree communicators: 2k-1 (gather) and 2k (scatter)
-    //  - Inter-group communicator: k (exchange)
-    // Each communicator sees consecutive generations starting at 1,
-    // which is required by the and_gate synchronization mechanism.
-    //
-    // A hierarchical_communicator instance used with all_to_all must not be
-    // shared with other collective operations; see the note on
-    // create_hierarchical_communicator.
+    //  - Inter-group communicator: 2k-1 (exchange), advancing the gate by two
+    //    in a single step so it stays in lock-step with the subtrees
+    // Each communicator therefore advances by two generations per call,
+    // which lets a single instance be shared across collectives; see the
+    // note on create_hierarchical_communicator.
 
     // Async overload (declared above; default arguments live on that
     // forward declaration).
@@ -504,10 +506,13 @@ namespace hpx::collectives {
         // generation numbers starting from 1 (the gate blocks until all
         // prior generations complete).  Subtree communicators participate
         // in both gather and scatter, so they use 2k-1 / 2k.  The
-        // inter-group communicator participates only in the exchange, so
-        // it uses k directly.
+        // inter-group communicator participates only in the exchange, but
+        // advances two generations per call as well so this communicator set
+        // can be shared with other collectives: the exchange runs at 2k-1 and
+        // the gate is advanced past 2k in a single step (num_generations == 2
+        // below).
         generation_arg const gather_gen(2 * generation - 1);
-        generation_arg const exchange_gen(generation);
+        generation_arg const exchange_gen(2 * generation - 1);
         generation_arg const scatter_gen(2 * generation);
 
         auto const groups =
@@ -543,9 +548,13 @@ namespace hpx::collectives {
                 }
             }
 
-            std::vector<std::vector<T>> received = all_to_all(hpx::launch::sync,
-                communicators.get(0), HPX_MOVE(exchange_blocks),
-                communicators.site(0), exchange_gen);
+            // The exchange touches the inter-group communicator once but must
+            // advance it by two generations to stay in lock-step with the
+            // subtree communicators, so request num_generations == 2.
+            std::vector<std::vector<T>> received =
+                all_to_all(communicators.get(0), HPX_MOVE(exchange_blocks),
+                    communicators.site(0), exchange_gen, /*num_generations=*/2)
+                    .get();
 
             // Phase 3: Transpose received blocks back to per-site vectors,
             // then scatter down the subtree.

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -249,7 +249,8 @@ namespace hpx::traits {
     {
         template <typename Result, typename T>
         static Result get(Communicator& communicator, std::size_t which,
-            std::size_t generation, std::size_t num_generations,
+            std::size_t generation,
+            hpx::collectives::detail::generation_mode num_generations,
             std::vector<T>&& t)
         {
             return communicator.template handle_data<std::vector<T>>(
@@ -281,7 +282,7 @@ namespace hpx::traits {
                     }
                     return result;
                 },
-                static_cast<std::size_t>(-1), num_generations);
+                num_generations);
         }
     };
 }    // namespace hpx::traits
@@ -289,64 +290,82 @@ namespace hpx::traits {
 namespace hpx::collectives {
 
     ///////////////////////////////////////////////////////////////////////////
+    namespace detail {
+
+        // all_to_all: detail entry point carrying the internal generation step.
+        // The public overload forwards with single_step; the hierarchical
+        // overload passes double_step for the flat fast path and the inter-group
+        // exchange.
+        template <typename T>
+        hpx::future<std::vector<T>> all_to_all(communicator fid,
+            std::vector<T>&& local_result, this_site_arg this_site,
+            generation_arg const generation, generation_mode num_generations)
+        {
+            if (this_site.is_default())
+            {
+                this_site = agas::get_locality_id();
+            }
+            if (generation == 0)
+            {
+                return hpx::make_exceptional_future<std::vector<T>>(
+                    HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                        "hpx::collectives::all_to_all",
+                        "the generation number shouldn't be zero"));
+            }
+
+            // Handle operation right away if there is only one value.
+            if (auto [num_sites, comm_site] = fid.get_info(); num_sites == 1)
+            {
+                if (this_site != comm_site)
+                {
+                    return hpx::make_exceptional_future<std::vector<T>>(
+                        HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                            "hpx::collectives::all_to_all",
+                            "the local site should be zero if only one site is "
+                            "involved"));
+                }
+                return hpx::make_ready_future(HPX_MOVE(local_result));
+            }
+
+            auto all_to_all_data =
+                [local_result = HPX_MOVE(local_result), this_site, generation,
+                    num_generations](
+                    communicator&& c) mutable -> hpx::future<std::vector<T>> {
+                using action_type =
+                    communicator_server::communication_get_direct_action<
+                        traits::communication::all_to_all_tag,
+                        hpx::future<std::vector<T>>, generation_mode,
+                        std::vector<T>>;
+
+                // explicitly unwrap returned future
+                hpx::future<std::vector<T>> result =
+                    hpx::async(action_type(), c, this_site, generation,
+                        num_generations, HPX_MOVE(local_result));
+
+                if (!result.is_ready())
+                {
+                    // make sure id is kept alive as long as the returned future
+                    traits::detail::get_shared_state(result)->set_on_completed(
+                        [client = HPX_MOVE(c)] { HPX_UNUSED(client); });
+                }
+
+                return result;
+            };
+
+            return fid.then(hpx::launch::sync, HPX_MOVE(all_to_all_data));
+        }
+    }    // namespace detail
+
+    ///////////////////////////////////////////////////////////////////////////
     // all_to_all
     HPX_CXX_EXPORT template <typename T>
     hpx::future<std::vector<T>> all_to_all(communicator fid,
         std::vector<T>&& local_result,
         this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg(),
-        std::size_t num_generations = 1)
+        generation_arg const generation = generation_arg())
     {
-        if (this_site.is_default())
-        {
-            this_site = agas::get_locality_id();
-        }
-        if (generation == 0)
-        {
-            return hpx::make_exceptional_future<std::vector<T>>(
-                HPX_GET_EXCEPTION(hpx::error::bad_parameter,
-                    "hpx::collectives::all_to_all",
-                    "the generation number shouldn't be zero"));
-        }
-
-        // Handle operation right away if there is only one value.
-        if (auto [num_sites, comm_site] = fid.get_info(); num_sites == 1)
-        {
-            if (this_site != comm_site)
-            {
-                return hpx::make_exceptional_future<std::vector<T>>(
-                    HPX_GET_EXCEPTION(hpx::error::bad_parameter,
-                        "hpx::collectives::all_to_all",
-                        "the local site should be zero if only one site is "
-                        "involved"));
-            }
-            return hpx::make_ready_future(HPX_MOVE(local_result));
-        }
-
-        auto all_to_all_data =
-            [local_result = HPX_MOVE(local_result), this_site, generation,
-                num_generations](
-                communicator&& c) mutable -> hpx::future<std::vector<T>> {
-            using action_type =
-                detail::communicator_server::communication_get_direct_action<
-                    traits::communication::all_to_all_tag,
-                    hpx::future<std::vector<T>>, std::size_t, std::vector<T>>;
-
-            // explicitly unwrap returned future
-            hpx::future<std::vector<T>> result = hpx::async(action_type(), c,
-                this_site, generation, num_generations, HPX_MOVE(local_result));
-
-            if (!result.is_ready())
-            {
-                // make sure id is kept alive as long as the returned future
-                traits::detail::get_shared_state(result)->set_on_completed(
-                    [client = HPX_MOVE(c)] { HPX_UNUSED(client); });
-            }
-
-            return result;
-        };
-
-        return fid.then(hpx::launch::sync, HPX_MOVE(all_to_all_data));
+        return detail::all_to_all(HPX_MOVE(fid), HPX_MOVE(local_result),
+            this_site, generation, detail::generation_mode::single_step);
     }
 
     HPX_CXX_EXPORT template <typename T>
@@ -488,18 +507,19 @@ namespace hpx::collectives {
                     "num_sites elements"));
         }
 
-        // Generation mapping: each communicator must see consecutive
-        // generation numbers starting from 1 (the gate blocks until all
-        // prior generations complete).  Subtree communicators participate
-        // in both gather and scatter, so they use 2k-1 / 2k.  The
-        // inter-group communicator participates only in the exchange, but
-        // advances two generations per call as well so this communicator set
-        // can be shared with other collectives: the exchange runs at 2k-1 and
-        // the gate is advanced past 2k in a single step (num_generations == 2
-        // below).
-        generation_arg const gather_gen(2 * generation - 1);
-        generation_arg const exchange_gen(2 * generation - 1);
-        generation_arg const scatter_gen(2 * generation);
+        // Generation mapping: every communicator advances two generations per
+        // call and must see consecutive generation numbers starting from 1 (the
+        // gate blocks until all prior generations complete). There are only two
+        // distinct internal generations per call -- the first (2k-1) and the
+        // second (2k). The subtree communicators run their gather at the first
+        // and their scatter at the second. The inter-group communicator runs
+        // its single exchange at that same first generation and advances the
+        // gate past the second in one step (double_step below), so it stays in
+        // lock-step with the subtrees and the instance can be shared across
+        // collectives. Gather, exchange and the collapsed flat fast path
+        // therefore share first_gen; only the subtree scatter uses second_gen.
+        generation_arg const first_gen(2 * generation - 1);
+        generation_arg const second_gen(2 * generation);
 
         // Flat fast path: when arity >= num_sites (either because the user
         // chose a large arity or because the factory overrode arity to
@@ -508,13 +528,14 @@ namespace hpx::collectives {
         // flat communicator spanning all sites. The 3-phase algorithm then
         // collapses to a flat all_to_all; dispatch directly to avoid the
         // intermediate allocations, but still advance the gate by two (run at
-        // 2k-1, num_generations == 2) so the flat instance stays shareable
-        // with other collectives.
+        // 2k-1, double_step) so the flat instance stays shareable with other
+        // collectives.
         if (arity_val >= num_sites_val)
         {
             HPX_ASSERT(communicators.size() == 1);
-            return all_to_all(communicators.get(0), HPX_MOVE(local_result),
-                communicators.site(0), exchange_gen, /*num_generations=*/2);
+            return detail::all_to_all(communicators.get(0),
+                HPX_MOVE(local_result), communicators.site(0), first_gen,
+                detail::generation_mode::double_step);
         }
 
         auto const groups =
@@ -528,7 +549,7 @@ namespace hpx::collectives {
             // Phase 1: Gather all subtree sites' data at this rep.
             std::vector<std::vector<T>> gathered =
                 detail::subtree_gather_at_top_rep(
-                    communicators, HPX_MOVE(local_result), gather_gen);
+                    communicators, HPX_MOVE(local_result), first_gen);
 
             std::size_t const my_group_size = groups[gidx].size;
             std::size_t const num_groups = groups.size();
@@ -552,10 +573,11 @@ namespace hpx::collectives {
 
             // The exchange touches the inter-group communicator once but must
             // advance it by two generations to stay in lock-step with the
-            // subtree communicators, so request num_generations == 2.
+            // subtree communicators, so request double_step.
             std::vector<std::vector<T>> received =
-                all_to_all(communicators.get(0), HPX_MOVE(exchange_blocks),
-                    communicators.site(0), exchange_gen, /*num_generations=*/2)
+                detail::all_to_all(communicators.get(0),
+                    HPX_MOVE(exchange_blocks), communicators.site(0), first_gen,
+                    detail::generation_mode::double_step)
                     .get();
 
             // Phase 3: Transpose received blocks back to per-site vectors,
@@ -577,17 +599,17 @@ namespace hpx::collectives {
             }
 
             return detail::subtree_scatter_at_top_rep(
-                communicators, HPX_MOVE(scatter_input), scatter_gen);
+                communicators, HPX_MOVE(scatter_input), second_gen);
         }
         else
         {
             // Non-representative: send data to rep, then receive
             // result from rep.
             detail::subtree_send_to_top_rep(
-                communicators, HPX_MOVE(local_result), gather_gen);
+                communicators, HPX_MOVE(local_result), first_gen);
 
             return detail::subtree_receive_from_top_rep<std::vector<T>>(
-                communicators, scatter_gen);
+                communicators, second_gen);
         }
     }
 }    // namespace hpx::collectives

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -447,12 +447,12 @@ namespace hpx::collectives {
         std::vector<T>&& local_result, this_site_arg this_site,
         generation_arg const generation)
     {
-        if (generation.is_default())
+        if (generation.is_default() || generation == 0)
         {
             return hpx::make_exceptional_future<std::vector<T>>(
                 HPX_GET_EXCEPTION(hpx::error::bad_parameter,
                     "hpx::collectives::all_to_all (hierarchical)",
-                    "hierarchical all_to_all requires an explicit "
+                    "hierarchical all_to_all requires an explicit, positive "
                     "generation number for its internal generation "
                     "mapping"));
         }

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -488,20 +488,6 @@ namespace hpx::collectives {
                     "num_sites elements"));
         }
 
-        // Flat fast path: when arity >= num_sites (either because the user
-        // chose a large arity or because the factory overrode arity to
-        // num_sites for the flat fallback), the tree builder's leaf condition
-        // (right - left < arity) fired at the root call and produced a single
-        // flat communicator spanning all sites. The 3-phase algorithm then
-        // collapses to a flat all_to_all; dispatch directly to avoid the
-        // intermediate allocations.
-        if (arity_val >= num_sites_val)
-        {
-            HPX_ASSERT(communicators.size() == 1);
-            return all_to_all(communicators.get(0), HPX_MOVE(local_result),
-                communicators.site(0), generation);
-        }
-
         // Generation mapping: each communicator must see consecutive
         // generation numbers starting from 1 (the gate blocks until all
         // prior generations complete).  Subtree communicators participate
@@ -514,6 +500,22 @@ namespace hpx::collectives {
         generation_arg const gather_gen(2 * generation - 1);
         generation_arg const exchange_gen(2 * generation - 1);
         generation_arg const scatter_gen(2 * generation);
+
+        // Flat fast path: when arity >= num_sites (either because the user
+        // chose a large arity or because the factory overrode arity to
+        // num_sites for the flat fallback), the tree builder's leaf condition
+        // (right - left < arity) fired at the root call and produced a single
+        // flat communicator spanning all sites. The 3-phase algorithm then
+        // collapses to a flat all_to_all; dispatch directly to avoid the
+        // intermediate allocations, but still advance the gate by two (run at
+        // 2k-1, num_generations == 2) so the flat instance stays shareable
+        // with other collectives.
+        if (arity_val >= num_sites_val)
+        {
+            HPX_ASSERT(communicators.size() == 1);
+            return all_to_all(communicators.get(0), HPX_MOVE(local_result),
+                communicators.site(0), exchange_gen, /*num_generations=*/2);
+        }
 
         auto const groups =
             detail::get_top_level_groups(num_sites_val, arity_val);

--- a/libs/full/collectives/include/hpx/collectives/argument_types.hpp
+++ b/libs/full/collectives/include/hpx/collectives/argument_types.hpp
@@ -11,11 +11,28 @@
 #include <hpx/config.hpp>
 
 #include <cstddef>
+#include <cstdint>
 
 ///////////////////////////////////////////////////////////////////////////////
 namespace hpx::collectives {
 
     namespace detail {
+
+        // The number of gate generations a single collective call consumes on a
+        // communicator. A hierarchical collective that touches a communicator
+        // only once per user call but has to stay in lock-step with collectives
+        // that touch it twice uses double_step, advancing the gate by two in a
+        // single step. This is an internal knob: the public collective API does
+        // not expose it, it is threaded only through the detail entry points the
+        // hierarchical overloads call. HPX serialization handles scoped enums
+        // natively (they are stored as their underlying integral type), so no
+        // explicit serialize function is required when a generation_mode crosses
+        // the wire as a collective action argument.
+        enum class generation_mode : std::uint8_t
+        {
+            single_step = 1,
+            double_step = 2
+        };
 
         template <typename Tag,
             std::size_t Default = static_cast<std::size_t>(-1)>

--- a/libs/full/collectives/include/hpx/collectives/barrier.hpp
+++ b/libs/full/collectives/include/hpx/collectives/barrier.hpp
@@ -247,13 +247,13 @@ namespace hpx::collectives {
         generation_arg const generation = generation_arg(),
         root_site_arg /*root_site*/ = root_site_arg())
     {
-        if (generation.is_default())
+        if (generation.is_default() || generation == 0)
         {
             return hpx::make_exceptional_future<void>(
                 HPX_GET_EXCEPTION(hpx::error::bad_parameter,
                     "hpx::collectives::barrier (hierarchical)",
-                    "hierarchical barrier requires an explicit generation "
-                    "number for the 2k-1/2k internal mapping"));
+                    "hierarchical barrier requires an explicit, positive "
+                    "generation number for the 2k-1/2k internal mapping"));
         }
 
         if (this_site.is_default())

--- a/libs/full/collectives/include/hpx/collectives/broadcast.hpp
+++ b/libs/full/collectives/include/hpx/collectives/broadcast.hpp
@@ -422,7 +422,8 @@ namespace hpx::traits {
     {
         template <typename Result>
         static Result get(Communicator& communicator, std::size_t which,
-            std::size_t generation, std::size_t num_generations)
+            std::size_t generation,
+            hpx::collectives::detail::generation_mode num_generations)
         {
             using data_type = typename Result::result_type;
 
@@ -437,12 +438,13 @@ namespace hpx::traits {
                     return Communicator::template handle_bool<data_type>(
                         data[0]);
                 },
-                1, num_generations);
+                num_generations, /*num_values=*/1);
         }
 
         template <typename Result, typename T>
         static Result set(Communicator& communicator, std::size_t which,
-            std::size_t generation, std::size_t num_generations, T&& t)
+            std::size_t generation,
+            hpx::collectives::detail::generation_mode num_generations, T&& t)
         {
             return communicator.template handle_data<std::decay_t<T>>(
                 communication::communicator_data<
@@ -455,104 +457,137 @@ namespace hpx::traits {
                     return Communicator::template handle_bool<std::decay_t<T>>(
                         data[0]);
                 },
-                1, num_generations);
+                num_generations, /*num_values=*/1);
         }
     };
 }    // namespace hpx::traits
 
 namespace hpx::collectives {
 
-    HPX_CXX_EXPORT template <typename T>
-    hpx::future<std::decay_t<T>> broadcast_to(communicator fid,
-        T&& local_result, this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg(),
-        std::size_t num_generations = 1)
-    {
-        using arg_type = std::decay_t<T>;
+    namespace detail {
 
-        if (this_site.is_default())
+        // broadcast_to: detail entry point carrying the internal generation
+        // step. The public overload forwards with single_step; the hierarchical
+        // broadcast_to walks its sub-communicators through this entry with the
+        // mapped step.
+        template <typename T>
+        hpx::future<std::decay_t<T>> broadcast_to(communicator fid,
+            T&& local_result, this_site_arg this_site,
+            generation_arg const generation, generation_mode num_generations)
         {
-            this_site = static_cast<std::size_t>(agas::get_locality_id());
-        }
-        if (generation == 0)
-        {
-            return hpx::make_exceptional_future<arg_type>(HPX_GET_EXCEPTION(
-                hpx::error::bad_parameter, "hpx::collectives::broadcast_to",
-                "the generation number shouldn't be zero"));
-        }
+            using arg_type = std::decay_t<T>;
 
-        // Handle operation right away if there is only one value.
-        if (auto [num_sites, _] = fid.get_info(); num_sites == 1)
-        {
-            if (this_site != 0)
+            if (this_site.is_default())
+            {
+                this_site = static_cast<std::size_t>(agas::get_locality_id());
+            }
+            if (generation == 0)
             {
                 return hpx::make_exceptional_future<arg_type>(HPX_GET_EXCEPTION(
                     hpx::error::bad_parameter, "hpx::collectives::broadcast_to",
-                    "the local site should be zero if only one site is "
-                    "involved"));
+                    "the generation number shouldn't be zero"));
             }
 
-            return hpx::make_ready_future(HPX_FORWARD(T, local_result));
-        }
-
-        auto broadcast_data =
-            [local_result = HPX_FORWARD(T, local_result), this_site, generation,
-                num_generations](
-                communicator&& c) mutable -> hpx::future<arg_type> {
-            using action_type =
-                detail::communicator_server::communication_set_direct_action<
-                    traits::communication::broadcast_tag, hpx::future<arg_type>,
-                    std::size_t, arg_type>;
-
-            // explicitly unwrap returned future
-            hpx::future<arg_type> result = hpx::async(action_type(), c,
-                this_site, generation, num_generations, HPX_MOVE(local_result));
-
-            if (!result.is_ready())
+            // Handle operation right away if there is only one value.
+            if (auto [num_sites, _] = fid.get_info(); num_sites == 1)
             {
-                // make sure id is kept alive as long as the returned future
-                traits::detail::get_shared_state(result)->set_on_completed(
-                    [client = HPX_MOVE(c)] { HPX_UNUSED(client); });
+                if (this_site != 0)
+                {
+                    return hpx::make_exceptional_future<arg_type>(
+                        HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                            "hpx::collectives::broadcast_to",
+                            "the local site should be zero if only one site is "
+                            "involved"));
+                }
+
+                return hpx::make_ready_future(HPX_FORWARD(T, local_result));
             }
 
-            return result;
-        };
+            auto broadcast_data =
+                [local_result = HPX_FORWARD(T, local_result), this_site,
+                    generation, num_generations](
+                    communicator&& c) mutable -> hpx::future<arg_type> {
+                using action_type =
+                    communicator_server::communication_set_direct_action<
+                        traits::communication::broadcast_tag,
+                        hpx::future<arg_type>, generation_mode, arg_type>;
 
-        return fid.then(hpx::launch::sync, HPX_MOVE(broadcast_data));
+                // explicitly unwrap returned future
+                hpx::future<arg_type> result =
+                    hpx::async(action_type(), c, this_site, generation,
+                        num_generations, HPX_MOVE(local_result));
+
+                if (!result.is_ready())
+                {
+                    // make sure id is kept alive as long as the returned future
+                    traits::detail::get_shared_state(result)->set_on_completed(
+                        [client = HPX_MOVE(c)] { HPX_UNUSED(client); });
+                }
+
+                return result;
+            };
+
+            return fid.then(hpx::launch::sync, HPX_MOVE(broadcast_data));
+        }
+    }    // namespace detail
+
+    HPX_CXX_EXPORT template <typename T>
+    hpx::future<std::decay_t<T>> broadcast_to(communicator fid,
+        T&& local_result, this_site_arg this_site = this_site_arg(),
+        generation_arg const generation = generation_arg())
+    {
+        return detail::broadcast_to(HPX_MOVE(fid), HPX_FORWARD(T, local_result),
+            this_site, generation, detail::generation_mode::single_step);
     }
 
     ////////////////////////////////////////////////////////////////////////////
+    namespace detail {
+
+        // broadcast_to over a hierarchical_communicator: detail entry carrying
+        // the internal generation step. The public overload forwards with
+        // double_step (standalone use); all_gather/all_reduce reuse it as their
+        // broadcast phase with single_step (they already pass the doubled
+        // generation).
+        template <typename T>
+        hpx::future<std::decay_t<T>> broadcast_to(
+            hierarchical_communicator const& communicators, T&& local_result,
+            this_site_arg this_site, generation_arg const generation,
+            generation_mode num_generations)
+        {
+            if (this_site.is_default())
+            {
+                this_site = agas::get_locality_id();
+            }
+
+            // Each sub-communicator advances num_generations per call. Used
+            // standalone (double_step) the user generation k maps to the first
+            // of its two internal generations (2k-1); used as the broadcast
+            // phase of all_gather/all_reduce (single_step) the caller already
+            // passes the doubled generation, so the mapping is the identity.
+            auto const [run_gen, run_step] =
+                hierarchical_run_params(generation, num_generations);
+
+            T result = HPX_FORWARD(T, local_result);
+            for (std::size_t i = 0; i < communicators.size() - 1; ++i)
+            {
+                result = broadcast_to(communicators.get(i), HPX_MOVE(result),
+                    this_site_arg(0), run_gen, run_step)
+                             .get();
+            }
+
+            return broadcast_to(communicators.back(), HPX_MOVE(result),
+                this_site_arg(0), run_gen, run_step);
+        }
+    }    // namespace detail
+
     HPX_CXX_EXPORT template <typename T>
     hpx::future<std::decay_t<T>> broadcast_to(
         hierarchical_communicator const& communicators, T&& local_result,
         this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg(),
-        std::size_t num_generations = 2)
+        generation_arg const generation = generation_arg())
     {
-        if (this_site.is_default())
-        {
-            this_site = agas::get_locality_id();
-        }
-
-        // Each sub-communicator advances num_generations per call. Used
-        // standalone (num_generations == 2) the user generation k maps to the
-        // first of its two internal generations (2k-1); used as the broadcast
-        // phase of all_gather/all_reduce (num_generations == 1) the caller
-        // already passes the doubled generation, so the mapping is the
-        // identity.
-        auto const [run_gen, run_step] =
-            detail::hierarchical_run_params(generation, num_generations);
-
-        T result = HPX_FORWARD(T, local_result);
-        for (std::size_t i = 0; i < communicators.size() - 1; ++i)
-        {
-            result = broadcast_to(communicators.get(i), HPX_MOVE(result),
-                this_site_arg(0), run_gen, run_step)
-                         .get();
-        }
-
-        return broadcast_to(communicators.back(), HPX_MOVE(result),
-            this_site_arg(0), run_gen, run_step);
+        return detail::broadcast_to(communicators, HPX_FORWARD(T, local_result),
+            this_site, generation, detail::generation_mode::double_step);
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -613,83 +648,113 @@ namespace hpx::collectives {
     }
 
     ///////////////////////////////////////////////////////////////////////////
+    namespace detail {
+
+        // broadcast_from: detail entry point carrying the internal generation
+        // step. The public overload forwards with single_step; the hierarchical
+        // broadcast_from reuses it with the mapped step.
+        template <typename T>
+        hpx::future<T> broadcast_from(communicator fid, this_site_arg this_site,
+            generation_arg const generation, generation_mode num_generations)
+        {
+            if (this_site.is_default())
+            {
+                this_site = static_cast<std::size_t>(agas::get_locality_id());
+            }
+            if (generation == 0)
+            {
+                return hpx::make_exceptional_future<T>(
+                    HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                        "hpx::collectives::broadcast_from",
+                        "the generation number shouldn't be zero"));
+            }
+
+            auto broadcast_data = [this_site, generation, num_generations](
+                                      communicator&& c) -> hpx::future<T> {
+                using action_type =
+                    communicator_server::communication_get_direct_action<
+                        traits::communication::broadcast_tag, hpx::future<T>,
+                        generation_mode>;
+
+                // make sure id is kept alive as long as the returned future,
+                // explicitly unwrap returned future
+                hpx::future<T> result = hpx::async(
+                    action_type(), c, this_site, generation, num_generations);
+
+                if (!result.is_ready())
+                {
+                    traits::detail::get_shared_state(result)->set_on_completed(
+                        [client = HPX_MOVE(c)]() { HPX_UNUSED(client); });
+                }
+
+                return result;
+            };
+
+            return fid.then(hpx::launch::sync, HPX_MOVE(broadcast_data));
+        }
+    }    // namespace detail
+
     HPX_CXX_EXPORT template <typename T>
     hpx::future<T> broadcast_from(communicator fid,
         this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg(),
-        std::size_t num_generations = 1)
+        generation_arg const generation = generation_arg())
     {
-        if (this_site.is_default())
-        {
-            this_site = static_cast<std::size_t>(agas::get_locality_id());
-        }
-        if (generation == 0)
-        {
-            return hpx::make_exceptional_future<T>(HPX_GET_EXCEPTION(
-                hpx::error::bad_parameter, "hpx::collectives::broadcast_from",
-                "the generation number shouldn't be zero"));
-        }
-
-        auto broadcast_data = [this_site, generation, num_generations](
-                                  communicator&& c) -> hpx::future<T> {
-            using action_type =
-                detail::communicator_server::communication_get_direct_action<
-                    traits::communication::broadcast_tag, hpx::future<T>,
-                    std::size_t>;
-
-            // make sure id is kept alive as long as the returned future,
-            // explicitly unwrap returned future
-            hpx::future<T> result = hpx::async(
-                action_type(), c, this_site, generation, num_generations);
-
-            if (!result.is_ready())
-            {
-                traits::detail::get_shared_state(result)->set_on_completed(
-                    [client = HPX_MOVE(c)]() { HPX_UNUSED(client); });
-            }
-
-            return result;
-        };
-
-        return fid.then(hpx::launch::sync, HPX_MOVE(broadcast_data));
+        return detail::broadcast_from<T>(HPX_MOVE(fid), this_site, generation,
+            detail::generation_mode::single_step);
     }
 
     ///////////////////////////////////////////////////////////////////////////
+    namespace detail {
+
+        // broadcast_from over a hierarchical_communicator: detail entry carrying
+        // the internal generation step. The public overload forwards with
+        // double_step; all_gather/all_reduce reuse it as their broadcast phase
+        // with single_step.
+        template <typename T>
+        hpx::future<T> broadcast_from(
+            hierarchical_communicator const& communicators,
+            this_site_arg this_site, generation_arg const generation,
+            generation_mode num_generations)
+        {
+            if (this_site.is_default())
+            {
+                this_site = agas::get_locality_id();
+            }
+
+            // See broadcast_to above for the internal generation mapping.
+            auto const [run_gen, run_step] =
+                hierarchical_run_params(generation, num_generations);
+
+            if (communicators.size() > 1)
+            {
+                T result = broadcast_from<T>(communicators.get(0),
+                    communicators.site(0), run_gen, run_step)
+                               .get();
+
+                for (std::size_t i = 1; i < communicators.size() - 1; ++i)
+                {
+                    result = broadcast_to(communicators.get(i),
+                        HPX_MOVE(result), this_site_arg(0), run_gen, run_step)
+                                 .get();
+                }
+
+                return broadcast_to(communicators.back(), HPX_MOVE(result),
+                    this_site_arg(0), run_gen, run_step);
+            }
+
+            return broadcast_from<T>(communicators.back(),
+                communicators.last_site(), run_gen, run_step);
+        }
+    }    // namespace detail
+
     HPX_CXX_EXPORT template <typename T>
     hpx::future<T> broadcast_from(
         hierarchical_communicator const& communicators,
         this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg(),
-        std::size_t num_generations = 2)
+        generation_arg const generation = generation_arg())
     {
-        if (this_site.is_default())
-        {
-            this_site = agas::get_locality_id();
-        }
-
-        // See broadcast_to above for the internal generation mapping.
-        auto const [run_gen, run_step] =
-            detail::hierarchical_run_params(generation, num_generations);
-
-        if (communicators.size() > 1)
-        {
-            T result = broadcast_from<T>(
-                communicators.get(0), communicators.site(0), run_gen, run_step)
-                           .get();
-
-            for (std::size_t i = 1; i < communicators.size() - 1; ++i)
-            {
-                result = broadcast_to(communicators.get(i), HPX_MOVE(result),
-                    this_site_arg(0), run_gen, run_step)
-                             .get();
-            }
-
-            return broadcast_to(communicators.back(), HPX_MOVE(result),
-                this_site_arg(0), run_gen, run_step);
-        }
-
-        return broadcast_from<T>(
-            communicators.back(), communicators.last_site(), run_gen, run_step);
+        return detail::broadcast_from<T>(communicators, this_site, generation,
+            detail::generation_mode::double_step);
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/libs/full/collectives/include/hpx/collectives/broadcast.hpp
+++ b/libs/full/collectives/include/hpx/collectives/broadcast.hpp
@@ -396,6 +396,7 @@ namespace hpx { namespace collectives {
 
 #include <hpx/collectives/argument_types.hpp>
 #include <hpx/collectives/create_communicator.hpp>
+#include <hpx/collectives/detail/hierarchical_helpers.hpp>
 
 #include <cstddef>
 #include <type_traits>
@@ -421,7 +422,7 @@ namespace hpx::traits {
     {
         template <typename Result>
         static Result get(Communicator& communicator, std::size_t which,
-            std::size_t generation)
+            std::size_t generation, std::size_t num_generations)
         {
             using data_type = typename Result::result_type;
 
@@ -436,12 +437,12 @@ namespace hpx::traits {
                     return Communicator::template handle_bool<data_type>(
                         data[0]);
                 },
-                1);
+                1, num_generations);
         }
 
         template <typename Result, typename T>
         static Result set(Communicator& communicator, std::size_t which,
-            std::size_t generation, T&& t)
+            std::size_t generation, std::size_t num_generations, T&& t)
         {
             return communicator.template handle_data<std::decay_t<T>>(
                 communication::communicator_data<
@@ -454,7 +455,7 @@ namespace hpx::traits {
                     return Communicator::template handle_bool<std::decay_t<T>>(
                         data[0]);
                 },
-                1);
+                1, num_generations);
         }
     };
 }    // namespace hpx::traits
@@ -464,7 +465,8 @@ namespace hpx::collectives {
     HPX_CXX_EXPORT template <typename T>
     hpx::future<std::decay_t<T>> broadcast_to(communicator fid,
         T&& local_result, this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg())
+        generation_arg const generation = generation_arg(),
+        std::size_t num_generations = 1)
     {
         using arg_type = std::decay_t<T>;
 
@@ -494,16 +496,17 @@ namespace hpx::collectives {
         }
 
         auto broadcast_data =
-            [local_result = HPX_FORWARD(T, local_result), this_site,
-                generation](communicator&& c) mutable -> hpx::future<arg_type> {
+            [local_result = HPX_FORWARD(T, local_result), this_site, generation,
+                num_generations](
+                communicator&& c) mutable -> hpx::future<arg_type> {
             using action_type =
                 detail::communicator_server::communication_set_direct_action<
                     traits::communication::broadcast_tag, hpx::future<arg_type>,
-                    arg_type>;
+                    std::size_t, arg_type>;
 
             // explicitly unwrap returned future
             hpx::future<arg_type> result = hpx::async(action_type(), c,
-                this_site, generation, HPX_MOVE(local_result));
+                this_site, generation, num_generations, HPX_MOVE(local_result));
 
             if (!result.is_ready())
             {
@@ -523,22 +526,33 @@ namespace hpx::collectives {
     hpx::future<std::decay_t<T>> broadcast_to(
         hierarchical_communicator const& communicators, T&& local_result,
         this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg())
+        generation_arg const generation = generation_arg(),
+        std::size_t num_generations = 2)
     {
         if (this_site.is_default())
         {
             this_site = agas::get_locality_id();
         }
 
+        // Each sub-communicator advances num_generations per call. Used
+        // standalone (num_generations == 2) the user generation k maps to the
+        // first of its two internal generations (2k-1); used as the broadcast
+        // phase of all_gather/all_reduce (num_generations == 1) the caller
+        // already passes the doubled generation, so the mapping is the
+        // identity.
+        auto const [run_gen, run_step] =
+            detail::hierarchical_run_params(generation, num_generations);
+
         T result = HPX_FORWARD(T, local_result);
         for (std::size_t i = 0; i < communicators.size() - 1; ++i)
         {
-            result = broadcast_to(hpx::launch::sync, communicators.get(i),
-                HPX_MOVE(result), this_site_arg(0), generation);
+            result = broadcast_to(communicators.get(i), HPX_MOVE(result),
+                this_site_arg(0), run_gen, run_step)
+                         .get();
         }
 
         return broadcast_to(communicators.back(), HPX_MOVE(result),
-            this_site_arg(0), generation);
+            this_site_arg(0), run_gen, run_step);
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -602,7 +616,8 @@ namespace hpx::collectives {
     HPX_CXX_EXPORT template <typename T>
     hpx::future<T> broadcast_from(communicator fid,
         this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg())
+        generation_arg const generation = generation_arg(),
+        std::size_t num_generations = 1)
     {
         if (this_site.is_default())
         {
@@ -615,16 +630,17 @@ namespace hpx::collectives {
                 "the generation number shouldn't be zero"));
         }
 
-        auto broadcast_data = [this_site, generation](
+        auto broadcast_data = [this_site, generation, num_generations](
                                   communicator&& c) -> hpx::future<T> {
             using action_type =
                 detail::communicator_server::communication_get_direct_action<
-                    traits::communication::broadcast_tag, hpx::future<T>>;
+                    traits::communication::broadcast_tag, hpx::future<T>,
+                    std::size_t>;
 
             // make sure id is kept alive as long as the returned future,
             // explicitly unwrap returned future
-            hpx::future<T> result =
-                hpx::async(action_type(), c, this_site, generation);
+            hpx::future<T> result = hpx::async(
+                action_type(), c, this_site, generation, num_generations);
 
             if (!result.is_ready())
             {
@@ -643,30 +659,37 @@ namespace hpx::collectives {
     hpx::future<T> broadcast_from(
         hierarchical_communicator const& communicators,
         this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg())
+        generation_arg const generation = generation_arg(),
+        std::size_t num_generations = 2)
     {
         if (this_site.is_default())
         {
             this_site = agas::get_locality_id();
         }
 
+        // See broadcast_to above for the internal generation mapping.
+        auto const [run_gen, run_step] =
+            detail::hierarchical_run_params(generation, num_generations);
+
         if (communicators.size() > 1)
         {
-            T result = broadcast_from<T>(hpx::launch::sync,
-                communicators.get(0), generation, communicators.site(0));
+            T result = broadcast_from<T>(
+                communicators.get(0), communicators.site(0), run_gen, run_step)
+                           .get();
 
             for (std::size_t i = 1; i < communicators.size() - 1; ++i)
             {
-                result = broadcast_to(hpx::launch::sync, communicators.get(i),
-                    HPX_MOVE(result), this_site_arg(0), generation);
+                result = broadcast_to(communicators.get(i), HPX_MOVE(result),
+                    this_site_arg(0), run_gen, run_step)
+                             .get();
             }
 
             return broadcast_to(communicators.back(), HPX_MOVE(result),
-                this_site_arg(0), generation);
+                this_site_arg(0), run_gen, run_step);
         }
 
         return broadcast_from<T>(
-            communicators.back(), generation, communicators.last_site());
+            communicators.back(), communicators.last_site(), run_gen, run_step);
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/libs/full/collectives/include/hpx/collectives/create_communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/create_communicator.hpp
@@ -134,19 +134,17 @@ namespace hpx { namespace collectives {
     ///                     is 16; pass 0 to disable the fallback and always
     ///                     build a tree.
     ///
-    /// \note   The sub-communicators of a hierarchical_communicator share
-    ///         one generation sequence per registered name, and the
-    ///         hierarchical collectives consume internal generations at
-    ///         different rates: \a broadcast and \a barrier consume one
-    ///         generation per call on every sub-communicator, \a all_gather
-    ///         and \a all_reduce consume two per call, and \a all_to_all
-    ///         consumes two per call on the subtree communicators but one on
-    ///         the inter-group communicator. A single
-    ///         hierarchical_communicator instance must therefore only be
-    ///         used with collective operations sharing one consumption
-    ///         scheme: \a all_gather and \a all_reduce may be mixed on one
-    ///         instance, while \a all_to_all, \a broadcast, and \a barrier
-    ///         each require their own instance.
+    /// \note   The sub-communicators of a hierarchical_communicator share one
+    ///         generation sequence per registered name. Every hierarchical
+    ///         collective advances each sub-communicator it touches by exactly
+    ///         two internal generations per call (a single-pass collective
+    ///         such as \a broadcast, \a gather, \a scatter or \a reduce, and
+    ///         the inter-group exchange of \a all_to_all, skip the second
+    ///         generation in one step rather than performing a second
+    ///         round-trip). A single hierarchical_communicator instance may
+    ///         therefore be shared freely across collective operations,
+    ///         provided every call uses an explicit, strictly consecutive
+    ///         generation number so the shared sequence stays gap-free.
     ///
     /// \returns    This function returns a new communicator object usable
     ///             with the collective operation.

--- a/libs/full/collectives/include/hpx/collectives/create_communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/create_communicator.hpp
@@ -144,7 +144,14 @@ namespace hpx { namespace collectives {
     ///         round-trip). A single hierarchical_communicator instance may
     ///         therefore be shared freely across collective operations,
     ///         provided every call uses an explicit, strictly consecutive
-    ///         generation number so the shared sequence stays gap-free.
+    ///         generation number so the shared sequence stays gap-free. Because
+    ///         the two-phase hierarchical collectives (\a all_gather, \a
+    ///         all_reduce, \a all_to_all and the hierarchical \a barrier)
+    ///         derive their phase generations from that explicit number, they
+    ///         require it and reject an auto (default) generation. The
+    ///         non-hierarchical (flat) collectives keep supporting the default
+    ///         generation, falling back to the internal per-communicator
+    ///         counter maintained in the and_gate.
     ///
     /// \returns    This function returns a new communicator object usable
     ///             with the collective operation.

--- a/libs/full/collectives/include/hpx/collectives/detail/communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/communicator.hpp
@@ -11,6 +11,7 @@
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 
 #include <hpx/assert.hpp>
+#include <hpx/collectives/argument_types.hpp>
 #include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/components_base.hpp>
@@ -239,7 +240,7 @@ namespace hpx::collectives::detail {
             HPX_ASSERT_OWNS_LOCK(l);
 
             // Wait for the requested generation to be processed.
-            gate_.synchronize(generation == static_cast<std::size_t>(-1) ?
+            gate_.synchronize(generation == generation_arg{} ?
                     gate_.generation(l) :
                     generation,
                 l);
@@ -272,7 +273,7 @@ namespace hpx::collectives::detail {
                         basename_, operation, which, generation);
                 }
 
-                if (generation == static_cast<std::size_t>(-1) ||
+                if (generation == generation_arg{} ||
                     generation == gate_.generation(l))
                 {
                     current_operation_ = operation;
@@ -288,19 +289,21 @@ namespace hpx::collectives::detail {
         // set or get).
         //
         // Finalizer will be invoked under lock after all sites have checked in.
-        // num_generations is the number of internal generations this operation
-        // consumes on this communicator's gate (default 1). A hierarchical
-        // collective that touches a communicator only once per user call but
-        // has to stay in lock-step with collectives that touch it twice passes
-        // num_generations == 2, advancing the gate by two in a single step so
-        // the skipped generation is consumed here instead of through a second
-        // round-trip.
+        // num_generations is how many internal generations this operation
+        // consumes on this communicator's gate (default generation_mode::
+        // single_step). A hierarchical collective that touches a communicator
+        // only once per user call but has to stay in lock-step with collectives
+        // that touch it twice passes generation_mode::double_step, advancing the
+        // gate by two in a single step so the skipped generation is consumed
+        // here instead of through a second round-trip. It comes before
+        // num_values so the common callers (which never override num_values) can
+        // leave that argument off.
         template <typename Data, typename Step, typename Finalizer>
         auto handle_data(char const* operation, std::size_t which,
             std::size_t generation, [[maybe_unused]] Step&& step,
             Finalizer&& finalizer,
-            std::size_t num_values = static_cast<std::size_t>(-1),
-            std::size_t num_generations = 1)
+            generation_mode num_generations = generation_mode::single_step,
+            std::size_t num_values = static_cast<std::size_t>(-1))
         {
             auto on_ready = [this, operation, which, generation, num_values,
                                 finalizer = HPX_FORWARD(Finalizer, finalizer)](
@@ -456,17 +459,17 @@ namespace hpx::collectives::detail {
                     // generation, advance the gate past the skipped ones in a
                     // single step (the gate only requires that the next value
                     // is not smaller than the current one). An auto generation
-                    // (-1) always advances by one; the assert enforces that a
-                    // multi-generation step is only requested with an explicit
-                    // generation. Note that generation + num_generations - 1
-                    // reduces to generation when num_generations == 1.
-                    HPX_ASSERT(num_generations != 0 &&
-                        (num_generations == 1 ||
-                            generation != static_cast<std::size_t>(-1)));
+                    // (the default sentinel) always advances by one; the assert
+                    // enforces that a multi-generation step is only requested
+                    // with an explicit generation. Note that the step reduces to
+                    // generation when num_generations == single_step.
+                    HPX_ASSERT(
+                        num_generations == generation_mode::single_step ||
+                        generation != generation_arg{});
                     std::size_t const next_gen =
-                        generation == static_cast<std::size_t>(-1) ?
-                        generation :
-                        generation + num_generations - 1;
+                        generation == generation_arg{} ? generation :
+                                                         generation +
+                            static_cast<std::size_t>(num_generations) - 1;
                     gate.next_generation(l, next_gen, ec);
                 });
 

--- a/libs/full/collectives/include/hpx/collectives/detail/communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/communicator.hpp
@@ -10,6 +10,7 @@
 
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 
+#include <hpx/assert.hpp>
 #include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/components_base.hpp>
@@ -287,11 +288,19 @@ namespace hpx::collectives::detail {
         // set or get).
         //
         // Finalizer will be invoked under lock after all sites have checked in.
+        // num_generations is the number of internal generations this operation
+        // consumes on this communicator's gate (default 1). A hierarchical
+        // collective that touches a communicator only once per user call but
+        // has to stay in lock-step with collectives that touch it twice passes
+        // num_generations == 2, advancing the gate by two in a single step so
+        // the skipped generation is consumed here instead of through a second
+        // round-trip.
         template <typename Data, typename Step, typename Finalizer>
         auto handle_data(char const* operation, std::size_t which,
             std::size_t generation, [[maybe_unused]] Step&& step,
             Finalizer&& finalizer,
-            std::size_t num_values = static_cast<std::size_t>(-1))
+            std::size_t num_values = static_cast<std::size_t>(-1),
+            std::size_t num_generations = 1)
         {
             auto on_ready = [this, operation, which, generation, num_values,
                                 finalizer = HPX_FORWARD(Finalizer, finalizer)](
@@ -414,7 +423,7 @@ namespace hpx::collectives::detail {
             // Make sure next generation is enabled only after previous
             // generation has finished executing.
             gate_.set(which, l,
-                [this, operation, which, generation](
+                [this, operation, which, generation, num_generations](
                     auto& l, auto& gate, error_code& ec) {
                     // This callback is invoked synchronously once for each
                     // collective operation after all data has been received and
@@ -443,8 +452,22 @@ namespace hpx::collectives::detail {
                     invalidate_data(l);
 
                     // Release threads possibly waiting for the next generation
-                    // to be handled.
-                    gate.next_generation(l, generation, ec);
+                    // to be handled. When this operation consumes more than one
+                    // generation, advance the gate past the skipped ones in a
+                    // single step (the gate only requires that the next value
+                    // is not smaller than the current one). An auto generation
+                    // (-1) always advances by one; the assert enforces that a
+                    // multi-generation step is only requested with an explicit
+                    // generation. Note that generation + num_generations - 1
+                    // reduces to generation when num_generations == 1.
+                    HPX_ASSERT(num_generations != 0 &&
+                        (num_generations == 1 ||
+                            generation != static_cast<std::size_t>(-1)));
+                    std::size_t const next_gen =
+                        generation == static_cast<std::size_t>(-1) ?
+                        generation :
+                        generation + num_generations - 1;
+                    gate.next_generation(l, next_gen, ec);
                 });
 
             return f;

--- a/libs/full/collectives/include/hpx/collectives/detail/hierarchical_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/hierarchical_helpers.hpp
@@ -11,6 +11,7 @@
 #include <hpx/config.hpp>
 
 #include <hpx/assert.hpp>
+#include <hpx/collectives/argument_types.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -19,6 +20,35 @@
 #include <vector>
 
 namespace hpx::collectives::detail {
+
+    // The per-call generation parameters a hierarchical sub-communicator uses:
+    // the run generation handed to the flat operation, and how many generations
+    // the gate advances by in a single step.
+    HPX_CXX_EXPORT struct hierarchical_run
+    {
+        generation_arg generation;
+        std::size_t num_generations;
+    };
+
+    // Map a user generation k to those parameters when the communicator
+    // advances num_generations per call: the run generation becomes
+    // num_generations * (k - 1) + 1 (so 2k-1 for the common step of two, and
+    // the identity for a step of one). A default (auto) generation is passed
+    // through unchanged and always advances by one, preserving the single-step
+    // behavior for instances that are not shared across collectives (sharing
+    // requires explicit, consecutive generations).
+    HPX_CXX_EXPORT inline hierarchical_run hierarchical_run_params(
+        generation_arg const generation, std::size_t const num_generations)
+    {
+        if (generation.is_default())
+        {
+            return {generation, 1};
+        }
+        return {generation_arg(num_generations *
+                        (static_cast<std::size_t>(generation) - 1) +
+                    1),
+            num_generations};
+    }
 
     HPX_CXX_EXPORT struct top_level_group
     {

--- a/libs/full/collectives/include/hpx/collectives/detail/hierarchical_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/hierarchical_helpers.hpp
@@ -36,11 +36,13 @@ namespace hpx::collectives::detail {
     // the identity for a step of one). A default (auto) generation is passed
     // through unchanged and always advances by one, preserving the single-step
     // behavior for instances that are not shared across collectives (sharing
-    // requires explicit, consecutive generations).
+    // requires explicit, consecutive generations). Generation 0 is also passed
+    // through so the downstream flat operation rejects it with bad_parameter
+    // rather than the mapping silently wrapping it onto the default sentinel.
     HPX_CXX_EXPORT inline hierarchical_run hierarchical_run_params(
         generation_arg const generation, std::size_t const num_generations)
     {
-        if (generation.is_default())
+        if (generation.is_default() || generation == 0)
         {
             return {generation, 1};
         }

--- a/libs/full/collectives/include/hpx/collectives/detail/hierarchical_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/hierarchical_helpers.hpp
@@ -24,31 +24,43 @@ namespace hpx::collectives::detail {
     // The per-call generation parameters a hierarchical sub-communicator uses:
     // the run generation handed to the flat operation, and how many generations
     // the gate advances by in a single step.
-    HPX_CXX_EXPORT struct hierarchical_run
+    struct hierarchical_run
     {
         generation_arg generation;
-        std::size_t num_generations;
+        generation_mode num_generations;
     };
 
     // Map a user generation k to those parameters when the communicator
     // advances num_generations per call: the run generation becomes
-    // num_generations * (k - 1) + 1 (so 2k-1 for the common step of two, and
-    // the identity for a step of one). A default (auto) generation is passed
+    // num_generations * (k - 1) + 1 (so 2k-1 for the common double_step, and
+    // the identity for single_step). A default (auto) generation is passed
     // through unchanged and always advances by one, preserving the single-step
     // behavior for instances that are not shared across collectives (sharing
     // requires explicit, consecutive generations). Generation 0 is also passed
     // through so the downstream flat operation rejects it with bad_parameter
     // rather than the mapping silently wrapping it onto the default sentinel.
-    HPX_CXX_EXPORT inline hierarchical_run hierarchical_run_params(
-        generation_arg const generation, std::size_t const num_generations)
+    inline hierarchical_run hierarchical_run_params(
+        generation_arg const generation, generation_mode const num_generations)
     {
         if (generation.is_default() || generation == 0)
         {
-            return {generation, 1};
+            return {generation, generation_mode::single_step};
         }
-        return {generation_arg(num_generations *
-                        (static_cast<std::size_t>(generation) - 1) +
-                    1),
+
+        // Each hierarchical call consumes `step` consecutive gate generations
+        // on every sub-communicator it touches, so user generation k (>= 1)
+        // owns the gap-free block of internal generations
+        // [step*(k-1) + 1, step*k]: k=1 -> [1, step], k=2 -> [step+1, 2*step],
+        // and so on. The flat operation is launched at the first generation of
+        // that block, step*(k-1) + 1, and `step` (== num_generations) is
+        // reported back so handle_data advances the gate past the remainder of
+        // the block in a single move. So double_step maps k -> 2k-1 (e.g. the
+        // 2k-1 gather/exchange phase, with 2k consumed by the paired
+        // broadcast/scatter) and single_step is the identity k -> k (used when
+        // the caller already passes the mapped generation).
+        std::size_t const step = static_cast<std::size_t>(num_generations);
+        return {generation_arg(
+                    step * (static_cast<std::size_t>(generation) - 1) + 1),
             num_generations};
     }
 

--- a/libs/full/collectives/include/hpx/collectives/gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/gather.hpp
@@ -412,6 +412,7 @@ namespace hpx { namespace collectives {
 
 #include <hpx/collectives/argument_types.hpp>
 #include <hpx/collectives/create_communicator.hpp>
+#include <hpx/collectives/detail/hierarchical_helpers.hpp>
 
 #include <cstddef>
 #include <type_traits>
@@ -438,7 +439,7 @@ namespace hpx::traits {
     {
         template <typename Result, typename T>
         static Result get(Communicator& communicator, std::size_t which,
-            std::size_t generation, T&& t)
+            std::size_t generation, std::size_t num_generations, T&& t)
         {
             return communicator.template handle_data<std::decay_t<T>>(
                 communication::communicator_data<
@@ -449,12 +450,13 @@ namespace hpx::traits {
                     data[which] = HPX_FORWARD(T, t);
                 },
                 // finalizer (invoked once after all data has been received)
-                [](auto& data, bool&, std::size_t) { return HPX_MOVE(data); });
+                [](auto& data, bool&, std::size_t) { return HPX_MOVE(data); },
+                static_cast<std::size_t>(-1), num_generations);
         }
 
         template <typename Result, typename T>
         static Result set(Communicator& communicator, std::size_t which,
-            std::size_t generation, T&& t)
+            std::size_t generation, std::size_t num_generations, T&& t)
         {
             return communicator.template handle_data<std::decay_t<T>>(
                 communication::communicator_data<
@@ -465,7 +467,7 @@ namespace hpx::traits {
                     data[which] = HPX_FORWARD(T, t);
                 },
                 // no finalizer
-                nullptr);
+                nullptr, static_cast<std::size_t>(-1), num_generations);
         }
     };
 }    // namespace hpx::traits
@@ -477,7 +479,8 @@ namespace hpx::collectives {
     HPX_CXX_EXPORT template <typename T>
     hpx::future<std::vector<std::decay_t<T>>> gather_here(communicator fid,
         T&& local_result, this_site_arg this_site = this_site_arg(),
-        generation_arg generation = generation_arg())
+        generation_arg generation = generation_arg(),
+        std::size_t num_generations = 1)
     {
         using arg_type = std::decay_t<T>;
 
@@ -510,18 +513,18 @@ namespace hpx::collectives {
         }
 
         auto gather_here_data = [local_result = HPX_FORWARD(T, local_result),
-                                    this_site,
-                                    generation](communicator&& c) mutable
+                                    this_site, generation,
+                                    num_generations](communicator&& c) mutable
             -> hpx::future<std::vector<arg_type>> {
             using action_type =
                 detail::communicator_server::communication_get_direct_action<
                     traits::communication::gather_tag,
-                    hpx::future<std::vector<arg_type>>, arg_type>;
+                    hpx::future<std::vector<arg_type>>, std::size_t, arg_type>;
 
             // explicitly unwrap returned future
             hpx::future<std::vector<arg_type>> result =
                 hpx::async(action_type(), c, this_site, generation,
-                    HPX_MOVE(local_result));
+                    num_generations, HPX_MOVE(local_result));
 
             if (!result.is_ready())
             {
@@ -574,23 +577,30 @@ namespace hpx::collectives {
     hpx::future<std::vector<std::decay_t<T>>> gather_here(
         hierarchical_communicator const& communicators, T&& local_result,
         this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg())
+        generation_arg const generation = generation_arg(),
+        std::size_t num_generations = 2)
     {
         if (this_site.is_default())
         {
             this_site = agas::get_locality_id();
         }
 
+        // Used standalone (num_generations == 2) the user generation maps to
+        // 2k-1 and the gate advances by two; used as the gather phase of
+        // all_gather (num_generations == 1) the caller passes 2k-1 already.
+        auto const [run_gen, run_step] =
+            detail::hierarchical_run_params(generation, num_generations);
+
         std::vector<std::decay_t<T>> result(1, HPX_FORWARD(T, local_result));
         for (std::size_t i = communicators.size() - 1; i != 0; --i)
         {
-            result = detail::gather_data(
-                gather_here(hpx::launch::sync, communicators.get(i),
-                    HPX_MOVE(result), this_site_arg(0), generation));
+            result = detail::gather_data(gather_here(communicators.get(i),
+                HPX_MOVE(result), this_site_arg(0), run_gen, run_step)
+                    .get());
         }
 
         return detail::gather_data(gather_here(communicators.get(0),
-            HPX_MOVE(result), this_site_arg(0), generation));
+            HPX_MOVE(result), this_site_arg(0), run_gen, run_step));
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -655,7 +665,8 @@ namespace hpx::collectives {
     HPX_CXX_EXPORT template <typename T>
     hpx::future<void> gather_there(communicator fid, T&& local_result,
         this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg())
+        generation_arg const generation = generation_arg(),
+        std::size_t num_generations = 1)
     {
         if (this_site.is_default())
         {
@@ -669,16 +680,17 @@ namespace hpx::collectives {
         }
 
         auto gather_there_data =
-            [local_result = HPX_FORWARD(T, local_result), this_site,
-                generation](communicator&& c) mutable -> hpx::future<void> {
+            [local_result = HPX_FORWARD(T, local_result), this_site, generation,
+                num_generations](
+                communicator&& c) mutable -> hpx::future<void> {
             using action_type =
                 detail::communicator_server::communication_set_direct_action<
                     traits::communication::gather_tag, hpx::future<void>,
-                    std::decay_t<T>>;
+                    std::size_t, std::decay_t<T>>;
 
             // explicitly unwrap returned future
             hpx::future<void> result = hpx::async(action_type(), c, this_site,
-                generation, HPX_MOVE(local_result));
+                generation, num_generations, HPX_MOVE(local_result));
 
             if (!result.is_ready())
             {
@@ -698,23 +710,28 @@ namespace hpx::collectives {
     hpx::future<void> gather_there(
         hierarchical_communicator const& communicators, T&& local_result,
         this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg())
+        generation_arg const generation = generation_arg(),
+        std::size_t num_generations = 2)
     {
         if (this_site.is_default())
         {
             this_site = agas::get_locality_id();
         }
 
+        // See gather_here above for the internal generation mapping.
+        auto const [run_gen, run_step] =
+            detail::hierarchical_run_params(generation, num_generations);
+
         std::vector<std::decay_t<T>> data(1, HPX_FORWARD(T, local_result));
         for (std::size_t i = communicators.size() - 1; i != 0; --i)
         {
-            data = detail::gather_data(
-                gather_here(hpx::launch::sync, communicators.get(i),
-                    HPX_MOVE(data), this_site_arg(0), generation));
+            data = detail::gather_data(gather_here(communicators.get(i),
+                HPX_MOVE(data), this_site_arg(0), run_gen, run_step)
+                    .get());
         }
 
         return gather_there(communicators.get(0), HPX_MOVE(data),
-            communicators.site(0), generation);
+            communicators.site(0), run_gen, run_step);
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/libs/full/collectives/include/hpx/collectives/gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/gather.hpp
@@ -439,7 +439,8 @@ namespace hpx::traits {
     {
         template <typename Result, typename T>
         static Result get(Communicator& communicator, std::size_t which,
-            std::size_t generation, std::size_t num_generations, T&& t)
+            std::size_t generation,
+            hpx::collectives::detail::generation_mode num_generations, T&& t)
         {
             return communicator.template handle_data<std::decay_t<T>>(
                 communication::communicator_data<
@@ -451,12 +452,13 @@ namespace hpx::traits {
                 },
                 // finalizer (invoked once after all data has been received)
                 [](auto& data, bool&, std::size_t) { return HPX_MOVE(data); },
-                static_cast<std::size_t>(-1), num_generations);
+                num_generations);
         }
 
         template <typename Result, typename T>
         static Result set(Communicator& communicator, std::size_t which,
-            std::size_t generation, std::size_t num_generations, T&& t)
+            std::size_t generation,
+            hpx::collectives::detail::generation_mode num_generations, T&& t)
         {
             return communicator.template handle_data<std::decay_t<T>>(
                 communication::communicator_data<
@@ -467,7 +469,7 @@ namespace hpx::traits {
                     data[which] = HPX_FORWARD(T, t);
                 },
                 // no finalizer
-                nullptr, static_cast<std::size_t>(-1), num_generations);
+                nullptr, num_generations);
         }
     };
 }    // namespace hpx::traits
@@ -476,67 +478,85 @@ namespace hpx::collectives {
 
     ///////////////////////////////////////////////////////////////////////////
     // gather plain values
-    HPX_CXX_EXPORT template <typename T>
-    hpx::future<std::vector<std::decay_t<T>>> gather_here(communicator fid,
-        T&& local_result, this_site_arg this_site = this_site_arg(),
-        generation_arg generation = generation_arg(),
-        std::size_t num_generations = 1)
-    {
-        using arg_type = std::decay_t<T>;
+    namespace detail {
 
-        if (this_site.is_default())
+        // gather_here: detail entry point carrying the internal generation
+        // step. The public overload forwards with single_step; the hierarchical
+        // gather_here walks its sub-communicators through this entry with the
+        // mapped step.
+        template <typename T>
+        hpx::future<std::vector<std::decay_t<T>>> gather_here(communicator fid,
+            T&& local_result, this_site_arg this_site,
+            generation_arg generation, generation_mode num_generations)
         {
-            this_site = agas::get_locality_id();
-        }
-        if (generation == 0)
-        {
-            return hpx::make_exceptional_future<std::vector<arg_type>>(
-                HPX_GET_EXCEPTION(hpx::error::bad_parameter,
-                    "hpx::collectives::gather_here",
-                    "the generation number shouldn't be zero"));
-        }
+            using arg_type = std::decay_t<T>;
 
-        // Handle operation right away if there is only one value.
-        if (auto [num_sites, comm_site] = fid.get_info(); num_sites == 1)
-        {
-            if (this_site != comm_site)
+            if (this_site.is_default())
+            {
+                this_site = agas::get_locality_id();
+            }
+            if (generation == 0)
             {
                 return hpx::make_exceptional_future<std::vector<arg_type>>(
                     HPX_GET_EXCEPTION(hpx::error::bad_parameter,
                         "hpx::collectives::gather_here",
-                        "the local site should be zero if only one site is "
-                        "involved"));
+                        "the generation number shouldn't be zero"));
             }
 
-            std::vector<arg_type> result(1, HPX_FORWARD(T, local_result));
-            return hpx::make_ready_future(HPX_MOVE(result));
-        }
-
-        auto gather_here_data = [local_result = HPX_FORWARD(T, local_result),
-                                    this_site, generation,
-                                    num_generations](communicator&& c) mutable
-            -> hpx::future<std::vector<arg_type>> {
-            using action_type =
-                detail::communicator_server::communication_get_direct_action<
-                    traits::communication::gather_tag,
-                    hpx::future<std::vector<arg_type>>, std::size_t, arg_type>;
-
-            // explicitly unwrap returned future
-            hpx::future<std::vector<arg_type>> result =
-                hpx::async(action_type(), c, this_site, generation,
-                    num_generations, HPX_MOVE(local_result));
-
-            if (!result.is_ready())
+            // Handle operation right away if there is only one value.
+            if (auto [num_sites, comm_site] = fid.get_info(); num_sites == 1)
             {
-                // make sure id is kept alive as long as the returned future
-                traits::detail::get_shared_state(result)->set_on_completed(
-                    [client = HPX_MOVE(c)] { HPX_UNUSED(client); });
+                if (this_site != comm_site)
+                {
+                    return hpx::make_exceptional_future<std::vector<arg_type>>(
+                        HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                            "hpx::collectives::gather_here",
+                            "the local site should be zero if only one site is "
+                            "involved"));
+                }
+
+                std::vector<arg_type> result(1, HPX_FORWARD(T, local_result));
+                return hpx::make_ready_future(HPX_MOVE(result));
             }
 
-            return result;
-        };
+            auto gather_here_data =
+                [local_result = HPX_FORWARD(T, local_result), this_site,
+                    generation, num_generations](communicator&& c) mutable
+                -> hpx::future<std::vector<arg_type>> {
+                using action_type =
+                    communicator_server::communication_get_direct_action<
+                        traits::communication::gather_tag,
+                        hpx::future<std::vector<arg_type>>, generation_mode,
+                        arg_type>;
 
-        return fid.then(hpx::launch::sync, HPX_MOVE(gather_here_data));
+                // explicitly unwrap returned future
+                hpx::future<std::vector<arg_type>> result =
+                    hpx::async(action_type(), c, this_site, generation,
+                        num_generations, HPX_MOVE(local_result));
+
+                if (!result.is_ready())
+                {
+                    // make sure id is kept alive as long as the returned future
+                    traits::detail::get_shared_state(result)->set_on_completed(
+                        [client = HPX_MOVE(c)] { HPX_UNUSED(client); });
+                }
+
+                return result;
+            };
+
+            return fid.then(hpx::launch::sync, HPX_MOVE(gather_here_data));
+        }
+    }    // namespace detail
+
+    ///////////////////////////////////////////////////////////////////////////
+    // gather plain values
+    HPX_CXX_EXPORT template <typename T>
+    hpx::future<std::vector<std::decay_t<T>>> gather_here(communicator fid,
+        T&& local_result, this_site_arg this_site = this_site_arg(),
+        generation_arg generation = generation_arg())
+    {
+        return detail::gather_here(HPX_MOVE(fid), HPX_FORWARD(T, local_result),
+            this_site, generation, detail::generation_mode::single_step);
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -573,34 +593,48 @@ namespace hpx::collectives {
         }
     }    // namespace detail
 
+    namespace detail {
+
+        // gather_here over a hierarchical_communicator: detail entry carrying
+        // the internal generation step. The public overload forwards with
+        // double_step; all_gather reuses it as its gather phase with
+        // single_step (it passes 2k-1 already).
+        template <typename T>
+        hpx::future<std::vector<std::decay_t<T>>> gather_here(
+            hierarchical_communicator const& communicators, T&& local_result,
+            this_site_arg this_site, generation_arg const generation,
+            generation_mode num_generations)
+        {
+            if (this_site.is_default())
+            {
+                this_site = agas::get_locality_id();
+            }
+
+            auto const [run_gen, run_step] =
+                hierarchical_run_params(generation, num_generations);
+
+            std::vector<std::decay_t<T>> result(
+                1, HPX_FORWARD(T, local_result));
+            for (std::size_t i = communicators.size() - 1; i != 0; --i)
+            {
+                result = gather_data(gather_here(communicators.get(i),
+                    HPX_MOVE(result), this_site_arg(0), run_gen, run_step)
+                        .get());
+            }
+
+            return gather_data(gather_here(communicators.get(0),
+                HPX_MOVE(result), this_site_arg(0), run_gen, run_step));
+        }
+    }    // namespace detail
+
     HPX_CXX_EXPORT template <typename T>
     hpx::future<std::vector<std::decay_t<T>>> gather_here(
         hierarchical_communicator const& communicators, T&& local_result,
         this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg(),
-        std::size_t num_generations = 2)
+        generation_arg const generation = generation_arg())
     {
-        if (this_site.is_default())
-        {
-            this_site = agas::get_locality_id();
-        }
-
-        // Used standalone (num_generations == 2) the user generation maps to
-        // 2k-1 and the gate advances by two; used as the gather phase of
-        // all_gather (num_generations == 1) the caller passes 2k-1 already.
-        auto const [run_gen, run_step] =
-            detail::hierarchical_run_params(generation, num_generations);
-
-        std::vector<std::decay_t<T>> result(1, HPX_FORWARD(T, local_result));
-        for (std::size_t i = communicators.size() - 1; i != 0; --i)
-        {
-            result = detail::gather_data(gather_here(communicators.get(i),
-                HPX_MOVE(result), this_site_arg(0), run_gen, run_step)
-                    .get());
-        }
-
-        return detail::gather_data(gather_here(communicators.get(0),
-            HPX_MOVE(result), this_site_arg(0), run_gen, run_step));
+        return detail::gather_here(communicators, HPX_FORWARD(T, local_result),
+            this_site, generation, detail::generation_mode::double_step);
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -661,77 +695,109 @@ namespace hpx::collectives {
     }
 
     ///////////////////////////////////////////////////////////////////////////
+    namespace detail {
+
+        // gather_there: detail entry point carrying the internal generation
+        // step. The public overload forwards with single_step; the hierarchical
+        // gather_there reuses it with the mapped step.
+        template <typename T>
+        hpx::future<void> gather_there(communicator fid, T&& local_result,
+            this_site_arg this_site, generation_arg const generation,
+            generation_mode num_generations)
+        {
+            if (this_site.is_default())
+            {
+                this_site = agas::get_locality_id();
+            }
+            if (generation == 0)
+            {
+                return hpx::make_exceptional_future<void>(HPX_GET_EXCEPTION(
+                    hpx::error::bad_parameter, "hpx::collectives::gather_there",
+                    "the generation number shouldn't be zero"));
+            }
+
+            auto gather_there_data =
+                [local_result = HPX_FORWARD(T, local_result), this_site,
+                    generation, num_generations](
+                    communicator&& c) mutable -> hpx::future<void> {
+                using action_type =
+                    communicator_server::communication_set_direct_action<
+                        traits::communication::gather_tag, hpx::future<void>,
+                        generation_mode, std::decay_t<T>>;
+
+                // explicitly unwrap returned future
+                hpx::future<void> result =
+                    hpx::async(action_type(), c, this_site, generation,
+                        num_generations, HPX_MOVE(local_result));
+
+                if (!result.is_ready())
+                {
+                    // make sure id is kept alive as long as the returned future
+                    traits::detail::get_shared_state(result)->set_on_completed(
+                        [client = HPX_MOVE(c)]() { HPX_UNUSED(client); });
+                }
+
+                return result;
+            };
+
+            return fid.then(hpx::launch::sync, HPX_MOVE(gather_there_data));
+        }
+    }    // namespace detail
+
+    ///////////////////////////////////////////////////////////////////////////
     // gather plain values
     HPX_CXX_EXPORT template <typename T>
     hpx::future<void> gather_there(communicator fid, T&& local_result,
         this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg(),
-        std::size_t num_generations = 1)
+        generation_arg const generation = generation_arg())
     {
-        if (this_site.is_default())
-        {
-            this_site = agas::get_locality_id();
-        }
-        if (generation == 0)
-        {
-            return hpx::make_exceptional_future<void>(HPX_GET_EXCEPTION(
-                hpx::error::bad_parameter, "hpx::collectives::gather_there",
-                "the generation number shouldn't be zero"));
-        }
-
-        auto gather_there_data =
-            [local_result = HPX_FORWARD(T, local_result), this_site, generation,
-                num_generations](
-                communicator&& c) mutable -> hpx::future<void> {
-            using action_type =
-                detail::communicator_server::communication_set_direct_action<
-                    traits::communication::gather_tag, hpx::future<void>,
-                    std::size_t, std::decay_t<T>>;
-
-            // explicitly unwrap returned future
-            hpx::future<void> result = hpx::async(action_type(), c, this_site,
-                generation, num_generations, HPX_MOVE(local_result));
-
-            if (!result.is_ready())
-            {
-                // make sure id is kept alive as long as the returned future
-                traits::detail::get_shared_state(result)->set_on_completed(
-                    [client = HPX_MOVE(c)]() { HPX_UNUSED(client); });
-            }
-
-            return result;
-        };
-
-        return fid.then(hpx::launch::sync, HPX_MOVE(gather_there_data));
+        return detail::gather_there(HPX_MOVE(fid), HPX_FORWARD(T, local_result),
+            this_site, generation, detail::generation_mode::single_step);
     }
 
     ///////////////////////////////////////////////////////////////////////////
+    namespace detail {
+
+        // gather_there over a hierarchical_communicator: detail entry carrying
+        // the internal generation step. The public overload forwards with
+        // double_step; all_gather reuses it as its gather phase with
+        // single_step.
+        template <typename T>
+        hpx::future<void> gather_there(
+            hierarchical_communicator const& communicators, T&& local_result,
+            this_site_arg this_site, generation_arg const generation,
+            generation_mode num_generations)
+        {
+            if (this_site.is_default())
+            {
+                this_site = agas::get_locality_id();
+            }
+
+            // See gather_here above for the internal generation mapping.
+            auto const [run_gen, run_step] =
+                hierarchical_run_params(generation, num_generations);
+
+            std::vector<std::decay_t<T>> data(1, HPX_FORWARD(T, local_result));
+            for (std::size_t i = communicators.size() - 1; i != 0; --i)
+            {
+                data = gather_data(gather_here(communicators.get(i),
+                    HPX_MOVE(data), this_site_arg(0), run_gen, run_step)
+                        .get());
+            }
+
+            return gather_there(communicators.get(0), HPX_MOVE(data),
+                communicators.site(0), run_gen, run_step);
+        }
+    }    // namespace detail
+
     HPX_CXX_EXPORT template <typename T>
     hpx::future<void> gather_there(
         hierarchical_communicator const& communicators, T&& local_result,
         this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg(),
-        std::size_t num_generations = 2)
+        generation_arg const generation = generation_arg())
     {
-        if (this_site.is_default())
-        {
-            this_site = agas::get_locality_id();
-        }
-
-        // See gather_here above for the internal generation mapping.
-        auto const [run_gen, run_step] =
-            detail::hierarchical_run_params(generation, num_generations);
-
-        std::vector<std::decay_t<T>> data(1, HPX_FORWARD(T, local_result));
-        for (std::size_t i = communicators.size() - 1; i != 0; --i)
-        {
-            data = detail::gather_data(gather_here(communicators.get(i),
-                HPX_MOVE(data), this_site_arg(0), run_gen, run_step)
-                    .get());
-        }
-
-        return gather_there(communicators.get(0), HPX_MOVE(data),
-            communicators.site(0), run_gen, run_step);
+        return detail::gather_there(communicators, HPX_FORWARD(T, local_result),
+            this_site, generation, detail::generation_mode::double_step);
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/libs/full/collectives/include/hpx/collectives/reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/reduce.hpp
@@ -433,7 +433,9 @@ namespace hpx::traits {
     {
         template <typename Result, typename T, typename F>
         static Result get(Communicator& communicator, std::size_t which,
-            std::size_t generation, std::size_t num_generations, T&& t, F&& op)
+            std::size_t generation,
+            hpx::collectives::detail::generation_mode num_generations, T&& t,
+            F&& op)
         {
             return communicator.template handle_data<std::decay_t<T>>(
                 communication::communicator_data<
@@ -474,12 +476,13 @@ namespace hpx::traits {
                         return static_cast<bool>(data[0]);
                     }
                 },
-                static_cast<std::size_t>(-1), num_generations);
+                num_generations);
         }
 
         template <typename Result, typename T>
         static Result set(Communicator& communicator, std::size_t which,
-            std::size_t generation, std::size_t num_generations, T&& t)
+            std::size_t generation,
+            hpx::collectives::detail::generation_mode num_generations, T&& t)
         {
             return communicator.template handle_data<std::decay_t<T>>(
                 communication::communicator_data<
@@ -490,7 +493,7 @@ namespace hpx::traits {
                     data[site] = HPX_FORWARD(T, t);
                 },
                 // no finalizer
-                nullptr, static_cast<std::size_t>(-1), num_generations);
+                nullptr, num_generations);
         }
     };
 }    // namespace hpx::traits
@@ -499,97 +502,131 @@ namespace hpx::collectives {
 
     ///////////////////////////////////////////////////////////////////////////
     // reduce implementation
-    HPX_CXX_EXPORT template <typename T, typename F>
-    hpx::future<std::decay_t<T>> reduce_here(communicator fid, T&& local_result,
-        F&& op, this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg(),
-        std::size_t num_generations = 1)
-    {
-        using arg_type = std::decay_t<T>;
+    namespace detail {
 
-        if (this_site.is_default())
+        // reduce_here: detail entry point carrying the internal generation
+        // step. The public overload forwards with single_step; the hierarchical
+        // reduce_here walks its sub-communicators through this entry with the
+        // mapped step.
+        template <typename T, typename F>
+        hpx::future<std::decay_t<T>> reduce_here(communicator fid,
+            T&& local_result, F&& op, this_site_arg this_site,
+            generation_arg const generation, generation_mode num_generations)
         {
-            this_site = agas::get_locality_id();
-        }
-        if (generation == 0)
-        {
-            return hpx::make_exceptional_future<arg_type>(HPX_GET_EXCEPTION(
-                hpx::error::bad_parameter, "hpx::collectives::reduce_here",
-                "the generation number shouldn't be zero"));
-        }
+            using arg_type = std::decay_t<T>;
 
-        // Handle operation right away if there is only one value.
-        if (auto [num_sites, comm_site] = fid.get_info(); num_sites == 1)
-        {
-            if (this_site != comm_site)
+            if (this_site.is_default())
+            {
+                this_site = agas::get_locality_id();
+            }
+            if (generation == 0)
             {
                 return hpx::make_exceptional_future<arg_type>(HPX_GET_EXCEPTION(
                     hpx::error::bad_parameter, "hpx::collectives::reduce_here",
-                    "the local site should be zero if only one site is "
-                    "involved"));
+                    "the generation number shouldn't be zero"));
             }
 
-            return hpx::make_ready_future(HPX_FORWARD(T, local_result));
-        }
-
-        auto reduction_data =
-            [local_result = HPX_FORWARD(T, local_result),
-                op = HPX_FORWARD(F, op), this_site, generation,
-                num_generations](
-                communicator&& c) mutable -> hpx::future<arg_type> {
-            using func_type = std::decay_t<F>;
-            using action_type =
-                detail::communicator_server::communication_get_direct_action<
-                    traits::communication::reduce_tag, hpx::future<arg_type>,
-                    std::size_t, arg_type, func_type>;
-
-            // explicitly unwrap returned future
-            hpx::future<arg_type> result = hpx::async(action_type(), c,
-                this_site, generation, num_generations,
-                HPX_FORWARD(T, local_result), HPX_FORWARD(F, op));
-
-            if (!result.is_ready())
+            // Handle operation right away if there is only one value.
+            if (auto [num_sites, comm_site] = fid.get_info(); num_sites == 1)
             {
-                // make sure id is kept alive as long as the returned future
-                traits::detail::get_shared_state(result)->set_on_completed(
-                    [client = HPX_MOVE(c)] { HPX_UNUSED(client); });
+                if (this_site != comm_site)
+                {
+                    return hpx::make_exceptional_future<arg_type>(
+                        HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                            "hpx::collectives::reduce_here",
+                            "the local site should be zero if only one site is "
+                            "involved"));
+                }
+
+                return hpx::make_ready_future(HPX_FORWARD(T, local_result));
             }
 
-            return result;
-        };
+            auto reduction_data =
+                [local_result = HPX_FORWARD(T, local_result),
+                    op = HPX_FORWARD(F, op), this_site, generation,
+                    num_generations](
+                    communicator&& c) mutable -> hpx::future<arg_type> {
+                using func_type = std::decay_t<F>;
+                using action_type =
+                    communicator_server::communication_get_direct_action<
+                        traits::communication::reduce_tag,
+                        hpx::future<arg_type>, generation_mode, arg_type,
+                        func_type>;
 
-        return fid.then(hpx::launch::sync, HPX_MOVE(reduction_data));
+                // explicitly unwrap returned future
+                hpx::future<arg_type> result = hpx::async(action_type(), c,
+                    this_site, generation, num_generations,
+                    HPX_FORWARD(T, local_result), HPX_FORWARD(F, op));
+
+                if (!result.is_ready())
+                {
+                    // make sure id is kept alive as long as the returned future
+                    traits::detail::get_shared_state(result)->set_on_completed(
+                        [client = HPX_MOVE(c)] { HPX_UNUSED(client); });
+                }
+
+                return result;
+            };
+
+            return fid.then(hpx::launch::sync, HPX_MOVE(reduction_data));
+        }
+    }    // namespace detail
+
+    ///////////////////////////////////////////////////////////////////////////
+    // reduce implementation
+    HPX_CXX_EXPORT template <typename T, typename F>
+    hpx::future<std::decay_t<T>> reduce_here(communicator fid, T&& local_result,
+        F&& op, this_site_arg this_site = this_site_arg(),
+        generation_arg const generation = generation_arg())
+    {
+        return detail::reduce_here(HPX_MOVE(fid), HPX_FORWARD(T, local_result),
+            HPX_FORWARD(F, op), this_site, generation,
+            detail::generation_mode::single_step);
     }
 
     ////////////////////////////////////////////////////////////////////////////
+    namespace detail {
+
+        // reduce_here over a hierarchical_communicator: detail entry carrying
+        // the internal generation step. The public overload forwards with
+        // double_step; all_reduce reuses it as its reduce phase with
+        // single_step (it passes 2k-1 already).
+        template <typename T, typename F>
+        hpx::future<std::decay_t<T>> reduce_here(
+            hierarchical_communicator const& communicators, T&& local_result,
+            F&& op, this_site_arg this_site, generation_arg const generation,
+            generation_mode num_generations)
+        {
+            if (this_site.is_default())
+            {
+                this_site = agas::get_locality_id();
+            }
+
+            auto const [run_gen, run_step] =
+                hierarchical_run_params(generation, num_generations);
+
+            std::decay_t<T> result = HPX_FORWARD(T, local_result);
+            for (std::size_t i = communicators.size() - 1; i != 0; --i)
+            {
+                result = reduce_here(communicators.get(i), HPX_MOVE(result), op,
+                    this_site_arg(0), run_gen, run_step)
+                             .get();
+            }
+
+            return reduce_here(communicators.get(0), HPX_MOVE(result),
+                HPX_FORWARD(F, op), this_site_arg(0), run_gen, run_step);
+        }
+    }    // namespace detail
+
     HPX_CXX_EXPORT template <typename T, typename F>
     hpx::future<std::decay_t<T>> reduce_here(
         hierarchical_communicator const& communicators, T&& local_result,
         F&& op, this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg(),
-        std::size_t num_generations = 2)
+        generation_arg const generation = generation_arg())
     {
-        if (this_site.is_default())
-        {
-            this_site = agas::get_locality_id();
-        }
-
-        // Used standalone (num_generations == 2) the user generation maps to
-        // 2k-1 and the gate advances by two; used as the reduce phase of
-        // all_reduce (num_generations == 1) the caller passes 2k-1 already.
-        auto const [run_gen, run_step] =
-            detail::hierarchical_run_params(generation, num_generations);
-
-        std::decay_t<T> result = HPX_FORWARD(T, local_result);
-        for (std::size_t i = communicators.size() - 1; i != 0; --i)
-        {
-            result = reduce_here(communicators.get(i), HPX_MOVE(result), op,
-                this_site_arg(0), run_gen, run_step)
-                         .get();
-        }
-
-        return reduce_here(communicators.get(0), HPX_MOVE(result),
-            HPX_FORWARD(F, op), this_site_arg(0), run_gen, run_step);
+        return detail::reduce_here(communicators, HPX_FORWARD(T, local_result),
+            HPX_FORWARD(F, op), this_site, generation,
+            detail::generation_mode::double_step);
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -654,77 +691,110 @@ namespace hpx::collectives {
     }
 
     ///////////////////////////////////////////////////////////////////////////
+    namespace detail {
+
+        // reduce_there: detail entry point carrying the internal generation
+        // step. The public overload forwards with single_step; the hierarchical
+        // reduce_there reuses it with the mapped step.
+        template <typename T>
+        hpx::future<void> reduce_there(communicator fid, T&& local_result,
+            this_site_arg this_site, generation_arg const generation,
+            generation_mode num_generations)
+        {
+            if (this_site.is_default())
+            {
+                this_site = agas::get_locality_id();
+            }
+            if (generation == 0)
+            {
+                return hpx::make_exceptional_future<void>(HPX_GET_EXCEPTION(
+                    hpx::error::bad_parameter, "hpx::collectives::reduce_there",
+                    "the generation number shouldn't be zero"));
+            }
+
+            auto reduction_data =
+                [local_result = HPX_FORWARD(T, local_result), this_site,
+                    generation, num_generations](
+                    communicator&& c) mutable -> hpx::future<void> {
+                using action_type =
+                    communicator_server::communication_set_direct_action<
+                        traits::communication::reduce_tag, hpx::future<void>,
+                        generation_mode, std::decay_t<T>>;
+
+                // explicitly unwrap returned future
+                hpx::future<void> result =
+                    hpx::async(action_type(), c, this_site, generation,
+                        num_generations, HPX_MOVE(local_result));
+
+                if (!result.is_ready())
+                {
+                    // make sure id is kept alive as long as the returned future
+                    traits::detail::get_shared_state(result)->set_on_completed(
+                        [client = HPX_MOVE(c)]() { HPX_UNUSED(client); });
+                }
+
+                return result;
+            };
+
+            return fid.then(hpx::launch::sync, HPX_MOVE(reduction_data));
+        }
+    }    // namespace detail
+
+    ///////////////////////////////////////////////////////////////////////////
     // reduce plain values
     HPX_CXX_EXPORT template <typename T>
     hpx::future<void> reduce_there(communicator fid, T&& local_result,
         this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg(),
-        std::size_t num_generations = 1)
+        generation_arg const generation = generation_arg())
     {
-        if (this_site.is_default())
-        {
-            this_site = agas::get_locality_id();
-        }
-        if (generation == 0)
-        {
-            return hpx::make_exceptional_future<void>(HPX_GET_EXCEPTION(
-                hpx::error::bad_parameter, "hpx::collectives::reduce_there",
-                "the generation number shouldn't be zero"));
-        }
-
-        auto reduction_data =
-            [local_result = HPX_FORWARD(T, local_result), this_site, generation,
-                num_generations](
-                communicator&& c) mutable -> hpx::future<void> {
-            using action_type =
-                detail::communicator_server::communication_set_direct_action<
-                    traits::communication::reduce_tag, hpx::future<void>,
-                    std::size_t, std::decay_t<T>>;
-
-            // explicitly unwrap returned future
-            hpx::future<void> result = hpx::async(action_type(), c, this_site,
-                generation, num_generations, HPX_MOVE(local_result));
-
-            if (!result.is_ready())
-            {
-                // make sure id is kept alive as long as the returned future
-                traits::detail::get_shared_state(result)->set_on_completed(
-                    [client = HPX_MOVE(c)]() { HPX_UNUSED(client); });
-            }
-
-            return result;
-        };
-
-        return fid.then(hpx::launch::sync, HPX_MOVE(reduction_data));
+        return detail::reduce_there(HPX_MOVE(fid), HPX_FORWARD(T, local_result),
+            this_site, generation, detail::generation_mode::single_step);
     }
 
     ////////////////////////////////////////////////////////////////////////////
+    namespace detail {
+
+        // reduce_there over a hierarchical_communicator: detail entry carrying
+        // the internal generation step. The public overload forwards with
+        // double_step; all_reduce reuses it as its reduce phase with
+        // single_step.
+        template <typename T, typename F>
+        hpx::future<void> reduce_there(
+            hierarchical_communicator const& communicators, T&& local_result,
+            F&& op, this_site_arg this_site, generation_arg const generation,
+            generation_mode num_generations)
+        {
+            if (this_site.is_default())
+            {
+                this_site = agas::get_locality_id();
+            }
+
+            // See reduce_here above for the internal generation mapping.
+            auto const [run_gen, run_step] =
+                hierarchical_run_params(generation, num_generations);
+
+            std::decay_t<T> result = HPX_FORWARD(T, local_result);
+            for (std::size_t i = communicators.size() - 1; i != 0; --i)
+            {
+                result = reduce_here(communicators.get(i), HPX_MOVE(result), op,
+                    this_site_arg(0), run_gen, run_step)
+                             .get();
+            }
+
+            return reduce_there(communicators.get(0), HPX_MOVE(result),
+                communicators.site(0), run_gen, run_step);
+        }
+    }    // namespace detail
+
     HPX_CXX_EXPORT template <typename T, typename F>
     hpx::future<void> reduce_there(
         hierarchical_communicator const& communicators, T&& local_result,
         F&& op, this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg(),
-        std::size_t num_generations = 2)
+        generation_arg const generation = generation_arg())
     {
-        if (this_site.is_default())
-        {
-            this_site = agas::get_locality_id();
-        }
-
-        // See reduce_here above for the internal generation mapping.
-        auto const [run_gen, run_step] =
-            detail::hierarchical_run_params(generation, num_generations);
-
-        std::decay_t<T> result = HPX_FORWARD(T, local_result);
-        for (std::size_t i = communicators.size() - 1; i != 0; --i)
-        {
-            result = reduce_here(communicators.get(i), HPX_MOVE(result), op,
-                this_site_arg(0), run_gen, run_step)
-                         .get();
-        }
-
-        return reduce_there(communicators.get(0), HPX_MOVE(result),
-            communicators.site(0), run_gen, run_step);
+        return detail::reduce_there(communicators, HPX_FORWARD(T, local_result),
+            HPX_FORWARD(F, op), this_site, generation,
+            detail::generation_mode::double_step);
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/libs/full/collectives/include/hpx/collectives/reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/reduce.hpp
@@ -407,6 +407,7 @@ namespace hpx { namespace collectives {
 
 #include <hpx/collectives/argument_types.hpp>
 #include <hpx/collectives/create_communicator.hpp>
+#include <hpx/collectives/detail/hierarchical_helpers.hpp>
 
 #include <cstddef>
 #include <type_traits>
@@ -432,7 +433,7 @@ namespace hpx::traits {
     {
         template <typename Result, typename T, typename F>
         static Result get(Communicator& communicator, std::size_t which,
-            std::size_t generation, T&& t, F&& op)
+            std::size_t generation, std::size_t num_generations, T&& t, F&& op)
         {
             return communicator.template handle_data<std::decay_t<T>>(
                 communication::communicator_data<
@@ -472,12 +473,13 @@ namespace hpx::traits {
                         }
                         return static_cast<bool>(data[0]);
                     }
-                });
+                },
+                static_cast<std::size_t>(-1), num_generations);
         }
 
         template <typename Result, typename T>
         static Result set(Communicator& communicator, std::size_t which,
-            std::size_t generation, T&& t)
+            std::size_t generation, std::size_t num_generations, T&& t)
         {
             return communicator.template handle_data<std::decay_t<T>>(
                 communication::communicator_data<
@@ -488,7 +490,7 @@ namespace hpx::traits {
                     data[site] = HPX_FORWARD(T, t);
                 },
                 // no finalizer
-                nullptr);
+                nullptr, static_cast<std::size_t>(-1), num_generations);
         }
     };
 }    // namespace hpx::traits
@@ -500,7 +502,8 @@ namespace hpx::collectives {
     HPX_CXX_EXPORT template <typename T, typename F>
     hpx::future<std::decay_t<T>> reduce_here(communicator fid, T&& local_result,
         F&& op, this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg())
+        generation_arg const generation = generation_arg(),
+        std::size_t num_generations = 1)
     {
         using arg_type = std::decay_t<T>;
 
@@ -531,18 +534,19 @@ namespace hpx::collectives {
 
         auto reduction_data =
             [local_result = HPX_FORWARD(T, local_result),
-                op = HPX_FORWARD(F, op), this_site,
-                generation](communicator&& c) mutable -> hpx::future<arg_type> {
+                op = HPX_FORWARD(F, op), this_site, generation,
+                num_generations](
+                communicator&& c) mutable -> hpx::future<arg_type> {
             using func_type = std::decay_t<F>;
             using action_type =
                 detail::communicator_server::communication_get_direct_action<
                     traits::communication::reduce_tag, hpx::future<arg_type>,
-                    arg_type, func_type>;
+                    std::size_t, arg_type, func_type>;
 
             // explicitly unwrap returned future
-            hpx::future<arg_type> result =
-                hpx::async(action_type(), c, this_site, generation,
-                    HPX_FORWARD(T, local_result), HPX_FORWARD(F, op));
+            hpx::future<arg_type> result = hpx::async(action_type(), c,
+                this_site, generation, num_generations,
+                HPX_FORWARD(T, local_result), HPX_FORWARD(F, op));
 
             if (!result.is_ready())
             {
@@ -562,22 +566,30 @@ namespace hpx::collectives {
     hpx::future<std::decay_t<T>> reduce_here(
         hierarchical_communicator const& communicators, T&& local_result,
         F&& op, this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg())
+        generation_arg const generation = generation_arg(),
+        std::size_t num_generations = 2)
     {
         if (this_site.is_default())
         {
             this_site = agas::get_locality_id();
         }
 
+        // Used standalone (num_generations == 2) the user generation maps to
+        // 2k-1 and the gate advances by two; used as the reduce phase of
+        // all_reduce (num_generations == 1) the caller passes 2k-1 already.
+        auto const [run_gen, run_step] =
+            detail::hierarchical_run_params(generation, num_generations);
+
         std::decay_t<T> result = HPX_FORWARD(T, local_result);
         for (std::size_t i = communicators.size() - 1; i != 0; --i)
         {
-            result = reduce_here(hpx::launch::sync, communicators.get(i),
-                HPX_MOVE(result), op, this_site_arg(0), generation);
+            result = reduce_here(communicators.get(i), HPX_MOVE(result), op,
+                this_site_arg(0), run_gen, run_step)
+                         .get();
         }
 
         return reduce_here(communicators.get(0), HPX_MOVE(result),
-            HPX_FORWARD(F, op), this_site_arg(0), generation);
+            HPX_FORWARD(F, op), this_site_arg(0), run_gen, run_step);
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -646,7 +658,8 @@ namespace hpx::collectives {
     HPX_CXX_EXPORT template <typename T>
     hpx::future<void> reduce_there(communicator fid, T&& local_result,
         this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg())
+        generation_arg const generation = generation_arg(),
+        std::size_t num_generations = 1)
     {
         if (this_site.is_default())
         {
@@ -660,16 +673,17 @@ namespace hpx::collectives {
         }
 
         auto reduction_data =
-            [local_result = HPX_FORWARD(T, local_result), this_site,
-                generation](communicator&& c) mutable -> hpx::future<void> {
+            [local_result = HPX_FORWARD(T, local_result), this_site, generation,
+                num_generations](
+                communicator&& c) mutable -> hpx::future<void> {
             using action_type =
                 detail::communicator_server::communication_set_direct_action<
                     traits::communication::reduce_tag, hpx::future<void>,
-                    std::decay_t<T>>;
+                    std::size_t, std::decay_t<T>>;
 
             // explicitly unwrap returned future
             hpx::future<void> result = hpx::async(action_type(), c, this_site,
-                generation, HPX_MOVE(local_result));
+                generation, num_generations, HPX_MOVE(local_result));
 
             if (!result.is_ready())
             {
@@ -689,22 +703,28 @@ namespace hpx::collectives {
     hpx::future<void> reduce_there(
         hierarchical_communicator const& communicators, T&& local_result,
         F&& op, this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg())
+        generation_arg const generation = generation_arg(),
+        std::size_t num_generations = 2)
     {
         if (this_site.is_default())
         {
             this_site = agas::get_locality_id();
         }
 
+        // See reduce_here above for the internal generation mapping.
+        auto const [run_gen, run_step] =
+            detail::hierarchical_run_params(generation, num_generations);
+
         std::decay_t<T> result = HPX_FORWARD(T, local_result);
         for (std::size_t i = communicators.size() - 1; i != 0; --i)
         {
-            result = reduce_here(hpx::launch::sync, communicators.get(i),
-                HPX_MOVE(result), op, this_site_arg(0), generation);
+            result = reduce_here(communicators.get(i), HPX_MOVE(result), op,
+                this_site_arg(0), run_gen, run_step)
+                         .get();
         }
 
         return reduce_there(communicators.get(0), HPX_MOVE(result),
-            communicators.site(0), generation);
+            communicators.site(0), run_gen, run_step);
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/libs/full/collectives/include/hpx/collectives/scatter.hpp
+++ b/libs/full/collectives/include/hpx/collectives/scatter.hpp
@@ -424,7 +424,8 @@ namespace hpx::traits {
     {
         template <typename Result>
         static Result get(Communicator& communicator, std::size_t which,
-            std::size_t generation, std::size_t num_generations)
+            std::size_t generation,
+            hpx::collectives::detail::generation_mode num_generations)
         {
             using data_type = typename Result::result_type;
 
@@ -439,12 +440,13 @@ namespace hpx::traits {
                     return Communicator::template handle_bool<data_type>(
                         HPX_MOVE(data[which]));
                 },
-                static_cast<std::size_t>(-1), num_generations);
+                num_generations);
         }
 
         template <typename Result, typename T>
         static Result set(Communicator& communicator, std::size_t which,
-            std::size_t generation, std::size_t num_generations,
+            std::size_t generation,
+            hpx::collectives::detail::generation_mode num_generations,
             std::vector<T>&& t)
         {
             return communicator.template handle_data<T>(
@@ -458,7 +460,7 @@ namespace hpx::traits {
                     return Communicator::template handle_bool<T>(
                         HPX_MOVE(data[which]));
                 },
-                static_cast<std::size_t>(-1), num_generations);
+                num_generations);
         }
     };
 }    // namespace hpx::traits
@@ -467,45 +469,59 @@ namespace hpx::collectives {
 
     ///////////////////////////////////////////////////////////////////////////
     // destination site needs to be handled differently
+    namespace detail {
+
+        // scatter_from: detail entry point carrying the internal generation
+        // step. The public overload forwards with single_step; the hierarchical
+        // scatter_from walks its sub-communicators through this entry with the
+        // mapped step.
+        template <typename T>
+        hpx::future<T> scatter_from(communicator fid, this_site_arg this_site,
+            generation_arg const generation, generation_mode num_generations)
+        {
+            if (this_site.is_default())
+            {
+                this_site = agas::get_locality_id();
+            }
+            if (generation == 0)
+            {
+                return hpx::make_exceptional_future<T>(HPX_GET_EXCEPTION(
+                    hpx::error::bad_parameter, "hpx::collectives::scatter_from",
+                    "the generation number shouldn't be zero"));
+            }
+
+            auto scatter_from_data = [this_site, generation, num_generations](
+                                         communicator&& c) -> hpx::future<T> {
+                using action_type =
+                    communicator_server::communication_get_direct_action<
+                        traits::communication::scatter_tag, hpx::future<T>,
+                        generation_mode>;
+
+                // explicitly unwrap returned future
+                hpx::future<T> result = hpx::async(
+                    action_type(), c, this_site, generation, num_generations);
+
+                if (!result.is_ready())
+                {
+                    // make sure id is kept alive as long as the returned future
+                    traits::detail::get_shared_state(result)->set_on_completed(
+                        [client = HPX_MOVE(c)] { HPX_UNUSED(client); });
+                }
+
+                return result;
+            };
+
+            return fid.then(hpx::launch::sync, HPX_MOVE(scatter_from_data));
+        }
+    }    // namespace detail
+
     HPX_CXX_EXPORT template <typename T>
     hpx::future<T> scatter_from(communicator fid,
         this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg(),
-        std::size_t num_generations = 1)
+        generation_arg const generation = generation_arg())
     {
-        if (this_site.is_default())
-        {
-            this_site = agas::get_locality_id();
-        }
-        if (generation == 0)
-        {
-            return hpx::make_exceptional_future<T>(HPX_GET_EXCEPTION(
-                hpx::error::bad_parameter, "hpx::collectives::scatter_from",
-                "the generation number shouldn't be zero"));
-        }
-
-        auto scatter_from_data = [this_site, generation, num_generations](
-                                     communicator&& c) -> hpx::future<T> {
-            using action_type =
-                detail::communicator_server::communication_get_direct_action<
-                    traits::communication::scatter_tag, hpx::future<T>,
-                    std::size_t>;
-
-            // explicitly unwrap returned future
-            hpx::future<T> result = hpx::async(
-                action_type(), c, this_site, generation, num_generations);
-
-            if (!result.is_ready())
-            {
-                // make sure id is kept alive as long as the returned future
-                traits::detail::get_shared_state(result)->set_on_completed(
-                    [client = HPX_MOVE(c)] { HPX_UNUSED(client); });
-            }
-
-            return result;
-        };
-
-        return fid.then(hpx::launch::sync, HPX_MOVE(scatter_from_data));
+        return detail::scatter_from<T>(HPX_MOVE(fid), this_site, generation,
+            detail::generation_mode::single_step);
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -537,44 +553,53 @@ namespace hpx::collectives {
 
             return grouped;
         }
+
+        // Forward declaration: the flat scatter_to detail entry is defined
+        // further down, but the hierarchical scatter_from below walks its
+        // sub-communicators through it.
+        template <typename T>
+        hpx::future<T> scatter_to(communicator fid,
+            std::vector<T>&& local_result, this_site_arg this_site,
+            generation_arg const generation, generation_mode num_generations);
     }    // namespace detail
 
     HPX_CXX_EXPORT template <typename T>
     hpx::future<T> scatter_from(hierarchical_communicator const& communicators,
         this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg(),
-        std::size_t num_generations = 2)
+        generation_arg const generation = generation_arg())
     {
         if (this_site.is_default())
         {
             this_site = agas::get_locality_id();
         }
 
-        // Used standalone (num_generations == 2) the user generation maps to
-        // 2k-1 and the gate advances by two per call.
-        auto const [run_gen, run_step] =
-            detail::hierarchical_run_params(generation, num_generations);
+        // A hierarchical scatter advances each sub-communicator by two
+        // generations per call (double_step): the user generation k maps to
+        // 2k-1. scatter is not reused as a phase of another collective, so it
+        // always runs standalone.
+        auto const [run_gen, run_step] = detail::hierarchical_run_params(
+            generation, detail::generation_mode::double_step);
 
         auto [current_communicator, current_site] = communicators[0];
         if (communicators.size() == 1)
         {
-            return scatter_from<T>(
+            return detail::scatter_from<T>(
                 current_communicator, current_site, run_gen, run_step);
         }
 
-        std::vector<T> data = scatter_from<std::vector<T>>(
+        std::vector<T> data = detail::scatter_from<std::vector<T>>(
             current_communicator, current_site, run_gen, run_step)
                                   .get();
 
         for (std::size_t i = 1; i < communicators.size() - 1; ++i)
         {
-            data = scatter_to(communicators.get(i),
+            data = detail::scatter_to(communicators.get(i),
                 detail::scatter_data(HPX_MOVE(data), communicators.get_arity()),
                 this_site_arg(0), run_gen, run_step)
                        .get();
         }
 
-        return scatter_to(communicators.back(), HPX_MOVE(data),
+        return detail::scatter_to(communicators.back(), HPX_MOVE(data),
             this_site_arg(0), run_gen, run_step);
     }
 
@@ -638,119 +663,138 @@ namespace hpx::collectives {
     }
 
     ///////////////////////////////////////////////////////////////////////////
+    namespace detail {
+
+        // scatter_to: detail entry point carrying the internal generation step.
+        // The public overload forwards with single_step; the hierarchical
+        // scatter_to walks its sub-communicators through this entry with the
+        // mapped step.
+        template <typename T>
+        hpx::future<T> scatter_to(communicator fid,
+            std::vector<T>&& local_result, this_site_arg this_site,
+            generation_arg const generation, generation_mode num_generations)
+        {
+            if (this_site.is_default())
+            {
+                this_site = agas::get_locality_id();
+            }
+            if (generation == 0)
+            {
+                return hpx::make_exceptional_future<T>(HPX_GET_EXCEPTION(
+                    hpx::error::bad_parameter, "hpx::collectives::scatter_to",
+                    "the generation number shouldn't be zero"));
+            }
+
+            auto [num_sites, comm_site] = fid.get_info();
+
+            if (local_result.size() != num_sites)
+            {
+                return hpx::make_exceptional_future<T>(HPX_GET_EXCEPTION(
+                    hpx::error::bad_parameter, "hpx::collectives::scatter_to",
+                    "the number of values to scatter must be equal to the "
+                    "number of participating sites"));
+            }
+
+            // Handle operation right away if there is only one value.
+            if (num_sites == 1)
+            {
+                if (this_site != comm_site)
+                {
+                    return hpx::make_exceptional_future<T>(
+                        HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                            "hpx::collectives::scatter_to",
+                            "the local site should be zero if only one site is "
+                            "involved"));
+                }
+
+                if constexpr (std::is_same_v<T, bool>)
+                {
+                    return hpx::make_ready_future(
+                        static_cast<bool>(local_result[0]));
+                }
+                else
+                {
+                    return hpx::make_ready_future(HPX_MOVE(local_result[0]));
+                }
+            }
+
+            auto scatter_to_data =
+                [local_result = HPX_MOVE(local_result), this_site, generation,
+                    num_generations](
+                    communicator&& c) mutable -> hpx::future<T> {
+                using action_type =
+                    communicator_server::communication_set_direct_action<
+                        traits::communication::scatter_tag, hpx::future<T>,
+                        generation_mode, std::vector<T>>;
+
+                // explicitly unwrap returned future
+                hpx::future<T> result = hpx::async(action_type(), c, this_site,
+                    generation, num_generations, HPX_MOVE(local_result));
+
+                if (!result.is_ready())
+                {
+                    // make sure id is kept alive as long as the returned future
+                    traits::detail::get_shared_state(result)->set_on_completed(
+                        [client = HPX_MOVE(c)]() { HPX_UNUSED(client); });
+                }
+
+                return result;
+            };
+
+            return fid.then(hpx::launch::sync, HPX_MOVE(scatter_to_data));
+        }
+    }    // namespace detail
+
+    ///////////////////////////////////////////////////////////////////////////
     // scatter implementation
     HPX_CXX_EXPORT template <typename T>
     hpx::future<T> scatter_to(communicator fid, std::vector<T>&& local_result,
         this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg(),
-        std::size_t num_generations = 1)
+        generation_arg const generation = generation_arg())
     {
-        if (this_site.is_default())
-        {
-            this_site = agas::get_locality_id();
-        }
-        if (generation == 0)
-        {
-            return hpx::make_exceptional_future<T>(HPX_GET_EXCEPTION(
-                hpx::error::bad_parameter, "hpx::collectives::scatter_to",
-                "the generation number shouldn't be zero"));
-        }
-
-        auto [num_sites, comm_site] = fid.get_info();
-
-        if (local_result.size() != num_sites)
-        {
-            return hpx::make_exceptional_future<T>(HPX_GET_EXCEPTION(
-                hpx::error::bad_parameter, "hpx::collectives::scatter_to",
-                "the number of values to scatter must be equal to the number "
-                "of participating sites"));
-        }
-
-        // Handle operation right away if there is only one value.
-        if (num_sites == 1)
-        {
-            if (this_site != comm_site)
-            {
-                return hpx::make_exceptional_future<T>(HPX_GET_EXCEPTION(
-                    hpx::error::bad_parameter, "hpx::collectives::scatter_to",
-                    "the local site should be zero if only one site is "
-                    "involved"));
-            }
-
-            if constexpr (std::is_same_v<T, bool>)
-            {
-                return hpx::make_ready_future(
-                    static_cast<bool>(local_result[0]));
-            }
-            else
-            {
-                return hpx::make_ready_future(HPX_MOVE(local_result[0]));
-            }
-        }
-
-        auto scatter_to_data = [local_result = HPX_MOVE(local_result),
-                                   this_site, generation, num_generations](
-                                   communicator&& c) mutable -> hpx::future<T> {
-            using action_type =
-                detail::communicator_server::communication_set_direct_action<
-                    traits::communication::scatter_tag, hpx::future<T>,
-                    std::size_t, std::vector<T>>;
-
-            // explicitly unwrap returned future
-            hpx::future<T> result = hpx::async(action_type(), c, this_site,
-                generation, num_generations, HPX_MOVE(local_result));
-
-            if (!result.is_ready())
-            {
-                // make sure id is kept alive as long as the returned future
-                traits::detail::get_shared_state(result)->set_on_completed(
-                    [client = HPX_MOVE(c)]() { HPX_UNUSED(client); });
-            }
-
-            return result;
-        };
-
-        return fid.then(hpx::launch::sync, HPX_MOVE(scatter_to_data));
+        return detail::scatter_to(HPX_MOVE(fid), HPX_MOVE(local_result),
+            this_site, generation, detail::generation_mode::single_step);
     }
 
     HPX_CXX_EXPORT template <typename T>
     hpx::future<T> scatter_to(hierarchical_communicator const& communicators,
         std::vector<T>&& local_result,
         this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg(),
-        std::size_t num_generations = 2)
+        generation_arg const generation = generation_arg())
     {
         if (this_site.is_default())
         {
             this_site = agas::get_locality_id();
         }
 
-        // See scatter_from above for the internal generation mapping.
-        auto const [run_gen, run_step] =
-            detail::hierarchical_run_params(generation, num_generations);
+        // A hierarchical scatter advances each sub-communicator by two
+        // generations per call (double_step); scatter is not reused as a phase
+        // of another collective, so it always runs standalone.
+        auto const [run_gen, run_step] = detail::hierarchical_run_params(
+            generation, detail::generation_mode::double_step);
 
         auto [current_communicator, current_site] = communicators[0];
         if (communicators.size() == 1)
         {
-            return scatter_to(current_communicator, HPX_MOVE(local_result),
-                current_site, run_gen, run_step);
+            return detail::scatter_to(current_communicator,
+                HPX_MOVE(local_result), current_site, run_gen, run_step);
         }
 
         arity_arg arity = communicators.get_arity();
-        std::vector<T> data = scatter_to(communicators.get(0),
+        std::vector<T> data = detail::scatter_to(communicators.get(0),
             detail::scatter_data(HPX_MOVE(local_result), arity),
             this_site_arg(0), run_gen, run_step)
                                   .get();
 
         for (std::size_t i = 1; i < communicators.size() - 1; ++i)
         {
-            data = scatter_to(communicators.get(i),
+            data = detail::scatter_to(communicators.get(i),
                 detail::scatter_data(HPX_MOVE(data), arity),
                 this_site_arg(this_site % arity), run_gen, run_step)
                        .get();
         }
 
-        return scatter_to(communicators.back(), HPX_MOVE(data),
+        return detail::scatter_to(communicators.back(), HPX_MOVE(data),
             this_site_arg(0), run_gen, run_step);
     }
 

--- a/libs/full/collectives/include/hpx/collectives/scatter.hpp
+++ b/libs/full/collectives/include/hpx/collectives/scatter.hpp
@@ -397,6 +397,7 @@ namespace hpx { namespace collectives {
 
 #include <hpx/collectives/argument_types.hpp>
 #include <hpx/collectives/create_communicator.hpp>
+#include <hpx/collectives/detail/hierarchical_helpers.hpp>
 
 #include <cstddef>
 #include <type_traits>
@@ -423,7 +424,7 @@ namespace hpx::traits {
     {
         template <typename Result>
         static Result get(Communicator& communicator, std::size_t which,
-            std::size_t generation)
+            std::size_t generation, std::size_t num_generations)
         {
             using data_type = typename Result::result_type;
 
@@ -437,12 +438,14 @@ namespace hpx::traits {
                 [](auto& data, bool&, std::size_t which) {
                     return Communicator::template handle_bool<data_type>(
                         HPX_MOVE(data[which]));
-                });
+                },
+                static_cast<std::size_t>(-1), num_generations);
         }
 
         template <typename Result, typename T>
         static Result set(Communicator& communicator, std::size_t which,
-            std::size_t generation, std::vector<T>&& t)
+            std::size_t generation, std::size_t num_generations,
+            std::vector<T>&& t)
         {
             return communicator.template handle_data<T>(
                 communication::communicator_data<
@@ -454,7 +457,8 @@ namespace hpx::traits {
                 [](auto& data, bool&, std::size_t which) {
                     return Communicator::template handle_bool<T>(
                         HPX_MOVE(data[which]));
-                });
+                },
+                static_cast<std::size_t>(-1), num_generations);
         }
     };
 }    // namespace hpx::traits
@@ -466,7 +470,8 @@ namespace hpx::collectives {
     HPX_CXX_EXPORT template <typename T>
     hpx::future<T> scatter_from(communicator fid,
         this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg())
+        generation_arg const generation = generation_arg(),
+        std::size_t num_generations = 1)
     {
         if (this_site.is_default())
         {
@@ -479,15 +484,16 @@ namespace hpx::collectives {
                 "the generation number shouldn't be zero"));
         }
 
-        auto scatter_from_data = [this_site, generation](
+        auto scatter_from_data = [this_site, generation, num_generations](
                                      communicator&& c) -> hpx::future<T> {
             using action_type =
                 detail::communicator_server::communication_get_direct_action<
-                    traits::communication::scatter_tag, hpx::future<T>>;
+                    traits::communication::scatter_tag, hpx::future<T>,
+                    std::size_t>;
 
             // explicitly unwrap returned future
-            hpx::future<T> result =
-                hpx::async(action_type(), c, this_site, generation);
+            hpx::future<T> result = hpx::async(
+                action_type(), c, this_site, generation, num_generations);
 
             if (!result.is_ready())
             {
@@ -536,32 +542,40 @@ namespace hpx::collectives {
     HPX_CXX_EXPORT template <typename T>
     hpx::future<T> scatter_from(hierarchical_communicator const& communicators,
         this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg())
+        generation_arg const generation = generation_arg(),
+        std::size_t num_generations = 2)
     {
         if (this_site.is_default())
         {
             this_site = agas::get_locality_id();
         }
 
+        // Used standalone (num_generations == 2) the user generation maps to
+        // 2k-1 and the gate advances by two per call.
+        auto const [run_gen, run_step] =
+            detail::hierarchical_run_params(generation, num_generations);
+
         auto [current_communicator, current_site] = communicators[0];
         if (communicators.size() == 1)
         {
             return scatter_from<T>(
-                current_communicator, current_site, generation);
+                current_communicator, current_site, run_gen, run_step);
         }
 
         std::vector<T> data = scatter_from<std::vector<T>>(
-            hpx::launch::sync, current_communicator, current_site, generation);
+            current_communicator, current_site, run_gen, run_step)
+                                  .get();
 
         for (std::size_t i = 1; i < communicators.size() - 1; ++i)
         {
-            data = scatter_to(hpx::launch::sync, communicators.get(i),
+            data = scatter_to(communicators.get(i),
                 detail::scatter_data(HPX_MOVE(data), communicators.get_arity()),
-                this_site_arg(0), generation);
+                this_site_arg(0), run_gen, run_step)
+                       .get();
         }
 
-        return scatter_to(
-            communicators.back(), HPX_MOVE(data), this_site_arg(0), generation);
+        return scatter_to(communicators.back(), HPX_MOVE(data),
+            this_site_arg(0), run_gen, run_step);
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -628,7 +642,8 @@ namespace hpx::collectives {
     HPX_CXX_EXPORT template <typename T>
     hpx::future<T> scatter_to(communicator fid, std::vector<T>&& local_result,
         this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg())
+        generation_arg const generation = generation_arg(),
+        std::size_t num_generations = 1)
     {
         if (this_site.is_default())
         {
@@ -674,16 +689,16 @@ namespace hpx::collectives {
         }
 
         auto scatter_to_data = [local_result = HPX_MOVE(local_result),
-                                   this_site, generation](
+                                   this_site, generation, num_generations](
                                    communicator&& c) mutable -> hpx::future<T> {
             using action_type =
                 detail::communicator_server::communication_set_direct_action<
                     traits::communication::scatter_tag, hpx::future<T>,
-                    std::vector<T>>;
+                    std::size_t, std::vector<T>>;
 
             // explicitly unwrap returned future
             hpx::future<T> result = hpx::async(action_type(), c, this_site,
-                generation, HPX_MOVE(local_result));
+                generation, num_generations, HPX_MOVE(local_result));
 
             if (!result.is_ready())
             {
@@ -702,35 +717,41 @@ namespace hpx::collectives {
     hpx::future<T> scatter_to(hierarchical_communicator const& communicators,
         std::vector<T>&& local_result,
         this_site_arg this_site = this_site_arg(),
-        generation_arg const generation = generation_arg())
+        generation_arg const generation = generation_arg(),
+        std::size_t num_generations = 2)
     {
         if (this_site.is_default())
         {
             this_site = agas::get_locality_id();
         }
 
+        // See scatter_from above for the internal generation mapping.
+        auto const [run_gen, run_step] =
+            detail::hierarchical_run_params(generation, num_generations);
+
         auto [current_communicator, current_site] = communicators[0];
         if (communicators.size() == 1)
         {
             return scatter_to(current_communicator, HPX_MOVE(local_result),
-                current_site, generation);
+                current_site, run_gen, run_step);
         }
 
         arity_arg arity = communicators.get_arity();
-        std::vector<T> data =
-            scatter_to(hpx::launch::sync, communicators.get(0),
-                detail::scatter_data(HPX_MOVE(local_result), arity),
-                this_site_arg(0), generation);
+        std::vector<T> data = scatter_to(communicators.get(0),
+            detail::scatter_data(HPX_MOVE(local_result), arity),
+            this_site_arg(0), run_gen, run_step)
+                                  .get();
 
         for (std::size_t i = 1; i < communicators.size() - 1; ++i)
         {
-            data = scatter_to(hpx::launch::sync, communicators.get(i),
+            data = scatter_to(communicators.get(i),
                 detail::scatter_data(HPX_MOVE(data), arity),
-                this_site_arg(this_site % arity), generation);
+                this_site_arg(this_site % arity), run_gen, run_step)
+                       .get();
         }
 
-        return scatter_to(
-            communicators.back(), HPX_MOVE(data), this_site_arg(0), generation);
+        return scatter_to(communicators.back(), HPX_MOVE(data),
+            this_site_arg(0), run_gen, run_step);
     }
 
     ////////////////////////////////////////////////////////////////////////////

--- a/libs/full/collectives/tests/unit/CMakeLists.txt
+++ b/libs/full/collectives/tests/unit/CMakeLists.txt
@@ -18,6 +18,7 @@ set(tests
     broadcast_sync
     channel_communicator
     cross_collective_hierarchical
+    cross_collective_hierarchical_mixed
     fold
     global_spmd_block
     hierarchical_helpers

--- a/libs/full/collectives/tests/unit/cross_collective_hierarchical.cpp
+++ b/libs/full/collectives/tests/unit/cross_collective_hierarchical.cpp
@@ -4,18 +4,15 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-// Cross-collective use of hierarchical communicators. A single
-// hierarchical_communicator instance may only be shared by collectives with
-// the same internal generation-consumption scheme (see the note on
-// create_hierarchical_communicator in create_communicator.hpp): all_gather
-// and all_reduce both consume internal generations 2k-1/2k per call on every
-// sub-communicator and may be mixed on one instance, while all_to_all
-// consumes generations at a different rate and needs its own instance.
-//
-// Deliberately not tested: mixing all_to_all with all_reduce on a single
-// instance. That misuse desynchronizes the per-communicator generation
-// sequences, and its failure mode is a deadlock, which cannot be asserted
-// without timeout scaffolding.
+// Cross-collective use of hierarchical communicators. Every hierarchical
+// collective advances each sub-communicator it touches by exactly two internal
+// generations per call (see the note on create_hierarchical_communicator in
+// create_communicator.hpp), so a single hierarchical_communicator instance can
+// be shared freely across collective operations as long as every call uses an
+// explicit, strictly consecutive generation number. These tests interleave
+// different collectives on one instance with a single shared generation
+// counter and verify the results of each operation, including the all_to_all +
+// all_reduce mix that used to deadlock before the generation step was unified.
 
 #include <hpx/config.hpp>
 
@@ -91,8 +88,8 @@ void test_same_instance_all_reduce_all_gather()
 
 // Interleave all_to_all and all_reduce, each on its own hierarchical
 // communicator instance with an independent, strictly consecutive
-// user-generation counter. This pins the supported usage pattern under the
-// documented one-consumption-scheme-per-instance restriction.
+// user-generation counter. Separate instances are always valid; the
+// same-instance variant below additionally exercises sharing one instance.
 void test_separate_instances_all_to_all_all_reduce()
 {
     constexpr std::uint32_t num_sites = 8;
@@ -154,12 +151,257 @@ void test_separate_instances_all_to_all_all_reduce()
     hpx::wait_all(std::move(sites));
 }
 
+// Interleave all_to_all and all_reduce on ONE hierarchical communicator
+// instance with a single shared, strictly consecutive user-generation
+// counter. Every hierarchical collective now advances every communicator by
+// two internal generations per call (all_to_all's inter-group exchange is
+// padded to two), so a single instance can be shared across collective
+// families. This is the case that used to deadlock.
+void test_same_instance_all_to_all_all_reduce()
+{
+    constexpr std::uint32_t num_sites = 8;
+
+    std::vector<hpx::future<void>> sites;
+    sites.reserve(num_sites);
+
+    for (std::uint32_t site = 0; site != num_sites; ++site)
+    {
+        sites.push_back(hpx::async([=]() {
+            auto const comms = create_hierarchical_communicator(
+                "/test/cross_collective/same_instance_a2a_reduce/",
+                num_sites_arg(num_sites), this_site_arg(site), arity_arg(2),
+                generation_arg(), root_site_arg(),
+                flat_fallback_threshold_arg(0));
+
+            std::size_t generation = 0;
+            for (int i = 0; i != ITERATIONS; ++i)
+            {
+                std::vector<std::uint32_t> values(num_sites);
+                for (std::uint32_t j = 0; j != num_sites; ++j)
+                {
+                    values[j] = site * num_sites + j + i;
+                }
+
+                std::vector<std::uint32_t> const exchanged =
+                    all_to_all(hpx::launch::sync, comms, std::move(values),
+                        this_site_arg(site), generation_arg(++generation));
+
+                HPX_TEST_EQ(
+                    exchanged.size(), static_cast<std::size_t>(num_sites));
+                for (std::uint32_t s = 0; s != num_sites; ++s)
+                {
+                    HPX_TEST_EQ(exchanged[s], s * num_sites + site + i);
+                }
+
+                std::uint32_t const reduced = all_reduce(hpx::launch::sync,
+                    comms, std::uint32_t(site + i), std::plus<std::uint32_t>{},
+                    this_site_arg(site), generation_arg(++generation));
+
+                std::uint32_t expected_sum = 0;
+                for (std::uint32_t j = 0; j != num_sites; ++j)
+                {
+                    expected_sum += j + i;
+                }
+                HPX_TEST_EQ(reduced, expected_sum);
+            }
+        }));
+    }
+
+    hpx::wait_all(std::move(sites));
+}
+
+// Interleave broadcast and all_gather on ONE hierarchical communicator
+// instance with a single shared, strictly consecutive user-generation
+// counter. Standalone broadcast now advances every communicator by two
+// internal generations per call (the same as all_gather), so the two can
+// share an instance.
+void test_same_instance_broadcast_all_gather()
+{
+    constexpr std::uint32_t num_sites = 8;
+
+    std::vector<hpx::future<void>> sites;
+    sites.reserve(num_sites);
+
+    for (std::uint32_t site = 0; site != num_sites; ++site)
+    {
+        sites.push_back(hpx::async([=]() {
+            auto const comms = create_hierarchical_communicator(
+                "/test/cross_collective/same_instance_bcast_gather/",
+                num_sites_arg(num_sites), this_site_arg(site), arity_arg(2),
+                generation_arg(), root_site_arg(),
+                flat_fallback_threshold_arg(0));
+
+            std::size_t generation = 0;
+            for (int i = 0; i != ITERATIONS; ++i)
+            {
+                std::uint32_t const bcast_value = 42 + i;
+                if (site == 0)
+                {
+                    std::uint32_t const received = broadcast_to(
+                        hpx::launch::sync, comms, std::uint32_t(bcast_value),
+                        this_site_arg(site), generation_arg(++generation));
+                    HPX_TEST_EQ(received, bcast_value);
+                }
+                else
+                {
+                    std::uint32_t const received =
+                        broadcast_from<std::uint32_t>(hpx::launch::sync, comms,
+                            this_site_arg(site), generation_arg(++generation));
+                    HPX_TEST_EQ(received, bcast_value);
+                }
+
+                std::vector<std::uint32_t> const gathered = all_gather(
+                    hpx::launch::sync, comms, std::uint32_t(site + i),
+                    this_site_arg(site), generation_arg(++generation));
+
+                HPX_TEST_EQ(
+                    gathered.size(), static_cast<std::size_t>(num_sites));
+                for (std::uint32_t j = 0; j != num_sites; ++j)
+                {
+                    HPX_TEST_EQ(gathered[j], j + i);
+                }
+            }
+        }));
+    }
+
+    hpx::wait_all(std::move(sites));
+}
+
+// Interleave gather and all_reduce on ONE hierarchical communicator instance
+// with a single shared, strictly consecutive user-generation counter.
+// Standalone gather now advances every communicator by two internal
+// generations per call, matching all_reduce.
+void test_same_instance_gather_all_reduce()
+{
+    constexpr std::uint32_t num_sites = 8;
+
+    std::vector<hpx::future<void>> sites;
+    sites.reserve(num_sites);
+
+    for (std::uint32_t site = 0; site != num_sites; ++site)
+    {
+        sites.push_back(hpx::async([=]() {
+            auto const comms = create_hierarchical_communicator(
+                "/test/cross_collective/same_instance_gather_reduce/",
+                num_sites_arg(num_sites), this_site_arg(site), arity_arg(2),
+                generation_arg(), root_site_arg(),
+                flat_fallback_threshold_arg(0));
+
+            std::size_t generation = 0;
+            for (int i = 0; i != ITERATIONS; ++i)
+            {
+                std::uint32_t const value = site + 42 + i;
+                if (site == 0)
+                {
+                    std::vector<std::uint32_t> const gathered =
+                        gather_here(comms, std::uint32_t(value),
+                            this_site_arg(site), generation_arg(++generation))
+                            .get();
+
+                    HPX_TEST_EQ(
+                        gathered.size(), static_cast<std::size_t>(num_sites));
+                    for (std::uint32_t j = 0; j != num_sites; ++j)
+                    {
+                        HPX_TEST_EQ(gathered[j], j + 42 + i);
+                    }
+                }
+                else
+                {
+                    gather_there(comms, std::uint32_t(value),
+                        this_site_arg(site), generation_arg(++generation))
+                        .get();
+                }
+
+                std::uint32_t const reduced = all_reduce(hpx::launch::sync,
+                    comms, std::uint32_t(site + i), std::plus<std::uint32_t>{},
+                    this_site_arg(site), generation_arg(++generation));
+
+                std::uint32_t expected_sum = 0;
+                for (std::uint32_t j = 0; j != num_sites; ++j)
+                {
+                    expected_sum += j + i;
+                }
+                HPX_TEST_EQ(reduced, expected_sum);
+            }
+        }));
+    }
+
+    hpx::wait_all(std::move(sites));
+}
+
+// Interleave scatter and all_reduce on ONE hierarchical communicator instance
+// with a single shared, strictly consecutive user-generation counter.
+// Standalone scatter now advances every communicator by two internal
+// generations per call, matching all_reduce.
+void test_same_instance_scatter_all_reduce()
+{
+    constexpr std::uint32_t num_sites = 8;
+
+    std::vector<hpx::future<void>> sites;
+    sites.reserve(num_sites);
+
+    for (std::uint32_t site = 0; site != num_sites; ++site)
+    {
+        sites.push_back(hpx::async([=]() {
+            auto const comms = create_hierarchical_communicator(
+                "/test/cross_collective/same_instance_scatter_reduce/",
+                num_sites_arg(num_sites), this_site_arg(site), arity_arg(2),
+                generation_arg(), root_site_arg(),
+                flat_fallback_threshold_arg(0));
+
+            std::size_t generation = 0;
+            for (int i = 0; i != ITERATIONS; ++i)
+            {
+                std::uint32_t const expected = site + 42 + i;
+                if (site == 0)
+                {
+                    std::vector<std::uint32_t> data(num_sites);
+                    for (std::uint32_t j = 0; j != num_sites; ++j)
+                    {
+                        data[j] = j + 42 + i;
+                    }
+                    std::uint32_t const received =
+                        scatter_to(comms, std::move(data), this_site_arg(site),
+                            generation_arg(++generation))
+                            .get();
+                    HPX_TEST_EQ(received, expected);
+                }
+                else
+                {
+                    std::uint32_t const received =
+                        scatter_from<std::uint32_t>(comms, this_site_arg(site),
+                            generation_arg(++generation))
+                            .get();
+                    HPX_TEST_EQ(received, expected);
+                }
+
+                std::uint32_t const reduced = all_reduce(hpx::launch::sync,
+                    comms, std::uint32_t(site + i), std::plus<std::uint32_t>{},
+                    this_site_arg(site), generation_arg(++generation));
+
+                std::uint32_t expected_sum = 0;
+                for (std::uint32_t j = 0; j != num_sites; ++j)
+                {
+                    expected_sum += j + i;
+                }
+                HPX_TEST_EQ(reduced, expected_sum);
+            }
+        }));
+    }
+
+    hpx::wait_all(std::move(sites));
+}
+
 int hpx_main()
 {
     if (hpx::get_locality_id() == 0)
     {
         test_same_instance_all_reduce_all_gather();
         test_separate_instances_all_to_all_all_reduce();
+        test_same_instance_all_to_all_all_reduce();
+        test_same_instance_broadcast_all_gather();
+        test_same_instance_gather_all_reduce();
+        test_same_instance_scatter_all_reduce();
     }
 
     return hpx::finalize();

--- a/libs/full/collectives/tests/unit/cross_collective_hierarchical_mixed.cpp
+++ b/libs/full/collectives/tests/unit/cross_collective_hierarchical_mixed.cpp
@@ -114,7 +114,8 @@ void run_explicit_mixed_sequence(std::string const& basename,
 void test_local_explicit_mixed_sequence(
     std::uint32_t const num_sites, int const arity)
 {
-    std::string const basename = "/test/independent_cross_collective/local/" +
+    std::string const basename =
+        "/test/cross_collective_hierarchical_mixed/local/" +
         std::to_string(num_sites) + "/" + std::to_string(arity) + "/";
 
     std::vector<hpx::future<void>> sites;
@@ -228,7 +229,7 @@ void test_local_default_generation(
     std::uint32_t const num_sites, int const arity)
 {
     std::string const basename =
-        "/test/independent_cross_collective/default/local/" +
+        "/test/cross_collective_hierarchical_mixed/default/local/" +
         std::to_string(num_sites) + "/" + std::to_string(arity) + "/";
 
     std::vector<hpx::future<void>> sites;
@@ -256,8 +257,8 @@ void test_distributed_explicit_mixed_sequence()
 
     int const arity = num_sites % 3 == 1 ? 2 : 3;
     run_explicit_mixed_sequence(
-        "/test/independent_cross_collective/distributed/explicit/", num_sites,
-        site, arity);
+        "/test/cross_collective_hierarchical_mixed/distributed/explicit/",
+        num_sites, site, arity);
 }
 
 void test_distributed_default_generation()
@@ -272,8 +273,104 @@ void test_distributed_default_generation()
 
     int const arity = num_sites % 3 == 1 ? 2 : 3;
     run_default_generation_sequence(
-        "/test/independent_cross_collective/distributed/default/", num_sites,
-        site, arity);
+        "/test/cross_collective_hierarchical_mixed/distributed/default/",
+        num_sites, site, arity);
+}
+
+// Flat-fallback sharing. With the default threshold (16), a small site count
+// collapses to a single flat communicator (create_hierarchical_communicator
+// overrides arity to num_sites). Mixing collectives on that flat instance must
+// still keep the shared generation sequence gap-free: every collective has to
+// advance the flat gate by two per call, just like in tree mode. This is a
+// regression guard for the flat fast paths of all_gather/all_reduce/all_to_all,
+// which previously advanced the flat gate by only one.
+void test_local_flat_fallback_sharing(std::uint32_t const num_sites)
+{
+    std::string const basename =
+        "/test/cross_collective_hierarchical_mixed/flat_fallback/" +
+        std::to_string(num_sites) + "/";
+
+    std::vector<hpx::future<void>> sites;
+    sites.reserve(num_sites);
+
+    for (std::uint32_t site = 0; site != num_sites; ++site)
+    {
+        sites.push_back(hpx::async([=]() {
+            // No flat_fallback_threshold_arg, so the default (16) applies and a
+            // site count below it produces a single flat communicator.
+            auto const comms = create_hierarchical_communicator(
+                basename.c_str(), num_sites_arg(num_sites), this_site_arg(site),
+                arity_arg(2), generation_arg(), root_site_arg());
+
+            std::size_t generation = 0;
+            for (std::uint32_t i = 0; i != iterations; ++i)
+            {
+                // all_gather (flat fast path) mixed with broadcast (step 2).
+                std::vector<std::int32_t> const gathered =
+                    all_gather(hpx::launch::sync, comms,
+                        static_cast<std::int32_t>(site + i),
+                        this_site_arg(site), generation_arg(++generation));
+                HPX_TEST_EQ(
+                    gathered.size(), static_cast<std::size_t>(num_sites));
+                for (std::uint32_t source = 0; source != num_sites; ++source)
+                {
+                    HPX_TEST_EQ(gathered[source],
+                        static_cast<std::int32_t>(source + i));
+                }
+
+                // all_reduce (flat fast path).
+                std::int32_t const reduced = all_reduce(hpx::launch::sync,
+                    comms, static_cast<std::int32_t>(site + i),
+                    std::plus<std::int32_t>{}, this_site_arg(site),
+                    generation_arg(++generation));
+                std::int32_t expected_sum = 0;
+                for (std::uint32_t source = 0; source != num_sites; ++source)
+                {
+                    expected_sum += static_cast<std::int32_t>(source + i);
+                }
+                HPX_TEST_EQ(reduced, expected_sum);
+
+                // all_to_all (flat fast path).
+                std::vector<std::int32_t> outgoing(num_sites);
+                for (std::uint32_t dest = 0; dest != num_sites; ++dest)
+                {
+                    outgoing[dest] =
+                        static_cast<std::int32_t>(1000 * i + 10 * site + dest);
+                }
+                std::vector<std::int32_t> const exchanged =
+                    all_to_all(hpx::launch::sync, comms, HPX_MOVE(outgoing),
+                        this_site_arg(site), generation_arg(++generation));
+                HPX_TEST_EQ(
+                    exchanged.size(), static_cast<std::size_t>(num_sites));
+                for (std::uint32_t source = 0; source != num_sites; ++source)
+                {
+                    HPX_TEST_EQ(exchanged[source],
+                        static_cast<std::int32_t>(
+                            1000 * i + 10 * source + site));
+                }
+
+                // broadcast (single-pass, step 2).
+                std::int32_t const broadcast_value =
+                    50000 + static_cast<std::int32_t>(i);
+                std::int32_t received = 0;
+                if (site == 0)
+                {
+                    received = broadcast_to(hpx::launch::sync, comms,
+                        std::int32_t(broadcast_value), this_site_arg(site),
+                        generation_arg(++generation));
+                }
+                else
+                {
+                    received =
+                        broadcast_from<std::int32_t>(hpx::launch::sync, comms,
+                            this_site_arg(site), generation_arg(++generation));
+                }
+                HPX_TEST_EQ(received, broadcast_value);
+            }
+        }));
+    }
+
+    hpx::wait_all(HPX_MOVE(sites));
 }
 
 int hpx_main()
@@ -287,6 +384,7 @@ int hpx_main()
                 test_local_explicit_mixed_sequence(num_sites, arity);
                 test_local_default_generation(num_sites, arity);
             }
+            test_local_flat_fallback_sharing(num_sites);
         }
     }
 

--- a/libs/full/collectives/tests/unit/cross_collective_hierarchical_mixed.cpp
+++ b/libs/full/collectives/tests/unit/cross_collective_hierarchical_mixed.cpp
@@ -1,0 +1,312 @@
+//  Copyright (c) 2026 Anshuman Agrawal
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Additional cross-collective coverage for hierarchical communicators,
+// complementing cross_collective_hierarchical.cpp (which pins the documented
+// contract with pairwise, explicit-generation mixes). This file:
+//   - chains four different collectives (broadcast, all_to_all, barrier,
+//     scatter) on one shared instance with a single strictly consecutive
+//     generation counter, so four different per-communicator consumption
+//     patterns must stay in lock-step;
+//   - separately exercises the default (auto) generation path across
+//     broadcast, gather, reduce and scatter on one shared instance; and
+//   - runs both locally and distributed at non-power-of-arity site counts
+//     (5 and 7) with arity 2 and 3, forcing real trees with uneven groups.
+
+#include <hpx/config.hpp>
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/modules/collectives.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace hpx::collectives;
+
+constexpr std::uint32_t iterations = 4;
+
+std::vector<std::int32_t> make_scatter_values(
+    std::uint32_t const num_sites, std::uint32_t const iteration)
+{
+    std::vector<std::int32_t> values(num_sites);
+    for (std::uint32_t site = 0; site != num_sites; ++site)
+    {
+        values[site] =
+            70000 + static_cast<std::int32_t>(100 * iteration + site);
+    }
+    return values;
+}
+
+void run_explicit_mixed_sequence(std::string const& basename,
+    std::uint32_t const num_sites, std::uint32_t const site, int const arity)
+{
+    auto const comms = create_hierarchical_communicator(basename.c_str(),
+        num_sites_arg(num_sites), this_site_arg(site), arity_arg(arity),
+        generation_arg(), root_site_arg(), flat_fallback_threshold_arg(0));
+
+    std::size_t generation = 0;
+    for (std::uint32_t i = 0; i != iterations; ++i)
+    {
+        std::int32_t const broadcast_value =
+            10000 + static_cast<std::int32_t>(i);
+        std::int32_t received_broadcast = 0;
+        if (site == 0)
+        {
+            received_broadcast = broadcast_to(hpx::launch::sync, comms,
+                std::int32_t(broadcast_value), this_site_arg(site),
+                generation_arg(++generation));
+        }
+        else
+        {
+            received_broadcast = broadcast_from<std::int32_t>(hpx::launch::sync,
+                comms, this_site_arg(site), generation_arg(++generation));
+        }
+        HPX_TEST_EQ(received_broadcast, broadcast_value);
+
+        std::vector<std::int32_t> outgoing(num_sites);
+        for (std::uint32_t dest = 0; dest != num_sites; ++dest)
+        {
+            outgoing[dest] =
+                static_cast<std::int32_t>(100000 * i + 1000 * site + dest);
+        }
+
+        std::vector<std::int32_t> const exchanged =
+            all_to_all(hpx::launch::sync, comms, HPX_MOVE(outgoing),
+                this_site_arg(site), generation_arg(++generation));
+
+        HPX_TEST_EQ(exchanged.size(), static_cast<std::size_t>(num_sites));
+        for (std::uint32_t source = 0; source != num_sites; ++source)
+        {
+            HPX_TEST_EQ(exchanged[source],
+                static_cast<std::int32_t>(100000 * i + 1000 * source + site));
+        }
+
+        barrier(hpx::launch::sync, comms, this_site_arg(site),
+            generation_arg(++generation));
+
+        std::int32_t scattered = 0;
+        if (site == 0)
+        {
+            scattered = scatter_to(hpx::launch::sync, comms,
+                make_scatter_values(num_sites, i), this_site_arg(site),
+                generation_arg(++generation));
+        }
+        else
+        {
+            scattered = scatter_from<std::int32_t>(hpx::launch::sync, comms,
+                this_site_arg(site), generation_arg(++generation));
+        }
+        HPX_TEST_EQ(
+            scattered, static_cast<std::int32_t>(70000 + 100 * i + site));
+    }
+}
+
+void test_local_explicit_mixed_sequence(
+    std::uint32_t const num_sites, int const arity)
+{
+    std::string const basename = "/test/independent_cross_collective/local/" +
+        std::to_string(num_sites) + "/" + std::to_string(arity) + "/";
+
+    std::vector<hpx::future<void>> sites;
+    sites.reserve(num_sites);
+
+    for (std::uint32_t site = 0; site != num_sites; ++site)
+    {
+        sites.push_back(hpx::async([=]() {
+            run_explicit_mixed_sequence(basename, num_sites, site, arity);
+        }));
+    }
+
+    hpx::wait_all(HPX_MOVE(sites));
+}
+
+void run_default_generation_sequence(std::string const& basename,
+    std::uint32_t const num_sites, std::uint32_t const site, int const arity)
+{
+    auto const comms = create_hierarchical_communicator(basename.c_str(),
+        num_sites_arg(num_sites), this_site_arg(site), arity_arg(arity),
+        generation_arg(), root_site_arg(), flat_fallback_threshold_arg(0));
+
+    for (std::uint32_t i = 0; i != iterations; ++i)
+    {
+        std::int32_t const broadcast_value =
+            20000 + static_cast<std::int32_t>(i);
+        std::int32_t received_broadcast = 0;
+        if (site == 0)
+        {
+            received_broadcast = broadcast_to(hpx::launch::sync, comms,
+                std::int32_t(broadcast_value), this_site_arg(site),
+                generation_arg());
+        }
+        else
+        {
+            received_broadcast = broadcast_from<std::int32_t>(hpx::launch::sync,
+                comms, this_site_arg(site), generation_arg());
+        }
+        HPX_TEST_EQ(received_broadcast, broadcast_value);
+    }
+
+    for (std::uint32_t i = 0; i != iterations; ++i)
+    {
+        if (site == 0)
+        {
+            std::vector<std::int32_t> const gathered =
+                gather_here(hpx::launch::sync, comms,
+                    static_cast<std::int32_t>(30000 + i + site),
+                    this_site_arg(site), generation_arg());
+
+            HPX_TEST_EQ(gathered.size(), static_cast<std::size_t>(num_sites));
+            for (std::uint32_t source = 0; source != num_sites; ++source)
+            {
+                HPX_TEST_EQ(gathered[source],
+                    static_cast<std::int32_t>(30000 + i + source));
+            }
+        }
+        else
+        {
+            gather_there(comms, static_cast<std::int32_t>(30000 + i + site),
+                this_site_arg(site), generation_arg())
+                .get();
+        }
+    }
+
+    for (std::uint32_t i = 0; i != iterations; ++i)
+    {
+        if (site == 0)
+        {
+            std::int32_t const reduced = reduce_here(hpx::launch::sync, comms,
+                static_cast<std::int32_t>(40000 + i + site),
+                std::plus<std::int32_t>{}, this_site_arg(site),
+                generation_arg());
+
+            std::int32_t expected = 0;
+            for (std::uint32_t source = 0; source != num_sites; ++source)
+            {
+                expected += static_cast<std::int32_t>(40000 + i + source);
+            }
+            HPX_TEST_EQ(reduced, expected);
+        }
+        else
+        {
+            reduce_there(comms, static_cast<std::int32_t>(40000 + i + site),
+                std::plus<std::int32_t>{}, this_site_arg(site),
+                generation_arg())
+                .get();
+        }
+    }
+
+    for (std::uint32_t i = 0; i != iterations; ++i)
+    {
+        std::int32_t scattered = 0;
+        if (site == 0)
+        {
+            scattered = scatter_to(hpx::launch::sync, comms,
+                make_scatter_values(num_sites, i), this_site_arg(site),
+                generation_arg());
+        }
+        else
+        {
+            scattered = scatter_from<std::int32_t>(hpx::launch::sync, comms,
+                this_site_arg(site), generation_arg());
+        }
+        HPX_TEST_EQ(
+            scattered, static_cast<std::int32_t>(70000 + 100 * i + site));
+    }
+}
+
+void test_local_default_generation(
+    std::uint32_t const num_sites, int const arity)
+{
+    std::string const basename =
+        "/test/independent_cross_collective/default/local/" +
+        std::to_string(num_sites) + "/" + std::to_string(arity) + "/";
+
+    std::vector<hpx::future<void>> sites;
+    sites.reserve(num_sites);
+
+    for (std::uint32_t site = 0; site != num_sites; ++site)
+    {
+        sites.push_back(hpx::async([=]() {
+            run_default_generation_sequence(basename, num_sites, site, arity);
+        }));
+    }
+
+    hpx::wait_all(HPX_MOVE(sites));
+}
+
+void test_distributed_explicit_mixed_sequence()
+{
+    std::uint32_t const site = hpx::get_locality_id();
+    std::uint32_t const num_sites = hpx::get_num_localities(hpx::launch::sync);
+
+    if (num_sites < 2)
+    {
+        return;
+    }
+
+    int const arity = num_sites % 3 == 1 ? 2 : 3;
+    run_explicit_mixed_sequence(
+        "/test/independent_cross_collective/distributed/explicit/", num_sites,
+        site, arity);
+}
+
+void test_distributed_default_generation()
+{
+    std::uint32_t const site = hpx::get_locality_id();
+    std::uint32_t const num_sites = hpx::get_num_localities(hpx::launch::sync);
+
+    if (num_sites < 2)
+    {
+        return;
+    }
+
+    int const arity = num_sites % 3 == 1 ? 2 : 3;
+    run_default_generation_sequence(
+        "/test/independent_cross_collective/distributed/default/", num_sites,
+        site, arity);
+}
+
+int hpx_main()
+{
+    if (hpx::get_locality_id() == 0)
+    {
+        for (std::uint32_t num_sites : {5u, 7u})
+        {
+            for (int arity : {2, 3})
+            {
+                test_local_explicit_mixed_sequence(num_sites, arity);
+                test_local_default_generation(num_sites, arity);
+            }
+        }
+    }
+
+#if defined(HPX_HAVE_NETWORKING)
+    test_distributed_explicit_mixed_sequence();
+    test_distributed_default_generation();
+#endif
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> const cfg = {"hpx.run_hpx_main!=1"};
+
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ(hpx::init(argc, argv, init_args), 0);
+    return hpx::util::report_errors();
+}
+
+#endif

--- a/libs/full/collectives/tests/unit/cross_collective_hierarchical_mixed.cpp
+++ b/libs/full/collectives/tests/unit/cross_collective_hierarchical_mixed.cpp
@@ -373,6 +373,66 @@ void test_local_flat_fallback_sharing(std::uint32_t const num_sites)
     hpx::wait_all(HPX_MOVE(sites));
 }
 
+// Generation 0 is invalid (generations must be positive). The hierarchical
+// collectives must reject it with bad_parameter, not silently treat it as an
+// auto generation -- both the collectives that require an explicit generation
+// (all_gather here) and the single-pass ones that map through
+// hierarchical_run_params (broadcast here).
+void test_local_zero_generation_rejected(std::uint32_t const num_sites)
+{
+    std::string const basename =
+        "/test/cross_collective_hierarchical_mixed/zero_gen/" +
+        std::to_string(num_sites) + "/";
+
+    std::vector<hpx::future<void>> sites;
+    sites.reserve(num_sites);
+
+    for (std::uint32_t site = 0; site != num_sites; ++site)
+    {
+        sites.push_back(hpx::async([=]() {
+            auto const comms = create_hierarchical_communicator(
+                basename.c_str(), num_sites_arg(num_sites), this_site_arg(site),
+                arity_arg(2), generation_arg(), root_site_arg(),
+                flat_fallback_threshold_arg(0));
+
+            bool all_gather_rejected = false;
+            try
+            {
+                all_gather(hpx::launch::sync, comms,
+                    static_cast<std::int32_t>(site), this_site_arg(site),
+                    generation_arg(0));
+            }
+            catch (hpx::exception const&)
+            {
+                all_gather_rejected = true;
+            }
+            HPX_TEST(all_gather_rejected);
+
+            bool broadcast_rejected = false;
+            try
+            {
+                if (site == 0)
+                {
+                    broadcast_to(hpx::launch::sync, comms, std::int32_t(1),
+                        this_site_arg(site), generation_arg(0));
+                }
+                else
+                {
+                    broadcast_from<std::int32_t>(hpx::launch::sync, comms,
+                        this_site_arg(site), generation_arg(0));
+                }
+            }
+            catch (hpx::exception const&)
+            {
+                broadcast_rejected = true;
+            }
+            HPX_TEST(broadcast_rejected);
+        }));
+    }
+
+    hpx::wait_all(HPX_MOVE(sites));
+}
+
 int hpx_main()
 {
     if (hpx::get_locality_id() == 0)
@@ -385,6 +445,7 @@ int hpx_main()
                 test_local_default_generation(num_sites, arity);
             }
             test_local_flat_fallback_sharing(num_sites);
+            test_local_zero_generation_rejected(num_sites);
         }
     }
 


### PR DESCRIPTION
### Proposed Changes

This PR unifies generation handling across hierarchical collectives so a single hierarchical_communicator can be shared by any mix of collectives.

It removes the one-instance-per-operation restriction from #7321 and implements the unification proposed by @hkaiser in #7200.

Previously, different collective families consumed the shared generation sequence at different rates, so only all_gather and all_reduce could safely share one instance. Now, every hierarchical collective advances each touched sub-communicator by exactly two internal generations per call:

user k -> 2k - 1
gate -> 2k

Single-pass collectives (broadcast, gather, scatter, reduce, and the all_to_all inter-group exchange) skip the second generation directly instead of doing another round trip.

### Main changes:

* Add num_generations to communicator_server::handle_data.
    * Gate advances to generation + num_generations - 1.
    * Default is still 1, so flat collectives are unchanged.
* Use a shared detail::hierarchical_run_params helper for hierarchical generation mapping.
    * Maps k -> 2k - 1.
    * Preserves the default-generation path.
* Update docs to allow sharing one instance across collectives, with explicit strictly consecutive generations.
* Add mixed same-instance coverage to cross_collective_hierarchical.
* Add cross_collective_hierarchical_mixed tests covering:
    * 4-way chains
    * default-generation path
    * non-power-of-arity trees
    * local and distributed runs

Also fixed two bugs with regression tests:

* Flat-fallback fast paths below 16 sites advanced the gate by one and could hang when sharing a small-N instance. They now step by two.
* Generation 0 wrapped onto the auto-generation sentinel instead of being rejected. It is now rejected like a default generation.

### Checklist

- [x] I have added a new feature and tests.
- [x] I have fixed a bug and added a regression test.