### PR TITLE
Duplication of the thread queues in the schedulers

### DIFF
--- a/.github/workflows/linux_debug.yml
+++ b/.github/workflows/linux_debug.yml
@@ -36,7 +36,8 @@ jobs:
               -DHPX_WITH_TESTS_MAX_THREADS_PER_LOCALITY=2 \
               -DHPX_WITH_VERIFY_LOCKS=ON \
               -DHPX_WITH_VERIFY_LOCKS_BACKTRACE=ON \
-              -DHPX_WITH_CHECK_MODULE_DEPENDENCIES=On
+              -DHPX_WITH_CHECK_MODULE_DEPENDENCIES=On \
+              -DHPX_WITH_TESTS_COMMAND_LINE=--hpx:queuing=local-priority-fifo-double
     - name: Build
       shell: bash
       run: |

--- a/.github/workflows/macos_debug.yml
+++ b/.github/workflows/macos_debug.yml
@@ -40,7 +40,8 @@ jobs:
               -DHPX_WITH_VERIFY_LOCKS=OFF \
               -DHPX_WITH_VERIFY_LOCKS_BACKTRACE=OFF \
               -DHPX_WITH_CHECK_MODULE_DEPENDENCIES=ON \
-              -DHPX_WITH_CONTRACTS_MODE=OBSERVE
+              -DHPX_WITH_CONTRACTS_MODE=OBSERVE \
+              -DHPX_WITH_TESTS_COMMAND_LINE=--hpx:queuing=local-priority-fifo-double
     - name: Build
       shell: bash
       run: |

--- a/.github/workflows/windows_release_2022.yml
+++ b/.github/workflows/windows_release_2022.yml
@@ -39,7 +39,8 @@ jobs:
               -DHPX_WITH_TESTS_EXAMPLES=ON \
               -DHPX_WITH_DEPRECATION_WARNINGS=OFF \
               -DHPX_WITH_TESTS_MAX_THREADS_PER_LOCALITY=2 \
-              -DHPX_WITH_CHECK_MODULE_DEPENDENCIES=On
+              -DHPX_WITH_CHECK_MODULE_DEPENDENCIES=On \
+              -DHPX_WITH_TESTS_COMMAND_LINE=--hpx:queuing=local-priority-fifo-double
     - name: Build
       shell: bash
       run: |

--- a/.jenkins/lsu-perftests/launch_perftests.sh
+++ b/.jenkins/lsu-perftests/launch_perftests.sh
@@ -15,6 +15,7 @@ hpx_targets=(
     "stream_report_test")
 hpx_test_options=(
     "--hpx:ini=hpx.thread_queue.init_threads_count=100 \
+    --hpx:queuing=local-priority-fifo-double \
     --hpx:threads=4 --vector_size=104857 --work_delay=1 \
     --chunk_size=0 --test_count=200 --detailed_bench"
     "--hpx:ini=hpx.thread_queue.init_threads_count=100 \

--- a/libs/core/async_base/include/hpx/async_base/launch_policy.hpp
+++ b/libs/core/async_base/include/hpx/async_base/launch_policy.hpp
@@ -151,15 +151,18 @@ namespace hpx {
                 policy_holder<D> const& p) noexcept;
 
             template <typename Left, typename Right>
-            friend policy_holder<Left> operator&=(policy_holder<Left>& lhs,
+            friend constexpr policy_holder<Left> operator&=(
+                policy_holder<Left>& lhs,
                 policy_holder<Right> const& rhs) noexcept;
 
             template <typename Left, typename Right>
-            friend policy_holder<Left> operator|=(policy_holder<Left>& lhs,
+            friend constexpr policy_holder<Left> operator|=(
+                policy_holder<Left>& lhs,
                 policy_holder<Right> const& rhs) noexcept;
 
             template <typename Left, typename Right>
-            friend policy_holder<Left> operator^=(policy_holder<Left>& lhs,
+            friend constexpr policy_holder<Left> operator^=(
+                policy_holder<Left>& lhs,
                 policy_holder<Right> const& rhs) noexcept;
 
         public:
@@ -419,7 +422,7 @@ namespace hpx {
         }
 
         template <typename Left, typename Right>
-        inline policy_holder<Left> operator&=(
+        constexpr policy_holder<Left> operator&=(
             policy_holder<Left>& lhs, policy_holder<Right> const& rhs) noexcept
         {
             lhs = policy_holder<Left>(lhs & rhs);
@@ -427,7 +430,7 @@ namespace hpx {
         }
 
         template <typename Left, typename Right>
-        inline policy_holder<Left> operator|=(
+        constexpr policy_holder<Left> operator|=(
             policy_holder<Left>& lhs, policy_holder<Right> const& rhs) noexcept
         {
             lhs = policy_holder<Left>(lhs | rhs);
@@ -435,7 +438,7 @@ namespace hpx {
         }
 
         template <typename Left, typename Right>
-        inline policy_holder<Left> operator^=(
+        constexpr policy_holder<Left> operator^=(
             policy_holder<Left>& lhs, policy_holder<Right> const& rhs) noexcept
         {
             lhs = policy_holder<Left>(lhs ^ rhs);

--- a/libs/core/command_line_handling_local/src/parse_command_line_local.cpp
+++ b/libs/core/command_line_handling_local/src/parse_command_line_local.cpp
@@ -560,7 +560,8 @@ namespace hpx::local::detail {
                 "on the number of total cores in the system)")
             ("hpx:queuing", value<argument_string>(),
                 "the queue scheduling policy to use, options are "
-                "'local', 'local-priority-fifo','local-priority-lifo', "
+                "'local', 'local-priority-fifo', 'local-priority-fifo-double', "
+                "'local-priority-lifo', "
                 "'abp-priority-fifo', 'abp-priority-lifo', 'static', "
                 "'static-priority', 'local-workrequesting-fifo',"
                 "'local-workrequesting-lifo', and 'local-workrequesting-mc' "

--- a/libs/core/concurrency/include/hpx/concurrency/deque.hpp
+++ b/libs/core/concurrency/include/hpx/concurrency/deque.hpp
@@ -4,7 +4,7 @@
 //  Link: http://www.research.ibm.com/people/m/michael/europar-2003.pdf
 //
 //  C++ implementation - Copyright (C) 2011 Bryce Lelbach
-//  Copyright (c) 2022-2025 Hartmut Kaiser
+//  Copyright (c) 2022-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -62,7 +62,7 @@ namespace hpx::lockfree {
         using pointer = hpx::lockfree::detail::tagged_ptr<deque_node>;
         using atomic_pointer = std::atomic<pointer>;
 
-        using tag_t = typename pointer::tag_t;
+        using tag_t = pointer::tag_t;
 
         atomic_pointer left;
         atomic_pointer right;
@@ -104,10 +104,10 @@ namespace hpx::lockfree {
     struct deque_anchor    //-V690
     {
         using node = deque_node<T>;
-        using node_pointer = typename node::pointer;
-        using atomic_node_pointer = typename node::atomic_pointer;
+        using node_pointer = node::pointer;
+        using atomic_node_pointer = node::atomic_pointer;
 
-        using tag_t = typename node::tag_t;
+        using tag_t = node::tag_t;
 
         using anchor = deque_anchor<T>;
         using pair = tagged_ptr_pair<node, node>;
@@ -243,22 +243,25 @@ namespace hpx::lockfree {
     struct deque
     {
     public:
-        HPX_NON_COPYABLE(deque);
+        deque(deque const&) = delete;
+        deque(deque&&) = delete;
+        deque& operator=(deque const&) = delete;
+        deque& operator=(deque&&) = delete;
 
     public:
         using node = deque_node<T>;
 
-        using node_pointer = typename node::pointer;
-        using atomic_node_pointer = typename node::atomic_pointer;
+        using node_pointer = node::pointer;
+        using atomic_node_pointer = node::atomic_pointer;
 
-        using tag_t = typename node::tag_t;
+        using tag_t = node::tag_t;
 
         using anchor = deque_anchor<T>;
-        using anchor_pair = typename anchor::pair;
-        using atomic_anchor_pair = typename anchor::atomic_pair;
+        using anchor_pair = anchor::pair;
+        using atomic_anchor_pair = anchor::atomic_pair;
 
         using node_allocator =
-            typename std::allocator_traits<Alloc>::template rebind_alloc<node>;
+            std::allocator_traits<Alloc>::template rebind_alloc<node>;
 
         using pool =
             std::conditional_t<std::is_same_v<freelist_t, caching_freelist_t>,
@@ -270,7 +273,8 @@ namespace hpx::lockfree {
         pool pool_;
 
         static constexpr std::size_t padding_size =
-            hpx::threads::get_cache_line_size() - sizeof(anchor);    //-V103
+            hpx::threads::get_cache_line_size() -
+            (sizeof(anchor) + sizeof(pool));    //-V103
         char padding[padding_size];
 
         node* alloc_node(

--- a/libs/core/concurrency/include/hpx/concurrency/queue.hpp
+++ b/libs/core/concurrency/include/hpx/concurrency/queue.hpp
@@ -1,5 +1,5 @@
 //  Copyright (C) 2008-2013 Tim Blechmann
-//  Copyright (c) 2022-2025 Hartmut Kaiser
+//  Copyright (c) 2022-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -36,7 +36,7 @@ namespace hpx::lockfree {
      *    hpx::lockfree::fixed_sized<false> \n Can be used to completely
      *    disable dynamic memory allocations during push in order to ensure
      *    lockfree behavior. \n If the data structure is configured as
-     *    fixed-sized, the internal nodes are stored inside an array and they
+     *    fixed-sized, the internal nodes are stored inside an array, and they
      *    are addressed by array indexing. This limits the possible size of the
      *    queue to the number of elements that can be addressed by the index
      *    type (usually 2**16-2), but on platforms that lack double-width
@@ -76,11 +76,10 @@ namespace hpx::lockfree {
         struct node;
         struct node_data
         {
-            using tagged_node_handle =
-                typename detail::select_tagged_handle<node,
-                    node_based>::tagged_handle_type;
-            using handle_type = typename detail::select_tagged_handle<node,
-                node_based>::handle_type;
+            using tagged_node_handle = detail::select_tagged_handle<node,
+                node_based>::tagged_handle_type;
+            using handle_type =
+                detail::select_tagged_handle<node, node_based>::handle_type;
 
             template <typename T_>
             node_data(T_&& t, handle_type null_handle) noexcept(
@@ -113,17 +112,17 @@ namespace hpx::lockfree {
                 node_data>::cache_aligned_data_derived;
         };
 
-        using node_allocator = typename std::allocator_traits<
-            Allocator>::template rebind_alloc<node>;
+        using node_allocator =
+            std::allocator_traits<Allocator>::template rebind_alloc<node>;
 
-        using pool_t = typename detail::select_freelist<node, node_allocator,
+        using pool_t = detail::select_freelist<node, node_allocator,
             compile_time_sized, fixed_sized, capacity>::type;
 
-        using tagged_node_handle = typename pool_t::tagged_node_handle;
-        using handle_type = typename detail::select_tagged_handle<node,
-            node_based>::handle_type;
+        using tagged_node_handle = pool_t::tagged_node_handle;
+        using handle_type =
+            detail::select_tagged_handle<node, node_based>::handle_type;
 
-        using index_t = typename tagged_node_handle::index_t;
+        using index_t = tagged_node_handle::index_t;
 
         static constexpr auto null_index_t() noexcept
         {
@@ -158,8 +157,8 @@ namespace hpx::lockfree {
         queue& operator=(queue&&) = delete;
 
         using value_type = T;
-        using allocator = typename implementation_defined::allocator;
-        using size_type = typename implementation_defined::size_type;
+        using allocator = implementation_defined::allocator;
+        using size_type = implementation_defined::size_type;
 
         /**
          * \return true, if implementation is lock-free.
@@ -199,8 +198,9 @@ namespace hpx::lockfree {
          *  \pre Must specify a capacity<> argument
          */
         template <typename U>
-        explicit queue(typename std::allocator_traits<
-            Allocator>::template rebind_alloc<U> const& alloc)
+        explicit queue(
+            std::allocator_traits<Allocator>::template rebind_alloc<U> const&
+                alloc)
           : head_(tagged_node_handle(null_index_t(), 0))
           , tail_(tagged_node_handle(null_index_t(), 0))
           , pool(alloc, capacity)
@@ -254,8 +254,8 @@ namespace hpx::lockfree {
          */
         template <typename U>
         queue(size_type n,
-            typename std::allocator_traits<Allocator>::template rebind_alloc<
-                U> const& alloc)
+            std::allocator_traits<Allocator>::template rebind_alloc<U> const&
+                alloc)
           : head_(tagged_node_handle(null_index_t(), 0))
           , tail_(tagged_node_handle(null_index_t(), 0))
           , pool(alloc, n + 1)
@@ -296,13 +296,13 @@ namespace hpx::lockfree {
          *
          * \return true, if the queue is empty, false otherwise
          * \note The result is only accurate, if no other thread modifies the
-         *       queue. Therefore it is rarely practical to use this value in
+         *       queue. Therefore, it is rarely practical to use this value in
          *       program logic.
          */
         [[nodiscard]] bool empty() const noexcept
         {
-            return pool.get_handle(head_.load()) ==
-                pool.get_handle(tail_.load());
+            return pool.get_handle(head_.load(std::memory_order_acquire)) ==
+                pool.get_handle(tail_.load(std::memory_order_acquire));
         }
 
         /**

--- a/libs/core/concurrency/include/hpx/concurrency/queue.hpp
+++ b/libs/core/concurrency/include/hpx/concurrency/queue.hpp
@@ -76,10 +76,11 @@ namespace hpx::lockfree {
         struct node;
         struct node_data
         {
-            using tagged_node_handle = detail::select_tagged_handle<node,
-                node_based>::tagged_handle_type;
-            using handle_type =
-                detail::select_tagged_handle<node, node_based>::handle_type;
+            using tagged_node_handle =
+                typename detail::select_tagged_handle<node,
+                    node_based>::tagged_handle_type;
+            using handle_type = typename detail::select_tagged_handle<node,
+                node_based>::handle_type;
 
             template <typename T_>
             node_data(T_&& t, handle_type null_handle) noexcept(
@@ -112,17 +113,17 @@ namespace hpx::lockfree {
                 node_data>::cache_aligned_data_derived;
         };
 
-        using node_allocator =
-            std::allocator_traits<Allocator>::template rebind_alloc<node>;
+        using node_allocator = typename std::allocator_traits<
+            Allocator>::template rebind_alloc<node>;
 
-        using pool_t = detail::select_freelist<node, node_allocator,
+        using pool_t = typename detail::select_freelist<node, node_allocator,
             compile_time_sized, fixed_sized, capacity>::type;
 
-        using tagged_node_handle = pool_t::tagged_node_handle;
-        using handle_type =
-            detail::select_tagged_handle<node, node_based>::handle_type;
+        using tagged_node_handle = typename pool_t::tagged_node_handle;
+        using handle_type = typename detail::select_tagged_handle<node,
+            node_based>::handle_type;
 
-        using index_t = tagged_node_handle::index_t;
+        using index_t = typename tagged_node_handle::index_t;
 
         static constexpr auto null_index_t() noexcept
         {
@@ -157,8 +158,8 @@ namespace hpx::lockfree {
         queue& operator=(queue&&) = delete;
 
         using value_type = T;
-        using allocator = implementation_defined::allocator;
-        using size_type = implementation_defined::size_type;
+        using allocator = typename implementation_defined::allocator;
+        using size_type = typename implementation_defined::size_type;
 
         /**
          * \return true, if implementation is lock-free.
@@ -198,9 +199,8 @@ namespace hpx::lockfree {
          *  \pre Must specify a capacity<> argument
          */
         template <typename U>
-        explicit queue(
-            std::allocator_traits<Allocator>::template rebind_alloc<U> const&
-                alloc)
+        explicit queue(typename std::allocator_traits<
+            Allocator>::template rebind_alloc<U> const& alloc)
           : head_(tagged_node_handle(null_index_t(), 0))
           , tail_(tagged_node_handle(null_index_t(), 0))
           , pool(alloc, capacity)
@@ -254,8 +254,8 @@ namespace hpx::lockfree {
          */
         template <typename U>
         queue(size_type n,
-            std::allocator_traits<Allocator>::template rebind_alloc<U> const&
-                alloc)
+            typename std::allocator_traits<Allocator>::template rebind_alloc<
+                U> const& alloc)
           : head_(tagged_node_handle(null_index_t(), 0))
           , tail_(tagged_node_handle(null_index_t(), 0))
           , pool(alloc, n + 1)

--- a/libs/core/coroutines/include/hpx/coroutines/detail/context_base.hpp
+++ b/libs/core/coroutines/include/hpx/coroutines/detail/context_base.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2006, Giovanni P. Deretta
-//  Copyright (c) 2007-2022 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  This code may be used under either of the following two licences:
 //
@@ -359,13 +359,11 @@ namespace hpx::threads::coroutines::detail {
         }
 
         // Nothrow.
-        void do_return(
-            context_exit_status status, std::exception_ptr&& info) noexcept
+        void do_return(context_exit_status status) noexcept
         {
             HPX_ASSERT(status != context_exit_status::not_exited);
             HPX_ASSERT(m_state == context_state::running);
 
-            m_type_info = HPX_MOVE(info);
             m_state = context_state::exited;
             m_exit_status = status;
 #if defined(HPX_HAVE_ADDRESS_SANITIZER)

--- a/libs/core/coroutines/src/detail/coroutine_impl.cpp
+++ b/libs/core/coroutines/src/detail/coroutine_impl.cpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2006, Giovanni P. Deretta
-//  Copyright (c) 2007-2024 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  This code may be used under either of the following two licences:
 //
@@ -66,7 +66,6 @@ namespace hpx::threads::coroutines::detail {
 #if defined(HPX_HAVE_ADDRESS_SANITIZER)
             finish_switch_fiber(nullptr, m_caller);
 #endif
-            std::exception_ptr tinfo;
             {
                 coroutine_self* old_self = coroutine_self::get_self();
                 coroutine_stackful_self self(this, old_self);
@@ -85,7 +84,7 @@ namespace hpx::threads::coroutines::detail {
                 catch (...)
                 {
                     status = context_exit_status::exited_abnormally;
-                    tinfo = std::current_exception();
+                    this->m_type_info = std::current_exception();
                 }
 
                 // Reset early as the destructors may still yield.
@@ -96,7 +95,7 @@ namespace hpx::threads::coroutines::detail {
                 this->bind_result(result_last);
             }
 
-            this->do_return(status, HPX_MOVE(tinfo));
+            this->do_return(status);
         } while (this->m_state == context_state::running);
 
         // should not get here, never
@@ -106,7 +105,7 @@ namespace hpx::threads::coroutines::detail {
     // execute the coroutine function directly in the context of the calling
     // thread
     coroutine_impl::result_type coroutine_impl::invoke_directly(
-        coroutine_impl::arg_type arg)
+        coroutine_impl::arg_type const arg)
     {
         using context_state = super_type::context_state;
         using context_exit_status = super_type::context_exit_status;

--- a/libs/core/init_runtime_local/src/init_runtime_local.cpp
+++ b/libs/core/init_runtime_local/src/init_runtime_local.cpp
@@ -500,7 +500,8 @@ namespace hpx {
                     }
                     catch (hpx::exception const& e)
                     {
-                        std::cerr << "hpx::init: hpx::exception caught: "
+                        resource::detail::delete_partitioner();
+                        std::cerr << "hpx::local::init: hpx::exception caught: "
                                   << hpx::get_error_what(e) << "\n";
                         return -1;
                     }
@@ -523,6 +524,7 @@ namespace hpx {
                 }
                 catch (hpx::detail::command_line_error const& e)
                 {
+                    resource::detail::delete_partitioner();
                     std::cerr << "hpx::local::init: std::exception caught: "
                               << e.what() << "\n";
                     return -1;

--- a/libs/core/init_runtime_local/src/init_runtime_local.cpp
+++ b/libs/core/init_runtime_local/src/init_runtime_local.cpp
@@ -418,8 +418,9 @@ namespace hpx {
                 // make sure the runtime system is not active yet
                 if (get_runtime_ptr() != nullptr)
                 {
-                    std::cerr << "hpx::init: can't initialize runtime system "
-                                 "more than once! Exiting...\n";
+                    std::cerr
+                        << "hpx::local::init: can't initialize runtime system "
+                           "more than once! Exiting...\n";
                     return -1;
                 }
                 return 0;

--- a/libs/core/resource_partitioner/include/hpx/resource_partitioner/partitioner.hpp
+++ b/libs/core/resource_partitioner/include/hpx/resource_partitioner/partitioner.hpp
@@ -132,8 +132,9 @@ namespace hpx::resource {
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
 
-        inline ::hpx::resource::partitioner make_partitioner(
-            resource::partitioner_mode rpmode, hpx::util::section const& rtcfg,
+        HPX_CXX_CORE_EXPORT inline ::hpx::resource::partitioner
+        make_partitioner(resource::partitioner_mode rpmode,
+            hpx::util::section const& rtcfg,
             hpx::threads::policies::detail::affinity_data const& affinity_data);
     }
 
@@ -219,7 +220,7 @@ namespace hpx::resource {
 
     namespace detail {
 
-        ::hpx::resource::partitioner make_partitioner(
+        HPX_CXX_CORE_EXPORT ::hpx::resource::partitioner make_partitioner(
             resource::partitioner_mode const rpmode,
             hpx::util::section const& rtcfg,
             hpx::threads::policies::detail::affinity_data const& affinity_data)

--- a/libs/core/resource_partitioner/include/hpx/resource_partitioner/partitioner_fwd.hpp
+++ b/libs/core/resource_partitioner/include/hpx/resource_partitioner/partitioner_fwd.hpp
@@ -95,6 +95,7 @@ namespace hpx::resource {
         unspecified = -1,
         local = 0,
         local_priority_fifo = 1,
+        local_priority_fifo_double = 11,
         local_priority_lifo = 2,
         static_ = 3,
         static_priority = 4,

--- a/libs/core/resource_partitioner/include/hpx/resource_partitioner/partitioner_fwd.hpp
+++ b/libs/core/resource_partitioner/include/hpx/resource_partitioner/partitioner_fwd.hpp
@@ -25,7 +25,7 @@ namespace hpx::resource {
     namespace detail {
 
         class HPX_CORE_EXPORT partitioner;
-        void HPX_CORE_EXPORT delete_partitioner();
+        HPX_CXX_CORE_EXPORT void HPX_CORE_EXPORT delete_partitioner();
     }    // namespace detail
 
     /// May be used anywhere in code and returns a reference to the single,
@@ -141,4 +141,9 @@ namespace hpx::resource {
         scheduling_policy::shared_priority;
 
 #undef HPX_SCHEDULING_POLICY_UNSCOPED_ENUM_DEPRECATION_MSG
+
+    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT char const* get_scheduler_name(
+        scheduling_policy policy);
+    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT scheduling_policy get_scheduling_policy(
+        char const* scheduler_name);
 }    // namespace hpx::resource

--- a/libs/core/resource_partitioner/src/detail_partitioner.cpp
+++ b/libs/core/resource_partitioner/src/detail_partitioner.cpp
@@ -30,6 +30,114 @@
 #include <utility>
 #include <vector>
 
+namespace hpx::resource {
+
+    char const* get_scheduler_name(scheduling_policy const policy)
+    {
+        switch (policy)
+        {
+        case resource::scheduling_policy::unspecified:
+            return "unspecified";
+        case resource::scheduling_policy::user_defined:
+            return "user supplied";
+        case resource::scheduling_policy::local:
+            return "local";
+        case resource::scheduling_policy::local_priority_fifo:
+            return "local_priority_fifo";
+        case resource::scheduling_policy::local_priority_fifo_double:
+            return "local_priority_fifo_double";
+        case resource::scheduling_policy::local_priority_lifo:
+            return "local_priority_lifo";
+#if defined(HPX_HAVE_WORK_REQUESTING_SCHEDULERS)
+        case resource::scheduling_policy::local_workrequesting_fifo:
+            return "local_workrequesting_fifo";
+        case resource::scheduling_policy::local_workrequesting_lifo:
+            return "local_workrequesting_lifo";
+        case resource::scheduling_policy::local_workrequesting_mc:
+            return "local_workrequesting_mc";
+#else
+        case resource::scheduling_policy::local_workrequesting_fifo:
+        case resource::scheduling_policy::local_workrequesting_lifo:
+        case resource::scheduling_policy::local_workrequesting_mc:
+            return "unknown";
+#endif
+        case resource::scheduling_policy::static_:
+            return "static";
+        case resource::scheduling_policy::static_priority:
+            return "static_priority";
+        case resource::scheduling_policy::abp_priority_fifo:
+            return "abp_priority_fifo";
+        case resource::scheduling_policy::abp_priority_lifo:
+            return "abp_priority_lifo";
+        case resource::scheduling_policy::shared_priority:
+            return "shared_priority";
+        default:
+            break;
+        }
+        return "unknown";
+    }
+
+    scheduling_policy get_scheduling_policy(char const* scheduler_name)
+    {
+        if (scheduler_name == nullptr || *scheduler_name == '\0')
+        {
+            return scheduling_policy::unspecified;
+        }
+
+        if (0 == std::string("local").find(scheduler_name))
+        {
+            return scheduling_policy::local;
+        }
+        if (0 == std::string("local-priority-fifo").find(scheduler_name))
+        {
+            return scheduling_policy::local_priority_fifo;
+        }
+        if (0 == std::string("local-priority-fifo-double").find(scheduler_name))
+        {
+            return scheduling_policy::local_priority_fifo_double;
+        }
+        if (0 == std::string("local-priority-lifo").find(scheduler_name))
+        {
+            return scheduling_policy::local_priority_lifo;
+        }
+#if defined(HPX_HAVE_WORK_REQUESTING_SCHEDULERS)
+        if (0 == std::string("local-workrequesting-fifo").find(scheduler_name))
+        {
+            return scheduling_policy::local_workrequesting_fifo;
+        }
+        if (0 == std::string("local-workrequesting-lifo").find(scheduler_name))
+        {
+            return scheduling_policy::local_workrequesting_lifo;
+        }
+        if (0 == std::string("local-workrequesting-mc").find(scheduler_name))
+        {
+            return scheduling_policy::local_workrequesting_mc;
+        }
+#endif
+        if (0 == std::string("static").find(scheduler_name))
+        {
+            return scheduling_policy::static_;
+        }
+        if (0 == std::string("static-priority").find(scheduler_name))
+        {
+            return scheduling_policy::static_priority;
+        }
+        if (0 == std::string("abp-priority-fifo").find(scheduler_name))
+        {
+            return scheduling_policy::abp_priority_fifo;
+        }
+        if (0 == std::string("abp-priority-lifo").find(scheduler_name))
+        {
+            return scheduling_policy::abp_priority_lifo;
+        }
+        if (0 == std::string("shared-priority").find(scheduler_name))
+        {
+            return scheduling_policy::shared_priority;
+        }
+        return scheduling_policy::unspecified;
+    }
+}    // namespace hpx::resource
+
 namespace hpx::resource::detail {
 
     ///////////////////////////////////////////////////////////////////////////
@@ -120,64 +228,9 @@ namespace hpx::resource::detail {
 
     void init_pool_data::print_pool(std::ostream& os) const
     {
-        os << "[pool \"" << pool_name_ << "\"] with scheduler ";
-
-        std::string sched;
-        switch (scheduling_policy_)
-        {
-        case resource::scheduling_policy::unspecified:
-            sched = "unspecified";
-            break;
-        case resource::scheduling_policy::user_defined:
-            sched = "user supplied";
-            break;
-        case resource::scheduling_policy::local:
-            sched = "local";
-            break;
-        case resource::scheduling_policy::local_priority_fifo:
-            sched = "local_priority_fifo";
-            break;
-        case resource::scheduling_policy::local_priority_fifo_double:
-            sched = "local_priority_fifo_double";
-            break;
-        case resource::scheduling_policy::local_priority_lifo:
-            sched = "local_priority_lifo";
-            break;
-#if defined(HPX_HAVE_WORK_REQUESTING_SCHEDULERS)
-        case resource::scheduling_policy::local_workrequesting_fifo:
-            sched = "local_workrequesting_fifo";
-            break;
-        case resource::scheduling_policy::local_workrequesting_lifo:
-            sched = "local_workrequesting_lifo";
-            break;
-        case resource::scheduling_policy::local_workrequesting_mc:
-            sched = "local_workrequesting_mc";
-            break;
-#else
-        case resource::scheduling_policy::local_workrequesting_fifo:
-        case resource::scheduling_policy::local_workrequesting_lifo:
-        case resource::scheduling_policy::local_workrequesting_mc:
-            sched = "unknown";
-            break;
-#endif
-        case resource::scheduling_policy::static_:
-            sched = "static";
-            break;
-        case resource::scheduling_policy::static_priority:
-            sched = "static_priority";
-            break;
-        case resource::scheduling_policy::abp_priority_fifo:
-            sched = "abp_priority_fifo";
-            break;
-        case resource::scheduling_policy::abp_priority_lifo:
-            sched = "abp_priority_lifo";
-            break;
-        case resource::scheduling_policy::shared_priority:
-            sched = "shared_priority";
-            break;
-        }
-
-        os << "\"" << sched << "\" is running on PUs : \n";
+        os << "[pool \"" << pool_name_ << "\"] with scheduler \""
+           << get_scheduler_name(scheduling_policy_)
+           << "\" is running on PUs : \n";
 
         for (threads::mask_cref_type assigned_pu : assigned_pus_)
         {
@@ -490,78 +543,17 @@ namespace hpx::resource::detail {
     void partitioner::setup_schedulers()
     {
         // select the default scheduler
-        scheduling_policy default_scheduler;
-
         std::string const default_scheduler_str =
             rtcfg_.get_entry("hpx.scheduler", std::string());
 
-        if (0 == std::string("local").find(default_scheduler_str))
-        {
-            default_scheduler = scheduling_policy::local;
-        }
-        else if (0 ==
-            std::string("local-priority-fifo").find(default_scheduler_str))
-        {
-            default_scheduler = scheduling_policy::local_priority_fifo;
-        }
-        else if (0 ==
-            std::string("local-priority-fifo-double")
-                .find(default_scheduler_str))
-        {
-            default_scheduler = scheduling_policy::local_priority_fifo_double;
-        }
-        else if (0 ==
-            std::string("local-priority-lifo").find(default_scheduler_str))
-        {
-            default_scheduler = scheduling_policy::local_priority_lifo;
-        }
-#if defined(HPX_HAVE_WORK_REQUESTING_SCHEDULERS)
-        else if (0 ==
-            std::string("local-workrequesting-fifo")
-                .find(default_scheduler_str))
-        {
-            default_scheduler = scheduling_policy::local_workrequesting_fifo;
-        }
-        else if (0 ==
-            std::string("local-workrequesting-lifo")
-                .find(default_scheduler_str))
-        {
-            default_scheduler = scheduling_policy::local_workrequesting_lifo;
-        }
-        else if (0 ==
-            std::string("local-workrequesting-mc").find(default_scheduler_str))
-        {
-            default_scheduler = scheduling_policy::local_workrequesting_mc;
-        }
-#endif
-        else if (0 == std::string("static").find(default_scheduler_str))
-        {
-            default_scheduler = scheduling_policy::static_;
-        }
-        else if (0 ==
-            std::string("static-priority").find(default_scheduler_str))
-        {
-            default_scheduler = scheduling_policy::static_priority;
-        }
-        else if (0 ==
-            std::string("abp-priority-fifo").find(default_scheduler_str))
-        {
-            default_scheduler = scheduling_policy::abp_priority_fifo;
-        }
-        else if (0 ==
-            std::string("abp-priority-lifo").find(default_scheduler_str))
-        {
-            default_scheduler = scheduling_policy::abp_priority_lifo;
-        }
-        else if (0 ==
-            std::string("shared-priority").find(default_scheduler_str))
-        {
-            default_scheduler = scheduling_policy::shared_priority;
-        }
-        else
+        scheduling_policy default_scheduler =
+            get_scheduling_policy(default_scheduler_str.c_str());
+        if (default_scheduler == scheduling_policy::unspecified)
         {
             throw hpx::detail::command_line_error(
-                "Bad value for command line option --hpx:queuing");
+                std::string(
+                    "Bad value for command line option --hpx:queuing: ") +
+                default_scheduler_str);
         }
 
         // set this scheduler on the pools that do not have a specified scheduler yet

--- a/libs/core/resource_partitioner/src/detail_partitioner.cpp
+++ b/libs/core/resource_partitioner/src/detail_partitioner.cpp
@@ -137,6 +137,9 @@ namespace hpx::resource::detail {
         case resource::scheduling_policy::local_priority_fifo:
             sched = "local_priority_fifo";
             break;
+        case resource::scheduling_policy::local_priority_fifo_double:
+            sched = "local_priority_fifo_double";
+            break;
         case resource::scheduling_policy::local_priority_lifo:
             sched = "local_priority_lifo";
             break;
@@ -500,6 +503,12 @@ namespace hpx::resource::detail {
             std::string("local-priority-fifo").find(default_scheduler_str))
         {
             default_scheduler = scheduling_policy::local_priority_fifo;
+        }
+        else if (0 ==
+            std::string("local-priority-fifo-double")
+                .find(default_scheduler_str))
+        {
+            default_scheduler = scheduling_policy::local_priority_fifo_double;
         }
         else if (0 ==
             std::string("local-priority-lifo").find(default_scheduler_str))

--- a/libs/core/resource_partitioner/tests/unit/CMakeLists.txt
+++ b/libs/core/resource_partitioner/tests/unit/CMakeLists.txt
@@ -11,6 +11,7 @@ set(tests
     resource_partitioner_info
     scheduler_binding_check
     scheduler_priority_check
+    scheduling_policy_wiring
     shutdown_suspended_pus
     suspend_disabled
     suspend_pool

--- a/libs/core/resource_partitioner/tests/unit/cross_pool_injection.cpp
+++ b/libs/core/resource_partitioner/tests/unit/cross_pool_injection.cpp
@@ -279,6 +279,7 @@ int main(int argc, char* argv[])
     std::vector<hpx::resource::scheduling_policy> schedulers = {
         hpx::resource::scheduling_policy::local,
         hpx::resource::scheduling_policy::local_priority_fifo,
+        hpx::resource::scheduling_policy::local_priority_fifo_double,
 #if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
         hpx::resource::scheduling_policy::local_priority_lifo,
 #endif

--- a/libs/core/resource_partitioner/tests/unit/scheduling_policy_wiring.cpp
+++ b/libs/core/resource_partitioner/tests/unit/scheduling_policy_wiring.cpp
@@ -1,0 +1,112 @@
+//  Copyright (c) 2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// This test verifies the wiring between the --hpx:queuing command line option
+// and the hpx::resource::scheduling_policy that ends up being used by the
+// "default" pool, i.e. the prefix-matching logic implemented in
+// partitioner::setup_schedulers(). It spawns the runtime once per queuing
+// string (similar to cross_pool_injection.cpp) so that the actual command line
+// parsing path is exercised, rather than only the explicit scheduling_policy
+// enum API.
+
+#include <hpx/future.hpp>
+#include <hpx/init.hpp>
+#include <hpx/modules/resource_partitioner.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <string>
+#include <vector>
+
+namespace {
+
+    auto expected_policy = hpx::resource::scheduling_policy::unspecified;
+
+    int hpx_main()
+    {
+        HPX_TEST_EQ(
+            static_cast<int>(
+                hpx::resource::get_partitioner().which_scheduler("default")),
+            static_cast<int>(expected_policy));
+
+        // make sure the pool actually constructed a working scheduler, not just
+        // that the enum resolution is correct
+        HPX_TEST_EQ(hpx::async([]() { return 42; }).get(), 42);
+
+        return hpx::local::finalize();
+    }
+
+    // Spawn the runtime with the given --hpx:queuing value and verify that it
+    // resolves to the expected scheduling policy.
+    void test_queuing_string(int const argc, char* argv[],
+        std::string const& queuing_value,
+        hpx::resource::scheduling_policy const policy)
+    {
+        expected_policy = policy;
+
+        hpx::local::init_params init_args;
+        init_args.cfg = {"--hpx:queuing=" + queuing_value};
+
+        HPX_TEST_EQ(hpx::local::init(hpx_main, argc, argv, init_args), 0);
+    }
+
+    // Spawn the runtime with a --hpx:queuing value that does not match (as a
+    // prefix) any known scheduler name and verify that this is rejected rather
+    // than silently mapped to some scheduler. This pins down the current
+    // fallback behavior as a regression guard. hpx_main is never invoked in
+    // this case, as the runtime fails to start.
+    void test_invalid_queuing_string(
+        int const argc, char* argv[], std::string const& queuing_value)
+    {
+        hpx::local::init_params init_args;
+        init_args.cfg = {"--hpx:queuing=" + queuing_value};
+
+        HPX_TEST_EQ(hpx::local::init(hpx_main, argc, argv, init_args), -1);
+    }
+
+    // Construct the scheduler directly through
+    // partitioner::create_thread_pool(), bypassing --hpx:queuing command line
+    // parsing altogether. This isolates the
+    // threadmanager::create_scheduler_local_priority_fifo_double dispatch from
+    // the string-mapping logic exercised above.
+    void test_explicit_policy(int const argc, char* argv[])
+    {
+        expected_policy =
+            hpx::resource::scheduling_policy::local_priority_fifo_double;
+
+        hpx::local::init_params init_args;
+        init_args
+            .rp_callback = [](hpx::resource::partitioner& rp,
+                               hpx::program_options::variables_map const&) {
+            rp.create_thread_pool("default",
+                hpx::resource::scheduling_policy::local_priority_fifo_double);
+        };
+
+        HPX_TEST_EQ(hpx::local::init(hpx_main, argc, argv, init_args), 0);
+    }
+}    // namespace
+
+int main(int argc, char* argv[])
+{
+    // Exact match: must resolve to local_priority_fifo and must not be
+    // short-circuited into the local_priority_fifo_double branch that is
+    // checked immediately afterward in partitioner::setup_schedulers().
+    test_queuing_string(argc, argv, "local-priority-fifo",
+        hpx::resource::scheduling_policy::local_priority_fifo);
+
+    // Must resolve to local_priority_fifo_double, and must not be
+    // short-circuited by the shorter local-priority-fifo branch that is checked
+    // earlier in the if/else-if chain.
+    test_queuing_string(argc, argv, "local-priority-fifo-double",
+        hpx::resource::scheduling_policy::local_priority_fifo_double);
+
+    // A value that is not a prefix of any known scheduler name.
+    test_invalid_queuing_string(argc, argv, "not-a-real-scheduler");
+
+    // Explicit scheduling_policy API, bypassing command line parsing.
+    test_explicit_policy(argc, argv);
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/resource_partitioner/tests/unit/scheduling_policy_wiring.cpp
+++ b/libs/core/resource_partitioner/tests/unit/scheduling_policy_wiring.cpp
@@ -17,6 +17,7 @@
 #include <hpx/modules/resource_partitioner.hpp>
 #include <hpx/modules/testing.hpp>
 
+#include <algorithm>
 #include <string>
 #include <vector>
 
@@ -90,9 +91,26 @@ namespace {
 
 int main(int argc, char* argv[])
 {
-    // Exact match: must resolve to local_priority_fifo and must not be
-    // short-circuited into the local_priority_fifo_double branch that is
-    // checked immediately afterward in partitioner::setup_schedulers().
+    // Explicit scheduling_policy API, bypassing command line parsing.
+    test_explicit_policy(argc, argv);
+
+    // Some CIs invoke tests with --hpx:queuing=... which would cause duplicated
+    // command line option exceptions below. Remove this option from argc/argv
+    // if found.
+    char** end = std::remove_if(&argv[0], &argv[argc], [](char const* arg) {
+        return std::strstr(arg, "--hpx:queuing") != nullptr;
+    });
+
+    if (end != &argv[argc])
+    {
+        argc = static_cast<int>(end - &argv[0]);
+        *end = nullptr;
+    }
+
+    // command line option exceptions below. Exact match: must resolve to
+    // local_priority_fifo and must not be short-circuited into the
+    // local_priority_fifo_double branch that is checked immediately afterward
+    // in partitioner::setup_schedulers().
     test_queuing_string(argc, argv, "local-priority-fifo",
         hpx::resource::scheduling_policy::local_priority_fifo);
 
@@ -104,9 +122,6 @@ int main(int argc, char* argv[])
 
     // A value that is not a prefix of any known scheduler name.
     test_invalid_queuing_string(argc, argv, "not-a-real-scheduler");
-
-    // Explicit scheduling_policy API, bypassing command line parsing.
-    test_explicit_policy(argc, argv);
 
     return hpx::util::report_errors();
 }

--- a/libs/core/resource_partitioner/tests/unit/shutdown_suspended_pus.cpp
+++ b/libs/core/resource_partitioner/tests/unit/shutdown_suspended_pus.cpp
@@ -79,6 +79,7 @@ int main(int argc, char* argv[])
         std::vector<hpx::resource::scheduling_policy> schedulers = {
             hpx::resource::scheduling_policy::local,
             hpx::resource::scheduling_policy::local_priority_fifo,
+            hpx::resource::scheduling_policy::local_priority_fifo_double,
 #if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
             hpx::resource::scheduling_policy::local_priority_lifo,
 #endif

--- a/libs/core/resource_partitioner/tests/unit/suspend_pool.cpp
+++ b/libs/core/resource_partitioner/tests/unit/suspend_pool.cpp
@@ -183,6 +183,7 @@ int main(int argc, char* argv[])
     std::vector<hpx::resource::scheduling_policy> const schedulers = {
         hpx::resource::scheduling_policy::local,
         hpx::resource::scheduling_policy::local_priority_fifo,
+        hpx::resource::scheduling_policy::local_priority_fifo_double,
 #if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
         hpx::resource::scheduling_policy::local_priority_lifo,
 #endif

--- a/libs/core/resource_partitioner/tests/unit/suspend_pool_external.cpp
+++ b/libs/core/resource_partitioner/tests/unit/suspend_pool_external.cpp
@@ -93,6 +93,7 @@ int main(int argc, char* argv[])
     std::vector<hpx::resource::scheduling_policy> const schedulers = {
         hpx::resource::scheduling_policy::local,
         hpx::resource::scheduling_policy::local_priority_fifo,
+        hpx::resource::scheduling_policy::local_priority_fifo_double,
 #if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
         hpx::resource::scheduling_policy::local_priority_lifo,
 #endif

--- a/libs/core/resource_partitioner/tests/unit/suspend_runtime.cpp
+++ b/libs/core/resource_partitioner/tests/unit/suspend_runtime.cpp
@@ -62,6 +62,7 @@ int main(int argc, char* argv[])
     std::vector<hpx::resource::scheduling_policy> schedulers = {
         hpx::resource::scheduling_policy::local,
         hpx::resource::scheduling_policy::local_priority_fifo,
+        hpx::resource::scheduling_policy::local_priority_fifo_double,
 #if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
         hpx::resource::scheduling_policy::local_priority_lifo,
 #endif

--- a/libs/core/resource_partitioner/tests/unit/suspend_thread.cpp
+++ b/libs/core/resource_partitioner/tests/unit/suspend_thread.cpp
@@ -239,6 +239,7 @@ int main(int argc, char* argv[])
         std::vector<hpx::resource::scheduling_policy> const schedulers = {
             hpx::resource::scheduling_policy::local,
             hpx::resource::scheduling_policy::local_priority_fifo,
+            hpx::resource::scheduling_policy::local_priority_fifo_double,
 #if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
             hpx::resource::scheduling_policy::local_priority_lifo,
 #endif

--- a/libs/core/resource_partitioner/tests/unit/suspend_thread_external.cpp
+++ b/libs/core/resource_partitioner/tests/unit/suspend_thread_external.cpp
@@ -198,6 +198,7 @@ int main(int argc, char* argv[])
     std::vector<hpx::resource::scheduling_policy> schedulers = {
         hpx::resource::scheduling_policy::local,
         hpx::resource::scheduling_policy::local_priority_fifo,
+        hpx::resource::scheduling_policy::local_priority_fifo_double,
 #if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
         hpx::resource::scheduling_policy::local_priority_lifo,
         hpx::resource::scheduling_policy::abp_priority_fifo,

--- a/libs/core/resource_partitioner/tests/unit/suspend_thread_timed.cpp
+++ b/libs/core/resource_partitioner/tests/unit/suspend_thread_timed.cpp
@@ -141,6 +141,7 @@ int main(int argc, char* argv[])
         std::vector<hpx::resource::scheduling_policy> schedulers = {
             hpx::resource::scheduling_policy::local,
             hpx::resource::scheduling_policy::local_priority_fifo,
+            hpx::resource::scheduling_policy::local_priority_fifo_double,
 #if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
             hpx::resource::scheduling_policy::local_priority_lifo,
 #endif

--- a/libs/core/schedulers/include/hpx/schedulers/lockfree_queue_backends.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/lockfree_queue_backends.hpp
@@ -95,6 +95,10 @@ namespace hpx::threads::policies {
         };
     };
 
+    // Dual-queue push-to-passive semantics, conditional (128-bit atomic)
+    // end-selection for pop, distinct steal=true vs. steal=false pop control
+    // flow (bounded retries + parity toggle), and empty() requiring both
+    // queues to be empty.
     HPX_CXX_CORE_EXPORT template <typename T>
     struct lockfree_fifo_double_backend
     {

--- a/libs/core/schedulers/include/hpx/schedulers/lockfree_queue_backends.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/lockfree_queue_backends.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 //  Copyright (c) 2012 Bryce Adelstein-Lelbach
-//  Copyright (c) 2019-2022 Hartmut Kaiser
+//  Copyright (c) 2019-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -13,6 +13,7 @@
 #include <hpx/modules/allocator_support.hpp>
 #include <hpx/modules/concurrency.hpp>
 
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <type_traits>
@@ -43,7 +44,7 @@ namespace hpx::threads::policies {
 
         static constexpr bool support_bulk_dequeue = false;
 
-        explicit lockfree_fifo_backend(size_type initial_size = 0,
+        explicit lockfree_fifo_backend(size_type const initial_size = 0,
             size_type /* num_thread */ = static_cast<size_type>(-1))
           : queue_(static_cast<std::size_t>(initial_size))
         {
@@ -94,6 +95,187 @@ namespace hpx::threads::policies {
         };
     };
 
+    HPX_CXX_CORE_EXPORT template <typename T>
+    struct lockfree_fifo_double_backend
+    {
+#if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
+        using container_type = hpx::lockfree::deque<T,
+            hpx::lockfree::caching_freelist_t, hpx::util::aligned_allocator<T>>;
+#else
+        using container_type =
+            hpx::lockfree::queue<T, hpx::util::aligned_allocator<T>>;
+#endif
+
+        using value_type = T;
+        using reference = T&;
+        using const_reference = T const&;
+        using rvalue_reference = T&&;
+        using size_type = std::uint64_t;
+
+        static constexpr bool support_bulk_dequeue = false;
+
+        explicit lockfree_fifo_double_backend(size_type const initial_size = 0,
+            size_type /* num_thread */ = static_cast<size_type>(-1))
+          : queues_(static_cast<std::size_t>(initial_size))
+        {
+        }
+
+#if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
+        bool push(const_reference val, bool /*other_end*/ = false)    //-V659
+        {
+            return current_passive().push_left(val);
+        }
+
+        bool push(rvalue_reference val, bool /*other_end*/ = false)    //-V659
+        {
+            return current_passive().push_left(HPX_MOVE(val));
+        }
+#else
+        bool push(const_reference val, bool /*other_end*/ = false)    //-V659
+        {
+            return current_passive().push(val);
+        }
+
+        bool push(rvalue_reference val, bool /*other_end*/ = false)    //-V659
+        {
+            return current_passive().push(HPX_MOVE(val));
+        }
+#endif
+
+        bool pop(reference val, bool const steal = true) noexcept
+        {
+            auto [active, passive] = indices(std::memory_order_acquire);
+
+#if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
+            if (steal)
+            {
+                return queues_[passive].pop_right(val) ||
+                    queues_[active].pop_left(val);
+            }
+
+            constexpr int max_retries = 4;
+            for (int i = 0; i < max_retries; ++i)
+            {
+                if (queues_[active].pop_right(val))
+                    return true;
+
+                HPX_SMT_PAUSE;
+            }
+
+            // Toggle parity (single-threaded exchanger, so no guard needed)
+            idx_.fetch_xor(1u, std::memory_order_acq_rel);
+
+            // After toggling parity, the newly-selected "active" is the other
+            // queue.
+            return queues_[passive].pop_right(val);
+#else
+            if (steal)
+            {
+                return queues_[passive].pop(val) || queues_[active].pop(val);
+            }
+
+            constexpr int max_retries = 4;
+            for (int i = 0; i < max_retries; ++i)
+            {
+                if (queues_[active].pop(val))
+                    return true;
+
+                HPX_SMT_PAUSE;
+            }
+
+            // Toggle parity (single-threaded exchanger, so no guard needed)
+            idx_.fetch_xor(1u, std::memory_order_acq_rel);
+
+            // After toggling parity, the newly-selected "active" is the other
+            // queue (the previously passive one).
+            return queues_[passive].pop(val);
+#endif
+        }
+
+        bool empty() const noexcept
+        {
+            auto [active, passive] = indices();
+            return queues_[active].empty() && queues_[passive].empty();
+        }
+
+    private:
+        static constexpr unsigned int active_index(
+            unsigned int const idx) noexcept
+        {
+            return (idx & 0x1) ? 0 : 1;
+        }
+
+        static constexpr unsigned int passive_index(
+            unsigned int const idx) noexcept
+        {
+            return (idx & 0x1) ? 1 : 0;
+        }
+
+        container_type& current_active(
+            std::memory_order const mo = std::memory_order_acquire) noexcept
+        {
+            return queues_[active_index(idx_.load(mo))];
+        }
+        container_type const& current_active(
+            std::memory_order const mo =
+                std::memory_order_acquire) const noexcept
+        {
+            return queues_[active_index(idx_.load(mo))];
+        }
+
+        container_type& current_passive(
+            std::memory_order const mo = std::memory_order_acquire) noexcept
+        {
+            return queues_[passive_index(idx_.load(mo))];
+        }
+        container_type const& current_passive(
+            std::memory_order const mo =
+                std::memory_order_acquire) const noexcept
+        {
+            return queues_[passive_index(idx_.load(mo))];
+        }
+
+        std::pair<unsigned int, unsigned int> indices(
+            std::memory_order const mo =
+                std::memory_order_relaxed) const noexcept
+        {
+            unsigned int const idx = idx_.load(mo);
+            return {active_index(idx), passive_index(idx)};
+        }
+
+        struct queues
+        {
+            explicit queues(std::size_t const initial_size)
+              : data{container_type(initial_size), container_type(initial_size)}
+            {
+            }
+
+            constexpr container_type& operator[](
+                unsigned int const idx) noexcept
+            {
+                return data[idx];
+            }
+            constexpr container_type const& operator[](
+                unsigned int const idx) const noexcept
+            {
+                return data[idx];
+            }
+
+            container_type data[2];
+        } queues_;
+
+        util::cache_aligned_data_derived<std::atomic<unsigned int>> idx_ = 0;
+    };
+
+    HPX_CXX_CORE_EXPORT struct lockfree_fifo_double
+    {
+        template <typename T>
+        struct apply
+        {
+            using type = lockfree_fifo_double_backend<T>;
+        };
+    };
+
     ////////////////////////////////////////////////////////////////////////////
     // MoodyCamel FIFO
     HPX_CXX_CORE_EXPORT template <typename T>
@@ -109,7 +291,7 @@ namespace hpx::threads::policies {
 
         static constexpr bool support_bulk_dequeue = true;
 
-        explicit moodycamel_fifo_backend(size_type initial_size = 0,
+        explicit moodycamel_fifo_backend(size_type const initial_size = 0,
             size_type /* num_thread */ = static_cast<size_type>(-1))
           : queue_(static_cast<std::size_t>(initial_size))
         {
@@ -157,7 +339,7 @@ namespace hpx::threads::policies {
         };
     };
 
-    // LIFO
+// LIFO
 #if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
     HPX_CXX_CORE_EXPORT struct lockfree_lifo;
 

--- a/libs/core/schedulers/include/hpx/schedulers/thread_queue.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/thread_queue.hpp
@@ -847,7 +847,7 @@ namespace hpx::threads::policies {
         void move_work_items_from(thread_queue* src, std::int64_t count)
         {
             thread_description_ptr trd;
-            while (src->work_items_.pop(trd))
+            while (src->work_items_.pop(trd, true))
             {
                 --src->work_items_count_.data_;
 
@@ -872,7 +872,7 @@ namespace hpx::threads::policies {
         void move_task_items_from(thread_queue* src, std::int64_t count)
         {
             task_description task;
-            while (src->new_tasks_.pop(task))
+            while (src->new_tasks_.pop(task, true))
             {
 #ifdef HPX_HAVE_THREAD_QUEUE_WAITTIME
                 if (get_maintain_queue_wait_times_enabled())

--- a/libs/core/schedulers/tests/unit/CMakeLists.txt
+++ b/libs/core/schedulers/tests/unit/CMakeLists.txt
@@ -4,7 +4,9 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(tests schedule_last schedule_hint_none_stale_queue_6978)
+set(tests lockfree_fifo_double_backend schedule_last
+          schedule_hint_none_stale_queue_6978
+)
 
 # ##############################################################################
 foreach(test ${tests})

--- a/libs/core/schedulers/tests/unit/lockfree_fifo_double_backend.cpp
+++ b/libs/core/schedulers/tests/unit/lockfree_fifo_double_backend.cpp
@@ -226,10 +226,10 @@ void test_concurrent_stress()
 
     backend_type backend(total_items);
 
-    // Bounds how long a consumer may wait without making progress (i.e. without
-    // a successful pop) before it is considered stalled. This guards against
-    // spinning forever if an item is ever lost, turning a silent CI hang into
-    // an actionable test failure.
+    // Bounds how long a producer or a consumer may wait without making progress
+    // (i.e. without a successful push or pop) before it is considered stalled.
+    // This guards against spinning forever if an item is ever lost, turning a
+    // silent CI hang into an actionable test failure.
     constexpr auto stress_stall_timeout = std::chrono::seconds(30);
 
     std::atomic<bool> producers_done(false);
@@ -239,92 +239,76 @@ void test_concurrent_stress()
 
     for (std::uint64_t p = 0; p != num_producers; ++p)
     {
-        producers.emplace_back([&backend, p]() {
+        producers.emplace_back([&, p]() {
+            auto last_progress = std::chrono::steady_clock::now();
             std::uint64_t const base = p * items_per_producer;
             for (std::uint64_t i = 0; i != items_per_producer; ++i)
             {
                 while (!backend.push(base + i))
                 {
-                    std::this_thread::yield();
-                }
-            }
-        });
-    }
-
-    // Stealer threads: pop(steal=true) only.
-    for (std::uint64_t s = 0; s != num_stealers; ++s)
-    {
-        consumers.emplace_back(
-            [&backend, &producers_done, &collected, s, stress_stall_timeout]() {
-                std::uint64_t val = 0;
-                auto last_progress = std::chrono::steady_clock::now();
-                while (true)
-                {
-                    if (backend.pop(val, /*steal=*/true))
-                    {
-                        collected[s].push_back(val);
-                        last_progress = std::chrono::steady_clock::now();
-                    }
-                    else if (producers_done.load(std::memory_order_acquire) &&
-                        backend.empty())
-                    {
-                        break;
-                    }
-                    else
-                    {
-                        if (std::chrono::steady_clock::now() - last_progress >
-                            stress_stall_timeout)
-                        {
-                            HPX_TEST_MSG(false,
-                                "stealer thread stalled: no progress for "
-                                "30s, producers_done=" +
-                                    std::to_string(producers_done.load()) +
-                                    ", backend.empty()=" +
-                                    std::to_string(backend.empty()) +
-                                    " (possible lost item)");
-                            return;
-                        }
-                        std::this_thread::yield();
-                    }
-                }
-            });
-    }
-
-    // Single owner thread: pop(steal=false) only.
-    consumers.emplace_back(
-        [&backend, &producers_done, &collected, stress_stall_timeout]() {
-            std::uint64_t val = 0;
-            auto last_progress = std::chrono::steady_clock::now();
-            while (true)
-            {
-                if (backend.pop(val, /*steal=*/false))
-                {
-                    collected[num_stealers].push_back(val);
-                    last_progress = std::chrono::steady_clock::now();
-                }
-                else if (producers_done.load(std::memory_order_acquire) &&
-                    backend.empty())
-                {
-                    break;
-                }
-                else
-                {
                     if (std::chrono::steady_clock::now() - last_progress >
                         stress_stall_timeout)
                     {
                         HPX_TEST_MSG(false,
-                            "owner thread stalled: no progress for 30s, "
-                            "producers_done=" +
-                                std::to_string(producers_done.load()) +
-                                ", backend.empty()=" +
-                                std::to_string(backend.empty()) +
-                                " (possible lost item)");
+                            std::string("producer thread stalled: no "
+                                        "progress for 30s while pushing "
+                                        "item ") +
+                                std::to_string(base + i));
                         return;
                     }
-                    std::this_thread::yield();
                 }
+                std::this_thread::yield();
             }
+            last_progress = std::chrono::steady_clock::now();
         });
+    }
+
+    auto run_consumer = [&, stress_stall_timeout](bool const steal,
+                            std::size_t const collected_index,
+                            char const* role) {
+        std::uint64_t val = 0;
+        auto last_progress = std::chrono::steady_clock::now();
+        while (true)
+        {
+            if (backend.pop(val, steal))
+            {
+                collected[collected_index].push_back(val);
+                last_progress = std::chrono::steady_clock::now();
+            }
+            else if (producers_done.load(std::memory_order_acquire) &&
+                backend.empty())
+            {
+                break;
+            }
+            else
+            {
+                if (std::chrono::steady_clock::now() - last_progress >
+                    stress_stall_timeout)
+                {
+                    HPX_TEST_MSG(false,
+                        std::string(role) +
+                            " thread stalled: no progress for 30s, "
+                            "producers_done=" +
+                            std::to_string(producers_done.load()) +
+                            ", backend.empty()=" +
+                            std::to_string(backend.empty()) +
+                            " (possible lost item)");
+                    return;
+                }
+                std::this_thread::yield();
+            }
+        }
+    };
+
+    // Stealer threads: pop(steal=true) only.
+    for (std::uint64_t s = 0; s != num_stealers; ++s)
+    {
+        consumers.emplace_back([&, s]() { run_consumer(true, s, "stealer"); });
+    }
+
+    // Single owner thread: pop(steal=false) only.
+    consumers.emplace_back(
+        [&]() { run_consumer(false, num_stealers, "owner"); });
 
     for (auto& t : producers)
     {

--- a/libs/core/schedulers/tests/unit/lockfree_fifo_double_backend.cpp
+++ b/libs/core/schedulers/tests/unit/lockfree_fifo_double_backend.cpp
@@ -1,0 +1,371 @@
+//  Copyright (c) 2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Unit tests for the dual-queue scheduler backend
+// (hpx::threads::policies::lockfree_fifo_double_backend), which provides
+// push-to-passive semantics, an active/passive parity toggle, and distinct
+// steal=true vs. steal=false pop control flow.
+
+#include <hpx/config.hpp>
+#include <hpx/modules/schedulers.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <thread>
+#include <vector>
+
+using backend_type =
+    hpx::threads::policies::lockfree_fifo_double_backend<std::uint64_t>;
+
+///////////////////////////////////////////////////////////////////////////////
+// 1. Single-threaded FIFO ordering with steal=false.
+void test_single_threaded_fifo_order_steal_false()
+{
+    backend_type backend(16);
+
+    constexpr std::uint64_t count = 8;
+    for (std::uint64_t i = 0; i != count; ++i)
+    {
+        HPX_TEST(backend.push(i));
+    }
+
+    // The very first pop(false) call finds the (initially empty) active queue
+    // exhausted and toggles parity so that the queue which had been receiving
+    // pushes becomes active. From that point on, items must come out in the
+    // order they were pushed (FIFO).
+    for (std::uint64_t i = 0; i != count; ++i)
+    {
+        std::uint64_t val = 0;
+        HPX_TEST(backend.pop(val, /*steal=*/false));
+        HPX_TEST_EQ(val, i);
+    }
+
+    std::uint64_t val = 0;
+    HPX_TEST(!backend.pop(val, /*steal=*/false));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// 2. empty() requires both queues to be empty.
+void test_empty_requires_both_queues_empty()
+{
+    backend_type backend(16);
+
+    HPX_TEST(backend.empty());
+
+    HPX_TEST(backend.push(static_cast<std::uint64_t>(42)));
+    HPX_TEST(!backend.empty());
+
+    // Toggle parity so that the pushed item ends up in what is now considered
+    // the active queue, while the (still empty) passive queue is the other one.
+    // empty() must not be fooled by inspecting only one of the two queues.
+    std::uint64_t val = 0;
+    HPX_TEST(backend.pop(val, /*steal=*/false));
+    HPX_TEST_EQ(val, static_cast<std::uint64_t>(42));
+
+    HPX_TEST(backend.empty());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// 3. Passive-push / parity-toggle correctness: push always lands on the
+//    current passive queue, and pop(steal=false) drains the active queue, only
+//    reaching the passive queue (by toggling parity) once active is exhausted.
+void test_passive_push_and_parity_toggle()
+{
+    backend_type backend(16);
+
+    HPX_TEST(backend.push(static_cast<std::uint64_t>(1)));
+    HPX_TEST(backend.push(static_cast<std::uint64_t>(2)));
+    HPX_TEST(backend.push(static_cast<std::uint64_t>(3)));
+
+    std::uint64_t val = 0;
+
+    // Active queue is empty -> retries fail -> toggle -> pop from what is now
+    // active (was passive, holds 1, 2, 3) -> first item pushed.
+    HPX_TEST(backend.pop(val, /*steal=*/false));
+    HPX_TEST_EQ(val, static_cast<std::uint64_t>(1));
+
+    // A push here must land in the *new* passive queue and must not interfere
+    // with the remaining items (2, 3) in the now-active queue.
+    HPX_TEST(backend.push(static_cast<std::uint64_t>(4)));
+
+    HPX_TEST(backend.pop(val, /*steal=*/false));
+    HPX_TEST_EQ(val, static_cast<std::uint64_t>(2));
+
+    HPX_TEST(backend.pop(val, /*steal=*/false));
+    HPX_TEST_EQ(val, static_cast<std::uint64_t>(3));
+
+    // Active is exhausted again -> toggle -> pop from the queue holding 4.
+    HPX_TEST(backend.pop(val, /*steal=*/false));
+    HPX_TEST_EQ(val, static_cast<std::uint64_t>(4));
+
+    HPX_TEST(backend.empty());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// 4. steal=true pop order: passive is tried first, falling back to active,
+//    without losing or duplicating items.
+void test_steal_pop_order()
+{
+    backend_type backend(16);
+
+    std::vector<std::uint64_t> expected;
+    for (std::uint64_t i = 0; i != 5; ++i)
+    {
+        HPX_TEST(backend.push(i));
+        expected.push_back(i);
+    }
+
+    std::vector<std::uint64_t> popped;
+    std::uint64_t val = 0;
+
+    // Force a toggle so that item 0 is consumed and items 1..4 remain in what
+    // is now the active queue, while the passive queue is empty.
+    HPX_TEST(backend.pop(val, /*steal=*/false));
+    HPX_TEST_EQ(val, static_cast<std::uint64_t>(0));
+    popped.push_back(val);
+
+#if defined(HPX_HAVE_CXX11_STD_ATOMIC_128BIT)
+    // Passive is empty, so steal=true must fall back to active and pop from its
+    // opposite (left) end, i.e. the most recently pushed remaining item.
+    HPX_TEST(backend.pop(val, /*steal=*/true));
+    HPX_TEST_EQ(val, std::uint64_t(4));
+    popped.push_back(val);
+
+    // New pushes land on the (empty) passive queue and must be preferred by
+    // steal=true over the remaining active items.
+    HPX_TEST(backend.push(std::uint64_t(99)));
+    expected.push_back(99);
+
+    HPX_TEST(backend.pop(val, /*steal=*/true));
+    HPX_TEST_EQ(val, std::uint64_t(99));
+    popped.push_back(val);
+#endif
+
+    // Drain everything else via steal=true; no items may be lost or duplicated
+    // regardless of the exact order they come out in. Without 128-bit atomics
+    // the backend falls back to a single-ended queue, so both the passive-first
+    // and active-fallback pops are plain FIFO.
+    while (backend.pop(val, /*steal=*/true))
+    {
+        popped.push_back(val);
+    }
+
+    HPX_TEST(backend.empty());
+
+    std::ranges::sort(popped);
+    std::ranges::sort(expected);
+    HPX_TEST(popped == expected);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// 5. Boundary behavior of the retry-then-toggle control flow in
+//    pop(steal=false): a pop must not spuriously succeed while both queues are
+//    empty, and must succeed via the parity toggle as soon as the (previously
+//    passive) queue holds an item once active is exhausted.
+void test_retry_then_toggle_boundary()
+{
+    backend_type backend(16);
+
+    std::uint64_t val = 0;
+
+    // Both queues empty: repeated pop(false) calls must consistently
+    // report failure.
+    for (int i = 0; i != 10; ++i)
+    {
+        HPX_TEST(!backend.pop(val, /*steal=*/false));
+    }
+
+    // Active is empty, passive holds exactly one item: pop(false) must still
+    // succeed after exhausting the retries and toggling parity.
+    HPX_TEST(backend.push(static_cast<std::uint64_t>(7)));
+    HPX_TEST(backend.pop(val, /*steal=*/false));
+    HPX_TEST_EQ(val, static_cast<std::uint64_t>(7));
+
+    HPX_TEST(!backend.pop(val, /*steal=*/false));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// 6. pop() returns false when both queues are truly empty, for both
+//    steal=true and steal=false.
+void test_pop_false_when_empty()
+{
+    backend_type backend(16);
+    std::uint64_t val = 0;
+
+    HPX_TEST(!backend.pop(val, /*steal=*/true));
+    HPX_TEST(!backend.pop(val, /*steal=*/false));
+
+    HPX_TEST(backend.push(static_cast<std::uint64_t>(1)));
+    HPX_TEST(backend.pop(val, /*steal=*/true));
+    HPX_TEST_EQ(val, static_cast<std::uint64_t>(1));
+
+    HPX_TEST(!backend.pop(val, /*steal=*/true));
+    HPX_TEST(!backend.pop(val, /*steal=*/false));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// 7. Concurrent multi-producer / multi-stealer stress test: every pushed
+//    item must be popped exactly once, with no lost or duplicated items. Only a
+//    single "owner" thread calls pop(steal=false), since the parity toggle is
+//    documented as a single-threaded operation; any number of threads may
+//    push() concurrently or call pop(steal=true).
+void test_concurrent_stress()
+{
+    constexpr std::uint64_t num_producers = 4;
+    constexpr std::uint64_t items_per_producer = 5000;
+    constexpr std::uint64_t num_stealers = 3;
+    constexpr std::uint64_t total_items = num_producers * items_per_producer;
+
+    backend_type backend(total_items);
+
+    // Bounds how long a consumer may wait without making progress (i.e. without
+    // a successful pop) before it is considered stalled. This guards against
+    // spinning forever if an item is ever lost, turning a silent CI hang into
+    // an actionable test failure.
+    constexpr auto stress_stall_timeout = std::chrono::seconds(30);
+
+    std::atomic<bool> producers_done(false);
+    std::vector<std::thread> producers;
+    std::vector<std::thread> consumers;
+    std::vector<std::vector<std::uint64_t>> collected(num_stealers + 1);
+
+    for (std::uint64_t p = 0; p != num_producers; ++p)
+    {
+        producers.emplace_back([&backend, p]() {
+            std::uint64_t const base = p * items_per_producer;
+            for (std::uint64_t i = 0; i != items_per_producer; ++i)
+            {
+                while (!backend.push(base + i))
+                {
+                    std::this_thread::yield();
+                }
+            }
+        });
+    }
+
+    // Stealer threads: pop(steal=true) only.
+    for (std::uint64_t s = 0; s != num_stealers; ++s)
+    {
+        consumers.emplace_back(
+            [&backend, &producers_done, &collected, s, stress_stall_timeout]() {
+                std::uint64_t val = 0;
+                auto last_progress = std::chrono::steady_clock::now();
+                while (true)
+                {
+                    if (backend.pop(val, /*steal=*/true))
+                    {
+                        collected[s].push_back(val);
+                        last_progress = std::chrono::steady_clock::now();
+                    }
+                    else if (producers_done.load(std::memory_order_acquire) &&
+                        backend.empty())
+                    {
+                        break;
+                    }
+                    else
+                    {
+                        if (std::chrono::steady_clock::now() - last_progress >
+                            stress_stall_timeout)
+                        {
+                            HPX_TEST_MSG(false,
+                                "stealer thread stalled: no progress for "
+                                "30s, producers_done=" +
+                                    std::to_string(producers_done.load()) +
+                                    ", backend.empty()=" +
+                                    std::to_string(backend.empty()) +
+                                    " (possible lost item)");
+                            return;
+                        }
+                        std::this_thread::yield();
+                    }
+                }
+            });
+    }
+
+    // Single owner thread: pop(steal=false) only.
+    consumers.emplace_back(
+        [&backend, &producers_done, &collected, stress_stall_timeout]() {
+            std::uint64_t val = 0;
+            auto last_progress = std::chrono::steady_clock::now();
+            while (true)
+            {
+                if (backend.pop(val, /*steal=*/false))
+                {
+                    collected[num_stealers].push_back(val);
+                    last_progress = std::chrono::steady_clock::now();
+                }
+                else if (producers_done.load(std::memory_order_acquire) &&
+                    backend.empty())
+                {
+                    break;
+                }
+                else
+                {
+                    if (std::chrono::steady_clock::now() - last_progress >
+                        stress_stall_timeout)
+                    {
+                        HPX_TEST_MSG(false,
+                            "owner thread stalled: no progress for 30s, "
+                            "producers_done=" +
+                                std::to_string(producers_done.load()) +
+                                ", backend.empty()=" +
+                                std::to_string(backend.empty()) +
+                                " (possible lost item)");
+                        return;
+                    }
+                    std::this_thread::yield();
+                }
+            }
+        });
+
+    for (auto& t : producers)
+    {
+        t.join();
+    }
+    producers_done.store(true, std::memory_order_release);
+
+    for (auto& t : consumers)
+    {
+        t.join();
+    }
+
+    HPX_TEST(backend.empty());
+
+    std::vector<std::uint64_t> all;
+    for (auto& v : collected)
+    {
+        all.insert(all.end(), v.begin(), v.end());
+    }
+
+    HPX_TEST_EQ(all.size(), static_cast<std::size_t>(total_items));
+
+    std::ranges::sort(all);
+    all.erase(std::ranges::unique(all).begin(), all.end());
+    HPX_TEST_EQ(all.size(), static_cast<std::size_t>(total_items));
+
+    for (std::uint64_t i = 0; i != total_items; ++i)
+    {
+        HPX_TEST_EQ(all[i], i);
+    }
+}
+
+int main()
+{
+    test_single_threaded_fifo_order_steal_false();
+    test_empty_requires_both_queues_empty();
+    test_passive_push_and_parity_toggle();
+    test_steal_pop_order();
+    test_retry_then_toggle_boundary();
+    test_pop_false_when_empty();
+    test_concurrent_stress();
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/synchronization/include/hpx/synchronization/latch.hpp
+++ b/libs/core/synchronization/include/hpx/synchronization/latch.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2015-2022 Hartmut Kaiser
+//  Copyright (c) 2015-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -48,7 +48,7 @@ namespace hpx {
         /// Synchronization: None
         /// Postconditions: counter_ == count.
         ///
-        explicit latch(std::ptrdiff_t count)
+        explicit latch(std::ptrdiff_t const count)
           : counter_(count)
           , notified_(count == 0)
         {
@@ -89,11 +89,14 @@ namespace hpx {
         ///
         /// \throws Nothing.
         ///
-        void count_down(std::ptrdiff_t update)
+        void count_down(std::ptrdiff_t const update)
         {
             HPX_ASSERT(update >= 0);
 
-            std::ptrdiff_t const new_count = (counter_ -= update);
+            // Explicit atomic RMW for clearer memory-order intent.
+            std::ptrdiff_t const new_count =
+                counter_.fetch_sub(update, std::memory_order_acq_rel) - update;
+
             HPX_ASSERT(new_count >= 0);
 
             // 26111: Caller failing to release lock 'this->mtx_.data_'
@@ -108,18 +111,8 @@ namespace hpx {
                 std::unique_lock l(mtx_.data_);
                 notified_ = true;
 
-                // Note: we use notify_one repeatedly instead of notify_all as we
-                // know that our implementation of condition_variable::notify_one
-                // relinquishes the lock before resuming the waiting thread
-                // that avoids suspension of this thread when it tries to
-                // re-lock the mutex while exiting from condition_variable::wait
-                while (cond_.data_.notify_one(
-                    HPX_MOVE(l), threads::thread_priority::boost))
-                {
-                    l = std::unique_lock(mtx_.data_);
-                }
+                notify_waiters(HPX_MOVE(l));
             }
-
 #if defined(HPX_MSVC)
 #pragma warning(pop)
 #endif
@@ -148,14 +141,15 @@ namespace hpx {
 #endif
 
             std::unique_lock l(mtx_.data_);
-            if (counter_.load(std::memory_order_relaxed) > 0 || !notified_)
+
+            // Robust predicate loop.
+            while (counter_.load(std::memory_order_acquire) > 0 || !notified_)
             {
                 cond_.data_.wait(l, "hpx::latch::wait");
-
-                HPX_ASSERT_LOCKED(
-                    l, counter_.load(std::memory_order_relaxed) == 0);
-                HPX_ASSERT_LOCKED(l, notified_);
             }
+
+            HPX_ASSERT_LOCKED(l, counter_.load(std::memory_order_relaxed) == 0);
+            HPX_ASSERT_LOCKED(l, notified_);
 
 #if defined(HPX_MSVC)
 #pragma warning(pop)
@@ -172,7 +166,7 @@ namespace hpx {
             std::unique_lock l(mtx_.data_);
 
             std::ptrdiff_t const old_count =
-                counter_.fetch_sub(update, std::memory_order_relaxed);
+                counter_.fetch_sub(update, std::memory_order_acq_rel);
             HPX_ASSERT_LOCKED(l, old_count >= update);
 
             // 26110: Caller failing to hold lock 'this->mtx_.data_'
@@ -183,10 +177,14 @@ namespace hpx {
 #pragma warning(push)
 #pragma warning(disable : 26110 26111 26115 26117)
 #endif
-
             if (old_count > update)
             {
-                cond_.data_.wait(l, "hpx::latch::arrive_and_wait");
+                // Robust predicate loop.
+                while (
+                    counter_.load(std::memory_order_acquire) > 0 || !notified_)
+                {
+                    cond_.data_.wait(l, "hpx::latch::arrive_and_wait");
+                }
 
                 HPX_ASSERT_LOCKED(
                     l, counter_.load(std::memory_order_relaxed) == 0);
@@ -195,25 +193,26 @@ namespace hpx {
             else
             {
                 notified_ = true;
-
-                // Note: we use notify_one repeatedly instead of notify_all as we
-                // know that our implementation of condition_variable::notify_one
-                // relinquishes the lock before resuming the waiting thread
-                // which avoids suspension of this thread when it tries to
-                // re-lock the mutex while exiting from condition_variable::wait
-                while (cond_.data_.notify_one(
-                    HPX_MOVE(l), threads::thread_priority::boost))
-                {
-                    l = std::unique_lock(mtx_.data_);
-                }
+                notify_waiters(HPX_MOVE(l));
             }
-
-#if defined(HPX_MSVC)
-#pragma warning(pop)
-#endif
         }
 
     protected:
+        // Factor the 'final thread' wake logic to avoid duplication.
+        void notify_waiters(std::unique_lock<mutex_type>&& l) const
+        {
+            // Note: we use notify_one repeatedly instead of notify_all as we
+            // know that our implementation of condition_variable::notify_one
+            // relinquishes the lock before resuming the waiting thread
+            // that avoids suspension of this thread when it tries to
+            // re-lock the mutex while exiting from condition_variable::wait
+            while (cond_.data_.notify_one(
+                HPX_MOVE(l), threads::thread_priority::boost))
+            {
+                l = std::unique_lock(mtx_.data_);
+            }
+        }
+
         mutable util::cache_line_data<mutex_type> mtx_;
         mutable util::cache_line_data<
             hpx::lcos::local::detail::condition_variable>
@@ -254,7 +253,7 @@ namespace hpx::lcos::local {
         /// Synchronization: None
         /// Postconditions: counter_ == count.
         ///
-        explicit latch(std::ptrdiff_t count)
+        explicit latch(std::ptrdiff_t const count)
           : hpx::latch(count)
         {
         }
@@ -317,7 +316,7 @@ namespace hpx::lcos::local {
         ///
         /// \throws Nothing.
         ///
-        void count_up(std::ptrdiff_t n)
+        void count_up(std::ptrdiff_t const n)
         {
             HPX_ASSERT(n >= 0);
 
@@ -333,7 +332,7 @@ namespace hpx::lcos::local {
         /// Requires:  n >= 0.
         ///
         /// \throws Nothing.
-        void reset(std::ptrdiff_t n)
+        void reset(std::ptrdiff_t const n)
         {
             HPX_ASSERT(n >= 0);
 
@@ -353,7 +352,7 @@ namespace hpx::lcos::local {
         ///             count_up(n);
         /// Returns: true if the latch was reset
         bool reset_if_needed_and_count_up(
-            std::ptrdiff_t n, std::ptrdiff_t count)
+            std::ptrdiff_t const n, std::ptrdiff_t const count)
         {
             HPX_ASSERT(n >= 0);
             HPX_ASSERT(count >= 0);

--- a/libs/core/synchronization/tests/unit/CMakeLists.txt
+++ b/libs/core/synchronization/tests/unit/CMakeLists.txt
@@ -20,6 +20,7 @@ set(tests
     in_place_stop_token
     in_place_stop_token_cb2
     latch_cpp20
+    latch_notification
     local_latch
     local_barrier
     local_barrier_count_up
@@ -45,6 +46,7 @@ set(counting_semaphore_PARAMETERS THREADS_PER_LOCALITY 4)
 set(counting_semaphore_cpp20_PARAMETERS THREADS_PER_LOCALITY 4)
 
 set(latch_cpp20_PARAMETERS THREADS_PER_LOCALITY 4)
+set(latch_notification_PARAMETERS THREADS_PER_LOCALITY 4)
 set(local_barrier_PARAMETERS THREADS_PER_LOCALITY 4)
 set(local_latch_PARAMETERS THREADS_PER_LOCALITY 4)
 set(local_event_PARAMETERS THREADS_PER_LOCALITY 4)

--- a/libs/core/synchronization/tests/unit/latch_notification.cpp
+++ b/libs/core/synchronization/tests/unit/latch_notification.cpp
@@ -1,0 +1,342 @@
+//  Copyright (c) 2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Concurrency stress tests for hpx::latch / hpx::lcos::local::latch that
+// specifically target:
+//   - the acq_rel counter update in count_down()/arrive_and_wait(),
+//   - the explicit notified_ flag guarding the robust predicate loop in
+//     wait()/arrive_and_wait(), and
+//   - the notify_waiters() loop that repeatedly calls notify_one() until all
+//     blocked waiters have been released.
+//
+// None of these are single-shot assertions: races only show up with repetition,
+// so most tests below loop many times, recreating the latch (and, where
+// relevant, varying the number of participating threads) on each iteration.
+// Every blocking wait on a future is bounded by a deadline rather than
+// performed unconditionally, so that a lost wakeup shows up as a test failure
+// instead of a hang.
+
+#define HPX_HAVE_FORCE_NO_CXX_MODULES
+
+#include <hpx/execution.hpp>
+#include <hpx/future.hpp>
+#include <hpx/init.hpp>
+#include <hpx/latch.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <cstddef>
+#include <vector>
+
+namespace {
+
+    constexpr std::size_t num_iterations = 25;
+    constexpr std::chrono::seconds wait_deadline(5);
+
+    // Convenience wrapper that turns a lost wakeup into a test failure rather
+    // than an indefinite hang.
+    void expect_ready(hpx::future<void> const& f)
+    {
+        HPX_TEST_EQ(static_cast<int>(f.wait_for(wait_deadline)),
+            static_cast<int>(hpx::future_status::ready));
+    }
+}    // namespace
+
+///////////////////////////////////////////////////////////////////////////////
+// 1. Exactly-once notification / no lost wakeups.
+//
+// A varying number of waiters block in wait() on a not-yet-ready latch. A
+// single count_down() drives the counter to zero. Every waiter must actually
+// return (bounded by a deadline, not an infinite wait); this exercises the
+// `while (cond_.data_.notify_one(...))` loop in notify_waiters().
+void test_no_lost_wakeups()
+{
+    std::size_t const waiter_counts[] = {1, 2, 4, 8, 16};
+
+    for (std::size_t num_waiters : waiter_counts)
+    {
+        for (std::size_t iter = 0; iter != num_iterations; ++iter)
+        {
+            hpx::latch l(1);
+            std::atomic<std::size_t> woken(0);
+
+            std::vector<hpx::future<void>> results;
+            results.reserve(num_waiters);
+            for (std::size_t i = 0; i != num_waiters; ++i)
+            {
+                results.push_back(hpx::async([&l, &woken]() {
+                    l.wait();
+                    ++woken;
+                }));
+            }
+
+            l.count_down(1);
+
+            for (auto& f : results)
+            {
+                expect_ready(f);
+            }
+
+            HPX_TEST_EQ(woken.load(), num_waiters);
+            HPX_TEST(l.try_wait());
+        }
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// 2. notified_ flag race on the "last decrementer".
+//
+// Many threads race count_down(1) against a latch initialized with their count,
+// while other threads are concurrently blocked in wait(). Exactly one
+// decrementer observes the counter reaching zero (guaranteed by the atomic
+// fetch_sub itself), sets notified_, and releases all waiters. This test
+// asserts none of the waiters hang (no lost wakeup) and none observe a
+// still-blocking predicate forever.
+//
+// It also documents the current contract that try_wait() (and thus is_ready())
+// only inspects counter_, not notified_: as soon as the last count_down() has
+// decremented the counter, try_wait() reports ready even though
+// notify_waiters() might not (yet) have released any concurrently blocked
+// waiters.
+void test_last_decrementer_notification()
+{
+    constexpr std::size_t decrementer_counts[] = {2, 4, 8, 16};
+
+    for (std::size_t const num_decrementers : decrementer_counts)
+    {
+        for (std::size_t iter = 0; iter != num_iterations; ++iter)
+        {
+            constexpr std::size_t num_waiters = 8;
+            hpx::latch l(static_cast<std::ptrdiff_t>(num_decrementers));
+            std::atomic<std::size_t> woken(0);
+
+            std::vector<hpx::future<void>> results;
+            results.reserve(num_decrementers + num_waiters);
+
+            // Launch waiters and decrementers interleaved (rather than
+            // waiters-then-decrementers) to maximize the chance that some
+            // waiters arrive at the predicate check exactly around the time the
+            // last decrementer flips notified_.
+            for (std::size_t i = 0; i != num_waiters; ++i)
+            {
+                results.push_back(hpx::async([&l, &woken]() {
+                    l.wait();
+                    ++woken;
+                }));
+            }
+            for (std::size_t i = 0; i != num_decrementers; ++i)
+            {
+                results.push_back(hpx::async([&l]() { l.count_down(1); }));
+            }
+
+            for (auto& f : results)
+            {
+                expect_ready(f);
+            }
+
+            HPX_TEST_EQ(woken.load(), num_waiters);
+            HPX_TEST(l.try_wait());
+        }
+    }
+}
+
+void test_try_wait_only_checks_counter()
+{
+    // As soon as count_down() has decremented counter_ to 0, try_wait() must
+    // report ready -- this holds even though the internal notified_ flag and
+    // any pending notify_waiters() work are separate from what try_wait()
+    // inspects.
+    hpx::latch l(1);
+    HPX_TEST(!l.try_wait());
+
+    l.count_down(1);
+
+    HPX_TEST(l.try_wait());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// 3. count_down() / arrive_and_wait() interleaving.
+//
+// Mixes plain (non-blocking) count_down() callers with arrive_and_wait()
+// callers (which both decrement and block) on the same latch. Asserts no lost
+// wakeups and that the final decrement total is correct.
+void test_count_down_arrive_and_wait_interleaving()
+{
+    for (std::size_t iter = 0; iter != num_iterations; ++iter)
+    {
+        constexpr std::size_t num_waiters = 8;
+        constexpr std::size_t num_decrementers = 8;
+
+        hpx::latch l(
+            static_cast<std::ptrdiff_t>(num_decrementers + num_waiters));
+        std::atomic<std::size_t> woken(0);
+
+        std::vector<hpx::future<void>> results;
+        results.reserve(num_decrementers + num_waiters);
+
+        for (std::size_t i = 0; i != num_decrementers; ++i)
+        {
+            results.push_back(hpx::async([&l]() { l.count_down(1); }));
+        }
+        for (std::size_t i = 0; i != num_waiters; ++i)
+        {
+            results.push_back(hpx::async([&l, &woken]() {
+                l.arrive_and_wait();
+                ++woken;
+            }));
+        }
+
+        for (auto& f : results)
+        {
+            expect_ready(f);
+        }
+
+        HPX_TEST_EQ(woken.load(), num_waiters);
+        HPX_TEST(l.try_wait());
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// 4a. reset() re-arm safety.
+//
+// After reset(), notified_ must have been cleared: a waiter that blocks after
+// the reset must not return until the latch reaches zero again, and must then
+// wake reliably. Repeated across many reset/wait/count_down cycles on the same
+// latch.
+void test_reset_rearm()
+{
+    hpx::lcos::local::latch l(0);
+
+    for (std::size_t iter = 0; iter != num_iterations; ++iter)
+    {
+        l.reset(1);
+        HPX_TEST(!l.try_wait());
+
+        hpx::future<void> f = hpx::async([&l]() { l.wait(); });
+
+        // The latch cannot possibly be ready yet -- wait() may only return once
+        // counter_ == 0 and notified_ is set, neither of which can happen
+        // before the count_down() call below. A timeout here is therefore a
+        // deterministic check, not a race.
+        HPX_TEST_EQ(static_cast<int>(f.wait_for(std::chrono::milliseconds(50))),
+            static_cast<int>(hpx::future_status::timeout));
+
+        l.count_down(1);
+
+        expect_ready(f);
+        HPX_TEST(l.try_wait());
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// 4b. reset_if_needed_and_count_up() re-arm safety.
+//
+// Many threads race reset_if_needed_and_count_up() against a latch that is
+// currently ready (notified_ == true). Exactly one of them must observe
+// notified_ == true and perform the reset (returning true); all others must see
+// the already-cleared flag and simply count up (returning false).
+void test_reset_if_needed_and_count_up()
+{
+    for (std::size_t iter = 0; iter != num_iterations; ++iter)
+    {
+        constexpr std::ptrdiff_t count = 5;
+        constexpr std::ptrdiff_t n = 3;
+        constexpr std::size_t num_callers = 8;
+
+        hpx::lcos::local::latch l(0);
+        HPX_TEST(l.try_wait());
+
+        std::atomic<std::size_t> reset_count(0);
+
+        std::vector<hpx::future<void>> results;
+        results.reserve(num_callers);
+        for (std::size_t i = 0; i != num_callers; ++i)
+        {
+            results.push_back(hpx::async([&l, &reset_count]() {
+                if (l.reset_if_needed_and_count_up(n, count))
+                {
+                    ++reset_count;
+                }
+            }));
+        }
+
+        for (auto& f : results)
+        {
+            expect_ready(f);
+        }
+
+        // Exactly one caller must have performed the reset.
+        HPX_TEST_EQ(reset_count.load(), static_cast<std::size_t>(1));
+        HPX_TEST(!l.try_wait());
+
+        constexpr std::ptrdiff_t expected_total =
+            n * static_cast<std::ptrdiff_t>(num_callers) + count;
+
+        l.count_down(expected_total);
+        HPX_TEST(l.try_wait());
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// 5. Memory-ordering sanity stress.
+//
+// A writer sets a plain (non-atomic) value before count_down(); waiters read it
+// only after wait() returns. Repeated over many iterations/threads, this is the
+// standard (non-formal) pattern used elsewhere in HPX sync tests to catch
+// acquire/release bugs.
+void test_memory_ordering_sanity()
+{
+    for (std::size_t iter = 0; iter != num_iterations; ++iter)
+    {
+        constexpr std::size_t num_waiters = 8;
+
+        hpx::latch l(1);
+        std::size_t shared_value = 0;    // plain, non-atomic
+
+        std::vector<hpx::future<void>> results;
+        results.reserve(num_waiters);
+        for (std::size_t i = 0; i != num_waiters; ++i)
+        {
+            results.push_back(hpx::async([&l, &shared_value]() {
+                l.wait();
+                HPX_TEST_EQ(shared_value, static_cast<std::size_t>(42));
+            }));
+        }
+
+        shared_value = 42;
+        l.count_down(1);
+
+        for (auto& f : results)
+        {
+            expect_ready(f);
+        }
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main()
+{
+    test_no_lost_wakeups();
+    test_last_decrementer_notification();
+    test_try_wait_only_checks_counter();
+    test_count_down_arrive_and_wait_interleaving();
+    test_reset_rearm();
+    test_reset_if_needed_and_count_up();
+    test_memory_ordering_sanity();
+
+    HPX_TEST_EQ(hpx::local::finalize(), 0);
+    return 0;
+}
+
+int main(int argc, char* argv[])
+{
+    // Initialize and run HPX
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/thread_pools/src/scheduled_thread_pool.cpp
+++ b/libs/core/thread_pools/src/scheduled_thread_pool.cpp
@@ -24,6 +24,9 @@ template class HPX_CORE_EXPORT hpx::threads::detail::scheduled_thread_pool<
 template class HPX_CORE_EXPORT hpx::threads::detail::scheduled_thread_pool<
     hpx::threads::policies::local_priority_queue_scheduler<std::mutex,
         hpx::threads::policies::lockfree_fifo>>;
+template class HPX_CORE_EXPORT hpx::threads::detail::scheduled_thread_pool<
+    hpx::threads::policies::local_priority_queue_scheduler<std::mutex,
+        hpx::threads::policies::lockfree_fifo_double>>;
 
 template class HPX_CORE_EXPORT hpx::threads::detail::scheduled_thread_pool<
     hpx::threads::policies::static_priority_queue_scheduler<>>;

--- a/libs/core/threading/src/thread.cpp
+++ b/libs/core/threading/src/thread.cpp
@@ -17,6 +17,7 @@
 
 #include <cstddef>
 #include <exception>
+#include <memory>
 #include <mutex>
 #include <utility>
 
@@ -183,15 +184,6 @@ namespace hpx {
         }
     }
 
-    namespace {
-
-        void resume_thread(threads::thread_id_ref_type const& id)
-        {
-            threads::set_thread_state(
-                id.noref(), threads::thread_schedule_state::pending);
-        }
-    }    // namespace
-
     void thread::join()
     {
         std::unique_lock l(mtx_);
@@ -204,8 +196,7 @@ namespace hpx {
         }
 
         // keep ourselves alive while being suspended
-        threads::thread_id_ref_type this_id = threads::get_self_id();
-        if (this_id == id_)
+        if (threads::get_self_id() == id_)
         {
             l.unlock();
             HPX_THROW_EXCEPTION(hpx::error::thread_resource_error,
@@ -217,15 +208,33 @@ namespace hpx {
         // register callback function to be called when thread exits
         auto const id = id_;
 
-        detach_locked();    // invalidate this object
-
-        if (threads::add_thread_exit_callback(
-                id.noref(), hpx::bind_front(&resume_thread, HPX_MOVE(this_id))))
+        // Register callback before detaching. The condition variable and done
+        // flag are held in a shared state so that they stay alive for as long
+        // as either the exit callback or this function needs them, even if this
+        // function is unwound (e.g. by an interruption while waiting) before
+        // the callback has run.
+        struct join_state
         {
-            // wait for thread to be terminated
-            unlock_guard ul(l);
-            this_thread::suspend(
-                threads::thread_schedule_state::suspended, "thread::join");
+            hpx::lcos::local::detail::condition_variable cv;
+            bool done = false;
+        };
+        auto const state = std::make_shared<join_state>();
+
+        bool const added =
+            threads::add_thread_exit_callback(id.noref(), [this, state]() {
+                std::unique_lock lock(mtx_);
+                state->done = true;
+                state->cv.notify_one(HPX_MOVE(lock));
+            });
+
+        detach_locked();    // Now safe to detach
+
+        if (added)
+        {
+            while (!state->done)
+            {
+                state->cv.wait(l);
+            }
         }
     }
 

--- a/libs/core/threading_base/include/hpx/threading_base/thread_data.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_data.hpp
@@ -375,14 +375,12 @@ namespace hpx::threads {
 #ifdef HPX_HAVE_THREAD_FULLBACKTRACE_ON_SUSPENSION
         char const* get_backtrace() const noexcept
         {
-            std::lock_guard<hpx::util::detail::spinlock> l(
-                spinlock_pool::spinlock_for(this));
+            std::unique_lock<hpx::util::detail::spinlock> l(mtx_);
             return backtrace_;
         }
         char const* set_backtrace(char const* value) noexcept
         {
-            std::lock_guard<hpx::util::detail::spinlock> l(
-                spinlock_pool::spinlock_for(this));
+            std::unique_lock<hpx::util::detail::spinlock> l(mtx_);
 
             char const* bt = backtrace_;
             backtrace_ = value;
@@ -391,15 +389,13 @@ namespace hpx::threads {
 #else
         util::backtrace const* get_backtrace() const noexcept
         {
-            std::lock_guard<hpx::util::detail::spinlock> l(
-                spinlock_pool::spinlock_for(this));
+            std::unique_lock<hpx::util::detail::spinlock> l(mtx_);
             return backtrace_;
         }
         util::backtrace const* set_backtrace(
             util::backtrace const* value) noexcept
         {
-            std::lock_guard<hpx::util::detail::spinlock> l(
-                spinlock_pool::spinlock_for(this));
+            std::unique_lock<hpx::util::detail::spinlock> l(mtx_);
 
             util::backtrace const* bt = backtrace_;
             backtrace_ = value;
@@ -410,8 +406,7 @@ namespace hpx::threads {
         // Generate full backtrace for captured stack
         std::string backtrace()
         {
-            std::lock_guard<hpx::util::detail::spinlock> l(
-                spinlock_pool::spinlock_for(this));
+            std::unique_lock<hpx::util::detail::spinlock> l(mtx_);
 
             std::string bt;
             if (0 != backtrace_)
@@ -455,8 +450,8 @@ namespace hpx::threads {
 
         void interrupt(bool const flag = true)
         {
-            std::unique_lock<hpx::util::detail::spinlock> l(
-                spinlock_pool::spinlock_for(this));
+            std::unique_lock<hpx::util::detail::spinlock> l(mtx_);
+
             if (flag && !enabled_interrupt_)
             {
                 l.unlock();
@@ -594,12 +589,13 @@ namespace hpx::threads {
     private:
         thread_priority priority_;
 
+        mutable hpx::util::detail::spinlock mtx_;
+
         bool requested_interrupt_;
         bool enabled_interrupt_;
         bool const is_stackless_;
-
-        std::atomic<bool> ran_exit_funcs_;
-        std::atomic<bool> has_exit_funcs_;
+        bool running_exit_funcs_;
+        bool ran_exit_funcs_;
 
         // support scoped child execution
         std::atomic<bool> runs_as_child_;

--- a/libs/core/threading_base/include/hpx/threading_base/thread_data.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/thread_data.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2025 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //  Copyright (c) 2008-2009 Chirag Dekate, Anshul Tandon
 //
@@ -596,8 +596,10 @@ namespace hpx::threads {
 
         bool requested_interrupt_;
         bool enabled_interrupt_;
-        bool ran_exit_funcs_;
         bool const is_stackless_;
+
+        std::atomic<bool> ran_exit_funcs_;
+        std::atomic<bool> has_exit_funcs_;
 
         // support scoped child execution
         std::atomic<bool> runs_as_child_;
@@ -657,12 +659,14 @@ namespace hpx::threads {
     }
 
 #if defined(HPX_HAVE_TRACY)
+    // tracy support
     HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT tracing::region_init_data
     get_region_init_data(thread_data const* thrdptr);
 
     HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT tracing::fiber_region_init_data
     get_fiber_region_init_data(thread_data const* thrdptr);
 #elif defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0
+    // ITTNotify support
     HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT tracing::region_init_data
     get_region_init_data(thread_data const* thrdptr);
 

--- a/libs/core/threading_base/src/thread_data.cpp
+++ b/libs/core/threading_base/src/thread_data.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2025 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c) 2008-2009 Chirag Dekate, Anshul Tandon
 //  Copyright (c) 2011      Bryce Lelbach
 //
@@ -61,8 +61,9 @@ namespace hpx::threads {
       , priority_(init_data.priority)
       , requested_interrupt_(false)
       , enabled_interrupt_(true)
-      , ran_exit_funcs_(false)
       , is_stackless_(is_stackless)
+      , ran_exit_funcs_(false)
+      , has_exit_funcs_(false)
       , runs_as_child_(init_data.schedulehint.runs_as_child_mode() ==
             hpx::threads::thread_execution_hint::run_as_child)
       , last_worker_thread_num_(
@@ -137,20 +138,25 @@ namespace hpx::threads {
 
     void thread_data::run_thread_exit_callbacks()
     {
-        std::unique_lock<hpx::util::detail::spinlock> l(
-            spinlock_pool::spinlock_for(this));
-
-        while (!exit_funcs_.empty())
+        if (has_exit_funcs_.load(std::memory_order_acquire))
         {
+            std::unique_lock<hpx::util::detail::spinlock> l(
+                spinlock_pool::spinlock_for(this));
+
+            while (!exit_funcs_.empty())
             {
-                hpx::unlock_guard<std::unique_lock<hpx::util::detail::spinlock>>
-                    ul(l);
-                if (!exit_funcs_.front().empty())
-                    exit_funcs_.front()();
+                if (auto& f = exit_funcs_.front(); !f.empty())
+                {
+                    hpx::unlock_guard<
+                        std::unique_lock<hpx::util::detail::spinlock>>
+                        ul(l);
+                    f();
+                }
+                exit_funcs_.pop_front();
             }
-            exit_funcs_.pop_front();
+            has_exit_funcs_.store(true, std::memory_order_release);
         }
-        ran_exit_funcs_ = true;
+        ran_exit_funcs_.store(true, std::memory_order_release);
     }
 
     bool thread_data::add_thread_exit_callback(hpx::function<void()> const& f)
@@ -158,7 +164,7 @@ namespace hpx::threads {
         std::lock_guard<hpx::util::detail::spinlock> l(
             spinlock_pool::spinlock_for(this));
 
-        if (ran_exit_funcs_ ||
+        if (ran_exit_funcs_.load(std::memory_order_relaxed) ||
             get_state().state() == thread_schedule_state::terminated ||
             get_state().state() == thread_schedule_state::deleted)
         {
@@ -166,17 +172,22 @@ namespace hpx::threads {
         }
 
         exit_funcs_.push_front(f);
+        has_exit_funcs_.store(true, std::memory_order_release);
 
         return true;
     }
 
     void thread_data::free_thread_exit_callbacks()
     {
+        if (!has_exit_funcs_.load(std::memory_order_relaxed))
+            return;
+
         std::scoped_lock<hpx::util::detail::spinlock> l(
             spinlock_pool::spinlock_for(this));
 
         // Exit functions should have been executed.
-        HPX_ASSERT(exit_funcs_.empty() || ran_exit_funcs_);
+        HPX_ASSERT(exit_funcs_.empty() ||
+            ran_exit_funcs_.load(std::memory_order_relaxed));
 
         exit_funcs_.clear();
     }
@@ -218,7 +229,8 @@ namespace hpx::threads {
         priority_ = init_data.priority;
         requested_interrupt_ = false;
         enabled_interrupt_ = true;
-        ran_exit_funcs_ = false;
+        ran_exit_funcs_.store(false, std::memory_order_relaxed);
+        has_exit_funcs_.store(false, std::memory_order_relaxed);
 
         runs_as_child_.store(init_data.schedulehint.runs_as_child_mode() ==
                 hpx::threads::thread_execution_hint::run_as_child,

--- a/libs/core/threading_base/src/thread_data.cpp
+++ b/libs/core/threading_base/src/thread_data.cpp
@@ -1,6 +1,7 @@
 //  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c) 2008-2009 Chirag Dekate, Anshul Tandon
 //  Copyright (c) 2011      Bryce Lelbach
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -62,8 +63,8 @@ namespace hpx::threads {
       , requested_interrupt_(false)
       , enabled_interrupt_(true)
       , is_stackless_(is_stackless)
+      , running_exit_funcs_(false)
       , ran_exit_funcs_(false)
-      , has_exit_funcs_(false)
       , runs_as_child_(init_data.schedulehint.runs_as_child_mode() ==
             hpx::threads::thread_execution_hint::run_as_child)
       , last_worker_thread_num_(
@@ -138,56 +139,73 @@ namespace hpx::threads {
 
     void thread_data::run_thread_exit_callbacks()
     {
-        if (has_exit_funcs_.load(std::memory_order_acquire))
-        {
-            std::unique_lock<hpx::util::detail::spinlock> l(
-                spinlock_pool::spinlock_for(this));
+        std::unique_lock<hpx::util::detail::spinlock> l(mtx_);
 
-            while (!exit_funcs_.empty())
+        // run the exit functions in the order they have been added
+        exit_funcs_.reverse();
+
+        HPX_ASSERT(!running_exit_funcs_);
+
+        running_exit_funcs_ = true;
+        auto on_exit = hpx::experimental::scope_exit([this] {
+            running_exit_funcs_ = false;
+            ran_exit_funcs_ = true;
+        });
+
+        while (!exit_funcs_.empty())
+        {
+            if (auto f = HPX_MOVE(exit_funcs_.front()); !f.empty())
             {
-                if (auto& f = exit_funcs_.front(); !f.empty())
-                {
-                    hpx::unlock_guard<
-                        std::unique_lock<hpx::util::detail::spinlock>>
-                        ul(l);
-                    f();
-                }
+                // Pop under lock to make sure that a recursive call to
+                // add_thread_exit_callback from inside f() or during the
+                // unlocked phase will not cause the wrong function to be
+                // popped.
+                exit_funcs_.pop_front();
+
+                hpx::unlock_guard<std::unique_lock<hpx::util::detail::spinlock>>
+                    ul(l);
+                f();
+            }
+            else
+            {
                 exit_funcs_.pop_front();
             }
-            has_exit_funcs_.store(true, std::memory_order_release);
         }
-        ran_exit_funcs_.store(true, std::memory_order_release);
     }
 
     bool thread_data::add_thread_exit_callback(hpx::function<void()> const& f)
     {
-        std::lock_guard<hpx::util::detail::spinlock> l(
-            spinlock_pool::spinlock_for(this));
+        std::unique_lock<hpx::util::detail::spinlock> l(mtx_);
 
-        if (ran_exit_funcs_.load(std::memory_order_relaxed) ||
+        if (ran_exit_funcs_ ||
             get_state().state() == thread_schedule_state::terminated ||
             get_state().state() == thread_schedule_state::deleted)
         {
             return false;
         }
 
-        exit_funcs_.push_front(f);
-        has_exit_funcs_.store(true, std::memory_order_release);
+        if (running_exit_funcs_)
+        {
+            // make sure new function ends up at the end of the list during the
+            // execution of exit functions
+            exit_funcs_.reverse();
+            exit_funcs_.push_front(f);
+            exit_funcs_.reverse();
+        }
+        else
+        {
+            exit_funcs_.push_front(f);
+        }
 
         return true;
     }
 
     void thread_data::free_thread_exit_callbacks()
     {
-        if (!has_exit_funcs_.load(std::memory_order_relaxed))
-            return;
-
-        std::scoped_lock<hpx::util::detail::spinlock> l(
-            spinlock_pool::spinlock_for(this));
+        std::unique_lock<hpx::util::detail::spinlock> l(mtx_);
 
         // Exit functions should have been executed.
-        HPX_ASSERT(exit_funcs_.empty() ||
-            ran_exit_funcs_.load(std::memory_order_relaxed));
+        HPX_ASSERT(exit_funcs_.empty() || ran_exit_funcs_);
 
         exit_funcs_.clear();
     }
@@ -229,8 +247,8 @@ namespace hpx::threads {
         priority_ = init_data.priority;
         requested_interrupt_ = false;
         enabled_interrupt_ = true;
-        ran_exit_funcs_.store(false, std::memory_order_relaxed);
-        has_exit_funcs_.store(false, std::memory_order_relaxed);
+        running_exit_funcs_ = false;
+        ran_exit_funcs_ = false;
 
         runs_as_child_.store(init_data.schedulehint.runs_as_child_mode() ==
                 hpx::threads::thread_execution_hint::run_as_child,
@@ -305,16 +323,15 @@ namespace hpx::threads {
 #if defined(HPX_HAVE_THREAD_DESCRIPTION)
     threads::thread_description thread_data::get_description() const
     {
-        std::scoped_lock<hpx::util::detail::spinlock> l(
-            spinlock_pool::spinlock_for(this));
+        std::unique_lock<hpx::util::detail::spinlock> l(mtx_);
         return description_;
     }
 
     threads::thread_description thread_data::set_description(
         threads::thread_description value)
     {
-        std::scoped_lock<hpx::util::detail::spinlock> l(
-            spinlock_pool::spinlock_for(this));
+        std::unique_lock<hpx::util::detail::spinlock> l(mtx_);
+
         std::swap(description_, value);
 
         hpx::tracing::rename_region(description_.get_description());
@@ -324,16 +341,15 @@ namespace hpx::threads {
 
     threads::thread_description thread_data::get_lco_description() const
     {
-        std::scoped_lock<hpx::util::detail::spinlock> l(
-            spinlock_pool::spinlock_for(this));
+        std::unique_lock<hpx::util::detail::spinlock> l(mtx_);
         return lco_description_;
     }
 
     threads::thread_description thread_data::set_lco_description(
         threads::thread_description value)
     {
-        std::scoped_lock<hpx::util::detail::spinlock> l(
-            spinlock_pool::spinlock_for(this));
+        std::unique_lock<hpx::util::detail::spinlock> l(mtx_);
+
         std::swap(lco_description_, value);
         return value;
     }

--- a/libs/core/threading_base/tests/unit/CMakeLists.txt
+++ b/libs/core/threading_base/tests/unit/CMakeLists.txt
@@ -4,7 +4,7 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(tests set_thread_affinity)
+set(tests set_thread_affinity thread_exit_callbacks)
 
 foreach(test ${tests})
   set(sources ${test}.cpp)

--- a/libs/core/threading_base/tests/unit/thread_exit_callbacks.cpp
+++ b/libs/core/threading_base/tests/unit/thread_exit_callbacks.cpp
@@ -1,0 +1,235 @@
+//  Copyright (c) 2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Tests for the thread exit-callback state maintained by thread_data
+// (thread_data.hpp/.cpp), in particular the atomic has_exit_funcs_
+// callback-presence flag used as a lock-free fast path guard for
+// run_thread_exit_callbacks()/free_thread_exit_callbacks() alongside the
+// spinlock-protected exit_funcs_ list.
+
+#define HPX_HAVE_FORCE_NO_CXX_MODULES
+
+#include <hpx/future.hpp>
+#include <hpx/init.hpp>
+#include <hpx/modules/runtime_local.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/modules/threading_base.hpp>
+
+#include <atomic>
+#include <cstddef>
+#include <mutex>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+// 1. A thread that never registers an exit callback must run and terminate
+//    cleanly, exercising the has_exit_funcs_ == false skip-lock fast paths in
+//    run_thread_exit_callbacks()/free_thread_exit_callbacks() without deadlock
+//    or triggering the HPX_ASSERT in free_thread_exit_callbacks().
+void test_no_callback_fast_path()
+{
+    hpx::async([]() {
+        // intentionally left blank: no exit callback registered
+    }).get();
+
+    hpx::mutex mtx;
+    hpx::condition_variable cond;
+    bool running = false;
+
+    hpx::thread t([&]() {
+        {
+            std::lock_guard<hpx::mutex> lk(mtx);
+            running = true;
+            cond.notify_all();
+        }
+        // no exit callback registered for this thread either
+    });
+
+    {
+        std::unique_lock<hpx::mutex> lk(mtx);
+        while (!running)
+            cond.wait(lk);
+    }
+
+    t.join();
+
+    HPX_TEST(true);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// 2. A single callback registered via add_thread_exit_callback must run exactly
+//    once.
+void test_single_callback_executes_once()
+{
+    std::atomic<int> call_count{0};
+
+    hpx::async([&call_count]() {
+        hpx::threads::thread_id_type const id = hpx::threads::get_self_id();
+
+        bool const added = hpx::threads::add_thread_exit_callback(
+            id, [&call_count]() { ++call_count; });
+        HPX_TEST(added);
+    }).get();
+
+    HPX_TEST_EQ(call_count.load(), 1);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Helper used by both the concurrent registration test and the stress test
+// below: spawns a target thread, keeps it suspended (i.e. running, not yet
+// terminated) while a number of racing tasks concurrently try to register an
+// exit callback on it, then releases the target thread and verifies that every
+// callback whose registration succeeded ran exactly once (and none that failed
+// to register ever ran).
+void run_concurrent_registration_round(std::size_t const num_racers)
+{
+    hpx::mutex mtx;
+    hpx::condition_variable cond;
+    bool running = false;
+
+    hpx::thread t([&]() {
+        {
+            std::lock_guard<hpx::mutex> lk(mtx);
+            running = true;
+            cond.notify_all();
+        }
+
+        // stay suspended (thread is still alive, not terminated) while the
+        // racers register their callbacks
+        hpx::this_thread::suspend(
+            hpx::threads::thread_schedule_state::suspended);
+    });
+
+    {
+        std::unique_lock<hpx::mutex> lk(mtx);
+        while (!running)
+        {
+            cond.wait(lk);
+        }
+    }
+
+    hpx::threads::thread_id_type const id = t.native_handle();
+
+    std::vector<std::atomic<bool>> registered(num_racers);
+    std::vector<std::atomic<bool>> executed(num_racers);
+    for (std::size_t i = 0; i != num_racers; ++i)
+    {
+        registered[i].store(false);
+        executed[i].store(false);
+    }
+
+    std::vector<hpx::future<void>> futures;
+    futures.reserve(num_racers);
+    for (std::size_t i = 0; i != num_racers; ++i)
+    {
+        futures.push_back(hpx::async([&, i]() {
+            bool const added = hpx::threads::add_thread_exit_callback(
+                id, [&executed, i]() { executed[i].store(true); });
+            registered[i].store(added);
+        }));
+    }
+    hpx::wait_all(futures);
+
+    // release the target thread so it can terminate, running all successfully
+    // registered exit callbacks
+    hpx::threads::set_thread_state(
+        id, hpx::threads::thread_schedule_state::pending);
+    t.join();
+
+    std::size_t registered_count = 0;
+    for (std::size_t i = 0; i != num_racers; ++i)
+    {
+        // a callback ran if and only if its registration succeeded
+        HPX_TEST_EQ(registered[i].load(), executed[i].load());
+        if (registered[i].load())
+        {
+            ++registered_count;
+        }
+    }
+
+    // all racers attempt registration while the target thread is still
+    // suspended (not terminated), so all of them are expected to succeed
+    HPX_TEST_EQ(registered_count, num_racers);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// 3. Multiple threads racing to register exit callbacks on the same
+//    still-running target thread: every callback whose registration returned
+//    true must run exactly once.
+void test_concurrent_registration()
+{
+    run_concurrent_registration_round(16);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// 4. Registering an exit callback after the target thread has already run its
+//    exit callbacks (i.e. it has terminated) must fail and the callback must
+//    never be invoked.
+void test_post_exit_rejection()
+{
+    hpx::mutex mtx;
+    hpx::condition_variable cond;
+    bool running = false;
+
+    hpx::thread t([&]() {
+        std::lock_guard<hpx::mutex> lk(mtx);
+        running = true;
+        cond.notify_all();
+        // falls through and terminates right away
+    });
+
+    {
+        std::unique_lock<hpx::mutex> lk(mtx);
+        while (!running)
+            cond.wait(lk);
+    }
+
+    hpx::threads::thread_id_type const id = t.native_handle();
+
+    // by the time join() returns, the thread has already run and freed
+    // its exit callbacks
+    t.join();
+
+    bool executed = false;
+    bool const added = hpx::threads::add_thread_exit_callback(
+        id, [&executed]() { executed = true; });
+
+    HPX_TEST(!added);
+    HPX_TEST(!executed);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// 5. Stress test: many rounds of spawn + concurrent racing registrations to
+//    catch lost or duplicated callbacks under contention.
+void test_stress_loop()
+{
+    constexpr int num_iterations = 50;
+
+    for (int i = 0; i != num_iterations; ++i)
+    {
+        constexpr std::size_t num_racers = 8;
+        run_concurrent_registration_round(num_racers);
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main()
+{
+    test_no_callback_fast_path();
+    test_single_callback_executes_once();
+    test_concurrent_registration();
+    test_post_exit_rejection();
+    test_stress_loop();
+
+    return hpx::local::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    HPX_TEST_EQ_MSG(hpx::local::init(hpx_main, argc, argv), 0,
+        "HPX main exited with non-zero status");
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/threading_base/tests/unit/thread_exit_callbacks.cpp
+++ b/libs/core/threading_base/tests/unit/thread_exit_callbacks.cpp
@@ -5,10 +5,11 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 // Tests for the thread exit-callback state maintained by thread_data
-// (thread_data.hpp/.cpp), in particular the atomic has_exit_funcs_
-// callback-presence flag used as a lock-free fast path guard for
-// run_thread_exit_callbacks()/free_thread_exit_callbacks() alongside the
-// spinlock-protected exit_funcs_ list.
+// (thread_data.hpp/.cpp): registration via add_thread_exit_callback(),
+// execution via run_thread_exit_callbacks(), and cleanup via
+// free_thread_exit_callbacks(), all serialized through the per-instance
+// spinlock mtx_ guarding exit_funcs_, running_exit_funcs_ and
+// ran_exit_funcs_.
 
 #define HPX_HAVE_FORCE_NO_CXX_MODULES
 

--- a/libs/core/threadmanager/include/hpx/threadmanager/threadmanager.hpp
+++ b/libs/core/threadmanager/include/hpx/threadmanager/threadmanager.hpp
@@ -302,6 +302,9 @@ namespace hpx::threads {
         void create_scheduler_local_priority_fifo(
             thread_pool_init_parameters const&,
             policies::thread_queue_init_parameters const&, std::size_t);
+        void create_scheduler_local_priority_fifo_double(
+            thread_pool_init_parameters const&,
+            policies::thread_queue_init_parameters const&, std::size_t);
         void create_scheduler_local_priority_lifo(
             thread_pool_init_parameters const&,
             policies::thread_queue_init_parameters const&, std::size_t);

--- a/libs/core/threadmanager/src/threadmanager.cpp
+++ b/libs/core/threadmanager/src/threadmanager.cpp
@@ -239,6 +239,51 @@ namespace hpx::threads {
         pools_.push_back(HPX_MOVE(pool));
     }
 
+    void threadmanager::create_scheduler_local_priority_fifo_double(
+        thread_pool_init_parameters const& thread_pool_init,
+        policies::thread_queue_init_parameters const& thread_queue_init,
+        std::size_t const numa_sensitive)
+    {
+        // set parameters for scheduler and pool instantiation and perform
+        // compatibility checks
+        std::size_t const num_high_priority_queues =
+            hpx::util::get_entry_as<std::size_t>(rtcfg_,
+                "hpx.thread_queue.high_priority_queues",
+                thread_pool_init.num_threads_);
+
+        detail::check_num_high_priority_queues(
+            thread_pool_init.num_threads_, num_high_priority_queues);
+
+        // instantiate the scheduler
+        using local_sched_type =
+            hpx::threads::policies::local_priority_queue_scheduler<std::mutex,
+                hpx::threads::policies::lockfree_fifo_double>;
+
+        local_sched_type::init_parameter_type init(
+            thread_pool_init.num_threads_, thread_pool_init.affinity_data_,
+            num_high_priority_queues, thread_queue_init,
+            "core-local_priority_queue_scheduler-fifo_double");
+
+        auto sched = std::make_unique<local_sched_type>(init);
+        auto const full_mask =
+            hpx::resource::get_partitioner().get_pool_pus_mask(
+                thread_pool_init.name_);
+
+        // set the default scheduler flags
+        sched->set_scheduler_mode(thread_pool_init.mode_, full_mask);
+
+        // conditionally set/unset this flag
+        sched->update_scheduler_mode(
+            policies::scheduler_mode::enable_stealing_numa, !numa_sensitive,
+            full_mask);
+
+        // instantiate the pool
+        std::unique_ptr<thread_pool_base> pool = std::make_unique<
+            hpx::threads::detail::scheduled_thread_pool<local_sched_type>>(
+            HPX_MOVE(sched), thread_pool_init);
+        pools_.push_back(HPX_MOVE(pool));
+    }
+
     void threadmanager::create_scheduler_local_priority_lifo(
         [[maybe_unused]] thread_pool_init_parameters const& thread_pool_init,
         [[maybe_unused]] policies::thread_queue_init_parameters const&
@@ -810,6 +855,11 @@ namespace hpx::threads {
 
             case resource::scheduling_policy::local_priority_fifo:
                 create_scheduler_local_priority_fifo(
+                    thread_pool_init, thread_queue_init, numa_sensitive);
+                break;
+
+            case resource::scheduling_policy::local_priority_fifo_double:
+                create_scheduler_local_priority_fifo_double(
                     thread_pool_init, thread_queue_init, numa_sensitive);
                 break;
 

--- a/libs/full/init_runtime/src/hpx_init.cpp
+++ b/libs/full/init_runtime/src/hpx_init.cpp
@@ -937,6 +937,7 @@ namespace hpx {
                 }
                 catch (hpx::exception const& e)
                 {
+                    resource::detail::delete_partitioner();
                     std::cerr << "hpx::init: hpx::exception caught: "
                               << hpx::get_error_what(e) << "\n";
                     return -1;
@@ -989,6 +990,7 @@ namespace hpx {
             }
             catch (detail::command_line_error const& e)
             {
+                resource::detail::delete_partitioner();
                 std::cerr << "hpx::init: std::exception caught: " << e.what()
                           << "\n";
                 return -1;


### PR DESCRIPTION
Allow to reduce the work-stealing overheads by minimizing cache interference. The idea is to add a 'passive' queue next to each 'active' one. The 'active' queue is used as long as it holds threads to run. As soon as it runs empty the scheduler swaps the queues and continues executing threads from the now 'active' (formerly 'passive') queue. New threads are scheduled on the currently 'passive' queue. Work-stealing happens from the 'passive' queue first and only if that was unsuccessful tries to steal from the 'active' queues (as before).

Fixes #7111

Depends on #7367

As flyby this adds a fix for a significant performance regression and fixes a race in hpx::thread;;join.
