### PR TITLE
add pre commit hooks

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# Copyright (c) 2026 The STE||AR Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+exec "$(git rev-parse --show-toplevel)/tools/pre-commit" "$@"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,17 @@ hpx_force_out_of_tree_build(
   "This project requires an out-of-source-tree build. See README.rst. Clean your CMake cache and CMakeFiles if this message persists."
 )
 
+hpx_option(
+  HPX_WITH_GIT_HOOKS BOOL
+  "Enable git commit hooks for formatting checks on commit (default: ON)."
+  ON ADVANCED
+)
+
+if(HPX_WITH_GIT_HOOKS)
+  include(HPX_SetupGitHooks)
+  hpx_setup_git_hooks()
+endif()
+
 if(NOT HPX_CMAKE_LOGLEVEL)
   set(HPX_CMAKE_LOGLEVEL "WARN")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,15 +116,13 @@ hpx_force_out_of_tree_build(
 
 hpx_option(
   HPX_WITH_GIT_HOOKS BOOL
-  "Enable git commit hooks for formatting checks on commit (default: ON)." ON
+  "Enable git commit hooks for formatting checks on commit (default: OFF)." OFF
   ADVANCED
 )
 
-include(HPX_SetupGitHooks)
 if(HPX_WITH_GIT_HOOKS)
+  include(HPX_SetupGitHooks)
   hpx_setup_git_hooks()
-else()
-  hpx_unset_git_hooks()
 endif()
 
 if(NOT HPX_CMAKE_LOGLEVEL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,13 +116,15 @@ hpx_force_out_of_tree_build(
 
 hpx_option(
   HPX_WITH_GIT_HOOKS BOOL
-  "Enable git commit hooks for formatting checks on commit (default: ON)."
-  ON ADVANCED
+  "Enable git commit hooks for formatting checks on commit (default: ON)." ON
+  ADVANCED
 )
 
+include(HPX_SetupGitHooks)
 if(HPX_WITH_GIT_HOOKS)
-  include(HPX_SetupGitHooks)
   hpx_setup_git_hooks()
+else()
+  hpx_unset_git_hooks()
 endif()
 
 if(NOT HPX_CMAKE_LOGLEVEL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,10 +125,6 @@ if(HPX_WITH_GIT_HOOKS)
   hpx_setup_git_hooks()
 endif()
 
-if(NOT HPX_CMAKE_LOGLEVEL)
-  set(HPX_CMAKE_LOGLEVEL "WARN")
-endif()
-
 # print initial diagnostics
 hpx_info("CMake version: ${CMAKE_VERSION}, generator: ${CMAKE_GENERATOR}")
 hpx_info("HPX version: ${HPX_VERSION}")

--- a/cmake/HPX_SetupGitHooks.cmake
+++ b/cmake/HPX_SetupGitHooks.cmake
@@ -16,7 +16,10 @@ function(_hpx_get_hookspath _out_var)
     OUTPUT_VARIABLE _current
     OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET
   )
-  set(${_out_var} "${_current}" PARENT_SCOPE)
+  set(${_out_var}
+      "${_current}"
+      PARENT_SCOPE
+  )
 endfunction()
 
 function(hpx_setup_git_hooks)

--- a/cmake/HPX_SetupGitHooks.cmake
+++ b/cmake/HPX_SetupGitHooks.cmake
@@ -1,0 +1,40 @@
+# Copyright (c) 2026 Sai Charan Arvapally
+# Copyright (c) 2026 The STE||AR Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(HPX_SETUP_GIT_HOOKS_LOADED TRUE)
+
+function(hpx_setup_git_hooks)
+  if(NOT EXISTS "${HPX_SOURCE_DIR}/.git")
+    return()
+  endif()
+
+  if(NOT EXISTS "${HPX_SOURCE_DIR}/.githooks/pre-commit")
+    hpx_warn("Git hooks script not found at .githooks/pre-commit")
+    return()
+  endif()
+
+  find_package(Git QUIET)
+  if(NOT GIT_FOUND)
+    hpx_warn("Git not found; skipping git hook setup")
+    return()
+  endif()
+
+  execute_process(
+    COMMAND "${GIT_EXECUTABLE}" config core.hooksPath .githooks
+    WORKING_DIRECTORY "${HPX_SOURCE_DIR}"
+    RESULT_VARIABLE _hpx_git_hooks_result
+    ERROR_VARIABLE _hpx_git_hooks_error
+  )
+
+  if(_hpx_git_hooks_result EQUAL 0)
+    hpx_info("Git commit hooks enabled (.githooks/)")
+  else()
+    hpx_warn(
+      "Could not enable git commit hooks: ${_hpx_git_hooks_error}"
+    )
+  endif()
+endfunction()

--- a/cmake/HPX_SetupGitHooks.cmake
+++ b/cmake/HPX_SetupGitHooks.cmake
@@ -7,6 +7,18 @@
 
 set(HPX_SETUP_GIT_HOOKS_LOADED TRUE)
 
+# Returns the currently configured core.hooksPath (empty if unset) in the given
+# output variable. Fails quietly when the key is not set.
+function(_hpx_get_hookspath _out_var)
+  execute_process(
+    COMMAND "${GIT_EXECUTABLE}" config --get core.hooksPath
+    WORKING_DIRECTORY "${HPX_SOURCE_DIR}"
+    OUTPUT_VARIABLE _current
+    OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET
+  )
+  set(${_out_var} "${_current}" PARENT_SCOPE)
+endfunction()
+
 function(hpx_setup_git_hooks)
   if(NOT EXISTS "${HPX_SOURCE_DIR}/.git")
     return()
@@ -23,6 +35,15 @@ function(hpx_setup_git_hooks)
     return()
   endif()
 
+  # Don't clobber an existing hook setup (husky, pre-commit framework, custom).
+  _hpx_get_hookspath(_hpx_current_hookspath)
+  if(_hpx_current_hookspath AND NOT _hpx_current_hookspath STREQUAL ".githooks")
+    hpx_warn(
+      "core.hooksPath already set to '${_hpx_current_hookspath}'; leaving it unchanged. Unset it or set HPX_WITH_GIT_HOOKS=OFF to opt out of HPX git hooks."
+    )
+    return()
+  endif()
+
   execute_process(
     COMMAND "${GIT_EXECUTABLE}" config core.hooksPath .githooks
     WORKING_DIRECTORY "${HPX_SOURCE_DIR}"
@@ -33,8 +54,29 @@ function(hpx_setup_git_hooks)
   if(_hpx_git_hooks_result EQUAL 0)
     hpx_info("Git commit hooks enabled (.githooks/)")
   else()
-    hpx_warn(
-      "Could not enable git commit hooks: ${_hpx_git_hooks_error}"
+    hpx_warn("Could not enable git commit hooks: ${_hpx_git_hooks_error}")
+  endif()
+endfunction()
+
+# Called when HPX_WITH_GIT_HOOKS is OFF. Only reverts the setting we own, i.e.
+# unset core.hooksPath when it still points at our .githooks directory.
+function(hpx_unset_git_hooks)
+  if(NOT EXISTS "${HPX_SOURCE_DIR}/.git")
+    return()
+  endif()
+
+  find_package(Git QUIET)
+  if(NOT GIT_FOUND)
+    return()
+  endif()
+
+  _hpx_get_hookspath(_hpx_current_hookspath)
+  if(_hpx_current_hookspath STREQUAL ".githooks")
+    execute_process(
+      COMMAND "${GIT_EXECUTABLE}" config --unset core.hooksPath
+      WORKING_DIRECTORY "${HPX_SOURCE_DIR}"
+      ERROR_QUIET
     )
+    hpx_info("Git commit hooks disabled (core.hooksPath unset)")
   endif()
 endfunction()

--- a/cmake/HPX_SetupGitHooks.cmake
+++ b/cmake/HPX_SetupGitHooks.cmake
@@ -42,7 +42,7 @@ function(hpx_setup_git_hooks)
   _hpx_get_hookspath(_hpx_current_hookspath)
   if(_hpx_current_hookspath AND NOT _hpx_current_hookspath STREQUAL ".githooks")
     hpx_warn(
-      "core.hooksPath already set to '${_hpx_current_hookspath}'; leaving it unchanged. Unset it or set HPX_WITH_GIT_HOOKS=OFF to opt out of HPX git hooks."
+      "core.hooksPath already set to '${_hpx_current_hookspath}'; leaving it unchanged."
     )
     return()
   endif()
@@ -58,28 +58,5 @@ function(hpx_setup_git_hooks)
     hpx_info("Git commit hooks enabled (.githooks/)")
   else()
     hpx_warn("Could not enable git commit hooks: ${_hpx_git_hooks_error}")
-  endif()
-endfunction()
-
-# Called when HPX_WITH_GIT_HOOKS is OFF. Only reverts the setting we own, i.e.
-# unset core.hooksPath when it still points at our .githooks directory.
-function(hpx_unset_git_hooks)
-  if(NOT EXISTS "${HPX_SOURCE_DIR}/.git")
-    return()
-  endif()
-
-  find_package(Git QUIET)
-  if(NOT GIT_FOUND)
-    return()
-  endif()
-
-  _hpx_get_hookspath(_hpx_current_hookspath)
-  if(_hpx_current_hookspath STREQUAL ".githooks")
-    execute_process(
-      COMMAND "${GIT_EXECUTABLE}" config --unset core.hooksPath
-      WORKING_DIRECTORY "${HPX_SOURCE_DIR}"
-      ERROR_QUIET
-    )
-    hpx_info("Git commit hooks disabled (core.hooksPath unset)")
   endif()
 endfunction()

--- a/tools/pre-commit
+++ b/tools/pre-commit
@@ -131,6 +131,22 @@ if [ ${#inspectroots[@]} -ne 0 ]; then
     fi
 fi
 
+spellfiles=()
+for file in `git diff --cached --name-only --diff-filter=ACMRT`; do
+    [ -f "${file}" ] && spellfiles+=("${file}")
+done
+
+if [ ${#spellfiles[@]} -ne 0 ]; then
+    if command -v codespell >/dev/null 2>&1; then
+        if ! codespell --ignore-words tools/.codespell_whitelist --skip='*.h5,*.png' "${spellfiles[@]}"; then
+            printf "# ${yellow}codespell ${red}error pre-commit${normal} : fix the spellings above (use git commit ${yellow}--no-verify${normal} to bypass)\n"
+            returncode=1
+        fi
+    else
+        printf "# ${yellow}codespell not found${normal} : skipping spell check (install codespell to match CI)\n"
+    fi
+fi
+
 if [ ! -z "$full_list" ]; then
     printf "\n# ${red}To commit the corrected files, run\n${normal}\ngit add ${full_list}\n"
 fi


### PR DESCRIPTION
Experimental: Trying to implement git pre-commit hooks so we don't have to deal with
clang-format or inspect report failures later in CI. Catch them at commit time instead of after push