### PR TITLE
Introduces better lifetime management for background/pool threads

### DIFF
--- a/libs/core/async_base/include/hpx/async_base/launch_policy.hpp
+++ b/libs/core/async_base/include/hpx/async_base/launch_policy.hpp
@@ -26,7 +26,7 @@ namespace hpx {
     HPX_CXX_CORE_EXPORT enum class launch_policy : std::int8_t {
         async = 0x01,
         deferred = 0x02,
-        task = 0x04,    // see N3632
+        task = 0x04,    // same as async, but disables inline execution
         sync = 0x08,
         fork = 0x10,    // same as async, but forces continuation stealing
         apply = 0x20,
@@ -88,18 +88,20 @@ namespace hpx {
                 return hint_;
             }
 
-            void set_priority(threads::thread_priority const priority) noexcept
+            constexpr void set_priority(
+                threads::thread_priority const priority) noexcept
             {
                 priority_ = priority;
             }
 
-            void set_stacksize(
+            constexpr void set_stacksize(
                 threads::thread_stacksize const stacksize) noexcept
             {
                 stacksize_ = stacksize;
             }
 
-            void set_hint(threads::thread_schedule_hint const hint) noexcept
+            constexpr void set_hint(
+                threads::thread_schedule_hint const hint) noexcept
             {
                 hint_ = hint;
             }
@@ -265,6 +267,23 @@ namespace hpx {
             }
         };
 
+        struct task_policy : policy_holder<task_policy>
+        {
+            constexpr explicit task_policy(
+                threads::thread_priority const priority =
+                    threads::thread_priority::default_,
+                threads::thread_stacksize const stacksize =
+                    threads::thread_stacksize::default_,
+                threads::thread_schedule_hint const hint = {}) noexcept
+              : policy_holder<task_policy>(
+                    launch_policy::task, priority, stacksize, hint)
+            {
+                // explicitly disable inline execution
+                hint_.runs_as_child_mode(
+                    hpx::threads::thread_execution_hint::none);
+            }
+        };
+
         struct fork_policy : policy_holder<fork_policy>
         {
             constexpr explicit fork_policy(
@@ -324,9 +343,8 @@ namespace hpx {
         template <typename Pred>
         struct select_policy : policy_holder<select_policy<Pred>>
         {
-            template <typename F,
-                typename U = std::enable_if_t<
-                    !std::is_same_v<select_policy<Pred>, std::decay_t<F>>>>
+            template <typename F>
+                requires(!std::is_same_v<select_policy<Pred>, std::decay_t<F>>)
             explicit select_policy(F&& f,
                 threads::thread_priority priority =
                     threads::thread_priority::default_,
@@ -380,8 +398,7 @@ namespace hpx {
 
         ///////////////////////////////////////////////////////////////////////
         template <typename Left, typename Right>
-        constexpr inline policy_holder_base operator&(
-            policy_holder<Left> const& lhs,
+        constexpr policy_holder_base operator&(policy_holder<Left> const& lhs,
             policy_holder<Right> const& rhs) noexcept
         {
             return policy_holder_base(
@@ -391,8 +408,7 @@ namespace hpx {
         }
 
         template <typename Left, typename Right>
-        constexpr inline policy_holder_base operator|(
-            policy_holder<Left> const& lhs,
+        constexpr policy_holder_base operator|(policy_holder<Left> const& lhs,
             policy_holder<Right> const& rhs) noexcept
         {
             return policy_holder_base(
@@ -402,8 +418,7 @@ namespace hpx {
         }
 
         template <typename Left, typename Right>
-        constexpr inline policy_holder_base operator^(
-            policy_holder<Left> const& lhs,
+        constexpr policy_holder_base operator^(policy_holder<Left> const& lhs,
             policy_holder<Right> const& rhs) noexcept
         {
             return policy_holder_base(
@@ -413,7 +428,7 @@ namespace hpx {
         }
 
         template <typename Derived>
-        constexpr inline policy_holder<Derived> operator~(
+        constexpr policy_holder<Derived> operator~(
             policy_holder<Derived> const& p) noexcept
         {
             return policy_holder<Derived>(
@@ -446,7 +461,7 @@ namespace hpx {
         }
 
         template <typename Left, typename Right>
-        constexpr inline bool operator==(policy_holder<Left> const& lhs,
+        constexpr bool operator==(policy_holder<Left> const& lhs,
             policy_holder<Right> const& rhs) noexcept
         {
             return static_cast<int>(lhs.policy()) ==
@@ -454,7 +469,7 @@ namespace hpx {
         }
 
         template <typename Left, typename Right>
-        constexpr inline bool operator!=(policy_holder<Left> const& lhs,
+        constexpr bool operator!=(policy_holder<Left> const& lhs,
             policy_holder<Right> const& rhs) noexcept
         {
             return !(lhs == rhs);
@@ -487,10 +502,18 @@ namespace hpx {
         }
         /// \endcond
 
-        /// Create a launch policy representing asynchronous execution
+        /// Create a launch policy representing asynchronous execution.
         constexpr launch(detail::async_policy const p) noexcept
           : detail::policy_holder<>{
                 launch_policy::async, p.priority(), p.stacksize(), p.hint()}
+        {
+        }
+
+        /// Create a launch policy representing asynchronous execution, but
+        /// disabled inline execution.
+        constexpr launch(detail::task_policy const p) noexcept
+          : detail::policy_holder<>{
+                launch_policy::task, p.priority(), p.stacksize(), p.hint()}
         {
         }
 
@@ -523,7 +546,7 @@ namespace hpx {
         {
         }
 
-        /// Create a launch policy representing fire and forget execution
+        /// Create a launch policy that is dynamically selected at runtime
         template <typename F>
         constexpr launch(detail::select_policy<F> const& p) noexcept
           : detail::policy_holder<>{
@@ -531,9 +554,8 @@ namespace hpx {
         {
         }
 
-        template <typename Launch,
-            typename Enable =
-                std::enable_if_t<hpx::traits::is_launch_policy_v<Launch>>>
+        template <typename Launch>
+            requires(hpx::traits::is_launch_policy_v<Launch>)
         constexpr launch(Launch l, threads::thread_priority const priority,
             threads::thread_stacksize const stacksize,
             threads::thread_schedule_hint const hint) noexcept
@@ -544,6 +566,7 @@ namespace hpx {
         ///////////////////////////////////////////////////////////////////////
         /// \cond NOINTERNAL
         using async_policy = detail::async_policy;
+        using task_policy = detail::task_policy;
         using fork_policy = detail::fork_policy;
         using sync_policy = detail::sync_policy;
         using deferred_policy = detail::deferred_policy;
@@ -556,7 +579,11 @@ namespace hpx {
         /// Predefined launch policy representing asynchronous execution
         HPX_CORE_EXPORT static detail::async_policy const async;
 
-        /// Predefined launch policy representing asynchronous execution.The
+        /// Predefined launch policy representing asynchronous execution with
+        /// disabled inline execution
+        HPX_CORE_EXPORT static detail::task_policy const task;
+
+        /// Predefined launch policy representing asynchronous execution. The
         /// new thread is executed in a preferred way
         HPX_CORE_EXPORT static detail::fork_policy const fork;
 

--- a/libs/core/async_base/src/launch_policy.cpp
+++ b/libs/core/async_base/src/launch_policy.cpp
@@ -16,6 +16,8 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     detail::async_policy const launch::async =
         detail::async_policy{threads::thread_priority::default_};
+    detail::task_policy const launch::task =
+        detail::task_policy{threads::thread_priority::default_};
     detail::fork_policy const launch::fork =
         detail::fork_policy{threads::thread_priority::default_};
     detail::sync_policy const launch::sync = detail::sync_policy{};
@@ -48,6 +50,9 @@ namespace hpx {
             ar >> mode;
             hint_.sharing_mode(
                 static_cast<hpx::threads::thread_sharing_hint>(mode));
+            ar >> mode;
+            hint_.runs_as_child_mode(
+                static_cast<hpx::threads::thread_execution_hint>(mode));
         }
 
         void policy_holder_base::save(
@@ -57,7 +62,8 @@ namespace hpx {
             ar << priority_;
             ar << hint_.hint << hint_.mode
                << static_cast<std::uint8_t>(hint_.placement_mode())
-               << static_cast<std::uint8_t>(hint_.sharing_mode());
+               << static_cast<std::uint8_t>(hint_.sharing_mode())
+               << static_cast<std::uint8_t>(hint_.runs_as_child_mode());
         }
     }    // namespace detail
 }    // namespace hpx

--- a/libs/core/async_base/tests/unit/launch_policy.cpp
+++ b/libs/core/async_base/tests/unit/launch_policy.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2021 Hartmut Kaiser
+//  Copyright (c) 2021-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -8,9 +8,11 @@
 #include <hpx/hpx_main.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/coroutines.hpp>
+#include <hpx/modules/serialization.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <cstdint>
+#include <vector>
 
 ///////////////////////////////////////////////////////////////////////////////
 template <typename Launch>
@@ -49,9 +51,71 @@ void test_policy(Launch policy)
     HPX_TEST(hpx::execution::experimental::get_hint(p2).hint == hint1.hint);
 }
 
+///////////////////////////////////////////////////////////////////////////////
+// hpx::launch::task disables inline/child-mode execution, unlike
+// hpx::launch::async which defaults to
+// hpx::threads::default_runs_as_child_hint.
+void test_task_policy_disables_child_mode()
+{
+    hpx::launch::task_policy t;
+    HPX_TEST(t.hint().runs_as_child_mode() ==
+        hpx::threads::thread_execution_hint::none);
+
+    t.set_priority(hpx::threads::thread_priority::high);
+    HPX_TEST(t.hint().runs_as_child_mode() ==
+        hpx::threads::thread_execution_hint::none);
+
+    t.set_stacksize(hpx::threads::thread_stacksize::medium);
+    HPX_TEST(t.hint().runs_as_child_mode() ==
+        hpx::threads::thread_execution_hint::none);
+
+    hpx::launch::async_policy a;
+    HPX_TEST(a.hint().runs_as_child_mode() ==
+        hpx::threads::default_runs_as_child_hint);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_launch_policy_bitmask()
+{
+    HPX_TEST_EQ(static_cast<int>(hpx::launch_policy::task), 0x04);
+    HPX_TEST_EQ(static_cast<int>(hpx::launch_policy::async_policies), 0x15);
+    HPX_TEST_EQ(static_cast<int>(hpx::launch_policy::sync_policies), 0x0a);
+
+    HPX_TEST(hpx::launch::task != hpx::launch::async);
+
+    // task is included in async_policies ...
+    HPX_TEST((static_cast<int>(hpx::launch_policy::async_policies) &
+                 static_cast<int>(hpx::launch_policy::task)) != 0);
+
+    // ... but excluded from sync_policies
+    HPX_TEST((static_cast<int>(hpx::launch_policy::sync_policies) &
+                 static_cast<int>(hpx::launch_policy::task)) == 0);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename Policy>
+void test_serialization(Policy const& p)
+{
+    std::vector<char> buffer;
+    hpx::serialization::output_archive oarchive(buffer);
+    oarchive << p;
+
+    hpx::serialization::input_archive iarchive(buffer);
+    Policy p1;
+    iarchive >> p1;
+
+    HPX_TEST_EQ(static_cast<int>(p1.policy()), static_cast<int>(p.policy()));
+    HPX_TEST(p1.priority() == p.priority());
+    HPX_TEST(p1.stacksize() == p.stacksize());
+    HPX_TEST(p1.hint().mode == p.hint().mode);
+    HPX_TEST_EQ(p1.hint().hint, p.hint().hint);
+    HPX_TEST(p1.hint().runs_as_child_mode() == p.hint().runs_as_child_mode());
+}
+
 int main()
 {
     static_assert(sizeof(hpx::launch::async_policy) <= sizeof(std::int64_t));
+    static_assert(sizeof(hpx::launch::task_policy) <= sizeof(std::int64_t));
     static_assert(sizeof(hpx::launch::sync_policy) <= sizeof(std::int64_t));
     static_assert(sizeof(hpx::launch::deferred_policy) <= sizeof(std::int64_t));
     static_assert(sizeof(hpx::launch::fork_policy) <= sizeof(std::int64_t));
@@ -59,6 +123,7 @@ int main()
     static_assert(sizeof(hpx::launch) <= sizeof(std::int64_t));
 
     test_policy(hpx::launch::async);
+    test_policy(hpx::launch::task);
     test_policy(hpx::launch::sync);
     test_policy(hpx::launch::deferred);
     test_policy(hpx::launch::fork);
@@ -66,10 +131,35 @@ int main()
 
     test_policy(hpx::launch());
     test_policy(hpx::launch(hpx::launch::async));
+    test_policy(hpx::launch(hpx::launch::task));
     test_policy(hpx::launch(hpx::launch::sync));
     test_policy(hpx::launch(hpx::launch::deferred));
     test_policy(hpx::launch(hpx::launch::fork));
     test_policy(hpx::launch(hpx::launch::apply));
+
+    test_task_policy_disables_child_mode();
+    test_launch_policy_bitmask();
+
+    test_serialization(hpx::launch::async_policy{});
+    test_serialization(hpx::launch::task_policy{});
+    test_serialization(hpx::launch::sync_policy{});
+    test_serialization(hpx::launch::deferred_policy{});
+    test_serialization(hpx::launch::fork_policy{});
+    test_serialization(hpx::launch::apply_policy{});
+
+    {
+        hpx::launch::async_policy a;
+        a.set_priority(hpx::threads::thread_priority::high);
+        a.set_stacksize(hpx::threads::thread_stacksize::medium);
+        a.set_hint(hpx::threads::thread_schedule_hint(3));
+        test_serialization(a);
+
+        hpx::launch::task_policy t;
+        t.set_priority(hpx::threads::thread_priority::high);
+        t.set_stacksize(hpx::threads::thread_stacksize::medium);
+        t.set_hint(hpx::threads::thread_schedule_hint(3));
+        test_serialization(t);
+    }
 
     return 0;
 }

--- a/libs/core/coroutines/include/hpx/coroutines/thread_enums.hpp
+++ b/libs/core/coroutines/include/hpx/coroutines/thread_enums.hpp
@@ -464,7 +464,7 @@ namespace hpx::threads {
         {
             return static_cast<thread_placement_hint>(placement_mode_bits);
         }
-        void placement_mode(thread_placement_hint bits) noexcept
+        constexpr void placement_mode(thread_placement_hint bits) noexcept
         {
             placement_mode_bits = static_cast<std::uint8_t>(bits);
         }
@@ -474,7 +474,7 @@ namespace hpx::threads {
         {
             return static_cast<thread_sharing_hint>(sharing_mode_bits);
         }
-        void sharing_mode(thread_sharing_hint bits) noexcept
+        constexpr void sharing_mode(thread_sharing_hint bits) noexcept
         {
             sharing_mode_bits = static_cast<std::uint8_t>(bits);
         }
@@ -484,12 +484,12 @@ namespace hpx::threads {
         {
             return static_cast<thread_execution_hint>(runs_as_child_mode_bits);
         }
-        void runs_as_child_mode(thread_execution_hint bits) noexcept
+        constexpr void runs_as_child_mode(thread_execution_hint bits) noexcept
         {
             runs_as_child_mode_bits = static_cast<std::uint8_t>(bits);
         }
 
-        void schedule_hint(std::int16_t core) noexcept
+        constexpr void schedule_hint(std::int16_t core) noexcept
         {
             mode = thread_schedule_hint_mode::thread;
             hint = core;

--- a/libs/core/coroutines/include/hpx/coroutines/thread_id_type.hpp
+++ b/libs/core/coroutines/include/hpx/coroutines/thread_id_type.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2018 Thomas Heller
-//  Copyright (c) 2019-2025 Hartmut Kaiser
+//  Copyright (c) 2019-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -248,8 +248,8 @@ namespace hpx::threads {
         {
         }
 
-        thread_id_ref(thread_id&& noref) noexcept
-          : thrd_(static_cast<thread_repr*>(noref.get()))
+        thread_id_ref(thread_id&& noref, bool const add_ref = true) noexcept
+          : thrd_(static_cast<thread_repr*>(noref.get()), add_ref)
         {
             noref.reset();
         }
@@ -384,6 +384,51 @@ namespace hpx::threads {
 #else
     HPX_CXX_CORE_EXPORT inline constexpr thread_id const invalid_thread_id;
 #endif
+
+    // This data type allows to optionally keep the provided thread_id alive
+    struct keep_alive_thread_id
+    {
+        explicit keep_alive_thread_id(
+            hpx::threads::thread_id id, bool const add_ref) noexcept
+          : add_ref(add_ref)
+          , id(HPX_MOVE(id), add_ref)
+        {
+        }
+
+        keep_alive_thread_id(keep_alive_thread_id const& other) = delete;
+        keep_alive_thread_id(keep_alive_thread_id&& other) = default;
+
+        keep_alive_thread_id& operator=(
+            keep_alive_thread_id const& other) = delete;
+        keep_alive_thread_id& operator=(keep_alive_thread_id&& other) noexcept
+        {
+            if (this != &other)
+            {
+                detach_if_necessary();
+                add_ref = other.add_ref;
+                id = HPX_MOVE(other.id);
+            }
+            return *this;
+        }
+
+        ~keep_alive_thread_id()
+        {
+            detach_if_necessary();
+        }
+
+        void detach_if_necessary()
+        {
+            // prevent for the reference count to be decremented if it was
+            // not incremented in the constructor
+            if (!add_ref)
+            {
+                [[maybe_unused]] auto* p = id.get().detach();
+            }
+        }
+
+        bool add_ref;
+        hpx::threads::thread_id_ref id;
+    };
 }    // namespace hpx::threads
 
 namespace std {

--- a/libs/core/coroutines/include/hpx/coroutines/thread_id_type.hpp
+++ b/libs/core/coroutines/include/hpx/coroutines/thread_id_type.hpp
@@ -386,7 +386,7 @@ namespace hpx::threads {
 #endif
 
     // This data type allows to optionally keep the provided thread_id alive
-    struct keep_alive_thread_id
+    HPX_CXX_CORE_EXPORT struct keep_alive_thread_id
     {
         explicit keep_alive_thread_id(
             hpx::threads::thread_id id, bool const add_ref) noexcept
@@ -400,11 +400,12 @@ namespace hpx::threads {
 
         keep_alive_thread_id& operator=(
             keep_alive_thread_id const& other) = delete;
+
         keep_alive_thread_id& operator=(keep_alive_thread_id&& other) noexcept
         {
             if (this != &other)
             {
-                detach_if_necessary();
+                detach_if_needed();
                 add_ref = other.add_ref;
                 id = HPX_MOVE(other.id);
             }
@@ -413,10 +414,10 @@ namespace hpx::threads {
 
         ~keep_alive_thread_id()
         {
-            detach_if_necessary();
+            detach_if_needed();
         }
 
-        void detach_if_necessary()
+        void detach_if_needed() noexcept
         {
             // prevent for the reference count to be decremented if it was
             // not incremented in the constructor

--- a/libs/core/coroutines/tests/unit/CMakeLists.txt
+++ b/libs/core/coroutines/tests/unit/CMakeLists.txt
@@ -1,5 +1,24 @@
-# Copyright (c) 2019 The STE||AR-Group
+# Copyright (c) 2026 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(tests thread_id_type)
+
+foreach(test ${tests})
+  set(sources ${test}.cpp)
+
+  source_group("Source Files" FILES ${sources})
+
+  add_hpx_executable(
+    ${test}_test INTERNAL_FLAGS
+    SOURCES ${sources} ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL NOLIBS
+    DEPENDENCIES hpx_core
+    FOLDER "Tests/Unit/Modules/Core/Coroutines"
+  )
+
+  add_hpx_unit_test("modules.coroutines" ${test} ${${test}_PARAMETERS})
+  target_compile_definitions(${test}_test PRIVATE -DHPX_MODULE_STATIC_LINKING)
+endforeach()

--- a/libs/core/coroutines/tests/unit/thread_id_type.cpp
+++ b/libs/core/coroutines/tests/unit/thread_id_type.cpp
@@ -1,0 +1,220 @@
+//  Copyright (c) 2026 The STE||AR-Group
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// This test focuses on the reference counting behavior of
+// hpx::threads::thread_id_ref's move-from-thread_id constructor (which now
+// takes an additional `add_ref` flag) and on
+// hpx::threads::keep_alive_thread_id, a helper type that optionally keeps a
+// thread_id alive without necessarily adding to its reference count.
+
+#include <hpx/config.hpp>
+#include <hpx/modules/coroutines.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <type_traits>
+#include <utility>
+
+namespace {
+
+    // A minimal thread_data_reference_counting implementation that allows tests
+    // to observe both the current reference count and whether destroy_thread()
+    // was invoked, without requiring a full thread_data / HPX runtime instance.
+    struct test_thread_data
+      : hpx::threads::detail::thread_data_reference_counting
+    {
+        explicit test_thread_data(hpx::threads::thread_id_addref const addref =
+                                      hpx::threads::thread_id_addref::yes)
+          : hpx::threads::detail::thread_data_reference_counting(addref)
+        {
+        }
+
+        void destroy_thread() override
+        {
+            destroyed = true;
+        }
+
+        [[nodiscard]] long use_count() const noexcept
+        {
+            return count_;
+        }
+
+        bool destroyed = false;
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
+    // hpx::threads::thread_id_ref(thread_id&&, bool add_ref = true)
+    void test_thread_id_ref_move_from_thread_id_default_add_ref()
+    {
+        test_thread_data data;    // starts with a use count of 1
+        HPX_TEST_EQ(data.use_count(), 1L);
+
+        {
+            hpx::threads::thread_id tid(&data);
+            HPX_TEST(tid);
+
+            // default add_ref == true increments the reference count
+            hpx::threads::thread_id_ref const ref(HPX_MOVE(tid));
+            // NOLINTNEXTLINE(bugprone-use-after-move)
+            HPX_TEST(!tid);    // moved-from thread_id was reset
+            HPX_TEST(ref);
+            HPX_TEST_EQ(data.use_count(), 2L);
+        }
+
+        // leaving scope releases the extra reference again
+        HPX_TEST_EQ(data.use_count(), 1L);
+        HPX_TEST(!data.destroyed);
+    }
+
+    void test_thread_id_ref_move_from_thread_id_no_add_ref()
+    {
+        test_thread_data data;    // starts with a use count of 1
+        HPX_TEST_EQ(data.use_count(), 1L);
+
+        {
+            hpx::threads::thread_id tid(&data);
+
+            // add_ref == false does not touch the reference count on
+            // construction...
+            hpx::threads::thread_id_ref const ref(HPX_MOVE(tid), false);
+            HPX_TEST(ref);
+            HPX_TEST_EQ(data.use_count(), 1L);
+        }
+
+        // ...but a plain thread_id_ref unconditionally releases on destruction,
+        // which (as it never added a reference) now under-counts and triggers
+        // destruction. This demonstrates why keep_alive_thread_id (tested below)
+        // needs special handling for the add_ref == false case.
+        HPX_TEST_EQ(data.use_count(), 0L);
+        HPX_TEST(data.destroyed);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // hpx::threads::keep_alive_thread_id
+    void test_keep_alive_thread_id_with_add_ref()
+    {
+        test_thread_data
+            data;    // simulate an already-alive object, use count 1
+        HPX_TEST_EQ(data.use_count(), 1L);
+
+        {
+            hpx::threads::thread_id tid(&data);
+            hpx::threads::keep_alive_thread_id const kept(HPX_MOVE(tid), true);
+
+            HPX_TEST(kept.add_ref);
+            HPX_TEST(kept.id);
+            HPX_TEST_EQ(data.use_count(), 2L);
+        }
+
+        // the temporary extra reference is released again, count returns to the
+        // original value; the object must not have been destroyed
+        HPX_TEST_EQ(data.use_count(), 1L);
+        HPX_TEST(!data.destroyed);
+    }
+
+    void test_keep_alive_thread_id_without_add_ref()
+    {
+        test_thread_data data;    // simulate an object already kept alive
+        // elsewhere (e.g. by the scheduler), use count 1
+        HPX_TEST_EQ(data.use_count(), 1L);
+
+        {
+            hpx::threads::thread_id tid(&data);
+            hpx::threads::keep_alive_thread_id const kept(HPX_MOVE(tid), false);
+
+            HPX_TEST(!kept.add_ref);
+            HPX_TEST(kept.id);
+
+            // constructing with add_ref == false must not increment the count
+            HPX_TEST_EQ(data.use_count(), 1L);
+        }
+
+        // destroying the keep_alive_thread_id must not decrement the count either
+        // (it detaches the underlying pointer instead of releasing it), so the
+        // object must still be alive with an unchanged reference count
+        HPX_TEST_EQ(data.use_count(), 1L);
+        HPX_TEST(!data.destroyed);
+    }
+
+    void test_keep_alive_thread_id_move_construction()
+    {
+        test_thread_data data;
+        HPX_TEST_EQ(data.use_count(), 1L);
+
+        hpx::threads::thread_id tid(&data);
+        hpx::threads::keep_alive_thread_id kept1(HPX_MOVE(tid), true);
+        HPX_TEST_EQ(data.use_count(), 2L);
+
+        hpx::threads::keep_alive_thread_id const kept2(HPX_MOVE(kept1));
+
+        // moving must not change the observed reference count
+        HPX_TEST_EQ(data.use_count(), 2L);
+
+        // NOLINTNEXTLINE(bugprone-use-after-move)
+        HPX_TEST(!kept1.id);    // moved-from thread_id_ref is now empty
+        HPX_TEST(kept2.id);
+        HPX_TEST(kept2.add_ref);
+
+        // kept1 (moved-from, holds no reference) destructs first without effect,
+        // then kept2 releases the single held reference
+        {
+            [[maybe_unused]] auto discard = HPX_MOVE(kept1);
+        }
+        HPX_TEST_EQ(data.use_count(), 2L);
+    }
+
+    void test_keep_alive_thread_id_move_assignment()
+    {
+        test_thread_data data;
+        HPX_TEST_EQ(data.use_count(), 1L);
+
+        hpx::threads::thread_id tid(&data);
+        hpx::threads::keep_alive_thread_id kept1(HPX_MOVE(tid), false);
+        HPX_TEST_EQ(data.use_count(), 1L);
+
+        hpx::threads::keep_alive_thread_id kept2(
+            hpx::threads::thread_id(), true);
+        HPX_TEST(!kept2.id);
+
+        kept2 = HPX_MOVE(kept1);
+
+        HPX_TEST(!kept2.add_ref);
+        HPX_TEST(kept2.id);
+        HPX_TEST_EQ(data.use_count(), 1L);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    void test_keep_alive_thread_id_is_move_only()
+    {
+        static_assert(
+            !std::is_copy_constructible_v<hpx::threads::keep_alive_thread_id>,
+            "keep_alive_thread_id must not be copy constructible");
+        static_assert(
+            !std::is_copy_assignable_v<hpx::threads::keep_alive_thread_id>,
+            "keep_alive_thread_id must not be copy assignable");
+        static_assert(
+            std::is_move_constructible_v<hpx::threads::keep_alive_thread_id>,
+            "keep_alive_thread_id must be move constructible");
+        static_assert(
+            std::is_move_assignable_v<hpx::threads::keep_alive_thread_id>,
+            "keep_alive_thread_id must be move assignable");
+
+        HPX_TEST(true);
+    }
+}    // namespace
+
+int main()
+{
+    test_thread_id_ref_move_from_thread_id_default_add_ref();
+    test_thread_id_ref_move_from_thread_id_no_add_ref();
+
+    test_keep_alive_thread_id_with_add_ref();
+    test_keep_alive_thread_id_without_add_ref();
+    test_keep_alive_thread_id_move_construction();
+    test_keep_alive_thread_id_move_assignment();
+    test_keep_alive_thread_id_is_move_only();
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/execution/include/hpx/execution/detail/async_launch_policy_dispatch.hpp
+++ b/libs/core/execution/include/hpx/execution/detail/async_launch_policy_dispatch.hpp
@@ -136,6 +136,43 @@ namespace hpx::detail {
     };
 
     template <>
+    struct async_launch_policy_dispatch<hpx::launch::task_policy>
+    {
+        template <typename Policy, typename F, typename... Ts>
+        HPX_FORCEINLINE static std::enable_if_t<
+            traits::detail::is_deferred_invocable_v<F, Ts...>,
+            hpx::future<util::detail::invoke_deferred_result_t<F, Ts...>>>
+        call(Policy policy, hpx::threads::thread_description const& desc,
+            threads::thread_pool_base* pool, F&& f, Ts&&... ts)
+        {
+            HPX_ASSERT(pool);
+
+            using result_type =
+                util::detail::invoke_deferred_result_t<F, Ts...>;
+
+            // explicitly disable inline execution for this launch policy
+            auto hint = policy.hint();
+            hint.runs_as_child_mode(hpx::threads::thread_execution_hint::none);
+            policy.set_hint(hint);
+
+            lcos::local::futures_factory<result_type()> p(
+                util::deferred_call(HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...));
+
+            if (threads::thread_id_ref_type tid =
+                    p.post(pool, desc.get_description(), HPX_MOVE(policy)))
+            {
+                // keep thread alive, if needed
+                auto result = p.get_future();
+                traits::detail::get_shared_state(result)->set_on_completed(
+                    [tid = HPX_MOVE(tid)]() { (void) tid; });
+                return result;
+            }
+
+            return p.get_future();
+        }
+    };
+
+    template <>
     struct async_launch_policy_dispatch<hpx::launch::async_policy>
     {
         template <typename Policy, typename F, typename... Ts>
@@ -317,10 +354,17 @@ namespace hpx::detail {
         call(launch policy, hpx::threads::thread_description const& desc,
             threads::thread_pool_base* pool, F&& f, Ts&&... ts)
         {
+            // launch::async is the default launch policy, check first
             if (policy == launch::async)
             {
                 return async_launch_policy_dispatch<
                     hpx::launch::async_policy>::call(HPX_MOVE(policy), desc,
+                    pool, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
+            }
+            if (policy == launch::task)
+            {
+                return async_launch_policy_dispatch<
+                    hpx::launch::task_policy>::call(HPX_MOVE(policy), desc,
                     pool, HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
             }
             if (policy == launch::sync)

--- a/libs/core/executors/include/hpx/executors/async.hpp
+++ b/libs/core/executors/include/hpx/executors/async.hpp
@@ -60,7 +60,8 @@ namespace hpx::detail {
     };
 
     // Launch the given function or function object asynchronously and return a
-    // future allowing to synchronize with the returned result.
+    // future allowing to synchronize with the returned result. Enable inline
+    // execution by default (uses launch::async).
     HPX_CXX_CORE_EXPORT template <typename Func, typename Enable>
     struct async_dispatch
     {

--- a/libs/core/thread_pools/CMakeLists.txt
+++ b/libs/core/thread_pools/CMakeLists.txt
@@ -36,6 +36,8 @@ add_hpx_module(
   SOURCES ${thread_pools_sources}
   HEADERS ${thread_pools_headers}
   COMPAT_HEADERS ${thread_pools_compat_headers}
+  ADD_TO_GLOBAL_HEADER "hpx/thread_pools/detail/scheduling_callbacks.hpp"
+                       "hpx/thread_pools/detail/background_thread.hpp"
   MODULE_DEPENDENCIES
     hpx_affinity
     hpx_assertion

--- a/libs/core/thread_pools/include/hpx/thread_pools/detail/background_thread.hpp
+++ b/libs/core/thread_pools/include/hpx/thread_pools/detail/background_thread.hpp
@@ -43,7 +43,8 @@ namespace hpx::threads::detail {
 
     ///////////////////////////////////////////////////////////////////////////
     // Create a new background thread
-    HPX_CORE_EXPORT thread_id_ref_type create_background_thread(
+    HPX_CORE_EXPORT void create_background_thread(
+        thread_id_ref_type& background_thread,
         threads::policies::scheduler_base& scheduler_base,
         std::size_t num_thread, scheduling_callbacks const& callbacks,
         std::shared_ptr<bool>& background_running,

--- a/libs/core/thread_pools/include/hpx/thread_pools/detail/background_thread.hpp
+++ b/libs/core/thread_pools/include/hpx/thread_pools/detail/background_thread.hpp
@@ -43,7 +43,7 @@ namespace hpx::threads::detail {
 
     ///////////////////////////////////////////////////////////////////////////
     // Create a new background thread
-    HPX_CORE_EXPORT void create_background_thread(
+    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT void create_background_thread(
         thread_id_ref_type& background_thread,
         threads::policies::scheduler_base& scheduler_base,
         std::size_t num_thread, scheduling_callbacks const& callbacks,

--- a/libs/core/thread_pools/include/hpx/thread_pools/detail/scheduling_callbacks.hpp
+++ b/libs/core/thread_pools/include/hpx/thread_pools/detail/scheduling_callbacks.hpp
@@ -16,7 +16,7 @@
 
 namespace hpx::threads::detail {
 
-    struct scheduling_callbacks
+    HPX_CXX_CORE_EXPORT struct scheduling_callbacks
     {
         using outer_callback_type = hpx::move_only_function<bool()>;
         using callback_type = hpx::move_only_function<void()>;

--- a/libs/core/thread_pools/include/hpx/thread_pools/scheduling_loop.hpp
+++ b/libs/core/thread_pools/include/hpx/thread_pools/scheduling_loop.hpp
@@ -109,7 +109,7 @@ namespace hpx::threads::detail {
         if (do_background_work)
         {
             // do background work in parcel layer and in agas
-            create_background_thread(background_thread , scheduler, num_thread,
+            create_background_thread(background_thread, scheduler, num_thread,
                 params, background_running, idle_loop_count);
         }
 

--- a/libs/core/thread_pools/include/hpx/thread_pools/scheduling_loop.hpp
+++ b/libs/core/thread_pools/include/hpx/thread_pools/scheduling_loop.hpp
@@ -109,7 +109,7 @@ namespace hpx::threads::detail {
         if (do_background_work)
         {
             // do background work in parcel layer and in agas
-            background_thread = create_background_thread(scheduler, num_thread,
+            create_background_thread(background_thread , scheduler, num_thread,
                 params, background_running, idle_loop_count);
         }
 

--- a/libs/core/thread_pools/src/detail/background_thread.cpp
+++ b/libs/core/thread_pools/src/detail/background_thread.cpp
@@ -38,7 +38,7 @@ namespace hpx::threads::detail {
                 // Assigning keep_alive = background_thread; as the very first
                 // statement ensures the background thread holds a
                 // self-reference before the external background_thread handle
-                // can be reassigned in call_and_create_background_thread, 
+                // can be reassigned in call_and_create_background_thread,
                 // preventing premature teardown of a "given back to scheduler"
                 // thread.
                 keep_alive = background_thread;

--- a/libs/core/thread_pools/src/detail/background_thread.cpp
+++ b/libs/core/thread_pools/src/detail/background_thread.cpp
@@ -21,7 +21,7 @@
 namespace hpx::threads::detail {
 
     ///////////////////////////////////////////////////////////////////////////
-    thread_id_ref_type create_background_thread(
+    void create_background_thread(thread_id_ref_type& background_thread,
         threads::policies::scheduler_base& scheduler_base,
         std::size_t const num_thread, scheduling_callbacks const& callbacks,
         std::shared_ptr<bool>& background_running,
@@ -30,12 +30,18 @@ namespace hpx::threads::detail {
         threads::thread_schedule_hint const schedulehint(
             static_cast<std::int16_t>(num_thread));
 
-        thread_id_ref_type background_thread;
         background_running = std::make_shared<bool>(true);
 
         thread_init_data background_init(
-            [&, background_running](
-                thread_restart_state) -> thread_result_type {
+            [&, background_running, keep_alive = thread_id_ref_type()](
+                thread_restart_state) mutable -> thread_result_type {
+                // Assigning keep_alive = background_thread; as the very first
+                // statement ensures the background thread holds a
+                // self-reference before the external background_thread handle
+                // can be reassigned in call_and_create_background_thread, 
+                // preventing premature teardown of a "given back to scheduler"
+                // thread.
+                keep_alive = background_thread;
                 while (*background_running)
                 {
                     if (callbacks.background_())
@@ -58,26 +64,27 @@ namespace hpx::threads::detail {
             hpx::threads::thread_description("background_work"),
             thread_priority::high_recursive, schedulehint,
             thread_stacksize::large,
-            // Create in suspended to prevent the thread from being scheduled
-            // directly...
+            // Create in suspended state to prevent the thread from being
+            // scheduled directly...
             thread_schedule_state::suspended, true, &scheduler_base);
 
         scheduler_base.create_thread(
             background_init, &background_thread, hpx::throws);
         HPX_ASSERT(background_thread);
 
+        auto* thread_ptr = get_thread_id_data(background_thread);
+        thread_ptr->set_is_background();
+
         scheduler_base.increment_background_thread_count();
 
         LTM_(debug).format("create_background_thread: pool({}), "
                            "scheduler({}), worker_thread({}), thread({})",
             scheduler_base.get_parent_pool(), scheduler_base, num_thread,
-            get_thread_id_data(background_thread));
+            thread_ptr);
 
         // We can now set the state to pending
         [[maybe_unused]] auto old_state =
-            get_thread_id_data(background_thread)
-                ->set_state(thread_schedule_state::pending);
-        return background_thread;
+            thread_ptr->set_state(thread_schedule_state::pending);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -306,7 +313,7 @@ namespace hpx::threads::detail {
 
             // Create a new one that will replace the current such we avoid
             // deadlock situations, if all background threads are blocked.
-            background_thread = create_background_thread(scheduler_base,
+            create_background_thread(background_thread, scheduler_base,
                 num_thread, callbacks, running, idle_loop_count);
 
             return true;

--- a/libs/core/thread_pools/tests/unit/CMakeLists.txt
+++ b/libs/core/thread_pools/tests/unit/CMakeLists.txt
@@ -1,5 +1,23 @@
-# Copyright (c) 2019 The STE||AR-Group
+# Copyright (c) 2026 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(tests create_background_thread)
+
+foreach(test ${tests})
+  set(sources ${test}.cpp)
+
+  source_group("Source Files" FILES ${sources})
+
+  add_hpx_executable(
+    ${test}_test INTERNAL_FLAGS
+    SOURCES ${sources} ${${test}_FLAGS}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Unit/Modules/Core/ThreadPools"
+  )
+
+  add_hpx_unit_test("modules.thread_pools" ${test} ${${test}_PARAMETERS})
+endforeach()

--- a/libs/core/thread_pools/tests/unit/create_background_thread.cpp
+++ b/libs/core/thread_pools/tests/unit/create_background_thread.cpp
@@ -1,0 +1,82 @@
+//  Copyright (c) 2026 The STE||AR-Group
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// This test verifies that hpx::threads::detail::create_background_thread()
+// correctly flags the newly created thread as a background thread (see
+// thread_data::is_background()/set_is_background()).
+
+#include <hpx/init.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/modules/thread_pools.hpp>
+#include <hpx/modules/threading_base.hpp>
+
+#include <atomic>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+namespace {
+
+    void test_create_background_thread_sets_is_background()
+    {
+        using namespace hpx::threads;
+
+        auto* scheduler =
+            hpx::threads::get_self_id_data()->get_scheduler_base();
+        HPX_TEST(scheduler != nullptr);
+
+        std::int64_t const initial_count =
+            scheduler->get_background_thread_count();
+
+        hpx::threads::detail::scheduling_callbacks callbacks(
+            []() -> bool { return false; },    // outer
+            []() {},                           // inner
+            []() -> bool { return true; }      // background
+        );
+
+        std::shared_ptr<bool> running;
+        std::int64_t idle_loop_count = 0;
+
+        thread_id_ref_type background_thread;
+        hpx::threads::detail::create_background_thread(background_thread,
+            *scheduler, 0, callbacks, running, idle_loop_count);
+
+        HPX_TEST(background_thread);
+        HPX_TEST(running);
+        HPX_TEST(*running);
+
+        // the newly created thread must be flagged as a background thread
+        auto* thrd_data = get_thread_id_data(background_thread);
+        HPX_TEST(thrd_data != nullptr);
+        HPX_TEST(thrd_data->is_background());
+
+        // the scheduler's background thread count must have been incremented
+        HPX_TEST_EQ(
+            scheduler->get_background_thread_count(), initial_count + 1);
+
+        // let the background work item terminate itself as quickly as possible
+        // instead of looping indefinitely for the remainder of the test run
+        *running = false;
+
+        // forcefully reset the background thread
+        hpx::threads::thread_init_data data;
+        data.scheduler_base = thrd_data->get_scheduler_base();
+        thrd_data->rebind(data);
+    }
+}    // namespace
+
+int hpx_main()
+{
+    test_create_background_thread_sets_is_background();
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    hpx::local::init(hpx_main, argc, argv);
+    return hpx::util::report_errors();
+}

--- a/libs/core/threading_base/include/hpx/threading_base/thread_data.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_data.hpp
@@ -142,7 +142,7 @@ namespace hpx::threads {
 
         bool set_state_tagged(thread_schedule_state const newstate,
             thread_state const& prev_state, thread_state& new_tagged_state,
-            std::memory_order exchange_order =
+            std::memory_order const exchange_order =
                 std::memory_order_acq_rel) const noexcept
         {
             new_tagged_state = thread_state(
@@ -198,7 +198,7 @@ namespace hpx::threads {
                 old_tmp, new_tmp, load_exchange);
         }
 
-        bool restore_state(thread_schedule_state new_state,
+        bool restore_state(thread_schedule_state const new_state,
             thread_restart_state const state_ex, thread_state old_state,
             std::memory_order const load_exchange =
                 std::memory_order_acq_rel) const noexcept
@@ -425,9 +425,18 @@ namespace hpx::threads {
         {
             return priority_;
         }
-        void set_priority(thread_priority priority) noexcept
+        void set_priority(thread_priority const priority) noexcept
         {
             priority_ = priority;
+        }
+
+        constexpr bool is_background() const noexcept
+        {
+            return is_background_;
+        }
+        void set_is_background() noexcept
+        {
+            is_background_ = true;
         }
 
         // handle thread interruption
@@ -471,8 +480,8 @@ namespace hpx::threads {
 
         // no need to protect the variables related to scoped children as those
         // are supposed to be accessed by ourselves only
-        bool runs_as_child(
-            std::memory_order mo = std::memory_order_acquire) const noexcept
+        bool runs_as_child(std::memory_order const mo =
+                               std::memory_order_acquire) const noexcept
         {
             return runs_as_child_.load(mo);
         }
@@ -495,7 +504,7 @@ namespace hpx::threads {
         }
 
         void set_last_worker_thread_num(
-            std::uint16_t last_worker_thread_num) noexcept
+            std::uint16_t const last_worker_thread_num) noexcept
         {
             last_worker_thread_num_ = last_worker_thread_num;
         }
@@ -596,6 +605,7 @@ namespace hpx::threads {
         bool const is_stackless_;
         bool running_exit_funcs_;
         bool ran_exit_funcs_;
+        bool is_background_;
 
         // support scoped child execution
         std::atomic<bool> runs_as_child_;
@@ -655,14 +665,14 @@ namespace hpx::threads {
     }
 
 #if defined(HPX_HAVE_TRACY)
-    // tracy support
+    // tracy implementation
     HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT tracing::region_init_data
     get_region_init_data(thread_data const* thrdptr);
 
     HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT tracing::fiber_region_init_data
     get_fiber_region_init_data(thread_data const* thrdptr);
 #elif defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0
-    // ITTNotify support
+    // ITTNotify implementation
     HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT tracing::region_init_data
     get_region_init_data(thread_data const* thrdptr);
 

--- a/libs/core/threading_base/src/execution_agent.cpp
+++ b/libs/core/threading_base/src/execution_agent.cpp
@@ -65,7 +65,7 @@ namespace hpx::threads {
         do_yield(desc, hpx::threads::thread_schedule_state::pending);
     }
 
-    bool execution_agent::yield_k(std::size_t k, char const* desc)
+    bool execution_agent::yield_k(std::size_t const k, char const* desc)
     {
         if (k < 4)    //-V112
         {
@@ -91,7 +91,7 @@ namespace hpx::threads {
     }
 
     void execution_agent::resume(
-        hpx::threads::thread_priority priority, char const* desc)
+        hpx::threads::thread_priority const priority, char const* desc)
     {
         do_resume(priority, desc, threads::thread_restart_state::signaled);
     }
@@ -155,7 +155,7 @@ namespace hpx::threads {
     hpx::threads::thread_restart_state execution_agent::do_yield(
         char const* desc, threads::thread_schedule_state state)
     {
-        thread_id_ref_type id = self_.get_thread_id();    // keep alive
+        thread_id_type id = self_.get_outer_thread_id();
         if (HPX_UNLIKELY(!id))
         {
             HPX_THROW_EXCEPTION(hpx::error::null_thread_id,
@@ -176,6 +176,11 @@ namespace hpx::threads {
 
         thrd_data->interruption_point();
 
+        // keep the thread alive if it's not a background thread (background
+        // threads are being kept alive by the scheduler)
+        hpx::threads::keep_alive_thread_id kept_alive(
+            id, !thrd_data->is_background());
+
         if (thrd_data->get_priority() == thread_priority::bound)
         {
             auto const num_thread = hpx::get_local_worker_thread_num();
@@ -188,7 +193,7 @@ namespace hpx::threads {
         {
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)
             [[maybe_unused]] threads::detail::reset_lco_description reset_desc(
-                id.noref(), threads::thread_description(desc));
+                id, threads::thread_description(desc));
 #endif
 #if defined(HPX_HAVE_THREAD_BACKTRACE_ON_SUSPENSION)
             [[maybe_unused]] threads::detail::reset_backtrace reset_bt(id);
@@ -206,9 +211,9 @@ namespace hpx::threads {
             // (current_fiber_zone). It does NOT touch the OS-thread zone
             // (current_region / stop_region), so there is no zone-stack
             // conflict. The sequence is:
-            //   constructor: close running zone \u2192 open grey "suspended" zone
+            //   constructor: close running zone -> open grey "suspended" zone
             //   self_.yield(): fiber parks, scheduler picks next task
-            //   destructor:  close "suspended" zone \u2192 reopen running zone
+            //   destructor:  close "suspended" zone -> reopen running zone
             hpx::tracing::fiber_suspend_region tracy_suspend(desc);
 
             HPX_ASSERT(thrd_data != nullptr &&
@@ -239,8 +244,9 @@ namespace hpx::threads {
         return statex;
     }
 
-    void execution_agent::do_resume(hpx::threads::thread_priority priority,
-        char const* /* desc */, hpx::threads::thread_restart_state statex) const
+    void execution_agent::do_resume(
+        hpx::threads::thread_priority const priority, char const* /* desc */,
+        hpx::threads::thread_restart_state const statex) const
     {
         threads::detail::set_thread_state(self_.get_thread_id(),
             thread_schedule_state::pending, statex, priority,

--- a/libs/core/threading_base/src/thread_data.cpp
+++ b/libs/core/threading_base/src/thread_data.cpp
@@ -65,6 +65,7 @@ namespace hpx::threads {
       , is_stackless_(is_stackless)
       , running_exit_funcs_(false)
       , ran_exit_funcs_(false)
+      , is_background_(false)
       , runs_as_child_(init_data.schedulehint.runs_as_child_mode() ==
             hpx::threads::thread_execution_hint::run_as_child)
       , last_worker_thread_num_(
@@ -249,6 +250,7 @@ namespace hpx::threads {
         enabled_interrupt_ = true;
         running_exit_funcs_ = false;
         ran_exit_funcs_ = false;
+        is_background_ = false;
 
         runs_as_child_.store(init_data.schedulehint.runs_as_child_mode() ==
                 hpx::threads::thread_execution_hint::run_as_child,

--- a/libs/core/threading_base/src/thread_helpers.cpp
+++ b/libs/core/threading_base/src/thread_helpers.cpp
@@ -455,13 +455,38 @@ namespace hpx::this_thread {
         // let the thread manager do other things while waiting
         threads::thread_self& self = threads::get_self();
 
-        // keep alive
-        threads::thread_id_ref_type id = self.get_outer_thread_id();
+        threads::thread_id_type id = self.get_outer_thread_id();
+        if (HPX_UNLIKELY(!id))
+        {
+            HPX_THROWS_IF(ec, hpx::error::yield_aborted, "suspend",
+                "thread({}, {}) aborted (invalid thread data)", id,
+                threads::get_thread_description(id));
+            return threads::thread_restart_state::unknown;
+        }
+
+        auto const* thrd_data = get_thread_id_data(id);
+        if (HPX_UNLIKELY(thrd_data == nullptr))
+        {
+            HPX_THROWS_IF(ec, hpx::error::yield_aborted, "suspend",
+                "thread({}, {}) aborted (invalid thread data)", id,
+                threads::get_thread_description(id));
+            return threads::thread_restart_state::unknown;
+        }
+
+        // keep the thread alive if it's not a background thread (background
+        // thread are being kept alive by the scheduler)
+        hpx::threads::keep_alive_thread_id kept_alive(
+            id, !thrd_data->is_background());
 
         // handle interruption, if needed
-        threads::interruption_point(id.noref(), ec);
+        threads::interruption_point(id, ec);
         if (ec)
+        {
+            HPX_THROWS_IF(ec, hpx::error::yield_aborted, "suspend",
+                "thread({}, {}) aborted (interrupt failed)", id,
+                threads::get_thread_description(id));
             return threads::thread_restart_state::unknown;
+        }
 
         threads::thread_restart_state statex;
 
@@ -476,8 +501,7 @@ namespace hpx::this_thread {
                 });
 #endif
 #ifdef HPX_HAVE_THREAD_DESCRIPTION
-            threads::detail::reset_lco_description desc(
-                id.noref(), description, ec);
+            threads::detail::reset_lco_description desc(id, description, ec);
 #endif
 #ifdef HPX_HAVE_THREAD_BACKTRACE_ON_SUSPENSION
             threads::detail::reset_backtrace bt(id, ec);
@@ -487,11 +511,12 @@ namespace hpx::this_thread {
 #endif
             hpx::tracing::fiber_suspend_region tracy_suspend(
                 get_suspend_reason(description));
+
             // We might need to dispatch 'nextid' to it's correct scheduler only
             // if our current scheduler is the same, we should yield to the id
             if (nextid &&
                 get_thread_id_data(nextid)->get_scheduler_base() !=
-                    get_thread_id_data(id)->get_scheduler_base())
+                    thrd_data->get_scheduler_base())
             {
                 auto* scheduler =
                     get_thread_id_data(nextid)->get_scheduler_base();
@@ -509,16 +534,21 @@ namespace hpx::this_thread {
         }
 
         // handle interruption, if needed
-        threads::interruption_point(id.noref(), ec);
+        threads::interruption_point(id, ec);
         if (ec)
+        {
+            HPX_THROWS_IF(ec, hpx::error::yield_aborted, "suspend",
+                "thread({}, {}) aborted (interrupt failed)", id,
+                threads::get_thread_description(id));
             return threads::thread_restart_state::unknown;
+        }
 
         // handle interrupt and abort
         if (statex == threads::thread_restart_state::abort)
         {
             HPX_THROWS_IF(ec, hpx::error::yield_aborted, "suspend",
-                "thread({}, {}) aborted (yield returned wait_abort)",
-                id.noref(), threads::get_thread_description(id.noref()));
+                "thread({}, {}) aborted (yield returned wait_abort)", id,
+                threads::get_thread_description(id));
         }
 
         if (&ec != &throws)
@@ -537,12 +567,38 @@ namespace hpx::this_thread {
         threads::thread_self& self = threads::get_self();
 
         // keep alive
-        threads::thread_id_ref_type id = self.get_outer_thread_id();
+        threads::thread_id_type id = self.get_outer_thread_id();
+        if (HPX_UNLIKELY(!id))
+        {
+            HPX_THROWS_IF(ec, hpx::error::yield_aborted, "suspend",
+                "thread({}, {}) aborted (invalid thread data)", id,
+                threads::get_thread_description(id));
+            return threads::thread_restart_state::unknown;
+        }
+
+        auto const* thrd_data = get_thread_id_data(id);
+        if (HPX_UNLIKELY(thrd_data == nullptr))
+        {
+            HPX_THROWS_IF(ec, hpx::error::yield_aborted, "suspend",
+                "thread({}, {}) aborted (invalid thread data)", id,
+                threads::get_thread_description(id));
+            return threads::thread_restart_state::unknown;
+        }
+
+        // keep the thread alive if it's not a background thread (background
+        // thread are being kept alive by the scheduler)
+        hpx::threads::keep_alive_thread_id kept_alive(
+            id, !thrd_data->is_background());
 
         // handle interruption, if needed
-        threads::interruption_point(id.noref(), ec);
+        threads::interruption_point(id, ec);
         if (ec)
+        {
+            HPX_THROWS_IF(ec, hpx::error::yield_aborted, "suspend",
+                "thread({}, {}) aborted (interrupt failed)", id,
+                threads::get_thread_description(id));
             return threads::thread_restart_state::unknown;
+        }
 
         // let the thread manager do other things while waiting
         threads::thread_restart_state statex;
@@ -558,8 +614,7 @@ namespace hpx::this_thread {
                 });
 #endif
 #ifdef HPX_HAVE_THREAD_DESCRIPTION
-            threads::detail::reset_lco_description desc(
-                id.noref(), description, ec);
+            threads::detail::reset_lco_description desc(id, description, ec);
 #endif
 #ifdef HPX_HAVE_THREAD_BACKTRACE_ON_SUSPENSION
             threads::detail::reset_backtrace bt(id, ec);
@@ -569,9 +624,10 @@ namespace hpx::this_thread {
 #endif
             hpx::tracing::fiber_suspend_region tracy_suspend(
                 get_suspend_reason(description));
+
             std::atomic<bool> timer_started(false);
             threads::thread_id_ref_type const timer_id =
-                threads::set_thread_state(id.noref(), abs_time, &timer_started,
+                threads::set_thread_state(id, abs_time, &timer_started,
                     threads::thread_schedule_state::pending,
                     threads::thread_restart_state::timeout,
                     threads::thread_priority::boost, true, ec);
@@ -582,7 +638,7 @@ namespace hpx::this_thread {
             // if our current scheduler is the same, we should yield to the id
             if (nextid &&
                 get_thread_id_data(nextid)->get_scheduler_base() !=
-                    get_thread_id_data(id)->get_scheduler_base())
+                    thrd_data->get_scheduler_base())
             {
                 auto* scheduler =
                     get_thread_id_data(nextid)->get_scheduler_base();
@@ -617,16 +673,21 @@ namespace hpx::this_thread {
         }
 
         // handle interruption, if needed
-        threads::interruption_point(id.noref(), ec);
+        threads::interruption_point(id, ec);
         if (ec)
+        {
+            HPX_THROWS_IF(ec, hpx::error::yield_aborted, "suspend",
+                "thread({}, {}) aborted (interrupt failed)", id,
+                threads::get_thread_description(id));
             return threads::thread_restart_state::unknown;
+        }
 
         // handle interrupt and abort
         if (statex == threads::thread_restart_state::abort)
         {
             HPX_THROWS_IF(ec, hpx::error::yield_aborted, "suspend_at",
-                "thread({}, {}) aborted (yield returned wait_abort)",
-                id.noref(), threads::get_thread_description(id.noref()));
+                "thread({}, {}) aborted (yield returned wait_abort)", id,
+                threads::get_thread_description(id));
         }
 
         if (&ec != &throws)

--- a/libs/core/threading_base/tests/unit/CMakeLists.txt
+++ b/libs/core/threading_base/tests/unit/CMakeLists.txt
@@ -1,10 +1,11 @@
 # Copyright (c) 2011 Bryce Adelstein-Lelbach
+# Copyright (c) 2026 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(tests set_thread_affinity thread_exit_callbacks)
+set(tests set_thread_affinity thread_exit_callbacks thread_data_is_background)
 
 foreach(test ${tests})
   set(sources ${test}.cpp)

--- a/libs/core/threading_base/tests/unit/thread_data_is_background.cpp
+++ b/libs/core/threading_base/tests/unit/thread_data_is_background.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2026 The STE||AR-Group
+//  Copyright (c) 2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -28,6 +28,77 @@
 namespace {
 
     ///////////////////////////////////////////////////////////////////////////
+    // Minimal thread_data subclass that can be constructed directly (i.e.
+    // without going through a scheduler) and that exposes the protected
+    // rebind_base() through its rebind() override. This allows testing the
+    // rebind-resets-is_background behavior deterministically, without depending
+    // on the thread_data allocator ever reusing an address.
+    class testable_thread_data : public hpx::threads::thread_data
+    {
+    public:
+        explicit testable_thread_data(hpx::threads::thread_init_data& init_data)
+          : hpx::threads::thread_data(init_data, nullptr, 0, true)
+        {
+        }
+
+        std::size_t get_thread_data() const override
+        {
+            return 0;
+        }
+
+        std::size_t set_thread_data(std::size_t) override
+        {
+            return 0;
+        }
+
+#if defined(HPX_HAVE_THREAD_PHASE_INFORMATION)
+        std::size_t get_thread_phase() const noexcept override
+        {
+            return 0;
+        }
+#endif
+
+#if defined(HPX_HAVE_LIBCDS)
+        std::size_t get_libcds_data() const override
+        {
+            return 0;
+        }
+        std::size_t set_libcds_data(std::size_t data) override
+        {
+            return data;
+        }
+        std::size_t get_libcds_hazard_pointer_data() const override
+        {
+            return 0;
+        }
+        std::size_t set_libcds_hazard_pointer_data(std::size_t data) override
+        {
+            return data;
+        }
+        std::size_t get_libcds_dynamic_hazard_pointer_data() const override
+        {
+            return 0;
+        }
+        std::size_t set_libcds_dynamic_hazard_pointer_data(
+            std::size_t data) override
+        {
+            return data;
+        }
+#endif
+
+        void init() override {}
+
+        void rebind(hpx::threads::thread_init_data& init_data) override
+        {
+            // exercise the actual behavior under test directly, without
+            // requiring a coroutine to have run to completion
+            this->thread_data::rebind_base(init_data);
+        }
+
+        void destroy() noexcept override {}
+    };
+
+    ///////////////////////////////////////////////////////////////////////////
     void test_is_background_default_false()
     {
         hpx::async([]() {
@@ -52,18 +123,7 @@ namespace {
         }).get();
     }
 
-    // Return thread_data pointer to the running thread itself, even if it is
-    // executed inline in the context of an outer parent thread.
-    hpx::threads::thread_data* get_self_inner_id_data() noexcept
-    {
-        if (auto const* self = hpx::threads::get_self_ptr();
-            HPX_LIKELY(nullptr != self))
-        {
-            return hpx::threads::get_thread_id_data(self->get_thread_id());
-        }
-        return nullptr;
-    }
-
+    ///////////////////////////////////////////////////////////////////////////
     // A newly (re-)initialized thread must not carry over the is_background
     // flag from a previous use of the same thread_data instance (see
     // thread_data::rebind_base resetting is_background_ to false). Since
@@ -72,7 +132,7 @@ namespace {
     // keep creating threads (alternating whether is_background is set) until a
     // reused address is actually observed, capped at max_iterations to avoid
     // looping forever if reuse never happens.
-    void test_is_background_reset_on_rebind()
+    void test_is_background_reset_on_rebind_probabilistic()
     {
         constexpr int max_iterations = 10000;
 
@@ -85,9 +145,9 @@ namespace {
         {
             bool const mark_background = (i % 2) == 0;
 
-            hpx::async([&previous_data, &observed_reuse, &mtx,
-                           mark_background]() {
-                auto* data = get_self_inner_id_data();
+            // explicitly disable inline execution (launch::task)
+            hpx::async(hpx::launch::task, [&, mark_background]() {
+                auto* data = hpx::threads::get_self_id_data();
                 HPX_TEST(data != nullptr);
 
                 {
@@ -95,9 +155,10 @@ namespace {
 
                     if (previous_data.contains(data))
                     {
-                        // this thread_data instance's storage has been reused;
-                        // its is_background flag must have been reset to its
-                        // default value (false) by thread_data::rebind_base
+                        // this thread_data instance's storage has been
+                        // reused; its is_background flag must have been
+                        // reset to its default value (false) by
+                        // thread_data::rebind_base
                         HPX_TEST(!data->is_background());
                         observed_reuse = true;
                     }
@@ -118,6 +179,29 @@ namespace {
     }
 
     ///////////////////////////////////////////////////////////////////////////
+    // A newly (re-)initialized thread must not carry over the is_background
+    // flag from a previous use of the same thread_data instance (see
+    // resetting is_background_ to false). Exercise thread_data::rebind_base
+    // directly on a locally-owned thread_data instance instead of relying on
+    // the scheduler ever reusing an address.
+    void test_is_background_reset_on_rebind_direct()
+    {
+        hpx::threads::thread_init_data init_data;
+        init_data.stacksize = hpx::threads::thread_stacksize::nostack;
+
+        testable_thread_data data(init_data);
+        HPX_TEST(!data.is_background());
+
+        data.set_is_background();
+        HPX_TEST(data.is_background());
+
+        hpx::threads::thread_init_data rebind_data;
+        rebind_data.stacksize = hpx::threads::thread_stacksize::nostack;
+
+        data.rebind(rebind_data);
+        HPX_TEST(!data.is_background());
+    }
+    ///////////////////////////////////////////////////////////////////////////
     // Regression test for
     // hpx::this_thread::suspend()/execution_agent::do_yield() correctly
     // handling threads that are flagged as background threads. Such threads
@@ -132,7 +216,7 @@ namespace {
         bool running = false;
         bool woken_up = false;
 
-        hpx::thread t([&mtx, &cond, &running, &woken_up, mark_background]() {
+        hpx::thread t([&, mark_background]() {
             auto* data = hpx::threads::get_self_id_data();
             if (mark_background)
             {
@@ -218,7 +302,9 @@ int hpx_main()
 {
     test_is_background_default_false();
     test_set_is_background();
-    test_is_background_reset_on_rebind();
+
+    test_is_background_reset_on_rebind_probabilistic();
+    test_is_background_reset_on_rebind_direct();
 
     test_suspend_resume_with_background_flag(false);
     test_suspend_resume_with_background_flag(true);

--- a/libs/core/threading_base/tests/unit/thread_data_is_background.cpp
+++ b/libs/core/threading_base/tests/unit/thread_data_is_background.cpp
@@ -1,0 +1,236 @@
+//  Copyright (c) 2026 The STE||AR-Group
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// This test exercises hpx::threads::thread_data::is_background() /
+// set_is_background() as well as the interaction of the "is background thread"
+// flag with hpx::this_thread::suspend() and
+// hpx::execution_base::this_thread::yield_k(), which now use
+// hpx::threads::keep_alive_thread_id to conditionally keep the running thread
+// alive depending on whether it is flagged as a background thread.
+
+#define HPX_HAVE_FORCE_NO_CXX_MODULES
+
+#include <hpx/future.hpp>
+#include <hpx/init.hpp>
+#include <hpx/modules/execution_base.hpp>
+#include <hpx/modules/runtime_local.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/modules/threading_base.hpp>
+
+#include <atomic>
+#include <cstddef>
+#include <mutex>
+#include <set>
+
+namespace {
+
+    ///////////////////////////////////////////////////////////////////////////
+    void test_is_background_default_false()
+    {
+        hpx::async([]() {
+            auto const* data = hpx::threads::get_self_id_data();
+            HPX_TEST(data != nullptr);
+            HPX_TEST(!data->is_background());
+        }).get();
+    }
+
+    void test_set_is_background()
+    {
+        hpx::async([]() {
+            auto* data = hpx::threads::get_self_id_data();
+            HPX_TEST(!data->is_background());
+
+            data->set_is_background();
+            HPX_TEST(data->is_background());
+
+            // setting it again is idempotent
+            data->set_is_background();
+            HPX_TEST(data->is_background());
+        }).get();
+    }
+
+    // Return thread_data pointer to the running thread itself, even if it is
+    // executed inline in the context of an outer parent thread.
+    hpx::threads::thread_data* get_self_inner_id_data() noexcept
+    {
+        if (auto const* self = hpx::threads::get_self_ptr();
+            HPX_LIKELY(nullptr != self))
+        {
+            return hpx::threads::get_thread_id_data(self->get_thread_id());
+        }
+        return nullptr;
+    }
+
+    // A newly (re-)initialized thread must not carry over the is_background
+    // flag from a previous use of the same thread_data instance (see
+    // thread_data::rebind_base resetting is_background_ to false). Since
+    // thread_data address reuse depends on allocator behavior and is not
+    // guaranteed to happen on the very first allocation/deallocation cycle,
+    // keep creating threads (alternating whether is_background is set) until a
+    // reused address is actually observed, capped at max_iterations to avoid
+    // looping forever if reuse never happens.
+    void test_is_background_reset_on_rebind()
+    {
+        constexpr int max_iterations = 10000;
+
+        hpx::mutex mtx;
+        std::set<hpx::threads::thread_data const*> previous_data;
+
+        std::atomic<bool> observed_reuse{false};
+
+        for (int i = 0; i != max_iterations && !observed_reuse.load(); ++i)
+        {
+            bool const mark_background = (i % 2) == 0;
+
+            hpx::async([&previous_data, &observed_reuse, &mtx,
+                           mark_background]() {
+                auto* data = get_self_inner_id_data();
+                HPX_TEST(data != nullptr);
+
+                {
+                    std::scoped_lock lk(mtx);
+
+                    if (previous_data.contains(data))
+                    {
+                        // this thread_data instance's storage has been reused;
+                        // its is_background flag must have been reset to its
+                        // default value (false) by thread_data::rebind_base
+                        HPX_TEST(!data->is_background());
+                        observed_reuse = true;
+                    }
+
+                    if (mark_background)
+                    {
+                        data->set_is_background();
+                        HPX_TEST(data->is_background());
+                        previous_data.insert(data);
+                    }
+                }
+            }).get();
+        }
+
+        HPX_TEST_MSG(observed_reuse.load(),
+            "expected thread_data address reuse to be observed within "
+            "max_iterations");
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Regression test for
+    // hpx::this_thread::suspend()/execution_agent::do_yield() correctly
+    // handling threads that are flagged as background threads. Such threads
+    // must not have an extra reference added/removed while suspended (the
+    // scheduler is assumed to keep them alive instead), while regular,
+    // non-background threads still get a temporary extra reference while
+    // suspended.
+    void test_suspend_resume_with_background_flag(bool const mark_background)
+    {
+        hpx::mutex mtx;
+        hpx::condition_variable cond;
+        bool running = false;
+        bool woken_up = false;
+
+        hpx::thread t([&mtx, &cond, &running, &woken_up, mark_background]() {
+            auto* data = hpx::threads::get_self_id_data();
+            if (mark_background)
+            {
+                data->set_is_background();
+            }
+            HPX_TEST_EQ(data->is_background(), mark_background);
+
+            {
+                std::scoped_lock lk(mtx);
+                running = true;
+                cond.notify_all();
+            }
+
+            // suspend and wait to be resumed from the outside
+            hpx::this_thread::suspend(
+                hpx::threads::thread_schedule_state::suspended);
+
+            // the thread_data instance (and its flag) must have survived the
+            // suspension unchanged
+            HPX_TEST_EQ(hpx::threads::get_self_id_data()->is_background(),
+                mark_background);
+
+            woken_up = true;
+        });
+
+        // wait for the new thread to reach the suspend point
+        {
+            std::unique_lock<hpx::mutex> lk(mtx);
+            // NOLINTNEXTLINE(bugprone-infinite-loop)
+            while (!running)
+                cond.wait(lk);
+        }
+
+        hpx::threads::thread_id_type const id = t.native_handle();
+        hpx::threads::set_thread_state(
+            id, hpx::threads::thread_schedule_state::pending);
+
+        t.join();
+
+        HPX_TEST(woken_up);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // execution_agent::yield_k is invoked (through
+    // hpx::execution_base::this_thread::yield_k) on the current HPX thread
+    // regardless of the is_background flag; verify its threshold behavior still
+    // holds (guarding against regressions from the const-qualification
+    // changes).
+    void test_yield_k_threshold_behavior()
+    {
+        hpx::async([]() {
+            // for small values of k, yield_k must not actually yield the thread
+            for (std::size_t k = 0; k != 4; ++k)
+            {
+                HPX_TEST(!hpx::execution_base::this_thread::yield_k(k));
+            }
+
+            // for sufficiently large (even) k, the thread is actually suspended
+            // and rescheduled, function returns true
+            HPX_TEST(hpx::execution_base::this_thread::yield_k(32));
+
+            // for odd k the "pending_boost" yield path is used, also returns
+            // true
+            HPX_TEST(hpx::execution_base::this_thread::yield_k(33));
+        }).get();
+    }
+
+    void test_yield_k_with_background_flag()
+    {
+        hpx::async([]() {
+            auto* data = hpx::threads::get_self_id_data();
+            data->set_is_background();
+
+            // must not crash/assert when yielding while flagged as background
+            HPX_TEST(hpx::execution_base::this_thread::yield_k(32));
+            HPX_TEST(data->is_background());
+        }).get();
+    }
+}    // namespace
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main()
+{
+    test_is_background_default_false();
+    test_set_is_background();
+    test_is_background_reset_on_rebind();
+
+    test_suspend_resume_with_background_flag(false);
+    test_suspend_resume_with_background_flag(true);
+
+    test_yield_k_threshold_behavior();
+    test_yield_k_with_background_flag();
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    hpx::local::init(hpx_main, argc, argv);
+    return hpx::util::report_errors();
+}

--- a/libs/core/threading_base/tests/unit/thread_exit_callbacks.cpp
+++ b/libs/core/threading_base/tests/unit/thread_exit_callbacks.cpp
@@ -66,7 +66,9 @@ void test_single_callback_executes_once()
 {
     std::atomic<int> call_count{0};
 
-    hpx::async([&call_count]() {
+    // disable inline execution as this may mis-identify self as the target
+    // thread
+    hpx::async(hpx::launch::task, [&call_count]() {
         hpx::threads::thread_id_type const id = hpx::threads::get_self_id();
 
         bool const added = hpx::threads::add_thread_exit_callback(

--- a/libs/full/async_distributed/include/hpx/async_distributed/dataflow.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/dataflow.hpp
@@ -106,6 +106,7 @@ namespace hpx::lcos::detail {
                 act,
             hpx::id_type const& id, Ts&&... ts)
         {
+            // Enable inline execution by default (uses launch::async).
             return dataflow_dispatch_impl<true, launch>::call(
                 alloc, launch::async, act, id, HPX_FORWARD(Ts, ts)...);
         }


### PR DESCRIPTION
- Background threads don't need to be kept alive during suspension explicitly as the scheduler hold a reference
- Introduce new launch policy `hpx::launch::task, which is equivalent to `hpx::launch::async` except that it explicitly disabled inline execution of the launched thread.

This transfers useful parts of the abandoned #7345.