### PR TITLE
Tracing runtime instrumentation

### DIFF
--- a/libs/core/futures/src/detail/execute_thread.cpp
+++ b/libs/core/futures/src/detail/execute_thread.cpp
@@ -154,12 +154,13 @@ namespace hpx::threads::detail {
                 thrd_stat = handle_execute_thread(thrd.noref());
 
                 auto prev_state = thrd_stat.get_previous();
+                auto on_exit = hpx::experimental::scope_exit([&] {
+                    if (prev_state == thread_schedule_state::terminated)
+                    {
+                        hpx::tracing::task_completed(thrdptr);
+                    }
+                });
                 profiler.handle_post_execution(thrdptr, prev_state);
-
-                if (prev_state == thread_schedule_state::terminated)
-                {
-                    hpx::tracing::task_completed(thrdptr);
-                }
             }
             else
             {

--- a/libs/core/futures/src/detail/execute_thread.cpp
+++ b/libs/core/futures/src/detail/execute_thread.cpp
@@ -148,25 +148,17 @@ namespace hpx::threads::detail {
 #endif
                 if (!recurse_asynchronously)
                 {
-                    hpx::tracing::task_executing(thrdptr,
-                        threads::thread_data::get_safe_description(
-                            thrdptr->get_description(), "thread"),
-                        hpx::get_worker_thread_num());
+                    hpx::tracing::task_executing(thrdptr);
                 }
 
                 thrd_stat = handle_execute_thread(thrd.noref());
 
-                profiler.handle_post_execution(
-                    thrdptr, thrd_stat.get_previous());
+                auto prev_state = thrd_stat.get_previous();
+                profiler.handle_post_execution(thrdptr, prev_state);
 
-                if (thrd_stat.get_previous() ==
-                        thread_schedule_state::deleted ||
-                    thrd_stat.get_previous() ==
-                        thread_schedule_state::terminated)
+                if (prev_state == thread_schedule_state::terminated)
                 {
-                    hpx::tracing::task_completed(thrdptr,
-                        threads::thread_data::get_safe_description(
-                            thrdptr->get_description(), "thread"));
+                    hpx::tracing::task_completed(thrdptr);
                 }
             }
             else

--- a/libs/core/futures/src/detail/execute_thread.cpp
+++ b/libs/core/futures/src/detail/execute_thread.cpp
@@ -142,9 +142,9 @@ namespace hpx::threads::detail {
                 bool const recurse_asynchronously =
                     !this_thread::has_sufficient_stack_space();
 #else
-                execute_thread_recursion_count const cnt;
                 bool const recurse_asynchronously =
-                    cnt.count_ > HPX_CONTINUATION_MAX_RECURSION_DEPTH;
+                    (threads::get_continuation_recursion_count() + 1) >
+                    HPX_CONTINUATION_MAX_RECURSION_DEPTH;
 #endif
                 if (!recurse_asynchronously)
                 {

--- a/libs/core/futures/src/detail/execute_thread.cpp
+++ b/libs/core/futures/src/detail/execute_thread.cpp
@@ -15,6 +15,7 @@
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/threading_base.hpp>
 #include <hpx/modules/tracing.hpp>
+#include <hpx/threading_base/thread_num_tss.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -137,10 +138,36 @@ namespace hpx::threads::detail {
                 hpx::tracing::scoped_task_timer profiler(
                     thrdptr->get_timer_data());
 
+#if defined(HPX_HAVE_THREADS_GET_STACK_POINTER)
+                bool const recurse_asynchronously =
+                    !this_thread::has_sufficient_stack_space();
+#else
+                execute_thread_recursion_count const cnt;
+                bool const recurse_asynchronously =
+                    cnt.count_ > HPX_CONTINUATION_MAX_RECURSION_DEPTH;
+#endif
+                if (!recurse_asynchronously)
+                {
+                    hpx::tracing::task_executing(thrdptr,
+                        threads::thread_data::get_safe_description(
+                            thrdptr->get_description(), "thread"),
+                        hpx::get_worker_thread_num());
+                }
+
                 thrd_stat = handle_execute_thread(thrd.noref());
 
                 profiler.handle_post_execution(
                     thrdptr, thrd_stat.get_previous());
+
+                if (thrd_stat.get_previous() ==
+                        thread_schedule_state::deleted ||
+                    thrd_stat.get_previous() ==
+                        thread_schedule_state::terminated)
+                {
+                    hpx::tracing::task_completed(thrdptr,
+                        threads::thread_data::get_safe_description(
+                            thrdptr->get_description(), "thread"));
+                }
             }
             else
             {

--- a/libs/core/thread_pools/include/hpx/thread_pools/scheduling_loop.hpp
+++ b/libs/core/thread_pools/include/hpx/thread_pools/scheduling_loop.hpp
@@ -187,10 +187,7 @@ namespace hpx::threads::detail {
                                 thrd_stat.get_previous(),
                                 thread_schedule_state::active);
 
-                            hpx::tracing::task_executing(thrdptr,
-                                threads::thread_data::get_safe_description(
-                                    thrdptr->get_description(), "thread"),
-                                num_thread);
+                            hpx::tracing::task_executing(thrdptr);
 
 #ifdef HPX_HAVE_THREAD_IDLE_RATES
                             auto tfunc_time_collector_inner =
@@ -235,20 +232,18 @@ namespace hpx::threads::detail {
 
                                 thrd_stat = (*thrdptr)(context_storage);
 
+                                auto prev_state = thrd_stat.get_previous();
+                                auto on_exit =
+                                    hpx::experimental::scope_exit([&] {
+                                        if (prev_state ==
+                                            thread_schedule_state::terminated)
+                                        {
+                                            hpx::tracing::task_completed(
+                                                thrdptr);
+                                        }
+                                    });
                                 profiler.handle_post_execution(
-                                    thrdptr, thrd_stat.get_previous());
-
-                                if (thrd_stat.get_previous() ==
-                                        thread_schedule_state::deleted ||
-                                    thrd_stat.get_previous() ==
-                                        thread_schedule_state::terminated)
-                                {
-                                    hpx::tracing::task_completed(thrdptr,
-                                        threads::thread_data::
-                                            get_safe_description(
-                                                thrdptr->get_description(),
-                                                "thread"));
-                                }
+                                    thrdptr, prev_state);
                             }
 
                             detail::write_state_log(scheduler, num_thread, thrd,

--- a/libs/core/thread_pools/include/hpx/thread_pools/scheduling_loop.hpp
+++ b/libs/core/thread_pools/include/hpx/thread_pools/scheduling_loop.hpp
@@ -187,6 +187,11 @@ namespace hpx::threads::detail {
                                 thrd_stat.get_previous(),
                                 thread_schedule_state::active);
 
+                            hpx::tracing::task_executing(thrdptr,
+                                threads::thread_data::get_safe_description(
+                                    thrdptr->get_description(), "thread"),
+                                num_thread);
+
 #ifdef HPX_HAVE_THREAD_IDLE_RATES
                             auto tfunc_time_collector_inner =
                                 hpx::experimental::scope_exit([&idle_rate] {
@@ -232,6 +237,18 @@ namespace hpx::threads::detail {
 
                                 profiler.handle_post_execution(
                                     thrdptr, thrd_stat.get_previous());
+
+                                if (thrd_stat.get_previous() ==
+                                        thread_schedule_state::deleted ||
+                                    thrd_stat.get_previous() ==
+                                        thread_schedule_state::terminated)
+                                {
+                                    hpx::tracing::task_completed(thrdptr,
+                                        threads::thread_data::
+                                            get_safe_description(
+                                                thrdptr->get_description(),
+                                                "thread"));
+                                }
                             }
 
                             detail::write_state_log(scheduler, num_thread, thrd,

--- a/libs/core/thread_pools/src/detail/background_thread.cpp
+++ b/libs/core/thread_pools/src/detail/background_thread.cpp
@@ -219,10 +219,7 @@ namespace hpx::threads::detail {
                 background_exec_time_wrapper bg_exec_time(bg_work_duration);
 #endif    // HPX_HAVE_BACKGROUND_THREAD_COUNTERS
 
-                hpx::tracing::task_executing(thrdptr,
-                    threads::thread_data::get_safe_description(
-                        thrdptr->get_description(), "thread"),
-                    num_thread);
+                hpx::tracing::task_executing(thrdptr);
 
                 // invoke background thread
                 thrd_stat = (*thrdptr)(context_storage);
@@ -249,12 +246,10 @@ namespace hpx::threads::detail {
             thrd_stat.store_state(state);
             state_val = state.state();
 
-            if (state_val == thread_schedule_state::terminated ||
-                state_val == thread_schedule_state::deleted)
+            HPX_ASSERT(state_val != thread_schedule_state::deleted);
+            if (state_val == thread_schedule_state::terminated)
             {
-                hpx::tracing::task_completed(thrdptr,
-                    threads::thread_data::get_safe_description(
-                        thrdptr->get_description(), "thread"));
+                hpx::tracing::task_completed(thrdptr);
             }
 
             if (HPX_LIKELY(state_val == thread_schedule_state::pending_boost))

--- a/libs/core/thread_pools/src/detail/background_thread.cpp
+++ b/libs/core/thread_pools/src/detail/background_thread.cpp
@@ -9,6 +9,7 @@
 #include <hpx/modules/execution_base.hpp>
 #include <hpx/modules/logging.hpp>
 #include <hpx/modules/threading_base.hpp>
+#include <hpx/modules/tracing.hpp>
 #include <hpx/thread_pools/detail/background_thread.hpp>
 #include <hpx/thread_pools/detail/scheduling_callbacks.hpp>
 #include <hpx/thread_pools/detail/scoped_background_timer.hpp>
@@ -218,6 +219,11 @@ namespace hpx::threads::detail {
                 background_exec_time_wrapper bg_exec_time(bg_work_duration);
 #endif    // HPX_HAVE_BACKGROUND_THREAD_COUNTERS
 
+                hpx::tracing::task_executing(thrdptr,
+                    threads::thread_data::get_safe_description(
+                        thrdptr->get_description(), "thread"),
+                    num_thread);
+
                 // invoke background thread
                 thrd_stat = (*thrdptr)(context_storage);
 
@@ -242,6 +248,14 @@ namespace hpx::threads::detail {
             }
             thrd_stat.store_state(state);
             state_val = state.state();
+
+            if (state_val == thread_schedule_state::terminated ||
+                state_val == thread_schedule_state::deleted)
+            {
+                hpx::tracing::task_completed(thrdptr,
+                    threads::thread_data::get_safe_description(
+                        thrdptr->get_description(), "thread"));
+            }
 
             if (HPX_LIKELY(state_val == thread_schedule_state::pending_boost))
             {

--- a/libs/core/threading_base/src/create_thread.cpp
+++ b/libs/core/threading_base/src/create_thread.cpp
@@ -63,8 +63,8 @@ namespace hpx::threads::detail {
             {
                 data.parent_id = get_thread_id_data(self->get_thread_id());
                 data.parent_phase = self->get_thread_phase();
+                parent_task_id = data.parent_id.get();
             }
-            parent_task_id = data.parent_id.get();
         }
         else
         {

--- a/libs/core/threading_base/src/create_thread.cpp
+++ b/libs/core/threading_base/src/create_thread.cpp
@@ -86,26 +86,22 @@ namespace hpx::threads::detail {
         if (data.priority == thread_priority::default_)
             data.priority = thread_priority::normal;
 
-        // create the new thread
-        scheduler->create_thread(data, &id, ec);
-
-        if (!ec)
-        {
 #ifdef HPX_HAVE_THREAD_PARENT_REFERENCE
-            void const* parent_task_id =
-                data.parent_id ? data.parent_id.get() : nullptr;
+        void const* parent_task_id =
+            data.parent_id ? data.parent_id.get() : nullptr;
 #else
-            void const* parent_task_id = nullptr;
+        void const* parent_task_id = nullptr;
 #endif
 #ifdef HPX_HAVE_THREAD_DESCRIPTION
-            hpx::tracing::task_staged(
-                threads::thread_data::get_safe_description(
-                    data.description, "thread"),
-                parent_task_id);
+        hpx::tracing::task_staged(threads::thread_data::get_safe_description(
+                                      data.description, "thread"),
+            parent_task_id);
 #else
-            hpx::tracing::task_staged("thread", parent_task_id);
+        hpx::tracing::task_staged("thread", parent_task_id);
 #endif
-        }
+
+        // create the new thread
+        scheduler->create_thread(data, &id, ec);
 
         LTM_(info)
             .format("create_thread: pool({}), scheduler({}), thread({}), "

--- a/libs/core/threading_base/src/create_thread.cpp
+++ b/libs/core/threading_base/src/create_thread.cpp
@@ -56,6 +56,7 @@ namespace hpx::threads::detail {
         thread_self const* self = get_self_ptr();
 
 #ifdef HPX_HAVE_THREAD_PARENT_REFERENCE
+        void const* parent_task_id = nullptr;
         if (nullptr == data.parent_id)
         {
             if (self)
@@ -64,8 +65,12 @@ namespace hpx::threads::detail {
                 data.parent_phase = self->get_thread_phase();
             }
         }
+        parent_task_id = data.parent_id.get();
+
         if (0 == data.parent_locality_id)
             data.parent_locality_id = detail::get_locality_id(hpx::throws);
+#else
+        void const* parent_task_id = nullptr;
 #endif
 
         if (nullptr == data.scheduler_base)
@@ -86,12 +91,6 @@ namespace hpx::threads::detail {
         if (data.priority == thread_priority::default_)
             data.priority = thread_priority::normal;
 
-#ifdef HPX_HAVE_THREAD_PARENT_REFERENCE
-        void const* parent_task_id =
-            data.parent_id ? data.parent_id.get() : nullptr;
-#else
-        void const* parent_task_id = nullptr;
-#endif
 #ifdef HPX_HAVE_THREAD_DESCRIPTION
         hpx::tracing::task_staged(threads::thread_data::get_safe_description(
                                       data.description, "thread"),

--- a/libs/core/threading_base/src/create_thread.cpp
+++ b/libs/core/threading_base/src/create_thread.cpp
@@ -93,7 +93,7 @@ namespace hpx::threads::detail {
         {
 #ifdef HPX_HAVE_THREAD_PARENT_REFERENCE
             void const* parent_task_id =
-                data.parent_id ? data.parent_id.noref().get() : nullptr;
+                data.parent_id ? data.parent_id.get() : nullptr;
 #else
             void const* parent_task_id = nullptr;
 #endif

--- a/libs/core/threading_base/src/create_thread.cpp
+++ b/libs/core/threading_base/src/create_thread.cpp
@@ -55,8 +55,8 @@ namespace hpx::threads::detail {
 
         thread_self const* self = get_self_ptr();
 
-#ifdef HPX_HAVE_THREAD_PARENT_REFERENCE
         void const* parent_task_id = nullptr;
+#ifdef HPX_HAVE_THREAD_PARENT_REFERENCE
         if (nullptr == data.parent_id)
         {
             if (self)
@@ -64,13 +64,15 @@ namespace hpx::threads::detail {
                 data.parent_id = get_thread_id_data(self->get_thread_id());
                 data.parent_phase = self->get_thread_phase();
             }
+            parent_task_id = data.parent_id.get();
         }
-        parent_task_id = data.parent_id.get();
+        else
+        {
+            parent_task_id = data.parent_id.get();
+        }
 
         if (0 == data.parent_locality_id)
             data.parent_locality_id = detail::get_locality_id(hpx::throws);
-#else
-        void const* parent_task_id = nullptr;
 #endif
 
         if (nullptr == data.scheduler_base)

--- a/libs/core/threading_base/src/create_thread.cpp
+++ b/libs/core/threading_base/src/create_thread.cpp
@@ -8,6 +8,7 @@
 #include <hpx/modules/coroutines.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/logging.hpp>
+#include <hpx/modules/tracing.hpp>
 #include <hpx/threading_base/create_thread.hpp>
 #include <hpx/threading_base/scheduler_base.hpp>
 #include <hpx/threading_base/thread_data.hpp>
@@ -87,6 +88,24 @@ namespace hpx::threads::detail {
 
         // create the new thread
         scheduler->create_thread(data, &id, ec);
+
+        if (!ec)
+        {
+#ifdef HPX_HAVE_THREAD_PARENT_REFERENCE
+            void const* parent_task_id =
+                data.parent_id ? data.parent_id.noref().get() : nullptr;
+#else
+            void const* parent_task_id = nullptr;
+#endif
+#ifdef HPX_HAVE_THREAD_DESCRIPTION
+            hpx::tracing::task_staged(
+                threads::thread_data::get_safe_description(
+                    data.description, "thread"),
+                parent_task_id);
+#else
+            hpx::tracing::task_staged("thread", parent_task_id);
+#endif
+        }
 
         LTM_(info)
             .format("create_thread: pool({}), scheduler({}), thread({}), "

--- a/libs/core/threading_base/src/thread_data.cpp
+++ b/libs/core/threading_base/src/thread_data.cpp
@@ -97,6 +97,7 @@ namespace hpx::threads {
         HPX_ASSERT(stacksize_enum_ != threads::thread_stacksize::current);
 
 #ifdef HPX_HAVE_THREAD_PARENT_REFERENCE
+        void const* parent_task_id = nullptr;
         // store the thread id of the parent thread, mainly for debugging
         // purposes
         if (parent_thread_id_ == nullptr)
@@ -107,22 +108,17 @@ namespace hpx::threads {
                 parent_thread_phase_ = self->get_thread_phase();
             }
         }
+        parent_task_id = parent_thread_id_.get();
         if (0 == parent_locality_id_)
             parent_locality_id_ = detail::get_locality_id(hpx::throws);
+#else
+        void const* parent_task_id = nullptr;
 #endif
         set_timer_data(init_data.timer_data);
 #if defined(HPX_HAVE_TRACY)
         fiber_name_[0] = '\0';
 #endif
-#ifdef HPX_HAVE_THREAD_PARENT_REFERENCE
-        void const* parent_task_id =
-            parent_thread_id_ ? parent_thread_id_.get() : nullptr;
-#else
-        void const* parent_task_id = nullptr;
-#endif
-        hpx::tracing::task_created(
-            get_safe_description(get_description(), "thread"), this,
-            parent_task_id);
+        hpx::tracing::task_created(this, parent_task_id);
     }
 
     thread_data::~thread_data()
@@ -275,6 +271,7 @@ namespace hpx::threads {
             get_description());
 
 #ifdef HPX_HAVE_THREAD_PARENT_REFERENCE
+        void const* parent_task_id = nullptr;
         // store the thread id of the parent thread, mainly for debugging
         // purposes
         if (parent_thread_id_ == nullptr)
@@ -285,22 +282,17 @@ namespace hpx::threads {
                 parent_thread_phase_ = self->get_thread_phase();
             }
         }
+        parent_task_id = parent_thread_id_.get();
         if (0 == parent_locality_id_)
         {
             parent_locality_id_ = detail::get_locality_id(hpx::throws);
         }
-#endif
-        set_timer_data(init_data.timer_data);
-
-#ifdef HPX_HAVE_THREAD_PARENT_REFERENCE
-        void const* parent_task_id =
-            parent_thread_id_ ? parent_thread_id_.get() : nullptr;
 #else
         void const* parent_task_id = nullptr;
 #endif
-        hpx::tracing::task_created(
-            get_safe_description(get_description(), "thread"), this,
-            parent_task_id);
+        set_timer_data(init_data.timer_data);
+
+        hpx::tracing::task_created(this, parent_task_id);
     }
 
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)

--- a/libs/core/threading_base/src/thread_data.cpp
+++ b/libs/core/threading_base/src/thread_data.cpp
@@ -106,9 +106,9 @@ namespace hpx::threads {
             {
                 parent_thread_id_ = threads::get_self_id();
                 parent_thread_phase_ = self->get_thread_phase();
+                parent_task_id = parent_thread_id_.get();
             }
         }
-        parent_task_id = parent_thread_id_.get();
         if (0 == parent_locality_id_)
             parent_locality_id_ = detail::get_locality_id(hpx::throws);
 #endif
@@ -277,9 +277,9 @@ namespace hpx::threads {
             {
                 parent_thread_id_ = threads::get_self_id();
                 parent_thread_phase_ = self->get_thread_phase();
+                parent_task_id = parent_thread_id_.get();
             }
         }
-        parent_task_id = parent_thread_id_.get();
         if (0 == parent_locality_id_)
         {
             parent_locality_id_ = detail::get_locality_id(hpx::throws);

--- a/libs/core/threading_base/src/thread_data.cpp
+++ b/libs/core/threading_base/src/thread_data.cpp
@@ -96,8 +96,8 @@ namespace hpx::threads {
             stacksize <= (std::numeric_limits<std::int32_t>::max)());
         HPX_ASSERT(stacksize_enum_ != threads::thread_stacksize::current);
 
-#ifdef HPX_HAVE_THREAD_PARENT_REFERENCE
         void const* parent_task_id = nullptr;
+#ifdef HPX_HAVE_THREAD_PARENT_REFERENCE
         // store the thread id of the parent thread, mainly for debugging
         // purposes
         if (parent_thread_id_ == nullptr)
@@ -111,8 +111,6 @@ namespace hpx::threads {
         parent_task_id = parent_thread_id_.get();
         if (0 == parent_locality_id_)
             parent_locality_id_ = detail::get_locality_id(hpx::throws);
-#else
-        void const* parent_task_id = nullptr;
 #endif
         set_timer_data(init_data.timer_data);
 #if defined(HPX_HAVE_TRACY)
@@ -214,9 +212,8 @@ namespace hpx::threads {
             "thread_data::rebind_base({}), description({}), phase({}), rebind",
             this, get_description(), get_thread_phase());
 
-        hpx::tracing::task_deleted(this);
-
         free_thread_exit_callbacks();
+        hpx::tracing::task_deleted(this);
 
         priority_ = init_data.priority;
         requested_interrupt_ = false;
@@ -270,8 +267,8 @@ namespace hpx::threads {
         LTM_(debug).format("thread::thread({}), description({}), rebind", this,
             get_description());
 
-#ifdef HPX_HAVE_THREAD_PARENT_REFERENCE
         void const* parent_task_id = nullptr;
+#ifdef HPX_HAVE_THREAD_PARENT_REFERENCE
         // store the thread id of the parent thread, mainly for debugging
         // purposes
         if (parent_thread_id_ == nullptr)
@@ -287,8 +284,6 @@ namespace hpx::threads {
         {
             parent_locality_id_ = detail::get_locality_id(hpx::throws);
         }
-#else
-        void const* parent_task_id = nullptr;
 #endif
         set_timer_data(init_data.timer_data);
 

--- a/libs/core/threading_base/src/thread_data.cpp
+++ b/libs/core/threading_base/src/thread_data.cpp
@@ -114,12 +114,22 @@ namespace hpx::threads {
 #if defined(HPX_HAVE_TRACY)
         fiber_name_[0] = '\0';
 #endif
+#ifdef HPX_HAVE_THREAD_PARENT_REFERENCE
+        void const* parent_task_id =
+            parent_thread_id_ ? parent_thread_id_.get() : nullptr;
+#else
+        void const* parent_task_id = nullptr;
+#endif
+        hpx::tracing::task_created(
+            get_safe_description(get_description(), "thread"), this,
+            parent_task_id);
     }
 
     thread_data::~thread_data()
     {
         LTM_(debug).format("thread_data::~thread_data({})", this);
         free_thread_exit_callbacks();
+        hpx::tracing::task_deleted(this);
     }
 
     void thread_data::destroy_thread()
@@ -208,6 +218,8 @@ namespace hpx::threads {
             "thread_data::rebind_base({}), description({}), phase({}), rebind",
             this, get_description(), get_thread_phase());
 
+        hpx::tracing::task_deleted(this);
+
         free_thread_exit_callbacks();
 
         priority_ = init_data.priority;
@@ -279,6 +291,16 @@ namespace hpx::threads {
         }
 #endif
         set_timer_data(init_data.timer_data);
+
+#ifdef HPX_HAVE_THREAD_PARENT_REFERENCE
+        void const* parent_task_id =
+            parent_thread_id_ ? parent_thread_id_.get() : nullptr;
+#else
+        void const* parent_task_id = nullptr;
+#endif
+        hpx::tracing::task_created(
+            get_safe_description(get_description(), "thread"), this,
+            parent_task_id);
     }
 
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)

--- a/libs/core/tracing/include/hpx/tracing/macros.hpp
+++ b/libs/core/tracing/include/hpx/tracing/macros.hpp
@@ -10,6 +10,12 @@
 #include <hpx/config.hpp>
 #include <hpx/preprocessor/cat.hpp>
 
+#if defined(HPX_HAVE_TRACY) ||                                                 \
+    (defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0) ||                \
+    defined(HPX_HAVE_APEX)
+#define HPX_HAVE_TRACING
+#endif
+
 #if defined(HPX_HAVE_TRACY)
 #define HPX_TRACING_MARK_EVENT(name)                                           \
     hpx::tracing::mark_event HPX_PP_CAT(hpx_trace_mark_, __LINE__)(name)

--- a/libs/core/tracing/include/hpx/tracing/tracing.hpp
+++ b/libs/core/tracing/include/hpx/tracing/tracing.hpp
@@ -123,3 +123,44 @@ namespace hpx::tracing {
     };
 }    // namespace hpx::tracing
 #endif
+
+namespace hpx::tracing {
+
+    template <typename ThreadData>
+    constexpr void task_created([[maybe_unused]] ThreadData* thrdptr,
+        [[maybe_unused]] void const* parent_task_id = nullptr) noexcept
+    {
+#if defined(HPX_HAVE_TRACY) ||                                                 \
+    (defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0) ||                \
+    defined(HPX_HAVE_APEX)
+        task_created(ThreadData::get_safe_description(
+                         thrdptr->get_description(), "thread"),
+            thrdptr, parent_task_id);
+#endif
+    }
+
+    template <typename ThreadData>
+    constexpr void task_executing([[maybe_unused]] ThreadData* thrdptr) noexcept
+    {
+#if defined(HPX_HAVE_TRACY) ||                                                 \
+    (defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0) ||                \
+    defined(HPX_HAVE_APEX)
+        task_executing(thrdptr,
+            ThreadData::get_safe_description(
+                thrdptr->get_description(), "thread"),
+            thrdptr->get_last_worker_thread_num());
+#endif
+    }
+
+    template <typename ThreadData>
+    constexpr void task_completed([[maybe_unused]] ThreadData* thrdptr) noexcept
+    {
+#if defined(HPX_HAVE_TRACY) ||                                                 \
+    (defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0) ||                \
+    defined(HPX_HAVE_APEX)
+        task_completed(thrdptr,
+            ThreadData::get_safe_description(
+                thrdptr->get_description(), "thread"));
+#endif
+    }
+}    // namespace hpx::tracing

--- a/libs/core/tracing/include/hpx/tracing/tracing.hpp
+++ b/libs/core/tracing/include/hpx/tracing/tracing.hpp
@@ -9,12 +9,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/preprocessor/cat.hpp>
-
-#if defined(HPX_HAVE_TRACY) ||                                                 \
-    (defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0) ||                \
-    defined(HPX_HAVE_APEX)
-#define HPX_HAVE_TRACING
-#endif
+#include <hpx/tracing/macros.hpp>
 
 #if defined(DOXYGEN)
 /// \defgroup tracing Tracing API

--- a/libs/core/tracing/include/hpx/tracing/tracing.hpp
+++ b/libs/core/tracing/include/hpx/tracing/tracing.hpp
@@ -10,6 +10,12 @@
 #include <hpx/config.hpp>
 #include <hpx/preprocessor/cat.hpp>
 
+#if defined(HPX_HAVE_TRACY) ||                                                 \
+    (defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0) ||                \
+    defined(HPX_HAVE_APEX)
+#define HPX_HAVE_TRACING
+#endif
+
 #if defined(DOXYGEN)
 /// \defgroup tracing Tracing API
 /// \brief Unconditionally defined tracing and profiling abstractions.
@@ -130,9 +136,7 @@ namespace hpx::tracing {
     constexpr void task_created([[maybe_unused]] ThreadData* thrdptr,
         [[maybe_unused]] void const* parent_task_id = nullptr) noexcept
     {
-#if defined(HPX_HAVE_TRACY) ||                                                 \
-    (defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0) ||                \
-    defined(HPX_HAVE_APEX)
+#if defined(HPX_HAVE_TRACING)
         task_created(ThreadData::get_safe_description(
                          thrdptr->get_description(), "thread"),
             thrdptr, parent_task_id);
@@ -142,9 +146,7 @@ namespace hpx::tracing {
     template <typename ThreadData>
     constexpr void task_executing([[maybe_unused]] ThreadData* thrdptr) noexcept
     {
-#if defined(HPX_HAVE_TRACY) ||                                                 \
-    (defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0) ||                \
-    defined(HPX_HAVE_APEX)
+#if defined(HPX_HAVE_TRACING)
         task_executing(thrdptr,
             ThreadData::get_safe_description(
                 thrdptr->get_description(), "thread"),
@@ -155,9 +157,7 @@ namespace hpx::tracing {
     template <typename ThreadData>
     constexpr void task_completed([[maybe_unused]] ThreadData* thrdptr) noexcept
     {
-#if defined(HPX_HAVE_TRACY) ||                                                 \
-    (defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0) ||                \
-    defined(HPX_HAVE_APEX)
+#if defined(HPX_HAVE_TRACING)
         task_completed(thrdptr,
             ThreadData::get_safe_description(
                 thrdptr->get_description(), "thread"));

--- a/libs/core/tracy/src/tracy_tls.cpp
+++ b/libs/core/tracy/src/tracy_tls.cpp
@@ -70,6 +70,7 @@ namespace hpx::tracy {
             char const* zone_name = "fiber";
             std::uint32_t color = 0;
             bool active = false;
+            bool just_entered = false;
         };
 
         fiber_zone_data& current_fiber_zone() noexcept
@@ -150,6 +151,7 @@ namespace hpx::tracy {
             open_fiber_zone(fz, safe_zone_name, color);
             fz.zone_name = safe_zone_name;
             fz.color = color;
+            fz.just_entered = true;
         }
 
         HPX_CORE_EXPORT void stop_fiber_zone() noexcept
@@ -174,6 +176,7 @@ namespace hpx::tracy {
             char const* suspend_reason) noexcept
         {
             auto& fz = current_fiber_zone();
+            fz.just_entered = false;
             if (!fz.active)
                 return;
 
@@ -206,6 +209,11 @@ namespace hpx::tracy {
             char const* zone_name, std::uint32_t color) noexcept
         {
             auto& fz = current_fiber_zone();
+            if (fz.just_entered)
+            {
+                fz.just_entered = false;
+                return;
+            }
             if (!fz.active)
                 return;
 


### PR DESCRIPTION

## Proposed Changes

- Added `task_staged`, `task_created`, `task_deleted` hooks into `create_thread.cpp` and `thread_data.cpp`. Thread recycling via `rebind_base()` is fully covered — it emits `task_deleted` for the old task and `task_created` for the new one.
- Added `task_executing` and `task_completed` hooks into the main scheduling loop (`scheduling_loop.hpp`) and background thread runner (`background_thread.cpp`).
- Added `task_executing` and `task_completed` into the direct/inline execution path in `execute_thread.cpp`, guarded by the same recursion-depth check used internally so duplicate events are not emitted when a task falls back to rescheduling.
- Fixed a double-zone-open crash in the Tracy fiber backend (`tracy_tls.cpp`) that was exposed during testing: added a `just_entered` flag to skip spurious zone-enter events on re-entrant context switches.

All hooks compile to `constexpr` no-ops when no tracing backend is enabled, so there is no overhead in default builds.

## Background

This follows PR #7347 which added the tracing API and backends. This PR wires those hooks into the thread manager and scheduler so task scheduling and fiber lifecycles show up in the profiler.

## Checklist

- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
