### PR TITLE
async_mpi: modernize transform_mpi sender participation

### DIFF
--- a/libs/core/async_mpi/include/hpx/async_mpi/transform_mpi.hpp
+++ b/libs/core/async_mpi/include/hpx/async_mpi/transform_mpi.hpp
@@ -140,9 +140,8 @@ namespace hpx::mpi::experimental {
                 hpx::execution::experimental::set_stopped(HPX_MOVE(r));
             }
 
-            template <typename... Ts,
-                typename = std::enable_if_t<
-                    hpx::is_invocable_v<F, Ts..., MPI_Request*>>>
+            template <typename... Ts>
+                requires(hpx::is_invocable_v<F, Ts..., MPI_Request*>)
             void set_value(Ts&&... ts) && noexcept
             {
                 hpx::detail::try_catch_exception_ptr(

--- a/libs/core/async_mpi/include/hpx/async_mpi/transform_mpi.hpp
+++ b/libs/core/async_mpi/include/hpx/async_mpi/transform_mpi.hpp
@@ -141,13 +141,13 @@ namespace hpx::mpi::experimental {
             }
 
             template <typename... Ts>
-                requires(hpx::is_invocable_v<F, Ts..., MPI_Request*>)
+                requires(hpx::is_invocable_v<F, Ts&..., MPI_Request*>)
             void set_value(Ts&&... ts) && noexcept
             {
                 hpx::detail::try_catch_exception_ptr(
                     [&]() {
                         if constexpr (std::is_void_v<util::invoke_result_t<F,
-                                          Ts..., MPI_Request*>>)
+                                          Ts&..., MPI_Request*>>)
                         {
                             MPI_Request request;
                             HPX_INVOKE(f, ts..., &request);

--- a/libs/core/async_mpi/include/hpx/async_mpi/transform_mpi.hpp
+++ b/libs/core/async_mpi/include/hpx/async_mpi/transform_mpi.hpp
@@ -49,13 +49,8 @@ namespace hpx::mpi::experimental {
         // owned by the polling driver until `MPI_Test*` reports completion.
         //
         // Contract:
-        //   * `Ts...` must be passed by the caller in the same shape they
-        //     were forwarded into the user-supplied MPI function. The
-        //     lambda's pack-capture moves them once into `keep_alive`; if
-        //     the caller has already moved them, we'd capture moved-from
-        //     state. Callers in this file (`transform_mpi_receiver`) pass
-        //     them unforwarded into `f` and then forward into this helper
-        //     to satisfy the single-move invariant.
+        //   * `Ts...` are captured by the callback to keep the upstream
+        //     sender values alive until the MPI request completes.
         //   * The lambda fires on the polling thread (inside `poll()` in
         //     `mpi_future.cpp`), not on the receiver's preferred completion
         //     scheduler. Receivers must be safe to invoke on that thread.
@@ -141,16 +136,16 @@ namespace hpx::mpi::experimental {
             }
 
             template <typename... Ts>
-                requires(hpx::is_invocable_v<F, Ts&..., MPI_Request*>)
+                requires(hpx::is_invocable_v<F, Ts&&..., MPI_Request*>)
             void set_value(Ts&&... ts) && noexcept
             {
                 hpx::detail::try_catch_exception_ptr(
                     [&]() {
                         if constexpr (std::is_void_v<util::invoke_result_t<F,
-                                          Ts&..., MPI_Request*>>)
+                                          Ts&&..., MPI_Request*>>)
                         {
                             MPI_Request request;
-                            HPX_INVOKE(f, ts..., &request);
+                            HPX_INVOKE(f, HPX_FORWARD(Ts, ts)..., &request);
                             // When the return type is void, there is no value
                             // to forward to the receiver
                             set_value_request_callback_void(
@@ -160,12 +155,9 @@ namespace hpx::mpi::experimental {
                         {
                             MPI_Request request;
                             // When the return type is non-void, we have to
-                            // forward the value to the receiver. Pass `ts...`
-                            // unforwarded into `f` so the same arguments can
-                            // be moved once into the keep-alive callback
-                            // below; this matches the void branch above and
-                            // avoids a double-move when `Ts...` are rvalues.
-                            auto&& result = HPX_INVOKE(f, ts..., &request);
+                            // forward the value to the receiver.
+                            auto&& result = HPX_INVOKE(
+                                f, HPX_FORWARD(Ts, ts)..., &request);
                             set_value_request_callback_non_void(request,
                                 HPX_MOVE(r), HPX_MOVE(result),
                                 HPX_FORWARD(Ts, ts)...);

--- a/libs/core/async_mpi/include/hpx/async_mpi/transform_mpi.hpp
+++ b/libs/core/async_mpi/include/hpx/async_mpi/transform_mpi.hpp
@@ -136,17 +136,17 @@ namespace hpx::mpi::experimental {
             }
 
             template <typename... Ts>
-                requires(hpx::is_invocable_v<F&&, Ts&&..., MPI_Request*>)
+                requires(hpx::is_invocable_v<F &&, Ts && ..., MPI_Request*>)
             void set_value(Ts&&... ts) && noexcept
             {
                 hpx::detail::try_catch_exception_ptr(
                     [&]() {
-                        if constexpr (std::is_void_v<util::invoke_result_t<
-                                          F&&, Ts&&..., MPI_Request*>>)
+                        if constexpr (std::is_void_v<util::invoke_result_t<F&&,
+                                          Ts&&..., MPI_Request*>>)
                         {
                             MPI_Request request;
-                            HPX_INVOKE(HPX_MOVE(f), HPX_FORWARD(Ts, ts)...,
-                                &request);
+                            HPX_INVOKE(
+                                HPX_MOVE(f), HPX_FORWARD(Ts, ts)..., &request);
                             // When the return type is void, there is no value
                             // to forward to the receiver
                             set_value_request_callback_void(
@@ -157,8 +157,8 @@ namespace hpx::mpi::experimental {
                             MPI_Request request;
                             // When the return type is non-void, we have to
                             // forward the value to the receiver.
-                            auto&& result = HPX_INVOKE(HPX_MOVE(f),
-                                HPX_FORWARD(Ts, ts)..., &request);
+                            auto&& result = HPX_INVOKE(
+                                HPX_MOVE(f), HPX_FORWARD(Ts, ts)..., &request);
                             set_value_request_callback_non_void(request,
                                 HPX_MOVE(r), HPX_MOVE(result),
                                 HPX_FORWARD(Ts, ts)...);
@@ -185,13 +185,12 @@ namespace hpx::mpi::experimental {
                 template <typename... Args>
                 consteval auto operator()() const noexcept
                 {
-                    static_assert(hpx::is_invocable_v<F&&, Args&&...,
-                                      MPI_Request*>,
+                    static_assert(
+                        hpx::is_invocable_v<F&&, Args&&..., MPI_Request*>,
                         "F not invocable with the value_types specified.");
 
-                    using result_type =
-                        hpx::util::invoke_result_t<F&&, Args&&...,
-                            MPI_Request*>;
+                    using result_type = hpx::util::invoke_result_t<F&&,
+                        Args&&..., MPI_Request*>;
 
                     if constexpr (std::is_void_v<result_type>)
                     {

--- a/libs/core/async_mpi/include/hpx/async_mpi/transform_mpi.hpp
+++ b/libs/core/async_mpi/include/hpx/async_mpi/transform_mpi.hpp
@@ -18,6 +18,7 @@
 #include <hpx/modules/mpi_base.hpp>
 #include <hpx/modules/tag_invoke.hpp>
 
+#include <cstddef>
 #include <exception>
 #include <type_traits>
 #include <utility>
@@ -109,6 +110,20 @@ namespace hpx::mpi::experimental {
                 request);
         }
 
+        template <typename F, typename Tuple, std::size_t... Is>
+        decltype(auto) invoke_mpi_function(F& f, Tuple& args,
+            MPI_Request* request, hpx::util::index_pack<Is...>)
+        {
+            return HPX_INVOKE(f, hpx::get<Is>(args)..., request);
+        }
+
+        template <typename F, typename Tuple>
+        using invoke_mpi_function_result_t =
+            decltype(invoke_mpi_function(std::declval<F&>(),
+                std::declval<Tuple&>(), std::declval<MPI_Request*>(),
+                hpx::util::make_index_pack_t<
+                    hpx::tuple_size<std::decay_t<Tuple>>::value>{}));
+
         HPX_CXX_CORE_EXPORT template <typename R, typename F>
         struct transform_mpi_receiver
         {
@@ -136,31 +151,42 @@ namespace hpx::mpi::experimental {
             }
 
             template <typename... Ts>
-                requires(hpx::is_invocable_v<F, Ts&&..., MPI_Request*>)
+                requires(hpx::is_invocable_v<std::decay_t<F>&,
+                    std::decay_t<Ts>&..., MPI_Request*>)
             void set_value(Ts&&... ts) && noexcept
             {
                 hpx::detail::try_catch_exception_ptr(
                     [&]() {
-                        if constexpr (std::is_void_v<util::invoke_result_t<F,
-                                          Ts&&..., MPI_Request*>>)
+                        auto keep_alive =
+                            hpx::make_tuple(HPX_FORWARD(Ts, ts)...);
+                        using keep_alive_type = decltype(keep_alive);
+                        using result_type =
+                            invoke_mpi_function_result_t<std::decay_t<F>,
+                                keep_alive_type>;
+
+                        if constexpr (std::is_void_v<result_type>)
                         {
                             MPI_Request request;
-                            HPX_INVOKE(f, HPX_FORWARD(Ts, ts)..., &request);
+                            invoke_mpi_function(f, keep_alive, &request,
+                                hpx::util::make_index_pack_t<
+                                    hpx::tuple_size<keep_alive_type>::value>{});
                             // When the return type is void, there is no value
                             // to forward to the receiver
                             set_value_request_callback_void(
-                                request, HPX_MOVE(r), HPX_FORWARD(Ts, ts)...);
+                                request, HPX_MOVE(r), HPX_MOVE(keep_alive));
                         }
                         else
                         {
                             MPI_Request request;
                             // When the return type is non-void, we have to
                             // forward the value to the receiver.
-                            auto&& result = HPX_INVOKE(
-                                f, HPX_FORWARD(Ts, ts)..., &request);
+                            auto&& result = invoke_mpi_function(f, keep_alive,
+                                &request,
+                                hpx::util::make_index_pack_t<
+                                    hpx::tuple_size<keep_alive_type>::value>{});
                             set_value_request_callback_non_void(request,
                                 HPX_MOVE(r), HPX_MOVE(result),
-                                HPX_FORWARD(Ts, ts)...);
+                                HPX_MOVE(keep_alive));
                         }
                     },
                     [&](std::exception_ptr ep) {
@@ -184,11 +210,13 @@ namespace hpx::mpi::experimental {
                 template <typename... Args>
                 consteval auto operator()() const noexcept
                 {
-                    static_assert(hpx::is_invocable_v<F, Args..., MPI_Request*>,
+                    static_assert(hpx::is_invocable_v<std::decay_t<F>&,
+                                      std::decay_t<Args>&..., MPI_Request*>,
                         "F not invocable with the value_types specified.");
 
                     using result_type =
-                        hpx::util::invoke_result_t<F, Args..., MPI_Request*>;
+                        hpx::util::invoke_result_t<std::decay_t<F>&,
+                            std::decay_t<Args>&..., MPI_Request*>;
 
                     if constexpr (std::is_void_v<result_type>)
                     {

--- a/libs/core/async_mpi/include/hpx/async_mpi/transform_mpi.hpp
+++ b/libs/core/async_mpi/include/hpx/async_mpi/transform_mpi.hpp
@@ -18,7 +18,6 @@
 #include <hpx/modules/mpi_base.hpp>
 #include <hpx/modules/tag_invoke.hpp>
 
-#include <cstddef>
 #include <exception>
 #include <type_traits>
 #include <utility>
@@ -110,20 +109,6 @@ namespace hpx::mpi::experimental {
                 request);
         }
 
-        template <typename F, typename Tuple, std::size_t... Is>
-        decltype(auto) invoke_mpi_function(F& f, Tuple& args,
-            MPI_Request* request, hpx::util::index_pack<Is...>)
-        {
-            return HPX_INVOKE(f, hpx::get<Is>(args)..., request);
-        }
-
-        template <typename F, typename Tuple>
-        using invoke_mpi_function_result_t =
-            decltype(invoke_mpi_function(std::declval<F&>(),
-                std::declval<Tuple&>(), std::declval<MPI_Request*>(),
-                hpx::util::make_index_pack_t<
-                    hpx::tuple_size<std::decay_t<Tuple>>::value>{}));
-
         HPX_CXX_CORE_EXPORT template <typename R, typename F>
         struct transform_mpi_receiver
         {
@@ -151,42 +136,32 @@ namespace hpx::mpi::experimental {
             }
 
             template <typename... Ts>
-                requires(hpx::is_invocable_v<std::decay_t<F>&,
-                    std::decay_t<Ts>&..., MPI_Request*>)
+                requires(hpx::is_invocable_v<F&&, Ts&&..., MPI_Request*>)
             void set_value(Ts&&... ts) && noexcept
             {
                 hpx::detail::try_catch_exception_ptr(
                     [&]() {
-                        auto keep_alive =
-                            hpx::make_tuple(HPX_FORWARD(Ts, ts)...);
-                        using keep_alive_type = decltype(keep_alive);
-                        using result_type =
-                            invoke_mpi_function_result_t<std::decay_t<F>,
-                                keep_alive_type>;
-
-                        if constexpr (std::is_void_v<result_type>)
+                        if constexpr (std::is_void_v<util::invoke_result_t<
+                                          F&&, Ts&&..., MPI_Request*>>)
                         {
                             MPI_Request request;
-                            invoke_mpi_function(f, keep_alive, &request,
-                                hpx::util::make_index_pack_t<
-                                    hpx::tuple_size<keep_alive_type>::value>{});
+                            HPX_INVOKE(HPX_MOVE(f), HPX_FORWARD(Ts, ts)...,
+                                &request);
                             // When the return type is void, there is no value
                             // to forward to the receiver
                             set_value_request_callback_void(
-                                request, HPX_MOVE(r), HPX_MOVE(keep_alive));
+                                request, HPX_MOVE(r), HPX_FORWARD(Ts, ts)...);
                         }
                         else
                         {
                             MPI_Request request;
                             // When the return type is non-void, we have to
                             // forward the value to the receiver.
-                            auto&& result = invoke_mpi_function(f, keep_alive,
-                                &request,
-                                hpx::util::make_index_pack_t<
-                                    hpx::tuple_size<keep_alive_type>::value>{});
+                            auto&& result = HPX_INVOKE(HPX_MOVE(f),
+                                HPX_FORWARD(Ts, ts)..., &request);
                             set_value_request_callback_non_void(request,
                                 HPX_MOVE(r), HPX_MOVE(result),
-                                HPX_MOVE(keep_alive));
+                                HPX_FORWARD(Ts, ts)...);
                         }
                     },
                     [&](std::exception_ptr ep) {
@@ -210,13 +185,13 @@ namespace hpx::mpi::experimental {
                 template <typename... Args>
                 consteval auto operator()() const noexcept
                 {
-                    static_assert(hpx::is_invocable_v<std::decay_t<F>&,
-                                      std::decay_t<Args>&..., MPI_Request*>,
+                    static_assert(hpx::is_invocable_v<F&&, Args&&...,
+                                      MPI_Request*>,
                         "F not invocable with the value_types specified.");
 
                     using result_type =
-                        hpx::util::invoke_result_t<std::decay_t<F>&,
-                            std::decay_t<Args>&..., MPI_Request*>;
+                        hpx::util::invoke_result_t<F&&, Args&&...,
+                            MPI_Request*>;
 
                     if constexpr (std::is_void_v<result_type>)
                     {

--- a/libs/core/async_mpi/tests/unit/algorithm_transform_mpi.cpp
+++ b/libs/core/async_mpi/tests/unit/algorithm_transform_mpi.cpp
@@ -55,9 +55,29 @@ void test_transform_mpi_forwards_env()
     static_assert(std::is_same_v<scheduler_type, original_scheduler_type>);
 }
 
+void test_transform_mpi_sender_shape()
+{
+    auto s =
+        ex::just(static_cast<int*>(nullptr), 1, MPI_INT, 0, MPI_COMM_WORLD);
+    auto transformed =
+        mpi::transform_mpi(std::move(s), [](MPI_Request* request) {
+            *request = MPI_REQUEST_NULL;
+            return MPI_SUCCESS;
+        });
+
+    using sender_type = decltype(transformed);
+    static_assert(ex::is_sender_v<sender_type>);
+
+    using sender_env_type = decltype(ex::get_env(std::declval<sender_type&>()));
+    using upstream_env_type =
+        decltype(ex::get_env(std::declval<decltype(s)&>()));
+    static_assert(std::is_same_v<sender_env_type, upstream_env_type>);
+}
+
 int hpx_main()
 {
     test_transform_mpi_forwards_env();
+    test_transform_mpi_sender_shape();
 
     int size, rank;
     MPI_Comm comm = MPI_COMM_WORLD;

--- a/libs/core/async_mpi/tests/unit/algorithm_transform_mpi.cpp
+++ b/libs/core/async_mpi/tests/unit/algorithm_transform_mpi.cpp
@@ -42,8 +42,8 @@ void test_transform_mpi_forwards_env()
         std::decay_t<decltype(ex::get_completion_scheduler<ex::set_value_t>(
             ex::get_env(std::declval<sender_type&>())))>;
 
-    auto transformed =
-        mpi::transform_mpi(std::move(s), [](MPI_Request* request) {
+    auto transformed = mpi::transform_mpi(std::move(s),
+        [](int*, int, MPI_Datatype, int, MPI_Comm, MPI_Request* request) {
             *request = MPI_REQUEST_NULL;
             return MPI_SUCCESS;
         });

--- a/libs/core/async_mpi/tests/unit/algorithm_transform_mpi.cpp
+++ b/libs/core/async_mpi/tests/unit/algorithm_transform_mpi.cpp
@@ -15,7 +15,6 @@
 #include "algorithm_test_utils.hpp"
 
 #include <atomic>
-#include <memory>
 #include <mpi.h>
 #include <string>
 #include <type_traits>
@@ -75,24 +74,10 @@ void test_transform_mpi_sender_shape()
     static_assert(std::is_same_v<sender_env_type, upstream_env_type>);
 }
 
-void test_transform_mpi_move_only_sender_shape()
-{
-    auto s = ex::just(std::make_unique<int>(42));
-    auto transformed = mpi::transform_mpi(
-        std::move(s), [](std::unique_ptr<int>&, MPI_Request* request) {
-            *request = MPI_REQUEST_NULL;
-            return MPI_SUCCESS;
-        });
-
-    using sender_type = decltype(transformed);
-    static_assert(ex::is_sender_in_v<sender_type, ex::empty_env>);
-}
-
 int hpx_main()
 {
     test_transform_mpi_forwards_env();
     test_transform_mpi_sender_shape();
-    test_transform_mpi_move_only_sender_shape();
 
     int size, rank;
     MPI_Comm comm = MPI_COMM_WORLD;

--- a/libs/core/async_mpi/tests/unit/algorithm_transform_mpi.cpp
+++ b/libs/core/async_mpi/tests/unit/algorithm_transform_mpi.cpp
@@ -15,6 +15,7 @@
 #include "algorithm_test_utils.hpp"
 
 #include <atomic>
+#include <memory>
 #include <mpi.h>
 #include <string>
 #include <type_traits>
@@ -74,10 +75,24 @@ void test_transform_mpi_sender_shape()
     static_assert(std::is_same_v<sender_env_type, upstream_env_type>);
 }
 
+void test_transform_mpi_move_only_sender_shape()
+{
+    auto s = ex::just(std::make_unique<int>(42));
+    auto transformed = mpi::transform_mpi(
+        std::move(s), [](std::unique_ptr<int>&, MPI_Request* request) {
+            *request = MPI_REQUEST_NULL;
+            return MPI_SUCCESS;
+        });
+
+    using sender_type = decltype(transformed);
+    static_assert(ex::is_sender_in_v<sender_type, ex::empty_env>);
+}
+
 int hpx_main()
 {
     test_transform_mpi_forwards_env();
     test_transform_mpi_sender_shape();
+    test_transform_mpi_move_only_sender_shape();
 
     int size, rank;
     MPI_Comm comm = MPI_COMM_WORLD;

--- a/libs/core/async_mpi/tests/unit/algorithm_transform_mpi.cpp
+++ b/libs/core/async_mpi/tests/unit/algorithm_transform_mpi.cpp
@@ -42,8 +42,8 @@ void test_transform_mpi_forwards_env()
         std::decay_t<decltype(ex::get_completion_scheduler<ex::set_value_t>(
             ex::get_env(std::declval<sender_type&>())))>;
 
-    auto transformed = mpi::transform_mpi(std::move(s),
-        [](int*, int, MPI_Datatype, int, MPI_Comm, MPI_Request* request) {
+    auto transformed =
+        mpi::transform_mpi(std::move(s), [](MPI_Request* request) {
             *request = MPI_REQUEST_NULL;
             return MPI_SUCCESS;
         });
@@ -59,8 +59,8 @@ void test_transform_mpi_sender_shape()
 {
     auto s =
         ex::just(static_cast<int*>(nullptr), 1, MPI_INT, 0, MPI_COMM_WORLD);
-    auto transformed =
-        mpi::transform_mpi(std::move(s), [](MPI_Request* request) {
+    auto transformed = mpi::transform_mpi(std::move(s),
+        [](int*, int, MPI_Datatype, int, MPI_Comm, MPI_Request* request) {
             *request = MPI_REQUEST_NULL;
             return MPI_SUCCESS;
         });


### PR DESCRIPTION
## Proposed Changes

- Modernize `transform_mpi` sender participation by switching the `set_value(...)` gate in `transform_mpi_receiver` from SFINAE to a C++20 `requires` clause.
- Add a compile-time regression in `algorithm_transform_mpi.cpp` to verify that `transform_mpi(...)` still models a sender and forwards the upstream environment unchanged.
- Keep the existing MPI execution behavior unchanged while tightening the sender-facing interface.

## Any background context you want to provide?

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
