### PR TITLE
ci: add actions_base reflection tests to CI workflows

### DIFF
--- a/.github/workflows/linux_release_clang_p2996_reflection.yml
+++ b/.github/workflows/linux_release_clang_p2996_reflection.yml
@@ -47,11 +47,12 @@ jobs:
       run: |
           cmake --build build --target all
           cmake --build build --target tests.unit.modules.serialization
+          cmake --build build --target tests.unit.modules.actions_base
     - name: Test
       shell: bash
       run: |
           cd build
           ctest \
             --output-on-failure \
-            --tests-regex "tests.unit.modules.serialization"
+            --tests-regex "tests.unit.modules.serialization|tests.unit.modules.actions_base"
            

--- a/.github/workflows/linux_release_gcc_trunk_reflection.yml
+++ b/.github/workflows/linux_release_gcc_trunk_reflection.yml
@@ -47,9 +47,11 @@ jobs:
           cmake --build build --target all
           cmake --build build --target tests.unit.modules.serialization
           cmake --build build --target tests.unit.modules.contracts
+          cmake --build build --target tests.unit.modules.actions_base
     - name: Test
       shell: bash
       run: |
           cd build
           ctest --output-on-failure --tests-regex "tests.unit.modules.serialization"
           ctest --output-on-failure --tests-regex "tests.unit.modules.contracts"
+          ctest --output-on-failure --tests-regex "tests.unit.modules.actions_base"


### PR DESCRIPTION
The reflect_action_test and reflect_component_action_test tests were
registered with add_hpx_unit_test but were never built or executed
in the reflection CI jobs — both workflows only targeted
tests.unit.modules.serialization.

This adds tests.unit.modules.actions_base to both the build step
and the ctest --tests-regex filter in:
- linux_release_gcc_trunk_reflection.yml
- linux_release_clang_p2996_reflection.yml

Addresses hkaiser's review comment on PR #7349.