### PR TITLE
actions_base: fix reflect_action for noexcept functions, add arity

### DIFF
--- a/libs/full/actions_base/include/hpx/actions_base/reflect_action.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/reflect_action.hpp
@@ -29,22 +29,6 @@ namespace hpx::actions {
 
     /// \cond NOINTERNAL
     namespace detail {
-
-        /// Helper to extract function type from reflection for use
-        /// as basic_action template argument (two-step workaround for
-        /// GCC/Clang restriction on splice expressions as template args).
-        template <std::meta::info F>
-        struct reflect_action_base
-        {
-            using func_type = [:std::meta::type_of(F):];
-            using type = basic_action<hpx::actions::detail::plain_function,
-                func_type, reflect_action_base<F>>;
-        };
-
-    }    // namespace detail
-    /// \endcond
-    /// \cond NOINTERNAL
-    namespace detail {
         /// Strips cv/ref/noexcept qualifiers from a (possibly qualified)
         /// member function type, producing the plain "R(Args...)" form
         /// that matches basic_action's partial specialization. Member
@@ -102,6 +86,18 @@ namespace hpx::actions {
         template <typename T>
         using unqualify_function_type_t =
             typename unqualify_function_type<T>::type;
+
+        /// Helper to extract function type from reflection for use
+        /// as basic_action template argument (two-step workaround for
+        /// GCC/Clang restriction on splice expressions as template args).
+        template <std::meta::info F>
+        struct reflect_action_base
+        {
+            using func_type =
+                unqualify_function_type_t<typename[:std::meta::type_of(F):]>;
+            static constexpr std::size_t arity =
+                std::meta::parameters_of(F).size();
+        };
 
         /// Helper to extract component type and function type from a member
         /// function reflection for use as basic_action template arguments.
@@ -257,7 +253,8 @@ namespace hpx::actions {
             naming::address::component_type /*comptype*/, Ts&&... vs)
         {
             using base_t = basic_action<hpx::actions::detail::plain_function,
-                func_type, detail::action_type_t<reflect_action, Derived>>;
+                typename detail::reflect_action_base<F>::func_type,
+                detail::action_type_t<reflect_action, Derived>>;
             base_t::increment_invocation_count();
             return func_ptr(HPX_FORWARD(Ts, vs)...);
         }

--- a/libs/full/actions_base/tests/unit/reflect_action_test.cpp
+++ b/libs/full/actions_base/tests/unit/reflect_action_test.cpp
@@ -100,6 +100,17 @@ int main()
         static_assert(!std::is_void_v<registrar_type>,
             "invocation_count_registrar_ must exist");
     }
+    // Test: invoke() works for noexcept functions (verifies that
+    // unqualify_function_type_t correctly strips noexcept from the
+    // function type so basic_action instantiation succeeds)
+    {
+        HPX_ACTION(app::broadcast, broadcast_action);
+        hpx::naming::address_type lva{};
+        hpx::naming::component_type comptype{};
+        broadcast_action::invoke(lva, comptype, 42);
+        static_assert(broadcast_action::arity == std::size_t(1),
+            "arity must be a compile-time constant");
+    }
     return hpx::util::report_errors();
 }
 


### PR DESCRIPTION
## Summary

Two related fixes to `reflect_action<F>` found while reviewing the
existing test suite.

## Fix 1: noexcept function type stripping

`reflect_action_base::func_type` previously used `[:std::meta::type_of(F):]`
directly. For `noexcept` plain functions, `type_of(F)` returns
`R(Args...) noexcept`, which does not match `basic_action`'s partial
specialization `R(Args...)`, causing an `invalid use of incomplete type`
compile error.

Fix: use `unqualify_function_type_t<typename[:std::meta::type_of(F):]>`
— the same pattern already applied to `reflect_component_action_base`
in PR #7311.

`reflect_action_base` is moved into the same `detail` namespace block
as `unqualify_function_type_t` so it is available at the point of use.
The previously unused `using type` member is also removed (confirmed:
zero uses across the codebase).

## Fix 2: arity member

`reflect_action_base` now exposes:
```cpp
static constexpr std::size_t arity = std::meta::parameters_of(F).size();
```
matching `reflect_component_action` (PR #7311). Inherited by
`reflect_action<F>`. Already tested in `reflect_action_test.cpp`
lines 79 and 84 — those tests were present but the member was missing.

## Testing

Both `reflect_action_test` and `reflect_component_action_test` pass
inside `stellargroup/gcc_trunk_build_env:1`.