### PR TITLE
async_mpi: use member async_execute on mpi executor

### DIFF
--- a/libs/core/async_mpi/include/hpx/async_mpi/mpi_executor.hpp
+++ b/libs/core/async_mpi/include/hpx/async_mpi/mpi_executor.hpp
@@ -52,12 +52,10 @@ namespace hpx::mpi::experimental {
 
         // TwoWayExecutor interface
         template <typename F, typename... Ts>
-        friend decltype(auto) tag_invoke(
-            hpx::parallel::execution::async_execute_t, executor const& exec,
-            F&& f, Ts&&... ts)
+        decltype(auto) async_execute(F&& f, Ts&&... ts) const
         {
             return hpx::mpi::experimental::detail::async(
-                HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)..., exec.communicator_);
+                HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)..., communicator_);
         }
 
         std::size_t in_flight_estimate() const

--- a/libs/core/async_mpi/tests/unit/mpi_ring_async_executor.cpp
+++ b/libs/core/async_mpi/tests/unit/mpi_ring_async_executor.cpp
@@ -18,6 +18,8 @@
 #include <iostream>
 #include <sstream>
 #include <string>
+#include <type_traits>
+#include <utility>
 #include <vector>
 
 #include <mpi.h>
@@ -34,6 +36,12 @@ using hpx::program_options::value;
 using hpx::program_options::variables_map;
 
 static bool output = true;
+
+static_assert(std::is_same_v<
+    decltype(std::declval<hpx::mpi::experimental::executor const&>()
+            .async_execute(
+                MPI_Isend, static_cast<int const*>(nullptr), 1, MPI_INT, 0, 0)),
+    hpx::future<int>>);
 
 void msg_recv(int rank, int size, int /*to*/, int from, int token, unsigned tag)
 {


### PR DESCRIPTION
## Proposed Changes

 - Replace `tag_invoke(async_execute_t, ...)` in `hpx::mpi::experimental::executor` with a member `async_execute(...) const`, matching the member-based executor style used by other HPX executors.
 - Keep the underlying MPI launch path unchanged by forwarding the member dispatch to `hpx::mpi::experimental::detail::async(...)`.
 - Add a compile-time regression check in `mpi_ring_async_executor.cpp` to verify that the executor's member `async_execute(...)` has the expected `hpx::future<int>` return type.

## Any background context you want to provide?

## Checklist

Not all points below apply to all pull requests.

- [x] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
