### PR TITLE
fix(datapar): guard mismatch SIMD path on zip_iterator compatibility

### DIFF
--- a/libs/core/algorithms/include/hpx/parallel/datapar/equal.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/datapar/equal.hpp
@@ -94,9 +94,7 @@ namespace hpx::parallel::detail {
         InIter2 first2, F&& f)
     {
         if constexpr (hpx::parallel::util::detail::iterator_datapar_compatible<
-                          InIter1>::value &&
-            hpx::parallel::util::detail::iterator_datapar_compatible<
-                InIter2>::value)
+                          hpx::util::zip_iterator<InIter1, InIter2>>::value)
         {
             return datapar_equal<ExPolicy>::call(
                 first1, last1, first2, HPX_FORWARD(F, f));
@@ -188,9 +186,7 @@ namespace hpx::parallel::detail {
         InIter2 first2, Sent2 last2, F&& f, Proj1&& proj1, Proj2&& proj2)
     {
         if constexpr (hpx::parallel::util::detail::iterator_datapar_compatible<
-                          InIter1>::value &&
-            hpx::parallel::util::detail::iterator_datapar_compatible<
-                InIter2>::value)
+                          hpx::util::zip_iterator<InIter1, InIter2>>::value)
         {
             return datapar_equal_binary<ExPolicy>::call(first1, last1, first2,
                 HPX_FORWARD(F, f), HPX_FORWARD(Proj1, proj1),

--- a/libs/core/algorithms/include/hpx/parallel/datapar/find.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/datapar/find.hpp
@@ -395,9 +395,7 @@ namespace hpx::parallel::detail {
         Iter2 first2, Sent2 last2, Pred&& op, Proj1&& proj1, Proj2&& proj2)
     {
         if constexpr (hpx::parallel::util::detail::iterator_datapar_compatible<
-                          Iter1>::value &&
-            hpx::parallel::util::detail::iterator_datapar_compatible<
-                Iter2>::value)
+                          hpx::util::zip_iterator<Iter1, Iter2>>::value)
         {
             return datapar_find_end_t<ExPolicy>::call(first1, last1, first2,
                 last2, HPX_FORWARD(Pred, op), HPX_FORWARD(Proj1, proj1),
@@ -424,9 +422,7 @@ namespace hpx::parallel::detail {
         Token& tok, Pred&& op, Proj1&& proj1, Proj2&& proj2)
     {
         if constexpr (hpx::parallel::util::detail::iterator_datapar_compatible<
-                          Iter1>::value &&
-            hpx::parallel::util::detail::iterator_datapar_compatible<
-                Iter2>::value)
+                          hpx::util::zip_iterator<Iter1, Iter2>>::value)
         {
             return datapar_find_end_t<ExPolicy>::call(it, first2, base_idx,
                 part_size, diff, tok, HPX_FORWARD(Pred, op),

--- a/libs/core/algorithms/include/hpx/parallel/datapar/mismatch.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/datapar/mismatch.hpp
@@ -108,9 +108,7 @@ namespace hpx::parallel::detail {
         F&& f)
     {
         if constexpr (hpx::parallel::util::detail::iterator_datapar_compatible<
-                          Iter1>::value &&
-            hpx::parallel::util::detail::iterator_datapar_compatible<
-                Iter2>::value)
+                          hpx::util::zip_iterator<Iter1, Iter2>>::value)
         {
             return datapar_mismatch<ExPolicy>::call(
                 first1, last1, first2, HPX_FORWARD(F, f));
@@ -220,9 +218,7 @@ namespace hpx::parallel::detail {
         Iter2 first2, Sent2 last2, F&& f, Proj1&& proj1, Proj2&& proj2)
     {
         if constexpr (hpx::parallel::util::detail::iterator_datapar_compatible<
-                          Iter1>::value &&
-            hpx::parallel::util::detail::iterator_datapar_compatible<
-                Iter2>::value)
+                          hpx::util::zip_iterator<Iter1, Iter2>>::value)
         {
             return datapar_mismatch_binary<ExPolicy>::call2(first1, last1,
                 first2, last2, HPX_FORWARD(F, f), HPX_FORWARD(Proj1, proj1),

--- a/libs/core/algorithms/include/hpx/parallel/datapar/search.hpp
+++ b/libs/core/algorithms/include/hpx/parallel/datapar/search.hpp
@@ -38,9 +38,7 @@ namespace hpx::parallel::detail {
         std::size_t count, Token& tok, Pred&& op, Proj1&& proj1, Proj2&& proj2)
     {
         if constexpr (hpx::parallel::util::detail::iterator_datapar_compatible<
-                          Iter1>::value &&
-            hpx::parallel::util::detail::iterator_datapar_compatible<
-                Iter2>::value)
+                          hpx::util::zip_iterator<Iter1, Iter2>>::value)
         {
             std::size_t idx = 0;
             util::loop_idx_n<hpx::execution::parallel_policy>(base_idx, it,

--- a/libs/core/algorithms/tests/unit/datapar_algorithms/CMakeLists.txt
+++ b/libs/core/algorithms/tests/unit/datapar_algorithms/CMakeLists.txt
@@ -11,6 +11,7 @@ if(HPX_WITH_DATAPAR)
       ${tests}
       adjacentfind_datapar
       adjacentdifference_datapar
+      datapar_zip_iterator_guard
       all_of_datapar
       any_of_datapar
       copy_datapar

--- a/libs/core/algorithms/tests/unit/datapar_algorithms/datapar_zip_iterator_guard.cpp
+++ b/libs/core/algorithms/tests/unit/datapar_algorithms/datapar_zip_iterator_guard.cpp
@@ -1,0 +1,114 @@
+//  Copyright (c) 2026 Adhithya Ragavan
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Regression test for the datapar zip_iterator guard fix.
+//
+// Before the fix, calling mismatch/equal/find_end/search with par_simd and
+// plain arithmetic pointers (int*) caused a hard compile error:
+//   iterator_datapar_compatible<int*> is true, so the SIMD path was selected.
+//   The SIMD path internally constructs zip_iterator<int*,int*> whose
+//   value_type is hpx::tuple<int,int> (not arithmetic), causing the EVE
+//   backend's store_/addressof to fail with no matching specialization.
+//
+// After the fix the guard checks iterator_datapar_compatible on the
+// zip_iterator directly (always false for tuple value_type), so the
+// algorithms correctly fall back to the scalar sequential path.
+
+#include <hpx/datapar.hpp>
+#include <hpx/init.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <cstddef>
+#include <numeric>
+#include <string>
+#include <vector>
+
+void test_mismatch_raw_ptr()
+{
+    std::vector<int> a(100), b(100);
+    std::iota(a.begin(), a.end(), 0);
+    std::iota(b.begin(), b.end(), 0);
+    b[42] = -1;
+
+    int* pa = a.data();
+    int* pb = b.data();
+
+    auto r = hpx::mismatch(hpx::execution::par_simd, pa, pa + 100, pb);
+    HPX_TEST_EQ(r.first - pa, std::ptrdiff_t(42));
+    HPX_TEST_EQ(r.second - pb, std::ptrdiff_t(42));
+
+    std::iota(b.begin(), b.end(), 0);
+    auto r2 = hpx::mismatch(hpx::execution::par_simd, pa, pa + 100, pb);
+    HPX_TEST(r2.first == pa + 100);
+}
+
+void test_equal_raw_ptr()
+{
+    std::vector<int> a(100), b(100);
+    std::iota(a.begin(), a.end(), 0);
+    std::iota(b.begin(), b.end(), 0);
+
+    int* pa = a.data();
+    int* pb = b.data();
+
+    HPX_TEST(hpx::equal(hpx::execution::par_simd, pa, pa + 100, pb));
+    b[50] = -1;
+    HPX_TEST(!hpx::equal(hpx::execution::par_simd, pa, pa + 100, pb));
+}
+
+void test_find_end_raw_ptr()
+{
+    // haystack: {1,2,3,4,1,2,3,4,1,2}
+    // needle:   {1,2,3}
+    // occurrences at index 0 and 4; last occurrence starts at index 4
+    std::vector<int> h = {1, 2, 3, 4, 1, 2, 3, 4, 1, 2};
+    std::vector<int> n = {1, 2, 3};
+    int* ph = h.data();
+    int* pn = n.data();
+
+    auto* r = hpx::find_end(hpx::execution::par_simd, ph,
+        ph + static_cast<std::ptrdiff_t>(h.size()), pn,
+        pn + static_cast<std::ptrdiff_t>(n.size()));
+    HPX_TEST_EQ(r - ph, std::ptrdiff_t(4));
+}
+
+void test_search_raw_ptr()
+{
+    // haystack: {1,2,3,4,5,6}
+    // needle:   {3,4,5}
+    // first occurrence starts at index 2
+    std::vector<int> h = {1, 2, 3, 4, 5, 6};
+    std::vector<int> n = {3, 4, 5};
+    int* ph = h.data();
+    int* pn = n.data();
+
+    auto* r = hpx::search(hpx::execution::par_simd, ph,
+        ph + static_cast<std::ptrdiff_t>(h.size()), pn,
+        pn + static_cast<std::ptrdiff_t>(n.size()));
+    HPX_TEST_EQ(r - ph, std::ptrdiff_t(2));
+}
+
+int hpx_main()
+{
+    test_mismatch_raw_ptr();
+    test_equal_raw_ptr();
+    test_find_end_raw_ptr();
+    test_search_raw_ptr();
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> const cfg = {"hpx.os_threads=all"};
+
+    hpx::local::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv, init_args), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}


### PR DESCRIPTION
## Summary

- The `tag_invoke` overloads for `sequential_mismatch_t`, `sequential_mismatch_binary_t`, `sequential_equal_t`, `sequential_equal_binary_t`, `sequential_search_t`, and `sequential_find_end_t` that accept flat iterator pairs were guarding the SIMD path by checking `iterator_datapar_compatible` on each iterator individually.
- For plain arithmetic pointers (e.g. `int*`) both checks pass, but the implementations then construct a `zip_iterator<Iter1, Iter2>` internally and forward it to a loop primitive running under a simd execution policy. The zip iterator's `value_type` is `hpx::tuple<...>` — not arithmetic — causing a hard compile error under the EVE backend:
  - `std::addressof(*zip_it)` fails (rvalue tuple, `addressof(const T&&) = delete`)
  - `eve::store_` has no specialization for tuple value types
- Fix: replace the per-iterator guards with a single check on `iterator_datapar_compatible<hpx::util::zip_iterator<Iter1, Iter2>>`, which correctly evaluates `false` for tuple `value_type`s and falls back gracefully to the scalar sequential path — consistent with the existing ZipIterator overloads which already check the zip iterator directly.

## Affected files

- `libs/core/algorithms/include/hpx/parallel/datapar/mismatch.hpp` — 2 guards
- `libs/core/algorithms/include/hpx/parallel/datapar/equal.hpp` — 2 guards
- `libs/core/algorithms/include/hpx/parallel/datapar/find.hpp` — 2 guards (`sequential_find_end_t`)
- `libs/core/algorithms/include/hpx/parallel/datapar/search.hpp` — 1 guard

No new includes required; `zip_iterator` is already included in each affected file.

## Test plan
- [ ] Compile probe for `mismatch` with `par_simd` and `int*` iterators exits 0 (verified locally with EVE backend)
- [ ] `ctest --test-dir build -R mismatch` passes
- [ ] `ctest --test-dir build -R datapar` passes (regression guard)