### PR TITLE
tracing: remove legacy ITT hooks from full components

### DIFF
--- a/libs/full/actions_base/include/hpx/actions_base/basic_action.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/basic_action.hpp
@@ -42,10 +42,6 @@
 #include <hpx/modules/runtime_local.hpp>
 #include <hpx/modules/type_support.hpp>
 #include <hpx/modules/util.hpp>
-#if defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0 &&                  \
-    !defined(HPX_HAVE_APEX)
-#include <hpx/modules/itt_notify.hpp>
-#endif
 
 #include <atomic>
 #include <cstddef>

--- a/libs/full/actions_base/include/hpx/actions_base/macros.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/macros.hpp
@@ -87,10 +87,7 @@
 #if !defined(HPX_HAVE_NETWORKING)
 
 #define HPX_DEFINE_GET_ACTION_NAME(action) /**/
-#if defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0 &&                  \
-    !defined(HPX_HAVE_APEX)
-#define HPX_DEFINE_GET_ACTION_NAME_ITT(action, actionname) /**/
-#endif
+
 #define HPX_REGISTER_ACTION_EXTERN_DECLARATION(action) /**/
 
 #define HPX_REGISTER_ACTION_2(action, actionname)                              \

--- a/libs/full/parcelset/src/parcel.cpp
+++ b/libs/full/parcelset/src/parcel.cpp
@@ -14,7 +14,7 @@
 #include <hpx/modules/datastructures.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/format.hpp>
-#include <hpx/modules/itt_notify.hpp>
+
 #include <hpx/modules/naming.hpp>
 #include <hpx/modules/parcelset_base.hpp>
 #include <hpx/modules/runtime_local.hpp>
@@ -471,10 +471,7 @@ namespace hpx::parcelset::detail {
         action_->load_schedule(ar, HPX_MOVE(data_.dest_), p.first, p.second,
             num_thread, deferred_schedule);
 
-#if HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
-        static util::itt::event parcel_recv("recv_parcel");
-        util::itt::event_tick(parcel_recv);
-#endif
+        HPX_TRACING_MARK_EVENT("recv_parcel");
 
 #if defined(HPX_HAVE_PARCEL_PROFILING)
         hpx::tracing::recv_parcel(data_.parcel_id_.get_lsb(), size_,

--- a/libs/full/parcelset/src/parcelhandler.cpp
+++ b/libs/full/parcelset/src/parcelhandler.cpp
@@ -16,7 +16,7 @@
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/io_service.hpp>
-#include <hpx/modules/itt_notify.hpp>
+
 #include <hpx/modules/logging.hpp>
 #include <hpx/modules/preprocessor.hpp>
 #include <hpx/modules/resource_partitioner.hpp>
@@ -540,10 +540,7 @@ namespace hpx::parcelset {
             // invoke the original handler
             f(ec, p);
 
-#if HPX_HAVE_ITTNOTIFY != 0 && !defined(HPX_HAVE_APEX)
-            static util::itt::event parcel_send("send_parcel");
-            util::itt::event_tick(parcel_send);
-#endif
+            HPX_TRACING_MARK_EVENT("send_parcel");
 
 #if defined(HPX_HAVE_PARCEL_PROFILING)
             hpx::tracing::send_parcel(

--- a/libs/full/performance_counters/include/hpx/performance_counters/query_counters.hpp
+++ b/libs/full/performance_counters/include/hpx/performance_counters/query_counters.hpp
@@ -8,7 +8,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/modules/errors.hpp>
-#include <hpx/modules/itt_notify.hpp>
+
 #include <hpx/modules/runtime_local.hpp>
 #include <hpx/modules/synchronization.hpp>
 


### PR DESCRIPTION

## Proposed Changes

  - Remove leftover direct `itt_notify` includes and empty ITT action-name scaffolding from `actions_base` and performance counter headers.
  - Replace raw parcel send/receive ITT event ticks with backend-agnostic `HPX_TRACING_MARK_EVENT` hooks.
  - Keep parcel profiling routed through the existing `hpx::tracing::send_parcel` and `hpx::tracing::recv_parcel` abstractions.

## Any background context you want to provide?

This continues the tracing unification work by removing remaining legacy ITT-specific instrumentation from selected `libs/full` components. The affected call sites now use the centralized tracing abstraction instead of directly depending on `hpx::util::itt` / `hpx/modules/itt_notify.hpp`.

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.