### PR TITLE
Fixing future::wait_until (and wait_for) to return once future was made ready

### DIFF
--- a/libs/core/execution_base/include/hpx/execution_base/agent_base.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/agent_base.hpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2019 Thomas Heller
+//  Copyright (c) 2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -9,6 +10,7 @@
 #include <hpx/config.hpp>
 #include <hpx/execution_base/context_base.hpp>
 #include <hpx/modules/coroutines.hpp>
+#include <hpx/modules/functional.hpp>
 #include <hpx/modules/timing.hpp>
 
 #include <cstddef>
@@ -30,11 +32,11 @@ namespace hpx::execution_base {
         virtual void resume(
             hpx::threads::thread_priority priority, char const* desc) = 0;
         virtual void abort(char const* desc) = 0;
-        virtual void sleep_for(
+        virtual threads::thread_restart_state sleep_for(
             hpx::chrono::steady_duration const& sleep_duration,
-            char const* desc) = 0;
-        virtual void sleep_until(
+            hpx::move_only_function<bool()>&& wait_cond, char const* desc) = 0;
+        virtual threads::thread_restart_state sleep_until(
             hpx::chrono::steady_time_point const& sleep_time,
-            char const* desc) = 0;
+            hpx::move_only_function<bool()>&& wait_cond, char const* desc) = 0;
     };
 }    // namespace hpx::execution_base

--- a/libs/core/execution_base/include/hpx/execution_base/agent_ref.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/agent_ref.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2019 Thomas Heller
-//  Copyright (c) 2023 Hartmut Kaiser
+//  Copyright (c) 2023-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -9,6 +9,7 @@
 
 #include <hpx/config.hpp>
 #include <hpx/modules/coroutines.hpp>
+#include <hpx/modules/functional.hpp>
 #include <hpx/modules/timing.hpp>
 
 #include <chrono>
@@ -58,20 +59,25 @@ namespace hpx::execution_base {
             char const* desc = "hpx::execution_base::agent_ref::abort") const;
 
         template <typename Rep, typename Period>
-        void sleep_for(std::chrono::duration<Rep, Period> const& sleep_duration,
+        threads::thread_restart_state sleep_for(
+            std::chrono::duration<Rep, Period> const& sleep_duration,
+            hpx::move_only_function<bool()>&& wait_cond,
             char const* desc =
                 "hpx::execution_base::agent_ref::sleep_for") const
         {
-            sleep_for(hpx::chrono::steady_duration{sleep_duration}, desc);
+            return sleep_for(hpx::chrono::steady_duration{sleep_duration},
+                HPX_MOVE(wait_cond), desc);
         }
 
         template <typename Clock, typename Duration>
-        void sleep_until(
+        threads::thread_restart_state sleep_until(
             std::chrono::time_point<Clock, Duration> const& sleep_time,
+            hpx::move_only_function<bool()>&& wait_cond,
             char const* desc =
                 "hpx::execution_base::agent_ref::sleep_until") const
         {
-            sleep_until(hpx::chrono::steady_time_point{sleep_time}, desc);
+            return sleep_until(hpx::chrono::steady_time_point{sleep_time},
+                HPX_MOVE(wait_cond), desc);
         }
 
         [[nodiscard]] agent_base& ref() const noexcept
@@ -87,9 +93,13 @@ namespace hpx::execution_base {
     private:
         agent_base* impl_ = nullptr;
 
-        void sleep_for(hpx::chrono::steady_duration const& sleep_duration,
+        threads::thread_restart_state sleep_for(
+            hpx::chrono::steady_duration const& sleep_duration,
+            hpx::move_only_function<bool()>&& wait_cond,
             char const* desc) const;
-        void sleep_until(hpx::chrono::steady_time_point const& sleep_time,
+        threads::thread_restart_state sleep_until(
+            hpx::chrono::steady_time_point const& sleep_time,
+            hpx::move_only_function<bool()>&& wait_cond,
             char const* desc) const;
 
         friend constexpr bool operator==(

--- a/libs/core/execution_base/include/hpx/execution_base/this_thread.hpp
+++ b/libs/core/execution_base/include/hpx/execution_base/this_thread.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2019 Thomas Heller
-//  Copyright (c) 2022 Hartmut Kaiser
+//  Copyright (c) 2022-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -11,6 +11,7 @@
 #include <hpx/execution_base/agent_base.hpp>
 #include <hpx/execution_base/agent_ref.hpp>
 #include <hpx/execution_base/sender.hpp>
+#include <hpx/modules/functional.hpp>
 #include <hpx/modules/timing.hpp>
 #include <hpx/modules/type_support.hpp>
 
@@ -70,15 +71,17 @@ namespace hpx::execution_base {
         void sleep_for(std::chrono::duration<Rep, Period> const& sleep_duration,
             char const* desc = "hpx::execution_base::this_thread::sleep_for")
         {
-            agent().sleep_for(sleep_duration, desc);
+            agent().sleep_for(
+                sleep_duration, hpx::move_only_function<bool()>{}, desc);
         }
 
         HPX_CXX_CORE_EXPORT template <class Clock, class Duration>
         void sleep_until(
             std::chrono::time_point<Clock, Duration> const& sleep_time,
-            char const* desc = "hpx::execution_base::this_thread::sleep_for")
+            char const* desc = "hpx::execution_base::this_thread::sleep_until")
         {
-            agent().sleep_until(sleep_time, desc);
+            agent().sleep_until(
+                sleep_time, hpx::move_only_function<bool()>{}, desc);
         }
     }    // namespace this_thread
 }    // namespace hpx::execution_base

--- a/libs/core/execution_base/src/agent_ref.cpp
+++ b/libs/core/execution_base/src/agent_ref.cpp
@@ -1,4 +1,5 @@
 //  Copyright (c) 2019 Thomas Heller
+//  Copyright (c) 2023-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -9,6 +10,7 @@
 #include <hpx/execution_base/this_thread.hpp>
 #include <hpx/modules/coroutines.hpp>
 #include <hpx/modules/format.hpp>
+#include <hpx/modules/functional.hpp>
 #include <hpx/modules/lock_registration.hpp>
 
 #include <cstddef>
@@ -56,20 +58,20 @@ namespace hpx::execution_base {
         impl_->abort(desc);
     }
 
-    void agent_ref::sleep_for(
+    threads::thread_restart_state agent_ref::sleep_for(
         hpx::chrono::steady_duration const& sleep_duration,
-        char const* desc) const
+        hpx::move_only_function<bool()>&& wait_cond, char const* desc) const
     {
         HPX_ASSERT(*this == hpx::execution_base::this_thread::agent());
-        impl_->sleep_for(sleep_duration, desc);
+        return impl_->sleep_for(sleep_duration, HPX_MOVE(wait_cond), desc);
     }
 
-    void agent_ref::sleep_until(
+    threads::thread_restart_state agent_ref::sleep_until(
         hpx::chrono::steady_time_point const& sleep_time,
-        char const* desc) const
+        hpx::move_only_function<bool()>&& wait_cond, char const* desc) const
     {
         HPX_ASSERT(*this == hpx::execution_base::this_thread::agent());
-        impl_->sleep_until(sleep_time, desc);
+        return impl_->sleep_until(sleep_time, HPX_MOVE(wait_cond), desc);
     }
 
     std::ostream& operator<<(std::ostream& os, agent_ref const& a)

--- a/libs/core/execution_base/src/this_thread.cpp
+++ b/libs/core/execution_base/src/this_thread.cpp
@@ -1,6 +1,6 @@
 //  Copyright (c) 2013-2019 Thomas Heller
 //  Copyright (c) 2008 Peter Dimov
-//  Copyright (c) 2018-2025 Hartmut Kaiser
+//  Copyright (c) 2018-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -14,6 +14,7 @@
 #include <hpx/modules/coroutines.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/format.hpp>
+#include <hpx/modules/functional.hpp>
 #include <hpx/modules/timing.hpp>
 
 #include <condition_variable>
@@ -141,9 +142,13 @@ namespace hpx::execution_base {
             void resume(hpx::threads::thread_priority priority,
                 char const* desc) override;
             void abort(char const* desc) override;
-            void sleep_for(hpx::chrono::steady_duration const& sleep_duration,
+            threads::thread_restart_state sleep_for(
+                hpx::chrono::steady_duration const& sleep_duration,
+                hpx::move_only_function<bool()>&& wait_cond,
                 char const* desc) override;
-            void sleep_until(hpx::chrono::steady_time_point const& sleep_time,
+            threads::thread_restart_state sleep_until(
+                hpx::chrono::steady_time_point const& sleep_time,
+                hpx::move_only_function<bool()>&& wait_cond,
                 char const* desc) override;
 
         private:
@@ -262,18 +267,22 @@ namespace hpx::execution_base {
             suspend_cv_.notify_one();
         }
 
-        void default_agent::sleep_for(
+        threads::thread_restart_state default_agent::sleep_for(
             hpx::chrono::steady_duration const& sleep_duration,
+            hpx::move_only_function<bool()>&& /* wait_cond */,
             char const* /* desc */)
         {
             std::this_thread::sleep_for(sleep_duration.value());
+            return threads::thread_restart_state::timeout;
         }
 
-        void default_agent::sleep_until(
+        threads::thread_restart_state default_agent::sleep_until(
             hpx::chrono::steady_time_point const& sleep_time,
+            hpx::move_only_function<bool()>&& /* wait_cond */,
             char const* /* desc */)
         {
             std::this_thread::sleep_until(sleep_time.value());
+            return threads::thread_restart_state::timeout;
         }
     }    // namespace
 

--- a/libs/core/execution_base/tests/unit/execution_context.cpp
+++ b/libs/core/execution_base/tests/unit/execution_context.cpp
@@ -1,10 +1,13 @@
 //  Copyright (c) 2019 Thomas Heller
+//  Copyright (c) 2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#include <hpx/modules/coroutines.hpp>
 #include <hpx/modules/execution_base.hpp>
+#include <hpx/modules/functional.hpp>
 #include <hpx/modules/testing.hpp>
 
 #include <atomic>
@@ -49,10 +52,18 @@ struct dummy_agent : hpx::execution_base::agent_base
     void suspend(char const*) override {}
     void resume(hpx::threads::thread_priority, char const*) override {}
     void abort(char const*) override {}
-    void sleep_for(hpx::chrono::steady_duration const&, char const*) override {}
-    void sleep_until(
-        hpx::chrono::steady_time_point const&, char const*) override
+
+    hpx::threads::thread_restart_state sleep_for(
+        hpx::chrono::steady_duration const&, hpx::move_only_function<bool()>&&,
+        char const*) override
     {
+        return hpx::threads::thread_restart_state::signaled;
+    }
+    hpx::threads::thread_restart_state sleep_until(
+        hpx::chrono::steady_time_point const&,
+        hpx::move_only_function<bool()>&&, char const*) override
+    {
+        return hpx::threads::thread_restart_state::signaled;
     }
 
     dummy_context context_;

--- a/libs/core/execution_base/tests/unit/execution_context.cpp
+++ b/libs/core/execution_base/tests/unit/execution_context.cpp
@@ -13,12 +13,16 @@
 #include <atomic>
 #include <chrono>
 #include <cstddef>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
+#include <utility>
 #include <vector>
 
 std::size_t dummy_called = 0;
+std::size_t dummy_sleep_for_called = 0;
+std::size_t dummy_sleep_until_called = 0;
 
 struct dummy_context final : hpx::execution_base::context_base
 {
@@ -54,16 +58,22 @@ struct dummy_agent : hpx::execution_base::agent_base
     void abort(char const*) override {}
 
     hpx::threads::thread_restart_state sleep_for(
-        hpx::chrono::steady_duration const&, hpx::move_only_function<bool()>&&,
-        char const*) override
+        hpx::chrono::steady_duration const&,
+        hpx::move_only_function<bool()>&& wait_cond, char const*) override
     {
-        return hpx::threads::thread_restart_state::signaled;
+        ++dummy_sleep_for_called;
+        return wait_cond && wait_cond() ?
+            hpx::threads::thread_restart_state::signaled :
+            hpx::threads::thread_restart_state::timeout;
     }
     hpx::threads::thread_restart_state sleep_until(
         hpx::chrono::steady_time_point const&,
-        hpx::move_only_function<bool()>&&, char const*) override
+        hpx::move_only_function<bool()>&& wait_cond, char const*) override
     {
-        return hpx::threads::thread_restart_state::signaled;
+        ++dummy_sleep_until_called;
+        return wait_cond && wait_cond() ?
+            hpx::threads::thread_restart_state::signaled :
+            hpx::threads::thread_restart_state::timeout;
     }
 
     dummy_context context_;
@@ -189,12 +199,68 @@ void test_sleep()
     HPX_TEST(now + sleep_duration * 2 <= std::chrono::steady_clock::now());
 }
 
+void test_sleep_with_predicate()
+{
+    // predicate satisfied immediately -> the agent should report that it was
+    // signaled, and the (move-only) predicate must have been forwarded all the
+    // way down to the agent implementation.
+    {
+        dummy_agent dummy;
+        hpx::execution_base::this_thread::reset_agent ctx(dummy);
+
+        dummy_sleep_for_called = 0;
+        auto state = hpx::execution_base::this_thread::agent().sleep_for(
+            std::chrono::milliseconds(100), []() { return true; });
+        HPX_TEST_EQ(dummy_sleep_for_called, 1u);
+        HPX_TEST(state == hpx::threads::thread_restart_state::signaled);
+    }
+
+    // predicate never satisfied -> the agent should report a timeout
+    {
+        dummy_agent dummy;
+        hpx::execution_base::this_thread::reset_agent ctx(dummy);
+
+        dummy_sleep_until_called = 0;
+        auto state = hpx::execution_base::this_thread::agent().sleep_until(
+            std::chrono::steady_clock::now() + std::chrono::milliseconds(100),
+            []() { return false; });
+        HPX_TEST_EQ(dummy_sleep_until_called, 1u);
+        HPX_TEST(state == hpx::threads::thread_restart_state::timeout);
+    }
+
+    // move-only predicates must be forwarded by value, not copied
+    {
+        dummy_agent dummy;
+        hpx::execution_base::this_thread::reset_agent ctx(dummy);
+
+        auto flag = std::make_unique<bool>(true);
+        auto state = hpx::execution_base::this_thread::agent().sleep_for(
+            std::chrono::milliseconds(100),
+            [flag = std::move(flag)]() { return *flag; });
+        HPX_TEST(state == hpx::threads::thread_restart_state::signaled);
+    }
+
+    // the real (default) agent used when no other agent context has been
+    // installed does not support predicate-based early wake up: it always waits
+    // out the full duration and reports a timeout, regardless of the predicate
+    // passed in.
+    {
+        auto now = std::chrono::steady_clock::now();
+        auto sleep_duration = std::chrono::milliseconds(100);
+        auto state = hpx::execution_base::this_thread::agent().sleep_for(
+            sleep_duration, []() { return true; });
+        HPX_TEST(state == hpx::threads::thread_restart_state::timeout);
+        HPX_TEST(now + sleep_duration <= std::chrono::steady_clock::now());
+    }
+}
+
 int main()
 {
     test_basic_functionality();
     test_yield();
     test_suspend_resume();
     test_sleep();
+    test_sleep_with_predicate();
 
     return hpx::util::report_errors();
 }

--- a/libs/core/futures/src/future_data.cpp
+++ b/libs/core/futures/src/future_data.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2015-2025 Hartmut Kaiser
+//  Copyright (c) 2015-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -390,8 +390,14 @@ namespace hpx::lcos::detail {
             std::unique_lock l(mtx_);
             if (state_.load(std::memory_order_relaxed) == empty)
             {
-                threads::thread_restart_state const reason = cond_.wait_until(
-                    l, abs_time, "future_data_base::wait_until", ec);
+                // stop waiting if the future becomes ready
+                hpx::move_only_function<bool()> wait_cond = [this]() {
+                    return state_.load(std::memory_order_acquire) != empty;
+                };
+
+                threads::thread_restart_state const reason =
+                    cond_.wait_until(l, abs_time, HPX_MOVE(wait_cond),
+                        "future_data_base::wait_until", ec);
                 if (ec)
                 {
                     return hpx::future_status::uninitialized;

--- a/libs/core/futures/tests/unit/future.cpp
+++ b/libs/core/futures/tests/unit/future.cpp
@@ -1,4 +1,4 @@
-//  Copyright (C) 2012-2017 Hartmut Kaiser
+//  Copyright (C) 2012-2026 Hartmut Kaiser
 //  (C) Copyright 2008-10 Anthony Williams
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -254,7 +254,7 @@ void test_invoking_a_packaged_task_twice_throws()
         HPX_TEST(false);
     }
     // retrieve the future so the destructor of packaged_task is happy.
-    // Otherwise an exception will be tried to set to future_data which
+    // Otherwise, an exception will be tried to set to future_data which
     // leads to another exception to the fact that the future has already been
     // set.
     pt.get_future().get();
@@ -457,28 +457,132 @@ void test_wait_callback_with_timed_wait()
     hpx::future<void> fv =
         fi.then(hpx::bind(&do_nothing_callback, std::ref(pi)));
 
-    int state = int(fv.wait_for(std::chrono::milliseconds(100)));
-    HPX_TEST_EQ(state, int(hpx::future_status::timeout));
+    int state = static_cast<int>(fv.wait_for(std::chrono::milliseconds(100)));
+    HPX_TEST_EQ(state, static_cast<int>(hpx::future_status::timeout));
     HPX_TEST_EQ(callback_called, 0U);
 
-    state = int(fv.wait_for(std::chrono::milliseconds(100)));
-    HPX_TEST_EQ(state, int(hpx::future_status::timeout));
-    state = int(fv.wait_for(std::chrono::milliseconds(100)));
-    HPX_TEST_EQ(state, int(hpx::future_status::timeout));
+    state = static_cast<int>(fv.wait_for(std::chrono::milliseconds(100)));
+    HPX_TEST_EQ(state, static_cast<int>(hpx::future_status::timeout));
+    state = static_cast<int>(fv.wait_for(std::chrono::milliseconds(100)));
+    HPX_TEST_EQ(state, static_cast<int>(hpx::future_status::timeout));
     HPX_TEST_EQ(callback_called, 0U);
 
     pi.set_value(42);
 
-    state = int(fv.wait_for(std::chrono::milliseconds(100)));
-    HPX_TEST_EQ(state, int(hpx::future_status::ready));
+    state = static_cast<int>(fv.wait_for(std::chrono::milliseconds(100)));
+    HPX_TEST_EQ(state, static_cast<int>(hpx::future_status::ready));
 
     HPX_TEST_EQ(callback_called, 1U);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_wait_for_returns_as_soon_as_value_is_set()
+{
+    hpx::promise<int> p;
+    hpx::future<int> f = p.get_future();
+
+    hpx::thread t([&p]() {
+        hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
+        p.set_value(42);
+    });
+
+    std::chrono::steady_clock::time_point const start =
+        std::chrono::steady_clock::now();
+    hpx::future_status const status = f.wait_for(std::chrono::seconds(2));
+    std::chrono::steady_clock::time_point const end =
+        std::chrono::steady_clock::now();
+
+    HPX_TEST_EQ(
+        static_cast<int>(status), static_cast<int>(hpx::future_status::ready));
+    HPX_TEST(end - start < std::chrono::milliseconds(1500));
+    HPX_TEST_EQ(f.get(), 42);
+
+    t.join();
+}
+
+void test_wait_until_returns_as_soon_as_value_is_set()
+{
+    hpx::promise<int> p;
+    hpx::future<int> f = p.get_future();
+
+    hpx::thread t([&p]() {
+        hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
+        p.set_value(42);
+    });
+
+    std::chrono::steady_clock::time_point const start =
+        std::chrono::steady_clock::now();
+    std::chrono::steady_clock::time_point const abs_time =
+        start + std::chrono::seconds(2);
+    hpx::future_status const status = f.wait_until(abs_time);
+    std::chrono::steady_clock::time_point const end =
+        std::chrono::steady_clock::now();
+
+    HPX_TEST_EQ(
+        static_cast<int>(status), static_cast<int>(hpx::future_status::ready));
+    HPX_TEST(end - start < std::chrono::milliseconds(1500));
+    HPX_TEST_EQ(f.get(), 42);
+
+    t.join();
+}
+
+void test_wait_for_returns_as_soon_as_exception_is_set()
+{
+    hpx::promise<int> p;
+    hpx::future<int> f = p.get_future();
+
+    hpx::thread t([&p]() {
+        hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
+        p.set_exception(std::make_exception_ptr(my_exception()));
+    });
+
+    std::chrono::steady_clock::time_point const start =
+        std::chrono::steady_clock::now();
+    hpx::future_status const status = f.wait_for(std::chrono::seconds(10));
+    std::chrono::steady_clock::time_point const end =
+        std::chrono::steady_clock::now();
+
+    HPX_TEST_EQ(
+        static_cast<int>(status), static_cast<int>(hpx::future_status::ready));
+    HPX_TEST(end - start < std::chrono::seconds(5));
+
+    try
+    {
+        f.get();
+        HPX_TEST(false);
+    }
+    catch (my_exception)
+    {
+        HPX_TEST(true);
+    }
+
+    t.join();
+}
+
+void test_wait_for_times_out_when_never_set()
+{
+    hpx::promise<int> p;
+    hpx::future<int> const f = p.get_future();
+
+    std::chrono::steady_clock::time_point const start =
+        std::chrono::steady_clock::now();
+    hpx::future_status const status =
+        f.wait_for(std::chrono::milliseconds(200));
+    std::chrono::steady_clock::time_point const end =
+        std::chrono::steady_clock::now();
+
+    HPX_TEST_EQ(static_cast<int>(status),
+        static_cast<int>(hpx::future_status::timeout));
+    HPX_TEST(end - start >= std::chrono::milliseconds(150));
+
+    // fulfill the promise so the destructor of promise is happy.
+    p.set_value(0);
 }
 
 void test_packaged_task_can_be_moved()
 {
     hpx::packaged_task<int()> pt(make_int);
-    hpx::future<int> fi = pt.get_future();
+    hpx::future<int> const fi = pt.get_future();
     HPX_TEST(!fi.is_ready());
 
     hpx::packaged_task<int()> pt2(std::move(pt));
@@ -594,6 +698,10 @@ int hpx_main(variables_map&)
         test_future_for_string();
         test_wait_callback();
         test_wait_callback_with_timed_wait();
+        test_wait_for_returns_as_soon_as_value_is_set();
+        test_wait_until_returns_as_soon_as_value_is_set();
+        test_wait_for_returns_as_soon_as_exception_is_set();
+        test_wait_for_times_out_when_never_set();
         test_packaged_task_can_be_moved();
         test_destroying_a_promise_stores_broken_promise();
         test_destroying_a_packaged_task_stores_broken_task();

--- a/libs/core/synchronization/include/hpx/synchronization/condition_variable.hpp
+++ b/libs/core/synchronization/include/hpx/synchronization/condition_variable.hpp
@@ -78,7 +78,7 @@ namespace hpx {
     ///          3. When the condition variable is notified, a timeout expires, or
     ///             a spurious wakeup occurs, the thread is awakened, and the
     ///             mutex is atomically reacquired. The thread should then check
-    ///             the condition and resume waiting if the wake up was spurious.
+    ///             the condition and resume waiting if the wake-up was spurious.
     ///          or
     ///          1. use the predicated overload of \a wait, \a wait_for, and
     ///          \a wait_until, which takes care of the three steps above.
@@ -343,6 +343,47 @@ namespace hpx {
                 cv_status::no_timeout;
         }
 
+    protected:
+        template <typename Mutex, typename Predicate>
+        cv_status wait_until_pred(std::unique_lock<Mutex>& lock,
+            hpx::chrono::steady_time_point const& abs_time, Predicate wait_cond,
+            error_code& ec = throws)
+        {
+            HPX_ASSERT_OWNS_LOCK(lock);
+
+            auto const data = data_;    // keep data alive
+
+            [[maybe_unused]] util::ignore_all_while_checking const ignore_lock;
+
+            std::unique_lock<mutex_type> l(data->mtx_);
+            unlock_guard<std::unique_lock<Mutex>> unlock(lock);
+
+            // The following ensures that the inner lock will be unlocked
+            // before the outer to avoid deadlock (fixes issue #3608)
+            std::lock_guard<std::unique_lock<mutex_type>> unlock_next(
+                l, std::adopt_lock);
+
+            threads::thread_restart_state const reason = data->cond_.wait_until(
+                l, abs_time,
+                [&, pred = HPX_MOVE(wait_cond)]() {
+                    // re-acquire the outer lock to make sure that the
+                    // user-supplied predicate is protected
+                    relock_guard<std::unique_lock<Mutex>> relock(unlock);
+                    return pred();
+                },
+                "condition_variable::wait_until_pred", ec);
+
+            if (ec)
+                return cv_status::error;
+
+            // if the timer has hit, the waiting period timed out
+            return (reason ==
+                       threads::thread_restart_state::timeout) ?    //-V110
+                cv_status::timeout :
+                cv_status::no_timeout;
+        }
+
+    public:
         ///
         /// \brief \a wait_until causes the current thread to block until the
         /// condition variable is notified, a specific time is reached, or a
@@ -398,8 +439,11 @@ namespace hpx {
 
             while (!pred())
             {
-                if (wait_until(lock, abs_time, ec) == cv_status::timeout)
+                if (wait_until_pred(lock, abs_time, pred, ec) ==
+                    cv_status::timeout)
+                {
                     return pred();
+                }
             }
             return true;
         }
@@ -688,7 +732,7 @@ namespace hpx {
         ///             \namedrequirement{BasicLockable} requirements, which
         ///             must be locked by the current thread
         /// \param ec   Used to hold error code value originated during the
-        ///             operation. Defaults to \a throws -- A special'throw on
+        ///             operation. Defaults to \a throws -- A special 'throw on
         ///             error' \a error_code.
         ///
         /// \returns \a wait returns \a void.
@@ -1179,7 +1223,15 @@ namespace hpx {
                         l, std::adopt_lock);
 
                     threads::thread_restart_state const reason =
-                        data->cond_.wait_until(l, abs_time, ec);
+                        data->cond_.wait_until(
+                            l, abs_time,
+                            [&]() {
+                                // re-acquire the outer lock to make sure that
+                                // the user-supplied predicate is protected
+                                relock_guard<Lock> relock(unlock);
+                                return pred();
+                            },
+                            "condition_variable::wait_until_stoken", ec);
 
                     if (ec)
                         return false;

--- a/libs/core/synchronization/include/hpx/synchronization/detail/condition_variable.hpp
+++ b/libs/core/synchronization/include/hpx/synchronization/detail/condition_variable.hpp
@@ -110,20 +110,26 @@ namespace hpx::lcos::local::detail {
             return wait(lock, "condition_variable::wait", ec);
         }
 
-        threads::thread_restart_state wait_until(
+        HPX_CORE_EXPORT threads::thread_restart_state wait_until(
             std::unique_lock<mutex_type>& lock,
             hpx::chrono::steady_time_point const& abs_time,
-            char const* description, error_code& ec = throws)
-        {
-            return wait_until(
-                lock, abs_time, []() { return false; }, description, ec);
-        }
+            char const* description, error_code& ec = throws);
 
         HPX_CORE_EXPORT threads::thread_restart_state wait_until(
             std::unique_lock<mutex_type>& lock,
             hpx::chrono::steady_time_point const& abs_time,
             hpx::move_only_function<bool()>&& wait_cond,
             char const* description, error_code& ec = throws);
+
+        threads::thread_restart_state wait_until(
+            std::unique_lock<mutex_type>& lock,
+            hpx::chrono::steady_time_point const& abs_time,
+            hpx::move_only_function<bool()>&& wait_cond,
+            error_code& ec = throws)
+        {
+            return wait_until(lock, abs_time, HPX_MOVE(wait_cond),
+                "condition_variable::wait_until", ec);
+        }
 
         threads::thread_restart_state wait_until(
             std::unique_lock<mutex_type>& lock,

--- a/libs/core/synchronization/include/hpx/synchronization/detail/condition_variable.hpp
+++ b/libs/core/synchronization/include/hpx/synchronization/detail/condition_variable.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2025 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c) 2013-2015 Agustin Berge
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -12,6 +12,7 @@
 #include <hpx/modules/coroutines.hpp>
 #include <hpx/modules/datastructures.hpp>
 #include <hpx/modules/errors.hpp>
+#include <hpx/modules/functional.hpp>
 #include <hpx/modules/thread_support.hpp>
 #include <hpx/modules/timing.hpp>
 #include <hpx/synchronization/spinlock.hpp>
@@ -109,9 +110,19 @@ namespace hpx::lcos::local::detail {
             return wait(lock, "condition_variable::wait", ec);
         }
 
+        threads::thread_restart_state wait_until(
+            std::unique_lock<mutex_type>& lock,
+            hpx::chrono::steady_time_point const& abs_time,
+            char const* description, error_code& ec = throws)
+        {
+            return wait_until(
+                lock, abs_time, []() { return false; }, description, ec);
+        }
+
         HPX_CORE_EXPORT threads::thread_restart_state wait_until(
             std::unique_lock<mutex_type>& lock,
             hpx::chrono::steady_time_point const& abs_time,
+            hpx::move_only_function<bool()>&& wait_cond,
             char const* description, error_code& ec = throws);
 
         threads::thread_restart_state wait_until(

--- a/libs/core/synchronization/src/detail/condition_variable.cpp
+++ b/libs/core/synchronization/src/detail/condition_variable.cpp
@@ -31,7 +31,7 @@ namespace hpx::lcos::local::detail {
     struct condition_variable::queue_entry
     {
         constexpr queue_entry(
-            hpx::execution_base::agent_ref ctx, void* q) noexcept
+            hpx::execution_base::agent_ref const ctx, void* q) noexcept
           : ctx_(ctx)
           , q_(q)
         {
@@ -39,6 +39,7 @@ namespace hpx::lcos::local::detail {
 
         hpx::execution_base::agent_ref ctx_;
         void* q_;
+        std::atomic<bool> was_reset_ = false;
 
         queue_entry* next = nullptr;
         queue_entry* prev = nullptr;
@@ -109,7 +110,8 @@ namespace hpx::lcos::local::detail {
     // Return false if no more threads are waiting (returns true if queue
     // is non-empty).
     bool condition_variable::notify_one(std::unique_lock<mutex_type>& lock,
-        threads::thread_priority priority, bool unlock, error_code& ec)
+        threads::thread_priority const priority, bool const unlock,
+        error_code& ec)
     {
         // Caller failing to hold lock 'lock' before calling function
 #if defined(HPX_MSVC)
@@ -121,10 +123,13 @@ namespace hpx::lcos::local::detail {
 
         if (!queue_.empty())
         {
-            auto const ctx = queue_.front()->ctx_;
+            auto* front = queue_.front();
+            auto const ctx = front->ctx_;
 
             // remove item from queue before error handling
-            queue_.front()->ctx_.reset();
+            front->ctx_.reset();
+            front->was_reset_.store(true, std::memory_order_relaxed);
+
             queue_.pop_front();
 
             if (HPX_UNLIKELY(!ctx))
@@ -160,7 +165,8 @@ namespace hpx::lcos::local::detail {
     }
 
     void condition_variable::notify_all(std::unique_lock<mutex_type>& lock,
-        threads::thread_priority priority, bool unlock, error_code& ec)
+        threads::thread_priority const priority, bool const unlock,
+        error_code& ec)
     {
         // Caller failing to hold lock 'lock' before calling function
 #if defined(HPX_MSVC)
@@ -183,10 +189,13 @@ namespace hpx::lcos::local::detail {
 
             do
             {
-                auto ctx = queue.front()->ctx_;
+                auto* front = queue.front();
+                auto ctx = front->ctx_;
 
                 // remove item from queue before error handling
-                queue.front()->ctx_.reset();
+                front->ctx_.reset();
+                front->was_reset_.store(true, std::memory_order_relaxed);
+
                 queue.pop_front();
 
                 if (HPX_UNLIKELY(!ctx))
@@ -226,7 +235,7 @@ namespace hpx::lcos::local::detail {
     }
 
     threads::thread_restart_state condition_variable::wait(
-        std::unique_lock<mutex_type>& lock, char const* /* description */,
+        std::unique_lock<mutex_type>& lock, char const* description,
         error_code& /* ec */)
     {
         HPX_ASSERT_OWNS_LOCK(lock);
@@ -240,7 +249,7 @@ namespace hpx::lcos::local::detail {
         {
             // suspend this thread
             unlock_guard<std::unique_lock<mutex_type>> ul(lock);
-            this_ctx.suspend();
+            this_ctx.suspend(description);
         }
 
         return f.ctx_ ? threads::thread_restart_state::timeout :
@@ -249,29 +258,38 @@ namespace hpx::lcos::local::detail {
 
     threads::thread_restart_state condition_variable::wait_until(
         std::unique_lock<mutex_type>& lock,
+        hpx::chrono::steady_time_point const& abs_time, char const* description,
+        error_code& ec)
+    {
+        return wait_until(
+            lock, abs_time, []() { return false; }, description, ec);
+    }
+
+    threads::thread_restart_state condition_variable::wait_until(
+        std::unique_lock<mutex_type>& lock,
         hpx::chrono::steady_time_point const& abs_time,
-        hpx::move_only_function<bool()>&& wait_cond,
-        char const* /* description */, error_code& /* ec */)
+        hpx::move_only_function<bool()>&& wait_cond, char const* description,
+        error_code& /* ec */)
     {
         HPX_ASSERT_OWNS_LOCK(lock);
 
         // enqueue the request and block this thread
-        auto this_ctx = hpx::execution_base::this_thread::agent();
+        auto const this_ctx = hpx::execution_base::this_thread::agent();
         queue_entry f(this_ctx, &queue_);
         queue_.push_back(f);
 
-        threads::thread_restart_state s;
         reset_queue_entry r(f);
 
-        {
-            // suspend this thread
-            unlock_guard<std::unique_lock<mutex_type>> ul(lock);
-            s = this_ctx.sleep_until(abs_time.value(), HPX_MOVE(wait_cond));
-        }
-
-        return f.ctx_ || s == threads::thread_restart_state::timeout ?
-            threads::thread_restart_state::timeout :
-            threads::thread_restart_state::signaled;
+        // suspend this thread
+        unlock_guard<std::unique_lock<mutex_type>> ul(lock);
+        return this_ctx.sleep_until(
+            abs_time.value(),
+            [&, pred = HPX_MOVE(wait_cond)]() {
+                if (f.was_reset_.load(std::memory_order_relaxed))
+                    return true;
+                return pred();
+            },
+            description);
     }
 
     template <typename Mutex>
@@ -292,10 +310,13 @@ namespace hpx::lcos::local::detail {
 
             while (!queue.empty())
             {
-                auto ctx = queue.front()->ctx_;
+                auto* front = queue.front();
+                auto ctx = front->ctx_;
 
                 // remove item from queue before error handling
-                queue.front()->ctx_.reset();
+                front->ctx_.reset();
+                front->was_reset_.store(true, std::memory_order_relaxed);
+
                 queue.pop_front();
 
                 if (HPX_UNLIKELY(!ctx))

--- a/libs/core/synchronization/src/detail/condition_variable.cpp
+++ b/libs/core/synchronization/src/detail/condition_variable.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2025 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c) 2013-2015 Agustin Berge
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -8,6 +8,7 @@
 #include <hpx/assert.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/execution_base.hpp>
+#include <hpx/modules/functional.hpp>
 #include <hpx/modules/logging.hpp>
 #include <hpx/modules/memory.hpp>
 #include <hpx/modules/thread_support.hpp>
@@ -249,6 +250,7 @@ namespace hpx::lcos::local::detail {
     threads::thread_restart_state condition_variable::wait_until(
         std::unique_lock<mutex_type>& lock,
         hpx::chrono::steady_time_point const& abs_time,
+        hpx::move_only_function<bool()>&& wait_cond,
         char const* /* description */, error_code& /* ec */)
     {
         HPX_ASSERT_OWNS_LOCK(lock);
@@ -258,15 +260,18 @@ namespace hpx::lcos::local::detail {
         queue_entry f(this_ctx, &queue_);
         queue_.push_back(f);
 
+        threads::thread_restart_state s;
         reset_queue_entry r(f);
+
         {
             // suspend this thread
             unlock_guard<std::unique_lock<mutex_type>> ul(lock);
-            this_ctx.sleep_until(abs_time.value());
+            s = this_ctx.sleep_until(abs_time.value(), HPX_MOVE(wait_cond));
         }
 
-        return f.ctx_ ? threads::thread_restart_state::timeout :
-                        threads::thread_restart_state::signaled;
+        return f.ctx_ || s == threads::thread_restart_state::timeout ?
+            threads::thread_restart_state::timeout :
+            threads::thread_restart_state::signaled;
     }
 
     template <typename Mutex>

--- a/libs/core/synchronization/tests/unit/condition_variable.cpp
+++ b/libs/core/synchronization/tests/unit/condition_variable.cpp
@@ -3,7 +3,7 @@
 // Copyright (C) 2001-2003 William E. Kempf
 // Copyright (C) 2007-2008 Anthony Williams
 // Copyright (C) 2013 Agustin Berge
-// Copyright (C) 2022 Hartmut Kaiser
+// Copyright (C) 2022-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -16,6 +16,7 @@
 #include <hpx/mutex.hpp>
 #include <hpx/thread.hpp>
 
+#include <atomic>
 #include <chrono>
 #include <cstddef>
 #include <functional>
@@ -251,12 +252,11 @@ void test_multiple_notify_one_calls_wakes_multiple_threads()
 
 void test_condition_notify_all_wakes_from_wait()
 {
-    wait_for_flag data;
-
     std::vector<hpx::thread> group;
 
     try
     {
+        wait_for_flag data;
         for (unsigned i = 0; i < 5; ++i)
         {
             group.push_back(hpx::thread(
@@ -282,12 +282,11 @@ void test_condition_notify_all_wakes_from_wait()
 
 void test_condition_notify_all_wakes_from_wait_with_predicate()
 {
-    wait_for_flag data;
-
     std::vector<hpx::thread> group;
 
     try
     {
+        wait_for_flag data;
         for (unsigned i = 0; i < 5; ++i)
         {
             group.push_back(hpx::thread(
@@ -313,12 +312,11 @@ void test_condition_notify_all_wakes_from_wait_with_predicate()
 
 void test_condition_notify_all_wakes_from_wait_until()
 {
-    wait_for_flag data;
-
     std::vector<hpx::thread> group;
 
     try
     {
+        wait_for_flag data;
         for (unsigned i = 0; i < 5; ++i)
         {
             group.push_back(hpx::thread(
@@ -344,12 +342,11 @@ void test_condition_notify_all_wakes_from_wait_until()
 
 void test_condition_notify_all_wakes_from_wait_until_with_predicate()
 {
-    wait_for_flag data;
-
     std::vector<hpx::thread> group;
 
     try
     {
+        wait_for_flag data;
         for (unsigned i = 0; i < 5; ++i)
         {
             group.push_back(hpx::thread(
@@ -375,12 +372,11 @@ void test_condition_notify_all_wakes_from_wait_until_with_predicate()
 
 void test_condition_notify_all_wakes_from_relative_wait_until_with_predicate()
 {
-    wait_for_flag data;
-
     std::vector<hpx::thread> group;
 
     try
     {
+        wait_for_flag data;
         for (unsigned i = 0; i < 5; ++i)
         {
             group.push_back(
@@ -451,7 +447,7 @@ void condition_test_thread(condition_test_data* data)
 {
     std::unique_lock<hpx::mutex> lock(data->mutex);
     HPX_TEST(lock ? true : false);
-    while (!(data->notified > 0))
+    while (data->notified <= 0)
         data->condition.wait(lock);
     HPX_TEST(lock ? true : false);
     data->awoken++;
@@ -459,13 +455,13 @@ void condition_test_thread(condition_test_data* data)
 
 struct cond_predicate
 {
-    cond_predicate(int& var, int val)
+    cond_predicate(int& var, int const val)
       : _var(var)
       , _val(val)
     {
     }
 
-    bool operator()()
+    bool operator()() const
     {
         return _var == _val;
     }
@@ -609,8 +605,8 @@ bool fake_predicate()
     return false;
 }
 
-std::chrono::milliseconds const delay(1000);
-std::chrono::milliseconds const timeout_resolution(100);
+constexpr std::chrono::milliseconds delay(1000);
+constexpr std::chrono::milliseconds timeout_resolution(100);
 
 void test_wait_until_times_out()
 {
@@ -649,6 +645,25 @@ void test_wait_until_with_predicate_times_out()
     HPX_TEST_LTE((delay - timeout_resolution).count(), (end - start).count());
 }
 
+void test_wait_until_with_predicate_already_expired_returns_immediately()
+{
+    hpx::condition_variable cond;
+    hpx::mutex m;
+
+    std::unique_lock<hpx::mutex> lock(m);
+    std::chrono::system_clock::time_point const start =
+        std::chrono::system_clock::now();
+    std::chrono::system_clock::time_point const already_expired =
+        start - std::chrono::seconds(1);
+
+    bool const res = cond.wait_until(lock, already_expired, fake_predicate);
+
+    std::chrono::system_clock::time_point const end =
+        std::chrono::system_clock::now();
+    HPX_TEST(!res);
+    HPX_TEST(end - start < timeout_resolution);
+}
+
 void test_relative_wait_until_with_predicate_times_out()
 {
     hpx::condition_variable cond;
@@ -685,6 +700,129 @@ void test_wait_until_relative_times_out()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// A notify_one/notify_all that fires while the predicate is still false must
+// not wake the waiter up: the wait has to keep looping until the predicate
+// actually becomes true.
+struct spurious_wakeup_data
+{
+    hpx::mutex mutex;
+    hpx::condition_variable cond_var;
+    int stage = 0;
+    bool woken = false;
+
+    void wait_for_stage_two()
+    {
+        std::unique_lock<hpx::mutex> lock(mutex);
+        bool const pred_satisfied = cond_var.wait_for(
+            lock, std::chrono::seconds(10), [this]() { return stage == 2; });
+        if (pred_satisfied)
+        {
+            woken = true;
+        }
+    }
+};
+
+void test_condition_notify_one_ignores_spurious_wakeup()
+{
+    spurious_wakeup_data data;
+
+    hpx::thread thread(&spurious_wakeup_data::wait_for_stage_two, &data);
+
+    // Give the waiting thread a chance to start waiting.
+    hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    std::chrono::steady_clock::time_point const start =
+        std::chrono::steady_clock::now();
+
+    {
+        // this notification must not satisfy the predicate (stage != 2) and
+        // therefore must not wake the waiter up
+        std::unique_lock<hpx::mutex> lock(data.mutex);
+        data.stage = 1;
+    }
+    data.cond_var.notify_one();
+
+    hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
+    HPX_TEST(!data.woken);
+
+    {
+        // this notification satisfies the predicate and must wake the waiter
+        std::unique_lock<hpx::mutex> lock(data.mutex);
+        data.stage = 2;
+    }
+    data.cond_var.notify_one();
+
+    thread.join();
+
+    std::chrono::steady_clock::time_point const end =
+        std::chrono::steady_clock::now();
+
+    HPX_TEST(data.woken);
+    // the waiter must have returned well before the 10-second timeout
+    HPX_TEST(end - start < std::chrono::seconds(5));
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Several waiters, each waiting on their own predicate, must each be woken up
+// individually as soon as their own condition becomes true, using a single
+// notify_all per change.
+struct distinct_predicate_data
+{
+    hpx::mutex mutex;
+    hpx::condition_variable cond_var;
+    int value = 0;
+    std::atomic<unsigned> woken{0};
+
+    void wait_for_value(int threshold)
+    {
+        std::unique_lock<hpx::mutex> lock(mutex);
+        if (cond_var.wait_for(lock, std::chrono::seconds(10),
+                [this, threshold]() { return value >= threshold; }))
+        {
+            ++woken;
+        }
+    }
+};
+
+void test_condition_notify_all_wakes_waiters_with_distinct_predicates()
+{
+    constexpr unsigned num_threads = 5;
+
+    distinct_predicate_data data;
+
+    std::vector<hpx::thread> threads;
+    for (unsigned i = 1; i <= num_threads; ++i)
+    {
+        threads.push_back(hpx::thread(&distinct_predicate_data::wait_for_value,
+            &data, static_cast<int>(i)));
+    }
+
+    // Give the waiting threads a chance to start waiting.
+    hpx::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    std::chrono::steady_clock::time_point const start =
+        std::chrono::steady_clock::now();
+
+    for (unsigned i = 1; i <= num_threads; ++i)
+    {
+        {
+            std::unique_lock<hpx::mutex> lock(data.mutex);
+            data.value = static_cast<int>(i);
+        }
+        data.cond_var.notify_all();
+    }
+
+    join_all(threads);
+
+    std::chrono::steady_clock::time_point const end =
+        std::chrono::steady_clock::now();
+
+    HPX_TEST_EQ(data.woken.load(), num_threads);
+    // all waiters must have returned well before the 10-second timeout
+    HPX_TEST(end - start < std::chrono::seconds(5));
+}
+
+///////////////////////////////////////////////////////////////////////////////
 using hpx::program_options::options_description;
 using hpx::program_options::variables_map;
 
@@ -712,8 +850,13 @@ int hpx_main(variables_map&)
     {
         test_wait_until_times_out();
         test_wait_until_with_predicate_times_out();
+        test_wait_until_with_predicate_already_expired_returns_immediately();
         test_relative_wait_until_with_predicate_times_out();
         test_wait_until_relative_times_out();
+    }
+    {
+        test_condition_notify_one_ignores_spurious_wakeup();
+        test_condition_notify_all_wakes_waiters_with_distinct_predicates();
     }
 
     hpx::local::finalize();
@@ -721,7 +864,7 @@ int hpx_main(variables_map&)
 }
 
 ///////////////////////////////////////////////////////////////////////////////
-int main(int argc, char* argv[])
+int main(int const argc, char* argv[])
 {
     // Configure application-specific options
     options_description cmdline("Usage: " HPX_APPLICATION_STRING " [options]");

--- a/libs/core/thread_support/include/hpx/thread_support/unlock_guard.hpp
+++ b/libs/core/thread_support/include/hpx/thread_support/unlock_guard.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2007-2008 Chirag Dekate
-//  Copyright (c) 2007-2025 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c) 2015 Agustin Berge
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -17,52 +17,105 @@
 namespace hpx {
 
     ///////////////////////////////////////////////////////////////////////////
-    // This is a helper structure to make sure a lock gets unlocked and locked
-    // again in a scope.
+    // These are a helper structures to make sure a lock gets unlocked and
+    // locked (relocked and unlocked) again in a scope.
+
+    HPX_CXX_CORE_EXPORT template <typename Lock>
+    class relock_guard;
 
     /// The class \c unlock_guard is a mutex wrapper that provides a convenient
     /// mechanism for releasing a mutex for the duration of a scoped block.
     /// \details \c unlock_guard performs the opposite functionality of
-    ///          \c lock_guard.
-    ///          When a \c lock_guard object is created, it attempts to take
-    ///          ownership of the mutex it is given. When control leaves the
-    ///          scope in which the \c lock_guard object was created, the
-    ///          \c lock_guard is destructed and the mutex is released.
-    ///          Accordingly, when an \c unlock_guard object is created, it
-    ///          attempts to release the ownership of the mutex it is given. So,
-    ///          when control leaves the scope in which the \c unlock_guard
-    ///          object was created, the \c unlock_guard is destructed and the
-    ///          mutex is owned again. In this way, the mutex is unlocked in the
-    ///          constructor and locked in the destructor, so that one can have
-    ///          an unlocked section within a locked one.
-    HPX_CXX_CORE_EXPORT template <typename Mutex>
+    /// \c lock_guard.
+    ///
+    /// When a \c lock_guard object is created, it attempts to take ownership of
+    /// the mutex it is given. When control leaves the scope in which the \c
+    /// lock_guard object was created, the \c lock_guard is destructed and the
+    /// mutex is released. Accordingly, when an \c unlock_guard object is
+    /// created, it attempts to release the ownership of the mutex it is given.
+    /// So, when control leaves the scope in which the \c unlock_guard object
+    /// was created, the \c unlock_guard is destructed and the mutex is owned
+    /// again. In this way, the mutex is unlocked in the constructor and locked
+    /// in the destructor, so that one can have an unlocked section within a
+    /// locked one.
+    ///
+    /// \tparam Lock The type of the lockable object managed by the
+    ///              \c unlock_guard.
+    ///
+    /// \note \c unlock_guard is non-copyable and non-movable.
+    HPX_CXX_CORE_EXPORT template <typename Lock>
     class unlock_guard
     {
     public:
-        using mutex_type = Mutex;
-
-        explicit constexpr unlock_guard(Mutex& m) noexcept
-          : m_(m)
+        explicit unlock_guard(Lock& l) noexcept
+          : l_(l)
         {
-            m_.unlock();
+            l_.unlock();
         }
 
-        HPX_NON_COPYABLE(unlock_guard);
+        unlock_guard(unlock_guard const&) = delete;
+        unlock_guard(unlock_guard&&) = delete;
+        unlock_guard& operator=(unlock_guard const&) = delete;
+        unlock_guard& operator=(unlock_guard&&) = delete;
 
         ~unlock_guard()
         {
-            m_.lock();
+            l_.lock();
         }
 
     private:
-        Mutex& m_;
+        friend class relock_guard<Lock>;
+        Lock& l_;
+    };
+
+    /// The class \c relock_guard is a mutex wrapper that provides a convenient
+    /// mechanism for reacquiring a lock that was released by an \c
+    /// unlock_guard, for the duration of a scoped block.
+    /// \details \c relock_guard performs the opposite functionality of
+    /// \c unlock_guard within an already-unlocked section.
+    ///
+    /// When a \c relock_guard object is created, it takes ownership of the
+    /// underlying \c Lock associated with the given \c unlock_guard by locking
+    /// it. When control leaves the scope in which the \c relock_guard object
+    /// was created, the \c relock_guard is destructed and the underlying \c
+    /// Lock is released again (unlocked), restoring the unlocked state managed
+    /// by the enclosing \c unlock_guard. In this way, \c relock_guard allows a
+    /// temporarily locked section to be nested within an unlocked section
+    /// created by \c unlock_guard.
+    ///
+    /// \tparam Lock The type of the lockable object managed by the associated
+    ///              \c unlock_guard.
+    ///
+    /// \note \c relock_guard is non-copyable and non-movable.
+    HPX_CXX_CORE_EXPORT template <typename Lock>
+    class relock_guard
+    {
+    public:
+        explicit relock_guard(unlock_guard<Lock>& ul) noexcept
+          : ul_(ul)
+        {
+            ul_.l_.lock();
+        }
+
+        relock_guard(relock_guard const&) = delete;
+        relock_guard(relock_guard&&) = delete;
+        relock_guard& operator=(relock_guard const&) = delete;
+        relock_guard& operator=(relock_guard&&) = delete;
+
+        ~relock_guard()
+        {
+            ul_.l_.unlock();
+        }
+
+    private:
+        unlock_guard<Lock>& ul_;
     };
 }    // namespace hpx
 
 namespace hpx::util {
 
-    template <typename Mutex>
+    template <typename Lock>
     using unlock_guard HPX_DEPRECATED_V(1, 9,
         "hpx::util::unlock_guard is deprecated, use hpx::unlock_guard "
-        "instead") = hpx::unlock_guard<Mutex>;
+        "instead") = hpx::unlock_guard<Lock>;
 }    // namespace hpx::util

--- a/libs/core/threading_base/include/hpx/threading_base/execution_agent.hpp
+++ b/libs/core/threading_base/include/hpx/threading_base/execution_agent.hpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2019 Thomas Heller
-//  Copyright (c) 2023-2025 Hartmut Kaiser
+//  Copyright (c) 2023-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -10,6 +10,7 @@
 #include <hpx/config.hpp>
 #include <hpx/modules/coroutines.hpp>
 #include <hpx/modules/execution_base.hpp>
+#include <hpx/modules/functional.hpp>
 #include <hpx/modules/timing.hpp>
 
 #include <cstddef>
@@ -50,9 +51,13 @@ namespace hpx::threads {
         void resume(
             hpx::threads::thread_priority priority, char const* desc) override;
         void abort(char const* desc) override;
-        void sleep_for(hpx::chrono::steady_duration const& sleep_duration,
+        threads::thread_restart_state sleep_for(
+            hpx::chrono::steady_duration const& sleep_duration,
+            hpx::move_only_function<bool()>&& wait_cond,
             char const* desc) override;
-        void sleep_until(hpx::chrono::steady_time_point const& sleep_time,
+        threads::thread_restart_state sleep_until(
+            hpx::chrono::steady_time_point const& sleep_time,
+            hpx::move_only_function<bool()>&& wait_cond,
             char const* desc) override;
 
     private:

--- a/libs/core/threading_base/src/execution_agent.cpp
+++ b/libs/core/threading_base/src/execution_agent.cpp
@@ -1,5 +1,5 @@
 //  Copyright (c) 2019 Thomas Heller
-//  Copyright (c) 2020-2025 Hartmut Kaiser
+//  Copyright (c) 2020-2026 Hartmut Kaiser
 //
 //  SPDX-License-Identifier: BSL-1.0
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -107,17 +107,22 @@ namespace hpx::threads {
         do_yield(desc, threads::thread_schedule_state::suspended);
     }
 
-    void execution_agent::sleep_for(
-        hpx::chrono::steady_duration const& sleep_duration, char const* desc)
+    threads::thread_restart_state execution_agent::sleep_for(
+        hpx::chrono::steady_duration const& sleep_duration,
+        hpx::move_only_function<bool()>&& wait_cond, char const* desc)
     {
-        sleep_until(sleep_duration.from_now(), desc);
+        return sleep_until(
+            sleep_duration.from_now(), HPX_MOVE(wait_cond), desc);
     }
 
-    void execution_agent::sleep_until(
-        hpx::chrono::steady_time_point const& sleep_time, char const* desc)
+    threads::thread_restart_state execution_agent::sleep_until(
+        hpx::chrono::steady_time_point const& sleep_time,
+        hpx::move_only_function<bool()>&& wait_cond, char const* desc)
     {
-        // Just yield until time has passed by...
+        // Just yield until time has passed by (or until wait_condition has been
+        // met)...
         auto now = std::chrono::steady_clock::now();
+        auto const cond = HPX_MOVE(wait_cond);
 
         // Note: we yield at least once to allow for other threads to make
         // progress in any case. We also use yield instead of yield_k for the
@@ -134,9 +139,17 @@ namespace hpx::threads {
             {
                 do_yield(desc, hpx::threads::thread_schedule_state::pending);
             }
+
+            if (cond && cond())
+            {
+                return threads::thread_restart_state::signaled;
+            }
+
             ++k;
             now = std::chrono::steady_clock::now();
         } while (now < sleep_time.value());
+
+        return threads::thread_restart_state::timeout;
     }
 
     hpx::threads::thread_restart_state execution_agent::do_yield(


### PR DESCRIPTION
Future waits now stop promptly once the associated shared state transitions to ready.