### PR TITLE
Harden collectives validation paths

### DIFF
--- a/libs/full/collectives/include/hpx/collectives/all_gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_gather.hpp
@@ -306,7 +306,6 @@ namespace hpx::collectives {
                 }
 
                 std::vector<arg_type> result;
-                result.reserve(1);
                 result.emplace_back(HPX_FORWARD(T, local_result));
                 return hpx::make_ready_future(HPX_MOVE(result));
             }

--- a/libs/full/collectives/include/hpx/collectives/all_gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_gather.hpp
@@ -305,7 +305,9 @@ namespace hpx::collectives {
                             "involved"));
                 }
 
-                std::vector<arg_type> result(1, HPX_FORWARD(T, local_result));
+                std::vector<arg_type> result;
+                result.reserve(1);
+                result.emplace_back(HPX_FORWARD(T, local_result));
                 return hpx::make_ready_future(HPX_MOVE(result));
             }
 
@@ -437,6 +439,15 @@ namespace hpx::collectives {
                     "generation number for the 2k-1/2k internal mapping"));
         }
 
+        if (!detail::is_valid_hierarchical_phase_generation(generation))
+        {
+            return hpx::make_exceptional_future<std::vector<arg_type>>(
+                HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                    "hpx::collectives::all_gather (hierarchical)",
+                    "the generation number is too large for the internal "
+                    "2k-1/2k generation mapping"));
+        }
+
         if (this_site.is_default())
         {
             this_site = agas::get_locality_id();
@@ -465,8 +476,8 @@ namespace hpx::collectives {
                     "participating sites"));
         }
 
-        generation_arg const gather_gen(2 * generation - 1);
-        generation_arg const broadcast_gen(2 * generation);
+        auto const [gather_gen, broadcast_gen] =
+            detail::hierarchical_phase_generations(generation);
 
         // Flat fast path: when arity >= num_sites, the tree builder's leaf
         // condition (right - left < arity) fired at the root call and

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -483,11 +483,11 @@ namespace hpx::collectives {
 
         if (!detail::is_valid_hierarchical_phase_generation(generation))
         {
-            return hpx::make_exceptional_future<arg_type>(HPX_GET_EXCEPTION(
-                hpx::error::bad_parameter,
-                "hpx::collectives::all_reduce (hierarchical)",
-                "the generation number is too large for the internal "
-                "2k-1/2k generation mapping"));
+            return hpx::make_exceptional_future<arg_type>(
+                HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                    "hpx::collectives::all_reduce (hierarchical)",
+                    "the generation number is too large for the internal "
+                    "2k-1/2k generation mapping"));
         }
 
         if (this_site.is_default())

--- a/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_reduce.hpp
@@ -481,6 +481,15 @@ namespace hpx::collectives {
                     "generation number for the 2k-1/2k internal mapping"));
         }
 
+        if (!detail::is_valid_hierarchical_phase_generation(generation))
+        {
+            return hpx::make_exceptional_future<arg_type>(HPX_GET_EXCEPTION(
+                hpx::error::bad_parameter,
+                "hpx::collectives::all_reduce (hierarchical)",
+                "the generation number is too large for the internal "
+                "2k-1/2k generation mapping"));
+        }
+
         if (this_site.is_default())
         {
             this_site = agas::get_locality_id();
@@ -509,8 +518,8 @@ namespace hpx::collectives {
                     "participating sites"));
         }
 
-        generation_arg const reduce_gen(2 * generation - 1);
-        generation_arg const broadcast_gen(2 * generation);
+        auto const [reduce_gen, broadcast_gen] =
+            detail::hierarchical_phase_generations(generation);
 
         // Flat fast path: when arity >= num_sites, the tree builder's leaf
         // condition (right - left < arity) fired at the root call and

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -316,6 +316,15 @@ namespace hpx::collectives {
             // Handle operation right away if there is only one value.
             if (auto [num_sites, comm_site] = fid.get_info(); num_sites == 1)
             {
+                if (local_result.size() != 1)
+                {
+                    return hpx::make_exceptional_future<std::vector<T>>(
+                        HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                            "hpx::collectives::all_to_all",
+                            "each participating site must contribute exactly "
+                            "num_sites elements"));
+                }
+
                 if (this_site != comm_site)
                 {
                     return hpx::make_exceptional_future<std::vector<T>>(
@@ -476,6 +485,15 @@ namespace hpx::collectives {
                     "mapping"));
         }
 
+        if (!detail::is_valid_hierarchical_phase_generation(generation))
+        {
+            return hpx::make_exceptional_future<std::vector<T>>(
+                HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                    "hpx::collectives::all_to_all (hierarchical)",
+                    "the generation number is too large for the internal "
+                    "generation mapping"));
+        }
+
         if (this_site.is_default())
         {
             this_site = agas::get_locality_id();
@@ -518,8 +536,8 @@ namespace hpx::collectives {
         // lock-step with the subtrees and the instance can be shared across
         // collectives. Gather, exchange and the collapsed flat fast path
         // therefore share first_gen; only the subtree scatter uses second_gen.
-        generation_arg const first_gen(2 * generation - 1);
-        generation_arg const second_gen(2 * generation);
+        auto const [first_gen, second_gen] =
+            detail::hierarchical_phase_generations(generation);
 
         // Flat fast path: when arity >= num_sites (either because the user
         // chose a large arity or because the factory overrode arity to

--- a/libs/full/collectives/include/hpx/collectives/barrier.hpp
+++ b/libs/full/collectives/include/hpx/collectives/barrier.hpp
@@ -102,6 +102,7 @@ namespace hpx { namespace distributed {
 
 #include <hpx/collectives/argument_types.hpp>
 #include <hpx/collectives/create_communicator.hpp>
+#include <hpx/collectives/detail/hierarchical_helpers.hpp>
 
 #include <atomic>
 #include <cstddef>
@@ -155,7 +156,7 @@ namespace hpx::collectives {
         {
             this_site = agas::get_locality_id();
         }
-        if (generation.is_default())
+        if (generation == 0)
         {
             return hpx::make_exceptional_future<void>(HPX_GET_EXCEPTION(
                 hpx::error::bad_parameter, "hpx::collectives::barrier",
@@ -206,7 +207,7 @@ namespace hpx::collectives {
     {
         return barrier(create_communicator(basename, num_sites, this_site,
                            generation, root_site),
-            this_site);
+            this_site, generation);
     }
 
     HPX_CXX_EXPORT inline void barrier(hpx::launch::sync_policy,
@@ -231,7 +232,7 @@ namespace hpx::collectives {
     {
         barrier(create_communicator(
                     basename, num_sites, this_site, generation, root_site),
-            this_site)
+            this_site, generation)
             .get();
     }
 
@@ -256,6 +257,15 @@ namespace hpx::collectives {
                     "generation number for the 2k-1/2k internal mapping"));
         }
 
+        if (!detail::is_valid_hierarchical_phase_generation(generation))
+        {
+            return hpx::make_exceptional_future<void>(
+                HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                    "hpx::collectives::barrier (hierarchical)",
+                    "the generation number is too large for the internal "
+                    "2k-1/2k generation mapping"));
+        }
+
         if (this_site.is_default())
         {
             this_site = agas::get_locality_id();
@@ -266,8 +276,8 @@ namespace hpx::collectives {
             return hpx::make_ready_future();
         }
 
-        generation_arg const reduce_gen(2 * generation - 1);
-        generation_arg const broadcast_gen(2 * generation);
+        auto const [reduce_gen, broadcast_gen] =
+            detail::hierarchical_phase_generations(generation);
 
         // Reduce phase: walk sub-communicators from deepest (end of vector) to
         // shallowest (start). Each sub-barrier releases only after all sites

--- a/libs/full/collectives/include/hpx/collectives/broadcast.hpp
+++ b/libs/full/collectives/include/hpx/collectives/broadcast.hpp
@@ -567,7 +567,7 @@ namespace hpx::collectives {
             auto const [run_gen, run_step] =
                 hierarchical_run_params(generation, num_generations);
 
-            T result = HPX_FORWARD(T, local_result);
+            std::decay_t<T> result = HPX_FORWARD(T, local_result);
             for (std::size_t i = 0; i < communicators.size() - 1; ++i)
             {
                 result = broadcast_to(communicators.get(i), HPX_MOVE(result),

--- a/libs/full/collectives/include/hpx/collectives/create_communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/create_communicator.hpp
@@ -259,7 +259,10 @@ namespace hpx::collectives {
 
         [[nodiscard]] bool is_root() const
         {
-            return !base_type::registered_name().empty();
+            auto const* client_data =
+                this->try_get_extra_data<detail::communicator_data>();
+            return client_data != nullptr &&
+                client_data->this_site_ == client_data->root_site_;
         }
     };
 

--- a/libs/full/collectives/include/hpx/collectives/detail/communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/communicator.hpp
@@ -62,7 +62,7 @@ namespace hpx::collectives::detail {
         HPX_EXPORT communicator_server() noexcept;
 
         HPX_EXPORT explicit communicator_server(
-            std::size_t num_sites, char const* basename);
+            std::size_t num_sites, char const* basename) noexcept;
 
         communicator_server(communicator_server const&) = delete;
         communicator_server(communicator_server&&) = delete;

--- a/libs/full/collectives/include/hpx/collectives/detail/communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/communicator.hpp
@@ -250,8 +250,7 @@ namespace hpx::collectives::detail {
             // generation.
             auto sf = gate_.get_shared_future(l);
 
-            traits::detail::get_shared_state(sf)->reserve_callbacks(
-                num_sites_);
+            traits::detail::get_shared_state(sf)->reserve_callbacks(num_sites_);
 
             return sf.then(hpx::launch::sync, HPX_FORWARD(F, f));
         }
@@ -352,8 +351,8 @@ namespace hpx::collectives::detail {
                         "number of on_ready callbacks have been invoked before "
                         "the end of the collective operation {}, which {}, "
                         "generation {}. Expected count {}, received count {}.",
-                        basename_, operation, which, generation,
-                        num_sites_, on_ready_count_);
+                        basename_, operation, which, generation, num_sites_,
+                        on_ready_count_);
                 }
 
                 if constexpr (!std::is_same_v<std::nullptr_t,
@@ -386,8 +385,8 @@ namespace hpx::collectives::detail {
             // operations on the same communicator.
             set_operation_and_check_sequencing(l, operation, which, generation);
 
-            auto f = get_future_and_synchronize(
-                generation, HPX_MOVE(on_ready), l);
+            auto f =
+                get_future_and_synchronize(generation, HPX_MOVE(on_ready), l);
 
             // We may have just finished a different operation, thus we have to
             // possibly reset the operation type stored in this communicator.

--- a/libs/full/collectives/include/hpx/collectives/detail/communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/communicator.hpp
@@ -26,6 +26,7 @@
 
 #include <cstddef>
 #include <mutex>
+#include <string>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -62,7 +63,7 @@ namespace hpx::collectives::detail {
         HPX_EXPORT communicator_server() noexcept;
 
         HPX_EXPORT explicit communicator_server(
-            std::size_t num_sites, char const* basename) noexcept;
+            std::size_t num_sites, char const* basename);
 
         communicator_server(communicator_server const&) = delete;
         communicator_server(communicator_server&&) = delete;
@@ -234,8 +235,7 @@ namespace hpx::collectives::detail {
         }
 
         template <typename F, typename Lock>
-        auto get_future_and_synchronize(
-            std::size_t generation, std::size_t capacity, F&& f, Lock& l)
+        auto get_future_and_synchronize(std::size_t generation, F&& f, Lock& l)
         {
             HPX_ASSERT_OWNS_LOCK(l);
 
@@ -251,7 +251,7 @@ namespace hpx::collectives::detail {
             auto sf = gate_.get_shared_future(l);
 
             traits::detail::get_shared_state(sf)->reserve_callbacks(
-                get_num_sites(capacity));
+                num_sites_);
 
             return sf.then(hpx::launch::sync, HPX_FORWARD(F, f));
         }
@@ -353,7 +353,7 @@ namespace hpx::collectives::detail {
                         "the end of the collective operation {}, which {}, "
                         "generation {}. Expected count {}, received count {}.",
                         basename_, operation, which, generation,
-                        on_ready_count_, num_sites_);
+                        num_sites_, on_ready_count_);
                 }
 
                 if constexpr (!std::is_same_v<std::nullptr_t,
@@ -387,7 +387,7 @@ namespace hpx::collectives::detail {
             set_operation_and_check_sequencing(l, operation, which, generation);
 
             auto f = get_future_and_synchronize(
-                generation, num_values, HPX_MOVE(on_ready), l);
+                generation, HPX_MOVE(on_ready), l);
 
             // We may have just finished a different operation, thus we have to
             // possibly reset the operation type stored in this communicator.
@@ -445,7 +445,7 @@ namespace hpx::collectives::detail {
                             "been invoked at the end of the collective {} "
                             "operation. Expected count {}, received count {}, "
                             "which {}, generation {}.",
-                            operation, on_ready_count_, num_sites_, which,
+                            operation, num_sites_, on_ready_count_, which,
                             generation);
                         return;
                     }
@@ -498,7 +498,7 @@ namespace hpx::collectives::detail {
         std::size_t const num_sites_;
         std::size_t on_ready_count_ = 0;
         char const* current_operation_ = nullptr;
-        char const* basename_ = nullptr;
+        std::string basename_;
         mutex_type mtx_;
         bool needs_initialization_ = true;
         bool data_available_ = false;

--- a/libs/full/collectives/include/hpx/collectives/detail/communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/communicator.hpp
@@ -26,7 +26,6 @@
 
 #include <cstddef>
 #include <mutex>
-#include <string>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -497,7 +496,7 @@ namespace hpx::collectives::detail {
         std::size_t const num_sites_;
         std::size_t on_ready_count_ = 0;
         char const* current_operation_ = nullptr;
-        std::string basename_;
+        char const* basename_ = nullptr;
         mutex_type mtx_;
         bool needs_initialization_ = true;
         bool data_available_ = false;

--- a/libs/full/collectives/include/hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
@@ -54,7 +54,9 @@ namespace hpx::collectives::detail {
 
         // Wrap local value in a vector (same pattern as hierarchical
         // gather_here).
-        std::vector<value_type> result(1, HPX_FORWARD(T, local_result));
+        std::vector<value_type> result;
+        result.reserve(1);
+        result.emplace_back(HPX_FORWARD(T, local_result));
 
         // Walk bottom-up from leaf (size()-1) to level 1, skipping level 0
         // (the inter-group communicator). At every subtree level this site
@@ -91,7 +93,9 @@ namespace hpx::collectives::detail {
 
         using value_type = std::decay_t<T>;
 
-        std::vector<value_type> data(1, HPX_FORWARD(T, local_result));
+        std::vector<value_type> data;
+        data.reserve(1);
+        data.emplace_back(HPX_FORWARD(T, local_result));
 
         // Walk bottom-up from leaf to level 1, calling gather_here
         // (each intermediate rep gathers from its children).

--- a/libs/full/collectives/include/hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
@@ -55,7 +55,6 @@ namespace hpx::collectives::detail {
         // Wrap local value in a vector (same pattern as hierarchical
         // gather_here).
         std::vector<value_type> result;
-        result.reserve(1);
         result.emplace_back(HPX_FORWARD(T, local_result));
 
         // Walk bottom-up from leaf (size()-1) to level 1, skipping level 0

--- a/libs/full/collectives/include/hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
@@ -93,7 +93,6 @@ namespace hpx::collectives::detail {
         using value_type = std::decay_t<T>;
 
         std::vector<value_type> data;
-        data.reserve(1);
         data.emplace_back(HPX_FORWARD(T, local_result));
 
         // Walk bottom-up from leaf to level 1, calling gather_here

--- a/libs/full/collectives/include/hpx/collectives/detail/hierarchical_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/hierarchical_helpers.hpp
@@ -15,8 +15,8 @@
 
 #include <algorithm>
 #include <cstddef>
-#include <cstdlib>
 #include <iterator>
+#include <limits>
 #include <vector>
 
 namespace hpx::collectives::detail {
@@ -29,6 +29,29 @@ namespace hpx::collectives::detail {
         generation_arg generation;
         generation_mode num_generations;
     };
+
+    struct hierarchical_phase_generation_pair
+    {
+        generation_arg first;
+        generation_arg second;
+    };
+
+    [[nodiscard]] inline bool is_valid_hierarchical_phase_generation(
+        generation_arg const generation) noexcept
+    {
+        return !generation.is_default() && generation != 0 &&
+            static_cast<std::size_t>(generation) <=
+            (std::numeric_limits<std::size_t>::max)() / 2;
+    }
+
+    inline hierarchical_phase_generation_pair hierarchical_phase_generations(
+        generation_arg const generation) noexcept
+    {
+        HPX_ASSERT(is_valid_hierarchical_phase_generation(generation));
+
+        std::size_t const k = generation;
+        return {generation_arg(2 * k - 1), generation_arg(2 * k)};
+    }
 
     // Map a user generation k to those parameters when the communicator
     // advances num_generations per call: the run generation becomes
@@ -85,8 +108,8 @@ namespace hpx::collectives::detail {
             arity = num_sites;
         }
 
-        auto const dv = std::lldiv(
-            static_cast<long long>(num_sites), static_cast<long long>(arity));
+        std::size_t const division_steps = num_sites / arity;
+        std::size_t const remainder = num_sites % arity;
 
         std::vector<top_level_group> groups;
         groups.reserve(arity);
@@ -94,8 +117,8 @@ namespace hpx::collectives::detail {
         std::size_t offset = 0;
         for (std::size_t i = 0; i != arity; ++i)
         {
-            std::size_t const group_size = static_cast<std::size_t>(dv.quot) +
-                (i < static_cast<std::size_t>(dv.rem) ? 1 : 0);
+            std::size_t const group_size =
+                division_steps + (i < remainder ? 1 : 0);
 
             std::size_t const left = offset;
             std::size_t const right = left + group_size - 1;

--- a/libs/full/collectives/include/hpx/collectives/gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/gather.hpp
@@ -515,7 +515,9 @@ namespace hpx::collectives {
                             "involved"));
                 }
 
-                std::vector<arg_type> result(1, HPX_FORWARD(T, local_result));
+                std::vector<arg_type> result;
+                result.reserve(1);
+                result.emplace_back(HPX_FORWARD(T, local_result));
                 return hpx::make_ready_future(HPX_MOVE(result));
             }
 
@@ -565,6 +567,11 @@ namespace hpx::collectives {
         template <typename T>
         std::vector<T> gather_data(std::vector<std::vector<T>>&& data)
         {
+            if (data.size() == 1)
+            {
+                return HPX_MOVE(data.front());
+            }
+
             std::size_t total_size = 0;
             for (auto const& row : data)
             {
@@ -613,8 +620,9 @@ namespace hpx::collectives {
             auto const [run_gen, run_step] =
                 hierarchical_run_params(generation, num_generations);
 
-            std::vector<std::decay_t<T>> result(
-                1, HPX_FORWARD(T, local_result));
+            std::vector<std::decay_t<T>> result;
+            result.reserve(1);
+            result.emplace_back(HPX_FORWARD(T, local_result));
             for (std::size_t i = communicators.size() - 1; i != 0; --i)
             {
                 result = gather_data(gather_here(communicators.get(i),
@@ -777,7 +785,9 @@ namespace hpx::collectives {
             auto const [run_gen, run_step] =
                 hierarchical_run_params(generation, num_generations);
 
-            std::vector<std::decay_t<T>> data(1, HPX_FORWARD(T, local_result));
+            std::vector<std::decay_t<T>> data;
+            data.reserve(1);
+            data.emplace_back(HPX_FORWARD(T, local_result));
             for (std::size_t i = communicators.size() - 1; i != 0; --i)
             {
                 data = gather_data(gather_here(communicators.get(i),

--- a/libs/full/collectives/include/hpx/collectives/gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/gather.hpp
@@ -516,7 +516,6 @@ namespace hpx::collectives {
                 }
 
                 std::vector<arg_type> result;
-                result.reserve(1);
                 result.emplace_back(HPX_FORWARD(T, local_result));
                 return hpx::make_ready_future(HPX_MOVE(result));
             }
@@ -621,7 +620,6 @@ namespace hpx::collectives {
                 hierarchical_run_params(generation, num_generations);
 
             std::vector<std::decay_t<T>> result;
-            result.reserve(1);
             result.emplace_back(HPX_FORWARD(T, local_result));
             for (std::size_t i = communicators.size() - 1; i != 0; --i)
             {
@@ -786,7 +784,6 @@ namespace hpx::collectives {
                 hierarchical_run_params(generation, num_generations);
 
             std::vector<std::decay_t<T>> data;
-            data.reserve(1);
             data.emplace_back(HPX_FORWARD(T, local_result));
             for (std::size_t i = communicators.size() - 1; i != 0; --i)
             {

--- a/libs/full/collectives/include/hpx/collectives/scatter.hpp
+++ b/libs/full/collectives/include/hpx/collectives/scatter.hpp
@@ -540,6 +540,7 @@ namespace hpx::collectives {
             {
                 std::size_t const current_group_size =
                     division_steps + (i < remainder ? 1 : 0);
+                grouped[i].reserve(current_group_size);
 
                 std::size_t const current_left = offset;
                 std::size_t const current_right =
@@ -765,6 +766,25 @@ namespace hpx::collectives {
         if (this_site.is_default())
         {
             this_site = agas::get_locality_id();
+        }
+
+        std::size_t const num_sites_val = hpx::get<0>(communicators.get_info());
+        if (this_site >= num_sites_val)
+        {
+            return hpx::make_exceptional_future<T>(
+                HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                    "hpx::collectives::scatter_to (hierarchical)",
+                    "this_site must be smaller than the number of "
+                    "participating sites"));
+        }
+
+        if (local_result.size() != num_sites_val)
+        {
+            return hpx::make_exceptional_future<T>(
+                HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                    "hpx::collectives::scatter_to (hierarchical)",
+                    "the number of values to scatter must be equal to the "
+                    "number of participating sites"));
         }
 
         // A hierarchical scatter advances each sub-communicator by two

--- a/libs/full/collectives/include/hpx/collectives/scatter.hpp
+++ b/libs/full/collectives/include/hpx/collectives/scatter.hpp
@@ -544,11 +544,11 @@ namespace hpx::collectives {
 
                 std::size_t const current_left = offset;
                 std::size_t const current_right =
-                    current_left + current_group_size - 1;
+                    current_left + current_group_size;
                 offset += current_group_size;
 
                 std::move(data.begin() + current_left,
-                    data.begin() + current_right + 1,
+                    data.begin() + current_right,
                     std::back_inserter(grouped[i]));
             }
 

--- a/libs/full/collectives/src/create_communicator.cpp
+++ b/libs/full/collectives/src/create_communicator.cpp
@@ -375,8 +375,7 @@ namespace hpx::collectives {
         void recursively_fill_communicators(
             std::vector<hpx::tuple<communicator, this_site_arg>>& communicators,
             std::size_t left, std::size_t right, std::string const& basename,
-            arity_arg arity, this_site_arg this_site,
-            generation_arg generation)
+            arity_arg arity, this_site_arg this_site, generation_arg generation)
         {
             std::string name(basename);
             name += std::to_string(left) + "-" + std::to_string(right) + "/";

--- a/libs/full/collectives/src/create_communicator.cpp
+++ b/libs/full/collectives/src/create_communicator.cpp
@@ -64,7 +64,7 @@ namespace hpx::collectives {
         }
 
         communicator_server::communicator_server(
-            std::size_t num_sites, char const* basename)
+            std::size_t num_sites, char const* basename) noexcept
           : gate_(num_sites)
           , num_sites_(num_sites)
           , basename_(basename)

--- a/libs/full/collectives/src/create_communicator.cpp
+++ b/libs/full/collectives/src/create_communicator.cpp
@@ -67,7 +67,7 @@ namespace hpx::collectives {
             std::size_t num_sites, char const* basename)
           : gate_(num_sites)
           , num_sites_(num_sites)
-          , basename_(basename != nullptr ? basename : "")
+          , basename_(basename)
         {
             HPX_ASSERT(
                 num_sites != 0 && num_sites != static_cast<std::size_t>(-1));

--- a/libs/full/collectives/src/create_communicator.cpp
+++ b/libs/full/collectives/src/create_communicator.cpp
@@ -64,10 +64,10 @@ namespace hpx::collectives {
         }
 
         communicator_server::communicator_server(
-            std::size_t num_sites, char const* basename) noexcept
+            std::size_t num_sites, char const* basename)
           : gate_(num_sites)
           , num_sites_(num_sites)
-          , basename_(basename)
+          , basename_(basename != nullptr ? basename : "")
         {
             HPX_ASSERT(
                 num_sites != 0 && num_sites != static_cast<std::size_t>(-1));
@@ -160,7 +160,7 @@ namespace hpx::collectives {
             // involved.
             if (num_sites == 1)
             {
-                c.set_info(num_sites, this_site);
+                c.set_info(num_sites, this_site, root_site);
                 return c;
             }
 
@@ -286,7 +286,7 @@ namespace hpx::collectives {
             // involved.
             if (num_sites == 1)
             {
-                c.set_info(num_sites, this_site);
+                c.set_info(num_sites, this_site, root_site);
                 return c;
             }
 
@@ -375,7 +375,7 @@ namespace hpx::collectives {
         void recursively_fill_communicators(
             std::vector<hpx::tuple<communicator, this_site_arg>>& communicators,
             std::size_t left, std::size_t right, std::string const& basename,
-            arity_arg arity, this_site_arg this_site, num_sites_arg num_sites,
+            arity_arg arity, this_site_arg this_site,
             generation_arg generation)
         {
             std::string name(basename);
@@ -413,8 +413,7 @@ namespace hpx::collectives {
                 if (this_site >= current_left && this_site <= current_right)
                 {
                     recursively_fill_communicators(communicators, current_left,
-                        current_right, basename, arity, this_site, num_sites,
-                        generation);
+                        current_right, basename, arity, this_site, generation);
                     break;
                 }
             }
@@ -455,6 +454,13 @@ namespace hpx::collectives {
                 "than the number of participating sites");
         }
 
+        if (arity < 2)
+        {
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "hpx::collectives::create_hierarchical_communicator",
+                "hierarchical communicators require arity >= 2");
+        }
+
         std::string name(basename);
         if (!generation.is_default())
         {
@@ -475,7 +481,7 @@ namespace hpx::collectives {
 
         std::vector<hpx::tuple<communicator, this_site_arg>> communicators;
         recursively_fill_communicators(communicators, 0, num_sites - 1, name,
-            arity, this_site, num_sites, generation);
+            arity, this_site, generation);
         return hierarchical_communicator(
             HPX_MOVE(communicators), arity, root_site, num_sites, this_site);
     }

--- a/libs/full/collectives/tests/unit/all_to_all.cpp
+++ b/libs/full/collectives/tests/unit/all_to_all.cpp
@@ -134,7 +134,7 @@ void test_local_use(std::uint32_t num_sites)
     for (std::uint32_t site = 0; site != num_sites; ++site)
     {
         sites.push_back(hpx::async([=]() {
-            auto const all_reduce_direct_client =
+            auto const all_to_all_direct_client =
                 create_local_communicator(all_to_all_direct_basename,
                     num_sites_arg(num_sites), this_site_arg(site));
 
@@ -142,19 +142,19 @@ void test_local_use(std::uint32_t num_sites)
 
             for (std::uint32_t i = 0; i != 10 * ITERATIONS; ++i)
             {
-                // test functionality based on immediate local result value
-                auto value = site;
+                std::vector<std::uint32_t> values(num_sites);
+                std::fill(values.begin(), values.end(), site + i);
 
                 hpx::future<std::vector<std::uint32_t>> overall_result =
-                    all_gather(all_reduce_direct_client, value,
-                        this_site_arg(value), generation_arg(i + 1));
+                    all_to_all(all_to_all_direct_client, std::move(values),
+                        this_site_arg(site), generation_arg(i + 1));
 
                 std::vector<std::uint32_t> r = overall_result.get();
                 HPX_TEST_EQ(r.size(), num_sites);
 
                 for (std::size_t j = 0; j != r.size(); ++j)
                 {
-                    HPX_TEST_EQ(r[j], j);
+                    HPX_TEST_EQ(r[j], j + i);
                 }
             }
 
@@ -168,6 +168,32 @@ void test_local_use(std::uint32_t num_sites)
     }
 
     hpx::wait_all(std::move(sites));
+}
+
+void test_singleton_payload_validation()
+{
+    for (std::size_t size : {0u, 2u})
+    {
+        auto const all_to_all_direct_client = create_local_communicator(
+            all_to_all_validation_basename, num_sites_arg(1),
+            this_site_arg(0), generation_arg(size + 1));
+
+        bool caught_exception = false;
+        try
+        {
+            [[maybe_unused]] auto result =
+                all_to_all(all_to_all_direct_client,
+                    std::vector<std::uint32_t>(size), this_site_arg(0),
+                    generation_arg(size + 1))
+                    .get();
+        }
+        catch (hpx::exception const& e)
+        {
+            caught_exception = true;
+            HPX_TEST_EQ(e.get_error(), hpx::error::bad_parameter);
+        }
+        HPX_TEST(caught_exception);
+    }
 }
 
 void test_local_use_undersized_payload(std::uint32_t num_sites)
@@ -235,6 +261,7 @@ int hpx_main()
 
         // Validate that malformed participant payload sizes are rejected.
         test_local_use_undersized_payload(10);
+        test_singleton_payload_validation();
     }
 
     return hpx::finalize();

--- a/libs/full/collectives/tests/unit/all_to_all.cpp
+++ b/libs/full/collectives/tests/unit/all_to_all.cpp
@@ -39,8 +39,7 @@ void test_one_shot_use()
     // test functionality based on immediate local result value
     for (int i = 0; i != ITERATIONS; ++i)
     {
-        std::vector<std::uint32_t> values(num_localities);
-        std::fill(values.begin(), values.end(), this_locality + i);
+        std::vector<std::uint32_t> values(num_localities, this_locality + i);
 
         hpx::future<std::vector<std::uint32_t>> overall_result =
             all_to_all(all_to_all_direct_basename, std::move(values),
@@ -71,8 +70,7 @@ void test_multiple_use()
     // test functionality based on immediate local result value
     for (int i = 0; i != ITERATIONS; ++i)
     {
-        std::vector<std::uint32_t> values(num_localities);
-        std::fill(values.begin(), values.end(), this_locality + i);
+        std::vector<std::uint32_t> values(num_localities, this_locality + i);
 
         hpx::future<std::vector<std::uint32_t>> overall_result =
             all_to_all(all_to_all_direct_client, std::move(values));
@@ -102,8 +100,7 @@ void test_multiple_use_with_generation()
 
     for (int i = 0; i != ITERATIONS; ++i)
     {
-        std::vector<std::uint32_t> values(num_localities);
-        std::fill(values.begin(), values.end(), this_locality + i);
+        std::vector<std::uint32_t> values(num_localities, this_locality + i);
 
         hpx::future<std::vector<std::uint32_t>> overall_result = all_to_all(
             all_to_all_direct_client, std::move(values), generation_arg(i + 1));
@@ -142,8 +139,7 @@ void test_local_use(std::uint32_t num_sites)
 
             for (std::uint32_t i = 0; i != 10 * ITERATIONS; ++i)
             {
-                std::vector<std::uint32_t> values(num_sites);
-                std::fill(values.begin(), values.end(), site + i);
+                std::vector<std::uint32_t> values(num_sites, site + i);
 
                 hpx::future<std::vector<std::uint32_t>> overall_result =
                     all_to_all(all_to_all_direct_client, std::move(values),

--- a/libs/full/collectives/tests/unit/all_to_all.cpp
+++ b/libs/full/collectives/tests/unit/all_to_all.cpp
@@ -174,18 +174,17 @@ void test_singleton_payload_validation()
 {
     for (std::size_t size : {0u, 2u})
     {
-        auto const all_to_all_direct_client = create_local_communicator(
-            all_to_all_validation_basename, num_sites_arg(1),
-            this_site_arg(0), generation_arg(size + 1));
+        auto const all_to_all_direct_client =
+            create_local_communicator(all_to_all_validation_basename,
+                num_sites_arg(1), this_site_arg(0), generation_arg(size + 1));
 
         bool caught_exception = false;
         try
         {
-            [[maybe_unused]] auto result =
-                all_to_all(all_to_all_direct_client,
-                    std::vector<std::uint32_t>(size), this_site_arg(0),
-                    generation_arg(size + 1))
-                    .get();
+            [[maybe_unused]] auto result = all_to_all(all_to_all_direct_client,
+                std::vector<std::uint32_t>(size), this_site_arg(0),
+                generation_arg(size + 1))
+                                               .get();
         }
         catch (hpx::exception const& e)
         {

--- a/libs/full/collectives/tests/unit/all_to_all_sync.cpp
+++ b/libs/full/collectives/tests/unit/all_to_all_sync.cpp
@@ -130,7 +130,7 @@ void test_local_use()
     for (std::uint32_t site = 0; site != num_sites; ++site)
     {
         sites.push_back(hpx::async([=]() {
-            auto const all_reduce_direct_client =
+            auto const all_to_all_direct_client =
                 create_local_communicator(all_to_all_direct_basename,
                     num_sites_arg(num_sites), this_site_arg(site));
 
@@ -138,18 +138,18 @@ void test_local_use()
 
             for (std::uint32_t i = 0; i != 10 * ITERATIONS; ++i)
             {
-                // test functionality based on immediate local result value
-                auto value = site;
+                std::vector<std::uint32_t> values(num_sites);
+                std::fill(values.begin(), values.end(), site + i);
 
-                std::vector<std::uint32_t> r =
-                    all_gather(hpx::launch::sync, all_reduce_direct_client,
-                        value, this_site_arg(value), generation_arg(i + 1));
+                std::vector<std::uint32_t> r = all_to_all(hpx::launch::sync,
+                    all_to_all_direct_client, std::move(values),
+                    this_site_arg(site), generation_arg(i + 1));
 
                 HPX_TEST_EQ(r.size(), num_sites);
 
                 for (std::size_t j = 0; j != r.size(); ++j)
                 {
-                    HPX_TEST_EQ(r[j], j);
+                    HPX_TEST_EQ(r[j], j + i);
                 }
             }
 

--- a/libs/full/collectives/tests/unit/barrier.cpp
+++ b/libs/full/collectives/tests/unit/barrier.cpp
@@ -153,9 +153,9 @@ void collectives_barrier_generation_tests()
         default_generation_client, this_site_arg(0), generation_arg())
         .get();
 
-    auto const zero_generation_client = create_local_communicator(
-        "/test/barrier/collectives/zero_generation/", num_sites_arg(1),
-        this_site_arg(0));
+    auto const zero_generation_client =
+        create_local_communicator("/test/barrier/collectives/zero_generation/",
+            num_sites_arg(1), this_site_arg(0));
 
     bool caught_exception = false;
     try
@@ -171,9 +171,8 @@ void collectives_barrier_generation_tests()
     }
     HPX_TEST(caught_exception);
 
-    hpx::collectives::barrier(
-        "/test/barrier/collectives/basename_async/", num_sites_arg(1),
-        this_site_arg(0), generation_arg(1))
+    hpx::collectives::barrier("/test/barrier/collectives/basename_async/",
+        num_sites_arg(1), this_site_arg(0), generation_arg(1))
         .get();
 
     hpx::collectives::barrier(hpx::launch::sync,

--- a/libs/full/collectives/tests/unit/barrier.cpp
+++ b/libs/full/collectives/tests/unit/barrier.cpp
@@ -10,6 +10,7 @@
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
 #include <hpx/include/lcos.hpp>
+#include <hpx/modules/collectives.hpp>
 #include <hpx/modules/format.hpp>
 #include <hpx/modules/testing.hpp>
 
@@ -141,11 +142,52 @@ void test_release_from_non_hpx_thread(hpx::program_options::variables_map& vm)
     }
 }
 
+void collectives_barrier_generation_tests()
+{
+    using namespace hpx::collectives;
+
+    auto const default_generation_client = create_local_communicator(
+        "/test/barrier/collectives/default_generation/", num_sites_arg(1),
+        this_site_arg(0));
+    hpx::collectives::barrier(
+        default_generation_client, this_site_arg(0), generation_arg())
+        .get();
+
+    auto const zero_generation_client = create_local_communicator(
+        "/test/barrier/collectives/zero_generation/", num_sites_arg(1),
+        this_site_arg(0));
+
+    bool caught_exception = false;
+    try
+    {
+        hpx::collectives::barrier(
+            zero_generation_client, this_site_arg(0), generation_arg(0))
+            .get();
+    }
+    catch (hpx::exception const& e)
+    {
+        caught_exception = true;
+        HPX_TEST_EQ(e.get_error(), hpx::error::bad_parameter);
+    }
+    HPX_TEST(caught_exception);
+
+    hpx::collectives::barrier(
+        "/test/barrier/collectives/basename_async/", num_sites_arg(1),
+        this_site_arg(0), generation_arg(1))
+        .get();
+
+    hpx::collectives::barrier(hpx::launch::sync,
+        "/test/barrier/collectives/basename_sync/", num_sites_arg(1),
+        this_site_arg(0), generation_arg(1));
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(hpx::program_options::variables_map& vm)
 {
     // Regression test for release() from non-HPX threads.
     test_release_from_non_hpx_thread(vm);
+
+    collectives_barrier_generation_tests();
 
     local_tests(vm);
 

--- a/libs/full/collectives/tests/unit/barrier_hierarchical.cpp
+++ b/libs/full/collectives/tests/unit/barrier_hierarchical.cpp
@@ -124,6 +124,29 @@ void test_non_power_of_arity()
     }
 }
 
+void test_invalid_arity_rejected()
+{
+    for (std::uint32_t arity : {0u, 1u})
+    {
+        bool caught_exception = false;
+        try
+        {
+            [[maybe_unused]] auto const barrier_clients =
+                create_hierarchical_communicator(
+                    "/test/barrier_hierarchical/invalid_arity/",
+                    num_sites_arg(1), this_site_arg(0), arity_arg(arity),
+                    generation_arg(), root_site_arg(),
+                    flat_fallback_threshold_arg(0));
+        }
+        catch (hpx::exception const& e)
+        {
+            caught_exception = true;
+            HPX_TEST_EQ(e.get_error(), hpx::error::bad_parameter);
+        }
+        HPX_TEST(caught_exception);
+    }
+}
+
 int hpx_main()
 {
 #if defined(HPX_HAVE_NETWORKING)
@@ -153,6 +176,7 @@ int hpx_main()
         }
 
         test_non_power_of_arity();
+        test_invalid_arity_rejected();
     }
 
     return hpx::finalize();

--- a/libs/full/collectives/tests/unit/concurrent_collectives.cpp
+++ b/libs/full/collectives/tests/unit/concurrent_collectives.cpp
@@ -501,8 +501,7 @@ double test_local_all_to_all(std::vector<communicator> const& comms)
 
                 hpx::future<std::vector<std::uint32_t>> overall_result =
                     all_to_all(comms[site], std::move(values),
-                        this_site_arg(site),
-                        generation_arg(gen));
+                        this_site_arg(site), generation_arg(gen));
 
                 std::vector<std::uint32_t> const r = overall_result.get();
                 HPX_TEST_EQ(r.size(), num_sites);

--- a/libs/full/collectives/tests/unit/concurrent_collectives.cpp
+++ b/libs/full/collectives/tests/unit/concurrent_collectives.cpp
@@ -120,9 +120,7 @@ private:
         template <typename Archive>
         void serialize(Archive& ar, unsigned)
         {
-            // clang-format off
             ar & generations;
-            // clang-format on
         }
 
         std::size_t current = 0;

--- a/libs/full/collectives/tests/unit/concurrent_collectives.cpp
+++ b/libs/full/collectives/tests/unit/concurrent_collectives.cpp
@@ -18,6 +18,7 @@
 #include <atomic>
 #include <cstdint>
 #include <iostream>
+#include <map>
 #include <random>
 #include <string>
 #include <utility>
@@ -116,6 +117,14 @@ private:
     bool was_initialized = false;
     struct generation_data
     {
+        template <typename Archive>
+        void serialize(Archive& ar, unsigned)
+        {
+            // clang-format off
+            ar & generations;
+            // clang-format on
+        }
+
         std::size_t current = 0;
         std::vector<std::size_t> generations;
     };
@@ -487,11 +496,12 @@ double test_local_all_to_all(std::vector<communicator> const& comms)
             sites.push_back(hpx::async([&, site]() {
                 hpx::chrono::high_resolution_timer const t;
 
-                // test functionality based on immediate local result value
-                auto value = site;
+                std::vector<std::uint32_t> values(num_sites);
+                std::fill(values.begin(), values.end(), site + i);
 
                 hpx::future<std::vector<std::uint32_t>> overall_result =
-                    all_gather(comms[site], value, this_site_arg(value),
+                    all_to_all(comms[site], std::move(values),
+                        this_site_arg(site),
                         generation_arg(gen));
 
                 std::vector<std::uint32_t> const r = overall_result.get();
@@ -499,7 +509,7 @@ double test_local_all_to_all(std::vector<communicator> const& comms)
 
                 for (std::size_t j = 0; j != r.size(); ++j)
                 {
-                    HPX_TEST_EQ(r[j], j);
+                    HPX_TEST_EQ(r[j], j + i);
                 }
 
                 if (site == 0)

--- a/libs/full/collectives/tests/unit/concurrent_collectives.cpp
+++ b/libs/full/collectives/tests/unit/concurrent_collectives.cpp
@@ -120,6 +120,8 @@ private:
         template <typename Archive>
         void serialize(Archive& ar, unsigned)
         {
+            // Only serialize the generated sequence; current is a local
+            // cursor and is reset after deserialization.
             ar & generations;
         }
 


### PR DESCRIPTION
Fixes #

## Proposed Changes

- Add explicit validation for invalid collectives inputs, including zero generations, oversized hierarchical generation mappings, invalid hierarchical arity, out-of-range sites, and malformed all_to_all/scatter payload sizes.
- Centralize hierarchical 2k-1/2k phase generation mapping to avoid overflow/wraparound in hierarchical collectives.
- Fix communicator root metadata for single-site communicators and correct local all_to_all test coverage, with regression tests for the hardened validation paths.

## Any background context you want to provide?

This hardens collectives failure paths that could previously assert, wrap internal generations, hang, or exercise the wrong collective when given malformed arguments.

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [x] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.