### PR TITLE
Reject explicit generations after auto generation on the same communicator

### DIFF
--- a/libs/full/collectives/include/hpx/collectives/argument_types.hpp
+++ b/libs/full/collectives/include/hpx/collectives/argument_types.hpp
@@ -89,7 +89,11 @@ namespace hpx::collectives {
     /// The generational counter identifying the sequence number of the
     /// operation performed on the given base name. It needs to be supplied only
     /// if the operation on the given base name has to be performed more than
-    /// once. It must be a positive number greater than zero.
+    /// once. It must be a positive number greater than zero. On any given
+    /// communicator instance, operations that pass an explicit generation may
+    /// not follow operations that used the default: the internal counter's
+    /// position is no longer reliably known to the caller. The reverse
+    /// transition, from explicit numbering back to the default, remains valid.
     HPX_CXX_EXPORT using generation_arg =
         detail::argument_type<detail::generation_tag>;
 

--- a/libs/full/collectives/include/hpx/collectives/create_communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/create_communicator.hpp
@@ -152,6 +152,13 @@ namespace hpx { namespace collectives {
     ///         non-hierarchical (flat) collectives keep supporting the default
     ///         generation, falling back to the internal per-communicator
     ///         counter maintained in the and_gate.
+    ///         Once any operation on a communicator has used that default,
+    ///         later operations on the same instance may no longer pass an
+    ///         explicit generation number: the counter's position is no
+    ///         longer reliably known to the caller. The reverse transition,
+    ///         from explicit numbering back to the default, remains valid.
+    ///         All participants of a single operation must use the same
+    ///         generation mode.
     ///
     /// \returns    This function returns a new communicator object usable
     ///             with the collective operation.

--- a/libs/full/collectives/include/hpx/collectives/detail/communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/communicator.hpp
@@ -506,9 +506,13 @@ namespace hpx::collectives::detail {
         std::size_t const num_sites_;
         std::size_t on_ready_count_ = 0;
         char const* current_operation_ = nullptr;
-        // Stored by value: the name arrives as a pointer into a caller-local
-        // buffer that does not outlive the component, and it is only ever
-        // needed again for diagnostics.
+        // Owned copy for diagnostics only. create_communicator passes the
+        // caller's char const* straight into local_new; hierarchical tree
+        // construction uses name.c_str() on a stack std::string that is
+        // destroyed when recursively_fill_communicators returns, while this
+        // component outlives that frame. A borrowed pointer would therefore
+        // dangle on later exception paths. Flat string-literal basenames are
+        // stable, but ownership keeps every path safe without special cases.
         std::string basename_;
         mutex_type mtx_;
         bool needs_initialization_ = true;

--- a/libs/full/collectives/include/hpx/collectives/detail/communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/communicator.hpp
@@ -26,6 +26,7 @@
 
 #include <cstddef>
 #include <mutex>
+#include <string>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -62,7 +63,7 @@ namespace hpx::collectives::detail {
         HPX_EXPORT communicator_server() noexcept;
 
         HPX_EXPORT explicit communicator_server(
-            std::size_t num_sites, char const* basename) noexcept;
+            std::size_t num_sites, char const* basename);
 
         communicator_server(communicator_server const&) = delete;
         communicator_server(communicator_server&&) = delete;
@@ -482,7 +483,10 @@ namespace hpx::collectives::detail {
         std::size_t const num_sites_;
         std::size_t on_ready_count_ = 0;
         char const* current_operation_ = nullptr;
-        char const* basename_ = nullptr;
+        // Stored by value: the name arrives as a pointer into a caller-local
+        // buffer that does not outlive the component, and it is only ever
+        // needed again for diagnostics.
+        std::string basename_;
         mutex_type mtx_;
         bool needs_initialization_ = true;
         bool data_available_ = false;

--- a/libs/full/collectives/include/hpx/collectives/detail/communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/communicator.hpp
@@ -381,6 +381,29 @@ namespace hpx::collectives::detail {
             std::unique_lock l(mtx_);
             [[maybe_unused]] util::ignore_all_while_checking il;
 
+            // An explicit generation number is usable only while the gate
+            // position remains a pure function of the numbers supplied so far.
+            // An auto (default) generation advances the gate without telling
+            // the caller by how much, leaving no reliable way to choose the
+            // next explicit number: too small throws, too large waits forever.
+            // Latch the first auto use and reject the transition up front; the
+            // reverse order stays valid because an auto generation always
+            // synchronizes on the gate's current position.
+            if (generation == generation_arg{})
+            {
+                auto_generation_used_ = true;
+            }
+            else if (auto_generation_used_)
+            {
+                l.unlock();
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                    "communicator::handle_data",
+                    "communicator {}: an explicit generation number cannot "
+                    "follow auto-generation operations on the same "
+                    "communicator: operation {}, which {}, generation {}.",
+                    basename_, operation, which, generation);
+            }
+
             // Verify that there is no overlap between different types of
             // operations on the same communicator.
             set_operation_and_check_sequencing(l, operation, which, generation);
@@ -490,6 +513,7 @@ namespace hpx::collectives::detail {
         mutex_type mtx_;
         bool needs_initialization_ = true;
         bool data_available_ = false;
+        bool auto_generation_used_ = false;
     };
 }    // namespace hpx::collectives::detail
 

--- a/libs/full/collectives/src/create_communicator.cpp
+++ b/libs/full/collectives/src/create_communicator.cpp
@@ -63,11 +63,14 @@ namespace hpx::collectives {
             HPX_ASSERT(false);    // shouldn't ever be called
         }
 
+        // Copy basename: it may point at a caller-local buffer (e.g. hierarchical
+        // create_communicator(name.c_str(), ...)) that does not outlive this
+        // component. std::string(nullptr) is undefined, so guard null.
         communicator_server::communicator_server(
             std::size_t num_sites, char const* basename)
           : gate_(num_sites)
           , num_sites_(num_sites)
-          , basename_(basename)
+          , basename_(basename != nullptr ? basename : "")
         {
             HPX_ASSERT(
                 num_sites != 0 && num_sites != static_cast<std::size_t>(-1));

--- a/libs/full/collectives/src/create_communicator.cpp
+++ b/libs/full/collectives/src/create_communicator.cpp
@@ -64,7 +64,7 @@ namespace hpx::collectives {
         }
 
         communicator_server::communicator_server(
-            std::size_t num_sites, char const* basename) noexcept
+            std::size_t num_sites, char const* basename)
           : gate_(num_sites)
           , num_sites_(num_sites)
           , basename_(basename)

--- a/libs/full/collectives/tests/unit/cross_collective_hierarchical_mixed.cpp
+++ b/libs/full/collectives/tests/unit/cross_collective_hierarchical_mixed.cpp
@@ -536,6 +536,137 @@ void test_local_zero_generation_rejected(std::uint32_t const num_sites)
     wait_for_sites(sites);
 }
 
+// An explicit generation number may not follow auto-generation operations on
+// the same communicator instance: the internal counter's position is not
+// observable, so any explicit number chosen afterwards could only be a guess
+// that previously either threw or hung. The reverse transition (explicit
+// first, default afterwards) stays valid because an auto generation always
+// synchronizes on the gate's current position.
+void test_local_generation_mode_transition(std::uint32_t const num_sites)
+{
+    std::string const basename =
+        "/test/cross_collective_hierarchical_mixed/mode_transition/" +
+        std::to_string(num_sites) + "/";
+
+    std::vector<hpx::future<void>> sites;
+    sites.reserve(num_sites);
+
+    for (std::uint32_t site = 0; site != num_sites; ++site)
+    {
+        sites.push_back(hpx::async([=]() {
+            // auto -> explicit: rejected on every site
+            {
+                auto const comms = create_hierarchical_communicator(
+                    (basename + "auto/").c_str(), num_sites_arg(num_sites),
+                    this_site_arg(site), arity_arg(2), generation_arg(),
+                    root_site_arg(), flat_fallback_threshold_arg(0));
+
+                std::int32_t received = 0;
+                if (site == 0)
+                {
+                    received = broadcast_to(hpx::launch::sync, comms,
+                        std::int32_t(41001), this_site_arg(site),
+                        generation_arg());
+                }
+                else
+                {
+                    received = broadcast_from<std::int32_t>(hpx::launch::sync,
+                        comms, this_site_arg(site), generation_arg());
+                }
+                HPX_TEST_EQ(received, 41001);
+
+                // The error code matters: before the latch this sequence
+                // already threw invalid_status from deep inside the gate
+                // (or hung, had the number landed above the gate position).
+                // The latch turns it into a bad_parameter at the boundary.
+                bool explicit_after_auto_rejected = false;
+                try
+                {
+                    if (site == 0)
+                    {
+                        broadcast_to(hpx::launch::sync, comms,
+                            std::int32_t(41002), this_site_arg(site),
+                            generation_arg(1));
+                    }
+                    else
+                    {
+                        broadcast_from<std::int32_t>(hpx::launch::sync, comms,
+                            this_site_arg(site), generation_arg(1));
+                    }
+                }
+                catch (hpx::exception const& e)
+                {
+                    explicit_after_auto_rejected =
+                        e.get_error() == hpx::error::bad_parameter;
+                }
+                HPX_TEST(explicit_after_auto_rejected);
+            }
+
+            // explicit -> auto: stays valid
+            {
+                auto const comms = create_hierarchical_communicator(
+                    (basename + "explicit/").c_str(), num_sites_arg(num_sites),
+                    this_site_arg(site), arity_arg(2), generation_arg(),
+                    root_site_arg(), flat_fallback_threshold_arg(0));
+
+                std::int32_t received = 0;
+                if (site == 0)
+                {
+                    received = broadcast_to(hpx::launch::sync, comms,
+                        std::int32_t(41003), this_site_arg(site),
+                        generation_arg(1));
+                }
+                else
+                {
+                    received = broadcast_from<std::int32_t>(hpx::launch::sync,
+                        comms, this_site_arg(site), generation_arg(1));
+                }
+                HPX_TEST_EQ(received, 41003);
+
+                if (site == 0)
+                {
+                    received = broadcast_to(hpx::launch::sync, comms,
+                        std::int32_t(41004), this_site_arg(site),
+                        generation_arg());
+                }
+                else
+                {
+                    received = broadcast_from<std::int32_t>(hpx::launch::sync,
+                        comms, this_site_arg(site), generation_arg());
+                }
+                HPX_TEST_EQ(received, 41004);
+
+                // The latch persists: once the auto call above has run,
+                // explicit numbering stays rejected for the instance's
+                // lifetime.
+                bool explicit_after_transition_rejected = false;
+                try
+                {
+                    if (site == 0)
+                    {
+                        broadcast_to(hpx::launch::sync, comms,
+                            std::int32_t(41005), this_site_arg(site),
+                            generation_arg(2));
+                    }
+                    else
+                    {
+                        broadcast_from<std::int32_t>(hpx::launch::sync, comms,
+                            this_site_arg(site), generation_arg(2));
+                    }
+                }
+                catch (hpx::exception const& e)
+                {
+                    explicit_after_transition_rejected =
+                        e.get_error() == hpx::error::bad_parameter;
+                }
+                HPX_TEST(explicit_after_transition_rejected);
+            }
+        }));
+    }
+
+    wait_for_sites(sites);
+}
+
 int hpx_main()
 {
     if (hpx::get_locality_id() == 0)
@@ -549,6 +680,7 @@ int hpx_main()
             }
             test_local_flat_fallback_sharing(num_sites);
             test_local_zero_generation_rejected(num_sites);
+            test_local_generation_mode_transition(num_sites);
         }
     }
 


### PR DESCRIPTION
Fixes #

## Proposed Changes

- Latch auto-generation use on a communicator and reject later explicit `generation_arg` values with `bad_parameter`, so callers cannot guess a generation after the internal counter has advanced unobservably.
- Keep explicit → auto transitions valid; document that all participants of one operation must use the same generation mode.
- Store the communicator basename by value so diagnostic messages do not use a dangling `char const*`.
- Add a regression test for auto → explicit rejection, explicit → auto success, and persistence of the latch after the reverse transition.

## Any background context you want to provide?

After an auto/default generation advances the and-gate, the caller no longer knows a reliable next explicit generation: too small previously threw from deep in the gate, too large could hang. This change rejects that transition at the communicator boundary with a clear error.

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [x] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
