### PR TITLE
Avoid communicator reuse between scan test phases

### DIFF
--- a/libs/full/collectives/tests/unit/exclusive_scan_.cpp
+++ b/libs/full/collectives/tests/unit/exclusive_scan_.cpp
@@ -20,7 +20,15 @@
 
 using namespace hpx::collectives;
 
+// Keep independently created communicators from aliasing in AGAS while
+// localities transition between test phases.
 constexpr char const* exclusive_scan_basename = "/test/exclusive_scan/";
+constexpr char const* exclusive_scan_multiple_use_basename =
+    "/test/exclusive_scan/multiple_use/";
+constexpr char const* exclusive_scan_explicit_generation_basename =
+    "/test/exclusive_scan/explicit_generation/";
+constexpr char const* exclusive_scan_local_basename =
+    "/test/exclusive_scan/local/";
 #if defined(HPX_DEBUG)
 constexpr int ITERATIONS = 100;
 #else
@@ -59,7 +67,7 @@ void test_multiple_use()
     HPX_TEST_LTE(static_cast<std::uint32_t>(2), num_localities);
 
     auto const exclusive_scan_client =
-        create_communicator(exclusive_scan_basename,
+        create_communicator(exclusive_scan_multiple_use_basename,
             num_sites_arg(num_localities), this_site_arg(here));
 
     // test functionality based on immediate local result value
@@ -86,7 +94,7 @@ void test_multiple_use_with_generation()
     HPX_TEST_LTE(static_cast<std::uint32_t>(2), num_localities);
 
     auto const exclusive_scan_client =
-        create_communicator(exclusive_scan_basename,
+        create_communicator(exclusive_scan_explicit_generation_basename,
             num_sites_arg(num_localities), this_site_arg(here));
 
     hpx::chrono::high_resolution_timer const t;
@@ -122,7 +130,7 @@ void test_local_use(std::uint32_t num_sites)
     {
         sites.push_back(hpx::async([=]() {
             auto const exclusive_scan_client =
-                create_communicator(exclusive_scan_basename,
+                create_communicator(exclusive_scan_local_basename,
                     num_sites_arg(num_sites), this_site_arg(site));
 
             hpx::chrono::high_resolution_timer const t;

--- a/libs/full/collectives/tests/unit/exclusive_scan_sync.cpp
+++ b/libs/full/collectives/tests/unit/exclusive_scan_sync.cpp
@@ -20,7 +20,15 @@
 
 using namespace hpx::collectives;
 
+// Keep independently created communicators from aliasing in AGAS while
+// localities transition between test phases.
 constexpr char const* exclusive_scan_basename = "/test/exclusive_scan_sync/";
+constexpr char const* exclusive_scan_multiple_use_basename =
+    "/test/exclusive_scan_sync/multiple_use/";
+constexpr char const* exclusive_scan_explicit_generation_basename =
+    "/test/exclusive_scan_sync/explicit_generation/";
+constexpr char const* exclusive_scan_local_basename =
+    "/test/exclusive_scan_sync/local/";
 #if defined(HPX_DEBUG)
 constexpr int ITERATIONS = 100;
 #else
@@ -59,7 +67,7 @@ void test_multiple_use()
     HPX_TEST_LTE(static_cast<std::uint32_t>(2), num_localities);
 
     auto const exclusive_scan_client =
-        create_communicator(exclusive_scan_basename,
+        create_communicator(exclusive_scan_multiple_use_basename,
             num_sites_arg(num_localities), this_site_arg(here));
 
     // test functionality based on immediate local result value
@@ -86,7 +94,7 @@ void test_multiple_use_with_generation()
     HPX_TEST_LTE(static_cast<std::uint32_t>(2), num_localities);
 
     auto const exclusive_scan_client =
-        create_communicator(exclusive_scan_basename,
+        create_communicator(exclusive_scan_explicit_generation_basename,
             num_sites_arg(num_localities), this_site_arg(here));
 
     hpx::chrono::high_resolution_timer const t;
@@ -124,7 +132,7 @@ void test_local_use()
     {
         sites.push_back(hpx::async([=]() {
             auto const exclusive_scan_client =
-                create_communicator(exclusive_scan_basename,
+                create_communicator(exclusive_scan_local_basename,
                     num_sites_arg(num_sites), this_site_arg(site));
 
             hpx::chrono::high_resolution_timer const t;

--- a/libs/full/collectives/tests/unit/inclusive_scan_.cpp
+++ b/libs/full/collectives/tests/unit/inclusive_scan_.cpp
@@ -21,7 +21,15 @@
 
 using namespace hpx::collectives;
 
+// Keep independently created communicators from aliasing in AGAS while
+// localities transition between test phases.
 constexpr char const* inclusive_scan_basename = "/test/inclusive_scan/";
+constexpr char const* inclusive_scan_multiple_use_basename =
+    "/test/inclusive_scan/multiple_use/";
+constexpr char const* inclusive_scan_explicit_generation_basename =
+    "/test/inclusive_scan/explicit_generation/";
+constexpr char const* inclusive_scan_local_basename =
+    "/test/inclusive_scan/local/";
 #if defined(HPX_DEBUG)
 constexpr int ITERATIONS = 100;
 #else
@@ -60,7 +68,7 @@ void test_multiple_use()
     HPX_TEST_LTE(static_cast<std::uint32_t>(2), num_localities);
 
     auto const inclusive_scan_client =
-        create_communicator(inclusive_scan_basename,
+        create_communicator(inclusive_scan_multiple_use_basename,
             num_sites_arg(num_localities), this_site_arg(here));
 
     // test functionality based on immediate local result value
@@ -86,7 +94,7 @@ void test_multiple_use_with_generation()
     HPX_TEST_LTE(static_cast<std::uint32_t>(2), num_localities);
 
     auto const inclusive_scan_client =
-        create_communicator(inclusive_scan_basename,
+        create_communicator(inclusive_scan_explicit_generation_basename,
             num_sites_arg(num_localities), this_site_arg(here));
 
     hpx::chrono::high_resolution_timer const t;
@@ -122,7 +130,7 @@ void test_local_use(std::uint32_t num_sites)
     {
         sites.push_back(hpx::async([=]() {
             auto const inclusive_scan_client =
-                create_communicator(inclusive_scan_basename,
+                create_communicator(inclusive_scan_local_basename,
                     num_sites_arg(num_sites), this_site_arg(site));
 
             hpx::chrono::high_resolution_timer const t;

--- a/libs/full/collectives/tests/unit/inclusive_scan_sync.cpp
+++ b/libs/full/collectives/tests/unit/inclusive_scan_sync.cpp
@@ -21,7 +21,15 @@
 
 using namespace hpx::collectives;
 
+// Keep independently created communicators from aliasing in AGAS while
+// localities transition between test phases.
 constexpr char const* inclusive_scan_basename = "/test/inclusive_scan/";
+constexpr char const* inclusive_scan_multiple_use_basename =
+    "/test/inclusive_scan/multiple_use/";
+constexpr char const* inclusive_scan_explicit_generation_basename =
+    "/test/inclusive_scan/explicit_generation/";
+constexpr char const* inclusive_scan_local_basename =
+    "/test/inclusive_scan/local/";
 #if defined(HPX_DEBUG)
 constexpr int ITERATIONS = 100;
 #else
@@ -60,7 +68,7 @@ void test_multiple_use()
     HPX_TEST_LTE(static_cast<std::uint32_t>(2), num_localities);
 
     auto const inclusive_scan_client =
-        create_communicator(inclusive_scan_basename,
+        create_communicator(inclusive_scan_multiple_use_basename,
             num_sites_arg(num_localities), this_site_arg(here));
 
     // test functionality based on immediate local result value
@@ -86,7 +94,7 @@ void test_multiple_use_with_generation()
     HPX_TEST_LTE(static_cast<std::uint32_t>(2), num_localities);
 
     auto const inclusive_scan_client =
-        create_communicator(inclusive_scan_basename,
+        create_communicator(inclusive_scan_explicit_generation_basename,
             num_sites_arg(num_localities), this_site_arg(here));
 
     hpx::chrono::high_resolution_timer const t;
@@ -124,7 +132,7 @@ void test_local_use()
     {
         sites.push_back(hpx::async([=]() {
             auto const inclusive_scan_client =
-                create_communicator(inclusive_scan_basename,
+                create_communicator(inclusive_scan_local_basename,
                     num_sites_arg(num_sites), this_site_arg(site));
 
             hpx::chrono::high_resolution_timer const t;


### PR DESCRIPTION
Fixes #

## Proposed Changes

- Treat already-passed `and_gate` generations as satisfied in `base_and_gate::synchronize`.
- Avoid throwing `invalid_status` when `generation_value < generation_`.
- Add a focused `and_gate` regression test for synchronizing a generation after the gate has advanced.

## Any background context you want to provide?

This fixes failures where distributed collectives, including `inclusive_scan_`, could hit `and_gate::synchronize` with a generation that had already been reached and then incorrectly fail with `generational counter too small`.

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [x] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.