### PR TITLE
actions_base: add reflect_direct_action and direct action macro reflection support

### DIFF
--- a/libs/full/actions_base/include/hpx/actions_base/macros.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/macros.hpp
@@ -539,11 +539,17 @@
     HPX_DEFINE_PLAIN_DIRECT_ACTION_3(HPX_PP_EMPTY(), func, name)               \
     /**/
 
+#if defined(HPX_HAVE_CXX26_REFLECTION)
+#define HPX_DEFINE_PLAIN_DIRECT_ACTION_3(Prefix, func, name)                   \
+    Prefix using name = hpx::actions::reflect_direct_action<^^func>;           \
+    /**/
+#else
 #define HPX_DEFINE_PLAIN_DIRECT_ACTION_3(Prefix, func, name)                   \
     Prefix struct name                                                         \
       : hpx::actions::make_direct_action_t<decltype(&func), &func, name>       \
     {                                                                          \
     } /**/
+#endif
 
 /// \endcond
 

--- a/libs/full/actions_base/include/hpx/actions_base/reflect_action.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/reflect_action.hpp
@@ -209,6 +209,17 @@ namespace hpx::actions {
     struct name : ::hpx::actions::reflect_component_action<^^component::func>  \
     {                                                                          \
     } /**/
+/// \brief Convenience macro for direct component actions.
+/// Usage: HPX_COMPONENT_DIRECT_ACTION(component, func, action_name)
+#define HPX_COMPONENT_DIRECT_ACTION(component, func, name)                     \
+    struct name                                                                \
+      : ::hpx::actions::reflect_component_direct_action<^^component::func>     \
+    {                                                                          \
+    } /**/
+/// \brief Convenience macro for direct plain actions.
+/// Usage: HPX_DIRECT_ACTION(func, action_name)
+#define HPX_DIRECT_ACTION(func, name)                                          \
+    using name = ::hpx::actions::reflect_direct_action<^^func>; /**/
 
     /// \brief Reflection-based action template.
     ///
@@ -269,6 +280,36 @@ namespace hpx::actions {
     template <std::meta::info F, typename Derived>
     detail::register_action_invocation_count<reflect_action<F, Derived>>
         reflect_action<F, Derived>::invocation_count_registrar_;
+    /// \endcond
+
+    /// \brief Reflection-based direct plain action template.
+    ///
+    /// Like reflect_action, but executes the reflected function
+    /// directly on the calling thread instead of spawning a new
+    /// thread, mirroring the relationship between basic_action's
+    /// action and direct_action.
+    ///
+    /// \tparam F       A std::meta::info reflection of a free function.
+    /// \tparam Derived CRTP derived type (defaults to void).
+    template <std::meta::info F, typename Derived = void>
+    struct reflect_direct_action
+      : reflect_action<F,
+            detail::action_type_t<reflect_direct_action<F, Derived>, Derived>>
+    {
+        using direct_execution = std::true_type;
+
+        static constexpr actions::action_flavor get_action_type() noexcept
+        {
+            return actions::action_flavor::direct_action;
+        }
+
+        static detail::register_action_invocation_count<reflect_direct_action>
+            invocation_count_registrar_;
+    };
+    /// \cond NOINTERNAL
+    template <std::meta::info F, typename Derived>
+    detail::register_action_invocation_count<reflect_direct_action<F, Derived>>
+        reflect_direct_action<F, Derived>::invocation_count_registrar_;
     /// \endcond
 
 }    // namespace hpx::actions

--- a/libs/full/actions_base/tests/unit/reflect_action_test.cpp
+++ b/libs/full/actions_base/tests/unit/reflect_action_test.cpp
@@ -111,6 +111,36 @@ int main()
         static_assert(broadcast_action::arity == std::size_t(1),
             "arity must be a compile-time constant");
     }
+    // Test: reflect_direct_action reports direct-execution semantics
+    // and dispatches correctly for both regular and noexcept functions
+    {
+        using direct_compute =
+            hpx::actions::reflect_direct_action<^^app::compute>;
+        static_assert(direct_compute::direct_execution::value,
+            "reflect_direct_action must report direct_execution");
+        static_assert(direct_compute::get_action_type() ==
+                hpx::actions::action_flavor::direct_action,
+            "reflect_direct_action must report action_flavor::direct_action");
+        static_assert(direct_compute::arity == std::size_t(2),
+            "arity must match function parameter count");
+        hpx::naming::address_type lva{};
+        hpx::naming::component_type comptype{};
+        HPX_TEST_EQ(direct_compute::invoke(lva, comptype, 3.0, 4.0), 7);
+        // Verify invocation_count_registrar_ exists (symmetry with reflect_action)
+        using registrar_type =
+            decltype(direct_compute::invocation_count_registrar_);
+        static_assert(!std::is_void_v<registrar_type>,
+            "reflect_direct_action must have invocation_count_registrar_");
+    }
+    {
+        using direct_broadcast =
+            hpx::actions::reflect_direct_action<^^app::broadcast>;
+        static_assert(direct_broadcast::direct_execution::value,
+            "reflect_direct_action must report direct_execution for noexcept");
+        hpx::naming::address_type lva{};
+        hpx::naming::component_type comptype{};
+        direct_broadcast::invoke(lva, comptype, 42);
+    }
     return hpx::util::report_errors();
 }
 


### PR DESCRIPTION
## Summary

Adds `reflect_direct_action<F, Derived>` for plain free functions,
completing the direct action support alongside the existing
`reflect_component_direct_action` for member functions (PR #7311).

## Changes

**New template: `reflect_direct_action<F>`**
Inherits from `reflect_action` and overrides `direct_execution` and
`get_action_type()` so HPX's dispatch machinery executes the action
on the calling thread without spawning a new thread — same pattern
as `reflect_component_direct_action` / `direct_action`.

**New convenience macros:**
- `HPX_DIRECT_ACTION(func, name)` — direct plain action
- `HPX_COMPONENT_DIRECT_ACTION(component, func, name)` — direct component action

**Updated macro:**
`HPX_DEFINE_PLAIN_DIRECT_ACTION_3` now uses `reflect_direct_action`
when `HPX_HAVE_CXX26_REFLECTION` is defined, matching the existing
reflection-aware `HPX_DEFINE_PLAIN_ACTION_3` pattern. Existing
`HPX_PLAIN_DIRECT_ACTION` code requires zero source changes.

## Testing

Tests verify `direct_execution::value`, `get_action_type()`, `arity`,
and runtime `invoke()` for both regular and `noexcept` functions.
Both `reflect_action_test` and `reflect_component_action_test` pass
inside `stellargroup/gcc_trunk_build_env:1`.

## Related

Addresses hkaiser's review comment on PR #7348 (migration guide).