### PR TITLE
Flatten hierarchical collective payloads

### DIFF
--- a/libs/full/collectives/CMakeLists.txt
+++ b/libs/full/collectives/CMakeLists.txt
@@ -23,6 +23,7 @@ set(collectives_headers
     hpx/collectives/create_communicator.hpp
     hpx/collectives/detail/channel_communicator.hpp
     hpx/collectives/detail/communicator.hpp
+    hpx/collectives/detail/flattened_data.hpp
     hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
     hpx/collectives/detail/hierarchical_helpers.hpp
     hpx/collectives/detail/hierarchical_scan_helpers.hpp

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -214,6 +214,7 @@ namespace hpx { namespace collectives {
 #include <hpx/assert.hpp>
 #include <hpx/collectives/argument_types.hpp>
 #include <hpx/collectives/create_communicator.hpp>
+#include <hpx/collectives/detail/flattened_data.hpp>
 #include <hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp>
 #include <hpx/collectives/detail/hierarchical_helpers.hpp>
 #include <hpx/modules/async_base.hpp>
@@ -282,6 +283,39 @@ namespace hpx::traits {
                                 HPX_MOVE(v[which])));
                     }
                     return result;
+                },
+                num_generations);
+        }
+
+        template <typename Result, typename T>
+        static Result get(Communicator& communicator, std::size_t which,
+            std::size_t generation,
+            hpx::collectives::detail::generation_mode num_generations,
+            hpx::collectives::detail::flattened_data<T>&& t,
+            hpx::collectives::detail::flattened_payload_mode)
+        {
+            using data_type = hpx::collectives::detail::flattened_data<T>;
+            std::size_t const num_sites = communicator.num_sites_;
+            hpx::collectives::detail::validate_flattened_data(
+                t, "hpx::collectives::all_to_all");
+            if ((t.offsets.size() - 1) % num_sites != 0)
+            {
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                    "hpx::collectives::all_to_all",
+                    "the flattened payload must contain a complete set of "
+                    "destination-group segments for every row");
+            }
+
+            return communicator.template handle_data<data_type>(
+                communication::communicator_data<
+                    communication::all_to_all_tag>::name(),
+                which, generation,
+                [&t](auto& data, std::size_t which) {
+                    data[which] = HPX_MOVE(t);
+                },
+                [](auto& data, auto&, std::size_t which) {
+                    return hpx::collectives::detail::select_flattened_column(
+                        data, which);
                 },
                 num_generations);
         }
@@ -355,6 +389,67 @@ namespace hpx::collectives {
                 if (!result.is_ready())
                 {
                     // make sure id is kept alive as long as the returned future
+                    traits::detail::get_shared_state(result)->set_on_completed(
+                        [client = HPX_MOVE(c)] { HPX_UNUSED(client); });
+                }
+
+                return result;
+            };
+
+            return fid.then(hpx::launch::sync, HPX_MOVE(all_to_all_data));
+        }
+
+        template <typename T>
+        hpx::future<flattened_data<T>> all_to_all_flattened(communicator fid,
+            flattened_data<T>&& local_result, this_site_arg this_site,
+            generation_arg const generation, generation_mode num_generations)
+        {
+            if (this_site.is_default())
+            {
+                this_site = agas::get_locality_id();
+            }
+            if (generation == 0)
+            {
+                return hpx::make_exceptional_future<flattened_data<T>>(
+                    HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                        "hpx::collectives::all_to_all",
+                        "the generation number shouldn't be zero"));
+            }
+
+            auto [num_sites, comm_site] = fid.get_info();
+            HPX_ASSERT(is_valid_flattened_data(local_result));
+            HPX_ASSERT((local_result.offsets.size() - 1) % num_sites == 0);
+
+            if (num_sites == 1)
+            {
+                if (this_site != comm_site)
+                {
+                    return hpx::make_exceptional_future<flattened_data<T>>(
+                        HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                            "hpx::collectives::all_to_all",
+                            "the local site should be zero if only one site "
+                            "is involved"));
+                }
+                return hpx::make_ready_future(HPX_MOVE(local_result));
+            }
+
+            auto all_to_all_data = [local_result = HPX_MOVE(local_result),
+                                       this_site, generation, num_generations](
+                                       communicator&& c) mutable
+                -> hpx::future<flattened_data<T>> {
+                using data_type = flattened_data<T>;
+                using action_type =
+                    communicator_server::communication_get_direct_action<
+                        traits::communication::all_to_all_tag,
+                        hpx::future<data_type>, generation_mode, data_type,
+                        flattened_payload_mode>;
+
+                hpx::future<data_type> result = hpx::async(action_type(), c,
+                    this_site, generation, num_generations,
+                    HPX_MOVE(local_result), flattened_payload_mode::enabled);
+
+                if (!result.is_ready())
+                {
                     traits::detail::get_shared_state(result)->set_on_completed(
                         [client = HPX_MOVE(c)] { HPX_UNUSED(client); });
                 }
@@ -566,56 +661,127 @@ namespace hpx::collectives {
         if (is_representative)
         {
             // Phase 1: Gather all subtree sites' data at this rep.
-            std::vector<std::vector<T>> gathered =
+            detail::flattened_data<T> gathered =
                 detail::subtree_gather_at_top_rep(
                     communicators, HPX_MOVE(local_result), first_gen);
 
-            std::size_t const my_group_size = groups[gidx].size;
+            std::size_t const group_index = static_cast<std::size_t>(gidx);
+            std::size_t const my_group_size = groups[group_index].size;
+            std::size_t const my_group_left = groups[group_index].left;
             std::size_t const num_groups = groups.size();
-
-            // Phase 2: Build exchange blocks -- pack gathered data by
-            // destination group, then perform flat all_to_all among reps.
-            std::vector<std::vector<T>> exchange_blocks(num_groups);
-            for (std::size_t group = 0; group != num_groups; ++group)
+            std::size_t const exchange_size = detail::checked_flattened_product(
+                my_group_size, num_sites_val - my_group_size);
+            std::size_t const exchange_segments =
+                detail::checked_flattened_product(my_group_size, num_groups);
+            std::size_t const scatter_size =
+                detail::checked_flattened_product(my_group_size, num_sites_val);
+            detail::validate_flattened_data(
+                gathered, "hpx::collectives::all_to_all (hierarchical)");
+            if (gathered.offsets.size() != my_group_size + 1)
             {
-                std::size_t const dest_group_size = groups[group].size;
-                std::size_t const dest_left = groups[group].left;
-
-                exchange_blocks[group].reserve(my_group_size * dest_group_size);
-                for (std::size_t s = 0; s != my_group_size; ++s)
+                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                    "hpx::collectives::all_to_all (hierarchical)",
+                    "the subtree gather returned an unexpected number of "
+                    "rows");
+            }
+            for (std::size_t row = 0; row != my_group_size; ++row)
+            {
+                if (gathered.offsets[row + 1] - gathered.offsets[row] !=
+                    num_sites_val)
                 {
-                    std::move(gathered[s].begin() + dest_left,
-                        gathered[s].begin() + dest_left + dest_group_size,
-                        std::back_inserter(exchange_blocks[group]));
+                    HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                        "hpx::collectives::all_to_all (hierarchical)",
+                        "the subtree gather returned a row with an unexpected "
+                        "number of elements");
                 }
             }
+
+            // Phase 2: Pack one flat sequence of destination-group segments
+            // for each gathered row. The local diagonal stays in gathered and
+            // is represented by an empty segment, avoiding its round trip
+            // through the inter-group communicator.
+            detail::flattened_data<T> exchange;
+            exchange.data.reserve(exchange_size);
+            exchange.offsets.reserve(exchange_segments + 1);
+            exchange.offsets.push_back(0);
+            for (std::size_t row = 0; row != my_group_size; ++row)
+            {
+                std::size_t const row_left = gathered.offsets[row];
+                for (std::size_t group = 0; group != num_groups; ++group)
+                {
+                    std::size_t const dest_group_size = groups[group].size;
+                    std::size_t const dest_left = groups[group].left;
+                    if (group != group_index)
+                    {
+                        detail::append_flattened_range(exchange.data,
+                            gathered.data.begin() + row_left + dest_left,
+                            gathered.data.begin() + row_left + dest_left +
+                                dest_group_size);
+                    }
+                    exchange.offsets.push_back(
+                        detail::checked_flattened_offset(exchange.data.size()));
+                }
+            }
+            HPX_ASSERT(exchange.data.size() == exchange_size);
 
             // The exchange touches the inter-group communicator once but must
             // advance it by two generations to stay in lock-step with the
             // subtree communicators, so request double_step.
-            std::vector<std::vector<T>> received =
-                detail::all_to_all(communicators.get(0),
-                    HPX_MOVE(exchange_blocks), communicators.site(0), first_gen,
-                    detail::generation_mode::double_step)
-                    .get();
+            detail::flattened_data<T> received = detail::all_to_all_flattened(
+                communicators.get(0), HPX_MOVE(exchange), communicators.site(0),
+                first_gen, detail::generation_mode::double_step)
+                                                     .get();
+            detail::validate_flattened_data(
+                received, "hpx::collectives::all_to_all (hierarchical)");
+            if (received.offsets.size() != num_groups + 1)
+            {
+                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                    "hpx::collectives::all_to_all (hierarchical)",
+                    "the inter-group exchange returned an unexpected number "
+                    "of blocks");
+            }
+            for (std::size_t group = 0; group != num_groups; ++group)
+            {
+                std::size_t const src_group_size = groups[group].size;
+                std::size_t const expected_size =
+                    group == group_index ? 0 : src_group_size * my_group_size;
+                if (received.offsets[group + 1] - received.offsets[group] !=
+                    expected_size)
+                {
+                    HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                        "hpx::collectives::all_to_all (hierarchical)",
+                        "the inter-group exchange returned a block with an "
+                        "unexpected number of elements");
+                }
+            }
 
-            // Phase 3: Transpose received blocks back to per-site vectors,
-            // then scatter down the subtree.
-            std::vector<std::vector<T>> scatter_input(my_group_size);
+            // Phase 3: Transpose the received off-diagonal blocks and the
+            // retained local diagonal into one row per subtree site.
+            detail::flattened_data<T> scatter_input;
+            scatter_input.data.reserve(scatter_size);
+            scatter_input.offsets.reserve(my_group_size + 1);
+            scatter_input.offsets.push_back(0);
             for (std::size_t j = 0; j != my_group_size; ++j)
             {
-                scatter_input[j].resize(num_sites_val);
                 for (std::size_t group = 0; group != num_groups; ++group)
                 {
                     std::size_t const src_group_size = groups[group].size;
-                    std::size_t const src_left = groups[group].left;
                     for (std::size_t s = 0; s != src_group_size; ++s)
                     {
-                        scatter_input[j][src_left + s] =
-                            HPX_MOVE(received[group][s * my_group_size + j]);
+                        std::size_t const index = group == group_index ?
+                            gathered.offsets[s] + my_group_left + j :
+                            received.offsets[group] + s * my_group_size + j;
+                        auto& source = group == group_index ? gathered.data :
+                                                              received.data;
+                        detail::append_flattened_value(
+                            scatter_input.data, HPX_MOVE(source[index]));
                     }
                 }
+                scatter_input.offsets.push_back(
+                    detail::checked_flattened_offset(
+                        scatter_input.data.size()));
             }
+            HPX_ASSERT(scatter_input.data.size() == scatter_size);
 
             return detail::subtree_scatter_at_top_rep(
                 communicators, HPX_MOVE(scatter_input), second_gen);
@@ -627,7 +793,7 @@ namespace hpx::collectives {
             detail::subtree_send_to_top_rep(
                 communicators, HPX_MOVE(local_result), first_gen);
 
-            return detail::subtree_receive_from_top_rep<std::vector<T>>(
+            return detail::subtree_receive_from_top_rep<T>(
                 communicators, second_gen);
         }
     }

--- a/libs/full/collectives/include/hpx/collectives/detail/flattened_data.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/flattened_data.hpp
@@ -1,0 +1,329 @@
+//  Copyright (c) 2026 Anshuman Agrawal
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file detail/flattened_data.hpp
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#include <hpx/assert.hpp>
+#include <hpx/modules/errors.hpp>
+#include <hpx/modules/serialization.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <limits>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace hpx::collectives::detail {
+
+    enum class flattened_payload_mode : std::uint8_t
+    {
+        enabled
+    };
+
+    template <typename T>
+    struct flattened_data
+    {
+        std::vector<T> data;
+
+        // Prefix boundaries into data. A boundary may describe a logical site
+        // row or an exchange segment, depending on the collective phase.
+        std::vector<std::uint32_t> offsets;
+
+        template <typename Archive>
+        void serialize(Archive& ar, unsigned int const)
+        {
+            ar & data & offsets;
+        }
+    };
+
+    [[nodiscard]] inline std::uint32_t checked_flattened_offset(
+        std::size_t const offset)
+    {
+        if (offset > (std::numeric_limits<std::uint32_t>::max)())
+        {
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "hpx::collectives::detail::flattened_data",
+                "a flattened hierarchical collective payload cannot exceed "
+                "UINT32_MAX elements");
+        }
+
+        return static_cast<std::uint32_t>(offset);
+    }
+
+    [[nodiscard]] inline std::size_t checked_flattened_sum(
+        std::size_t const lhs, std::size_t const rhs)
+    {
+        constexpr std::size_t max_offset =
+            (std::numeric_limits<std::uint32_t>::max)();
+        if (lhs > max_offset || rhs > max_offset - lhs)
+        {
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "hpx::collectives::detail::flattened_data",
+                "a flattened hierarchical collective payload cannot exceed "
+                "UINT32_MAX elements");
+        }
+        return lhs + rhs;
+    }
+
+    [[nodiscard]] inline std::size_t checked_flattened_product(
+        std::size_t const lhs, std::size_t const rhs)
+    {
+        constexpr std::size_t max_offset =
+            (std::numeric_limits<std::uint32_t>::max)();
+        if (rhs != 0 && lhs > max_offset / rhs)
+        {
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "hpx::collectives::detail::flattened_data",
+                "a flattened hierarchical collective payload cannot exceed "
+                "UINT32_MAX elements");
+        }
+        return lhs * rhs;
+    }
+
+    template <typename T>
+    [[nodiscard]] bool is_valid_flattened_data(
+        flattened_data<T> const& value) noexcept
+    {
+        if (value.offsets.empty() || value.offsets.front() != 0 ||
+            value.offsets.back() != value.data.size())
+        {
+            return false;
+        }
+
+        for (std::size_t i = 1; i != value.offsets.size(); ++i)
+        {
+            if (value.offsets[i] < value.offsets[i - 1])
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    template <typename T>
+    void validate_flattened_data(
+        flattened_data<T> const& value, char const* const operation)
+    {
+        if (!is_valid_flattened_data(value))
+        {
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter, operation,
+                "the flattened hierarchical collective payload has invalid "
+                "offsets");
+        }
+    }
+
+    template <typename T, typename Iterator>
+    void append_flattened_range(
+        std::vector<T>& destination, Iterator first, Iterator const last)
+    {
+        if constexpr (std::is_same_v<T, bool>)
+        {
+            for (; first != last; ++first)
+            {
+                destination.push_back(static_cast<bool>(*first));
+            }
+        }
+        else
+        {
+            destination.insert(destination.end(),
+                std::make_move_iterator(first), std::make_move_iterator(last));
+        }
+    }
+
+    template <typename T, typename U>
+    void append_flattened_value(std::vector<T>& destination, U&& value)
+    {
+        if constexpr (std::is_same_v<T, bool>)
+        {
+            destination.push_back(static_cast<bool>(value));
+        }
+        else
+        {
+            destination.emplace_back(HPX_FORWARD(U, value));
+        }
+    }
+
+    template <typename T>
+    flattened_data<T> make_flattened_rows(std::vector<T>&& values)
+    {
+        flattened_data<T> result;
+        result.data = HPX_MOVE(values);
+        static_cast<void>(checked_flattened_offset(result.data.size()));
+        result.offsets.reserve(result.data.size() + 1);
+        for (std::size_t i = 0; i <= result.data.size(); ++i)
+        {
+            result.offsets.push_back(checked_flattened_offset(i));
+        }
+        return result;
+    }
+
+    template <typename T>
+    flattened_data<T> make_flattened_row(std::vector<T>&& values)
+    {
+        flattened_data<T> result;
+        result.data = HPX_MOVE(values);
+        result.offsets = {0, checked_flattened_offset(result.data.size())};
+        return result;
+    }
+
+    template <typename T>
+    flattened_data<std::decay_t<T>> make_flattened_value(T&& value)
+    {
+        flattened_data<std::decay_t<T>> result;
+        result.data.emplace_back(HPX_FORWARD(T, value));
+        result.offsets = {0, 1};
+        return result;
+    }
+
+    template <typename T>
+    flattened_data<T> merge_flattened_data(
+        std::vector<flattened_data<T>>& values)
+    {
+        std::size_t total_size = 0;
+        std::size_t total_rows = 0;
+        for (auto const& value : values)
+        {
+            HPX_ASSERT(is_valid_flattened_data(value));
+            total_size = checked_flattened_sum(total_size, value.data.size());
+            total_rows =
+                checked_flattened_sum(total_rows, value.offsets.size() - 1);
+        }
+
+        flattened_data<T> result;
+        result.data.reserve(total_size);
+        result.offsets.reserve(total_rows + 1);
+        result.offsets.push_back(0);
+
+        for (auto& value : values)
+        {
+            std::size_t const base = result.data.size();
+            append_flattened_range(
+                result.data, value.data.begin(), value.data.end());
+
+            for (std::size_t i = 1; i != value.offsets.size(); ++i)
+            {
+                result.offsets.push_back(checked_flattened_offset(
+                    base + static_cast<std::size_t>(value.offsets[i])));
+            }
+        }
+
+        HPX_ASSERT(is_valid_flattened_data(result));
+        return result;
+    }
+
+    template <typename T>
+    flattened_data<T> slice_flattened_data(flattened_data<T>& value,
+        std::size_t const slice, std::size_t const num_slices)
+    {
+        HPX_ASSERT(is_valid_flattened_data(value));
+        HPX_ASSERT(num_slices != 0 && slice < num_slices);
+
+        std::size_t const num_rows = value.offsets.size() - 1;
+        std::size_t const division_steps = num_rows / num_slices;
+        std::size_t const remainder = num_rows % num_slices;
+        std::size_t const first_row =
+            slice * division_steps + (std::min) (slice, remainder);
+        std::size_t const row_count =
+            division_steps + (slice < remainder ? 1 : 0);
+        std::size_t const last_row = first_row + row_count;
+
+        std::size_t const first = value.offsets[first_row];
+        std::size_t const last = value.offsets[last_row];
+
+        flattened_data<T> result;
+        result.data.reserve(last - first);
+        append_flattened_range(
+            result.data, value.data.begin() + first, value.data.begin() + last);
+        result.offsets.reserve(row_count + 1);
+        for (std::size_t i = first_row; i <= last_row; ++i)
+        {
+            result.offsets.push_back(
+                static_cast<std::uint32_t>(value.offsets[i] - first));
+        }
+
+        HPX_ASSERT(is_valid_flattened_data(result));
+        return result;
+    }
+
+    template <typename T>
+    flattened_data<T> select_flattened_column(
+        std::vector<flattened_data<T>>& values, std::size_t const column)
+    {
+        std::size_t const num_columns = values.size();
+        HPX_ASSERT(num_columns != 0 && column < num_columns);
+
+        std::size_t total_size = 0;
+        for (auto const& value : values)
+        {
+            HPX_ASSERT(is_valid_flattened_data(value));
+            std::size_t const num_segments = value.offsets.size() - 1;
+            HPX_ASSERT(num_segments % num_columns == 0);
+
+            std::size_t const num_rows = num_segments / num_columns;
+            for (std::size_t row = 0; row != num_rows; ++row)
+            {
+                std::size_t const segment = row * num_columns + column;
+                total_size = checked_flattened_sum(total_size,
+                    value.offsets[segment + 1] - value.offsets[segment]);
+            }
+        }
+
+        flattened_data<T> result;
+        result.data.reserve(total_size);
+        result.offsets.reserve(num_columns + 1);
+        result.offsets.push_back(0);
+
+        for (auto& value : values)
+        {
+            std::size_t const num_rows =
+                (value.offsets.size() - 1) / num_columns;
+            for (std::size_t row = 0; row != num_rows; ++row)
+            {
+                std::size_t const segment = row * num_columns + column;
+                append_flattened_range(result.data,
+                    value.data.begin() + value.offsets[segment],
+                    value.data.begin() + value.offsets[segment + 1]);
+            }
+            result.offsets.push_back(
+                checked_flattened_offset(result.data.size()));
+        }
+
+        HPX_ASSERT(is_valid_flattened_data(result));
+        return result;
+    }
+
+    template <typename T>
+    T unwrap_flattened_value(flattened_data<T>&& value)
+    {
+        HPX_ASSERT(is_valid_flattened_data(value));
+        HPX_ASSERT(value.offsets.size() == 2 && value.data.size() == 1);
+
+        if constexpr (std::is_same_v<T, bool>)
+        {
+            return static_cast<bool>(value.data.front());
+        }
+        else
+        {
+            return HPX_MOVE(value.data.front());
+        }
+    }
+
+    template <typename T>
+    std::vector<T> unwrap_flattened_row(flattened_data<T>&& value)
+    {
+        HPX_ASSERT(is_valid_flattened_data(value));
+        HPX_ASSERT(value.offsets.size() == 2);
+        return HPX_MOVE(value.data);
+    }
+}    // namespace hpx::collectives::detail

--- a/libs/full/collectives/include/hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
@@ -18,6 +18,7 @@
 
 #include <hpx/assert.hpp>
 #include <hpx/collectives/create_communicator.hpp>
+#include <hpx/collectives/detail/flattened_data.hpp>
 #include <hpx/collectives/gather.hpp>
 #include <hpx/collectives/scatter.hpp>
 #include <hpx/modules/async_base.hpp>
@@ -44,18 +45,13 @@ namespace hpx::collectives::detail {
     // own data wrapped in a single-element vector.
     ///////////////////////////////////////////////////////////////////////////
     HPX_CXX_EXPORT template <typename T>
-    std::vector<std::decay_t<T>> subtree_gather_at_top_rep(
-        hierarchical_communicator const& comms, T&& local_result,
+    flattened_data<T> subtree_gather_at_top_rep(
+        hierarchical_communicator const& comms, std::vector<T>&& local_result,
         generation_arg const generation)
     {
         HPX_ASSERT(comms.size() != 0);
 
-        using value_type = std::decay_t<T>;
-
-        // Wrap local value in a vector (same pattern as hierarchical
-        // gather_here).
-        std::vector<value_type> result;
-        result.emplace_back(HPX_FORWARD(T, local_result));
+        flattened_data<T> result = make_flattened_row(HPX_MOVE(local_result));
 
         // Walk bottom-up from leaf (size()-1) to level 1, skipping level 0
         // (the inter-group communicator). At every subtree level this site
@@ -65,8 +61,9 @@ namespace hpx::collectives::detail {
         // data is returned.
         for (std::size_t i = comms.size() - 1; i != 0; --i)
         {
-            result = gather_data(gather_here(hpx::launch::sync, comms.get(i),
-                HPX_MOVE(result), this_site_arg(0), generation));
+            result = gather_flattened_here(comms.get(i), HPX_MOVE(result),
+                this_site_arg(0), generation, generation_mode::single_step)
+                         .get();
         }
 
         return result;
@@ -86,28 +83,27 @@ namespace hpx::collectives::detail {
     ///////////////////////////////////////////////////////////////////////////
     HPX_CXX_EXPORT template <typename T>
     void subtree_send_to_top_rep(hierarchical_communicator const& comms,
-        T&& local_result, generation_arg const generation)
+        std::vector<T>&& local_result, generation_arg const generation)
     {
         HPX_ASSERT(comms.size() != 0);
 
-        using value_type = std::decay_t<T>;
-
-        std::vector<value_type> data;
-        data.emplace_back(HPX_FORWARD(T, local_result));
+        flattened_data<T> data = make_flattened_row(HPX_MOVE(local_result));
 
         // Walk bottom-up from leaf to level 1, calling gather_here
         // (each intermediate rep gathers from its children).
         for (std::size_t i = comms.size() - 1; i != 0; --i)
         {
-            data = gather_data(gather_here(hpx::launch::sync, comms.get(i),
-                HPX_MOVE(data), this_site_arg(0), generation));
+            data = gather_flattened_here(comms.get(i), HPX_MOVE(data),
+                this_site_arg(0), generation, generation_mode::single_step)
+                       .get();
         }
 
         // At the topmost level (level 0 in this site's vector, which is
         // a subtree-internal communicator, NOT the inter-group one),
         // send to the subtree root via gather_there.
-        gather_there(hpx::launch::sync, comms.get(0), HPX_MOVE(data),
-            comms.site(0), generation);
+        gather_flattened_there(comms.get(0), HPX_MOVE(data), comms.site(0),
+            generation, generation_mode::single_step)
+            .get();
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -123,8 +119,8 @@ namespace hpx::collectives::detail {
     // (and only) element of the input data.
     ///////////////////////////////////////////////////////////////////////////
     HPX_CXX_EXPORT template <typename T>
-    hpx::future<T> subtree_scatter_at_top_rep(
-        hierarchical_communicator const& comms, std::vector<T>&& data,
+    hpx::future<std::vector<T>> subtree_scatter_at_top_rep(
+        hierarchical_communicator const& comms, flattened_data<T>&& data,
         generation_arg const generation)
     {
         HPX_ASSERT(comms.size() != 0);
@@ -133,26 +129,28 @@ namespace hpx::collectives::detail {
         // belongs to this site.
         if (comms.size() == 1)
         {
-            return hpx::make_ready_future(HPX_MOVE(data[0]));
+            return hpx::make_ready_future(unwrap_flattened_row(HPX_MOVE(data)));
         }
-
-        arity_arg const arity = comms.get_arity();
 
         // Walk top-down from level 1 through size()-2, partitioning and
         // scattering at each level. At each level, this site is rank 0
         // (subtree root).
         for (std::size_t i = 1; i < comms.size() - 1; ++i)
         {
-            data = scatter_to(hpx::launch::sync, comms.get(i),
-                scatter_data(HPX_MOVE(data), arity), this_site_arg(0),
-                generation);
+            data = scatter_flattened_to(comms.get(i), HPX_MOVE(data),
+                this_site_arg(0), generation, generation_mode::single_step)
+                       .get();
         }
 
         // At the leaf level (size()-1), scatter asynchronously and return
         // the future directly (no scatter_data; each element maps 1:1 to a
         // leaf site).
-        return scatter_to(
-            comms.back(), HPX_MOVE(data), this_site_arg(0), generation);
+        return hpx::make_future<std::vector<T>>(
+            scatter_flattened_to(comms.back(), HPX_MOVE(data), this_site_arg(0),
+                generation, generation_mode::single_step),
+            [](flattened_data<T>&& result) {
+                return unwrap_flattened_row(HPX_MOVE(result));
+            });
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -166,7 +164,7 @@ namespace hpx::collectives::detail {
     // level 0, then scatter down through intermediate levels to the leaf.
     ///////////////////////////////////////////////////////////////////////////
     HPX_CXX_EXPORT template <typename T>
-    hpx::future<T> subtree_receive_from_top_rep(
+    hpx::future<std::vector<T>> subtree_receive_from_top_rep(
         hierarchical_communicator const& comms, generation_arg const generation)
     {
         HPX_ASSERT(comms.size() != 0);
@@ -177,29 +175,36 @@ namespace hpx::collectives::detail {
         // portion (a single T) as a future, returned directly.
         if (comms.size() == 1)
         {
-            return scatter_from<T>(
-                current_communicator, current_site, generation);
+            return hpx::make_future<std::vector<T>>(
+                scatter_flattened_from<T>(current_communicator, current_site,
+                    generation, generation_mode::single_step),
+                [](flattened_data<T>&& result) {
+                    return unwrap_flattened_row(HPX_MOVE(result));
+                });
         }
 
         // An intermediate representative receives a vector<T> (one element
         // per site in its subtree) to scatter further down.
-        std::vector<T> data = scatter_from<std::vector<T>>(
-            hpx::launch::sync, current_communicator, current_site, generation);
-
-        arity_arg const arity = comms.get_arity();
+        flattened_data<T> data = scatter_flattened_from<T>(current_communicator,
+            current_site, generation, generation_mode::single_step)
+                                     .get();
 
         // Walk down through intermediate levels.
         for (std::size_t i = 1; i < comms.size() - 1; ++i)
         {
-            data = scatter_to(hpx::launch::sync, comms.get(i),
-                scatter_data(HPX_MOVE(data), arity), this_site_arg(0),
-                generation);
+            data = scatter_flattened_to(comms.get(i), HPX_MOVE(data),
+                this_site_arg(0), generation, generation_mode::single_step)
+                       .get();
         }
 
         // At the leaf level, scatter asynchronously and return the future
         // directly (no scatter_data; each element maps 1:1 to a leaf site).
-        return scatter_to(
-            comms.back(), HPX_MOVE(data), this_site_arg(0), generation);
+        return hpx::make_future<std::vector<T>>(
+            scatter_flattened_to(comms.back(), HPX_MOVE(data), this_site_arg(0),
+                generation, generation_mode::single_step),
+            [](flattened_data<T>&& result) {
+                return unwrap_flattened_row(HPX_MOVE(result));
+            });
     }
 
 }    // namespace hpx::collectives::detail

--- a/libs/full/collectives/include/hpx/collectives/gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/gather.hpp
@@ -412,6 +412,7 @@ namespace hpx { namespace collectives {
 
 #include <hpx/collectives/argument_types.hpp>
 #include <hpx/collectives/create_communicator.hpp>
+#include <hpx/collectives/detail/flattened_data.hpp>
 #include <hpx/collectives/detail/hierarchical_helpers.hpp>
 
 #include <cstddef>
@@ -456,6 +457,30 @@ namespace hpx::traits {
         }
 
         template <typename Result, typename T>
+        static Result get(Communicator& communicator, std::size_t which,
+            std::size_t generation,
+            hpx::collectives::detail::generation_mode num_generations,
+            hpx::collectives::detail::flattened_data<T>&& t,
+            hpx::collectives::detail::flattened_payload_mode)
+        {
+            using data_type = hpx::collectives::detail::flattened_data<T>;
+            hpx::collectives::detail::validate_flattened_data(
+                t, "hpx::collectives::gather_here");
+
+            return communicator.template handle_data<data_type>(
+                communication::communicator_data<
+                    communication::gather_tag>::name(),
+                which, generation,
+                [&t](auto& data, std::size_t which) {
+                    data[which] = HPX_MOVE(t);
+                },
+                [](auto& data, bool&, std::size_t) {
+                    return hpx::collectives::detail::merge_flattened_data(data);
+                },
+                num_generations);
+        }
+
+        template <typename Result, typename T>
         static Result set(Communicator& communicator, std::size_t which,
             std::size_t generation,
             hpx::collectives::detail::generation_mode num_generations, T&& t)
@@ -469,6 +494,27 @@ namespace hpx::traits {
                     data[which] = HPX_FORWARD(T, t);
                 },
                 // no finalizer
+                nullptr, num_generations);
+        }
+
+        template <typename Result, typename T>
+        static Result set(Communicator& communicator, std::size_t which,
+            std::size_t generation,
+            hpx::collectives::detail::generation_mode num_generations,
+            hpx::collectives::detail::flattened_data<T>&& t,
+            hpx::collectives::detail::flattened_payload_mode)
+        {
+            using data_type = hpx::collectives::detail::flattened_data<T>;
+            hpx::collectives::detail::validate_flattened_data(
+                t, "hpx::collectives::gather_there");
+
+            return communicator.template handle_data<data_type>(
+                communication::communicator_data<
+                    communication::gather_tag>::name(),
+                which, generation,
+                [&t](auto& data, std::size_t which) {
+                    data[which] = HPX_MOVE(t);
+                },
                 nullptr, num_generations);
         }
     };
@@ -538,6 +584,64 @@ namespace hpx::collectives {
                 if (!result.is_ready())
                 {
                     // make sure id is kept alive as long as the returned future
+                    traits::detail::get_shared_state(result)->set_on_completed(
+                        [client = HPX_MOVE(c)] { HPX_UNUSED(client); });
+                }
+
+                return result;
+            };
+
+            return fid.then(hpx::launch::sync, HPX_MOVE(gather_here_data));
+        }
+
+        template <typename T>
+        hpx::future<flattened_data<T>> gather_flattened_here(communicator fid,
+            flattened_data<T>&& local_result, this_site_arg this_site,
+            generation_arg const generation, generation_mode num_generations)
+        {
+            if (this_site.is_default())
+            {
+                this_site = agas::get_locality_id();
+            }
+            if (generation == 0)
+            {
+                return hpx::make_exceptional_future<flattened_data<T>>(
+                    HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                        "hpx::collectives::gather_here",
+                        "the generation number shouldn't be zero"));
+            }
+
+            if (auto [num_sites, comm_site] = fid.get_info(); num_sites == 1)
+            {
+                if (this_site != comm_site)
+                {
+                    return hpx::make_exceptional_future<flattened_data<T>>(
+                        HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                            "hpx::collectives::gather_here",
+                            "the local site should be zero if only one site "
+                            "is involved"));
+                }
+
+                return hpx::make_ready_future(HPX_MOVE(local_result));
+            }
+
+            auto gather_here_data = [local_result = HPX_MOVE(local_result),
+                                        this_site, generation, num_generations](
+                                        communicator&& c) mutable
+                -> hpx::future<flattened_data<T>> {
+                using data_type = flattened_data<T>;
+                using action_type =
+                    communicator_server::communication_get_direct_action<
+                        traits::communication::gather_tag,
+                        hpx::future<data_type>, generation_mode, data_type,
+                        flattened_payload_mode>;
+
+                hpx::future<data_type> result = hpx::async(action_type(), c,
+                    this_site, generation, num_generations,
+                    HPX_MOVE(local_result), flattened_payload_mode::enabled);
+
+                if (!result.is_ready())
+                {
                     traits::detail::get_shared_state(result)->set_on_completed(
                         [client = HPX_MOVE(c)] { HPX_UNUSED(client); });
                 }
@@ -630,17 +734,22 @@ namespace hpx::collectives {
             auto const [run_gen, run_step] =
                 hierarchical_run_params(generation, num_generations);
 
-            std::vector<std::decay_t<T>> result;
-            result.emplace_back(HPX_FORWARD(T, local_result));
+            using value_type = std::decay_t<T>;
+            flattened_data<value_type> result =
+                make_flattened_value(HPX_FORWARD(T, local_result));
             for (std::size_t i = communicators.size() - 1; i != 0; --i)
             {
-                result = gather_data(gather_here(communicators.get(i),
+                result = gather_flattened_here(communicators.get(i),
                     HPX_MOVE(result), this_site_arg(0), run_gen, run_step)
-                        .get());
+                             .get();
             }
 
-            return gather_data(gather_here(communicators.get(0),
-                HPX_MOVE(result), this_site_arg(0), run_gen, run_step));
+            return hpx::make_future<std::vector<value_type>>(
+                gather_flattened_here(communicators.get(0), HPX_MOVE(result),
+                    this_site_arg(0), run_gen, run_step),
+                [](flattened_data<value_type>&& data) {
+                    return HPX_MOVE(data.data);
+                });
         }
     }    // namespace detail
 
@@ -759,6 +868,48 @@ namespace hpx::collectives {
 
             return fid.then(hpx::launch::sync, HPX_MOVE(gather_there_data));
         }
+
+        template <typename T>
+        hpx::future<void> gather_flattened_there(communicator fid,
+            flattened_data<T>&& local_result, this_site_arg this_site,
+            generation_arg const generation, generation_mode num_generations)
+        {
+            if (this_site.is_default())
+            {
+                this_site = agas::get_locality_id();
+            }
+            if (generation == 0)
+            {
+                return hpx::make_exceptional_future<void>(HPX_GET_EXCEPTION(
+                    hpx::error::bad_parameter, "hpx::collectives::gather_there",
+                    "the generation number shouldn't be zero"));
+            }
+
+            auto gather_there_data =
+                [local_result = HPX_MOVE(local_result), this_site, generation,
+                    num_generations](
+                    communicator&& c) mutable -> hpx::future<void> {
+                using data_type = flattened_data<T>;
+                using action_type =
+                    communicator_server::communication_set_direct_action<
+                        traits::communication::gather_tag, hpx::future<void>,
+                        generation_mode, data_type, flattened_payload_mode>;
+
+                hpx::future<void> result = hpx::async(action_type(), c,
+                    this_site, generation, num_generations,
+                    HPX_MOVE(local_result), flattened_payload_mode::enabled);
+
+                if (!result.is_ready())
+                {
+                    traits::detail::get_shared_state(result)->set_on_completed(
+                        [client = HPX_MOVE(c)]() { HPX_UNUSED(client); });
+                }
+
+                return result;
+            };
+
+            return fid.then(hpx::launch::sync, HPX_MOVE(gather_there_data));
+        }
     }    // namespace detail
 
     ///////////////////////////////////////////////////////////////////////////
@@ -804,16 +955,17 @@ namespace hpx::collectives {
             auto const [run_gen, run_step] =
                 hierarchical_run_params(generation, num_generations);
 
-            std::vector<std::decay_t<T>> data;
-            data.emplace_back(HPX_FORWARD(T, local_result));
+            using value_type = std::decay_t<T>;
+            flattened_data<value_type> data =
+                make_flattened_value(HPX_FORWARD(T, local_result));
             for (std::size_t i = communicators.size() - 1; i != 0; --i)
             {
-                data = gather_data(gather_here(communicators.get(i),
+                data = gather_flattened_here(communicators.get(i),
                     HPX_MOVE(data), this_site_arg(0), run_gen, run_step)
-                        .get());
+                           .get();
             }
 
-            return gather_there(communicators.get(0), HPX_MOVE(data),
+            return gather_flattened_there(communicators.get(0), HPX_MOVE(data),
                 communicators.site(0), run_gen, run_step);
         }
     }    // namespace detail

--- a/libs/full/collectives/include/hpx/collectives/scatter.hpp
+++ b/libs/full/collectives/include/hpx/collectives/scatter.hpp
@@ -397,6 +397,7 @@ namespace hpx { namespace collectives {
 
 #include <hpx/collectives/argument_types.hpp>
 #include <hpx/collectives/create_communicator.hpp>
+#include <hpx/collectives/detail/flattened_data.hpp>
 #include <hpx/collectives/detail/hierarchical_helpers.hpp>
 
 #include <cstddef>
@@ -443,6 +444,26 @@ namespace hpx::traits {
                 num_generations);
         }
 
+        template <typename Result>
+        static Result get(Communicator& communicator, std::size_t which,
+            std::size_t generation,
+            hpx::collectives::detail::generation_mode num_generations,
+            hpx::collectives::detail::flattened_payload_mode)
+        {
+            using data_type = typename Result::result_type;
+            std::size_t const num_sites = communicator.num_sites_;
+
+            return communicator.template handle_data<data_type>(
+                communication::communicator_data<
+                    communication::scatter_tag>::name(),
+                which, generation, nullptr,
+                [num_sites](auto& data, bool&, std::size_t which) {
+                    return hpx::collectives::detail::slice_flattened_data(
+                        data[0], which, num_sites);
+                },
+                num_generations, 1);
+        }
+
         template <typename Result, typename T>
         static Result set(Communicator& communicator, std::size_t which,
             std::size_t generation,
@@ -461,6 +482,37 @@ namespace hpx::traits {
                         HPX_MOVE(data[which]));
                 },
                 num_generations);
+        }
+
+        template <typename Result, typename T>
+        static Result set(Communicator& communicator, std::size_t which,
+            std::size_t generation,
+            hpx::collectives::detail::generation_mode num_generations,
+            hpx::collectives::detail::flattened_data<T>&& t,
+            hpx::collectives::detail::flattened_payload_mode)
+        {
+            using data_type = hpx::collectives::detail::flattened_data<T>;
+            std::size_t const num_sites = communicator.num_sites_;
+            hpx::collectives::detail::validate_flattened_data(
+                t, "hpx::collectives::scatter_to");
+            if (t.offsets.size() - 1 < num_sites)
+            {
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                    "hpx::collectives::scatter_to",
+                    "the flattened payload must contain at least one row per "
+                    "participating site");
+            }
+
+            return communicator.template handle_data<data_type>(
+                communication::communicator_data<
+                    communication::scatter_tag>::name(),
+                which, generation,
+                [&t](auto& data, std::size_t) { data[0] = HPX_MOVE(t); },
+                [num_sites](auto& data, bool&, std::size_t which) {
+                    return hpx::collectives::detail::slice_flattened_data(
+                        data[0], which, num_sites);
+                },
+                num_generations, 1);
         }
     };
 }    // namespace hpx::traits
@@ -504,6 +556,49 @@ namespace hpx::collectives {
                 if (!result.is_ready())
                 {
                     // make sure id is kept alive as long as the returned future
+                    traits::detail::get_shared_state(result)->set_on_completed(
+                        [client = HPX_MOVE(c)] { HPX_UNUSED(client); });
+                }
+
+                return result;
+            };
+
+            return fid.then(hpx::launch::sync, HPX_MOVE(scatter_from_data));
+        }
+
+        template <typename T>
+        hpx::future<flattened_data<T>> scatter_flattened_from(communicator fid,
+            this_site_arg this_site, generation_arg const generation,
+            generation_mode num_generations)
+        {
+            if (this_site.is_default())
+            {
+                this_site = agas::get_locality_id();
+            }
+            if (generation == 0)
+            {
+                return hpx::make_exceptional_future<flattened_data<T>>(
+                    HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                        "hpx::collectives::scatter_from",
+                        "the generation number shouldn't be zero"));
+            }
+
+            auto scatter_from_data =
+                [this_site, generation, num_generations](
+                    communicator&& c) -> hpx::future<flattened_data<T>> {
+                using data_type = flattened_data<T>;
+                using action_type =
+                    communicator_server::communication_get_direct_action<
+                        traits::communication::scatter_tag,
+                        hpx::future<data_type>, generation_mode,
+                        flattened_payload_mode>;
+
+                hpx::future<data_type> result =
+                    hpx::async(action_type(), c, this_site, generation,
+                        num_generations, flattened_payload_mode::enabled);
+
+                if (!result.is_ready())
+                {
                     traits::detail::get_shared_state(result)->set_on_completed(
                         [client = HPX_MOVE(c)] { HPX_UNUSED(client); });
                 }
@@ -563,6 +658,11 @@ namespace hpx::collectives {
             std::vector<T>&& local_result, this_site_arg this_site,
             generation_arg const generation, generation_mode num_generations);
 
+        template <typename T>
+        hpx::future<flattened_data<T>> scatter_flattened_to(communicator fid,
+            flattened_data<T>&& local_result, this_site_arg this_site,
+            generation_arg const generation, generation_mode num_generations);
+
         // scatter_from over a hierarchical_communicator: detail entry carrying
         // the internal generation step. The public overload forwards with
         // double_step; scan collectives reuse it as their scatter phase with
@@ -594,24 +694,31 @@ namespace hpx::collectives {
             auto [current_communicator, current_site] = communicators[0];
             if (communicators.size() == 1)
             {
-                return scatter_from<T>(
-                    current_communicator, current_site, run_gen, run_step);
+                return hpx::make_future<T>(
+                    scatter_flattened_from<T>(
+                        current_communicator, current_site, run_gen, run_step),
+                    [](flattened_data<T>&& result) {
+                        return unwrap_flattened_value(HPX_MOVE(result));
+                    });
             }
 
-            std::vector<T> data = scatter_from<std::vector<T>>(
+            flattened_data<T> data = scatter_flattened_from<T>(
                 current_communicator, current_site, run_gen, run_step)
-                                      .get();
+                                         .get();
 
             for (std::size_t i = 1; i < communicators.size() - 1; ++i)
             {
-                data = scatter_to(communicators.get(i),
-                    scatter_data(HPX_MOVE(data), communicators.get_arity()),
-                    this_site_arg(0), run_gen, run_step)
+                data = scatter_flattened_to(communicators.get(i),
+                    HPX_MOVE(data), this_site_arg(0), run_gen, run_step)
                            .get();
             }
 
-            return scatter_to(communicators.back(), HPX_MOVE(data),
-                this_site_arg(0), run_gen, run_step);
+            return hpx::make_future<T>(
+                scatter_flattened_to(communicators.back(), HPX_MOVE(data),
+                    this_site_arg(0), run_gen, run_step),
+                [](flattened_data<T>&& result) {
+                    return unwrap_flattened_value(HPX_MOVE(result));
+                });
         }
     }    // namespace detail
 
@@ -764,6 +871,68 @@ namespace hpx::collectives {
 
             return fid.then(hpx::launch::sync, HPX_MOVE(scatter_to_data));
         }
+
+        template <typename T>
+        hpx::future<flattened_data<T>> scatter_flattened_to(communicator fid,
+            flattened_data<T>&& local_result, this_site_arg this_site,
+            generation_arg const generation, generation_mode num_generations)
+        {
+            if (this_site.is_default())
+            {
+                this_site = agas::get_locality_id();
+            }
+            if (generation == 0)
+            {
+                return hpx::make_exceptional_future<flattened_data<T>>(
+                    HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                        "hpx::collectives::scatter_to",
+                        "the generation number shouldn't be zero"));
+            }
+
+            auto [num_sites, comm_site] = fid.get_info();
+            HPX_ASSERT(is_valid_flattened_data(local_result));
+            HPX_ASSERT(local_result.offsets.size() - 1 >= num_sites);
+
+            if (num_sites == 1)
+            {
+                if (this_site != comm_site)
+                {
+                    return hpx::make_exceptional_future<flattened_data<T>>(
+                        HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                            "hpx::collectives::scatter_to",
+                            "the local site should be zero if only one site "
+                            "is involved"));
+                }
+
+                return hpx::make_ready_future(HPX_MOVE(local_result));
+            }
+
+            auto scatter_to_data = [local_result = HPX_MOVE(local_result),
+                                       this_site, generation, num_generations](
+                                       communicator&& c) mutable
+                -> hpx::future<flattened_data<T>> {
+                using data_type = flattened_data<T>;
+                using action_type =
+                    communicator_server::communication_set_direct_action<
+                        traits::communication::scatter_tag,
+                        hpx::future<data_type>, generation_mode, data_type,
+                        flattened_payload_mode>;
+
+                hpx::future<data_type> result = hpx::async(action_type(), c,
+                    this_site, generation, num_generations,
+                    HPX_MOVE(local_result), flattened_payload_mode::enabled);
+
+                if (!result.is_ready())
+                {
+                    traits::detail::get_shared_state(result)->set_on_completed(
+                        [client = HPX_MOVE(c)]() { HPX_UNUSED(client); });
+                }
+
+                return result;
+            };
+
+            return fid.then(hpx::launch::sync, HPX_MOVE(scatter_to_data));
+        }
     }    // namespace detail
 
     ///////////////////////////////////////////////////////////////////////////
@@ -830,26 +999,35 @@ namespace hpx::collectives {
             auto [current_communicator, current_site] = communicators[0];
             if (communicators.size() == 1)
             {
-                return scatter_to(current_communicator, HPX_MOVE(local_result),
-                    current_site, run_gen, run_step);
+                flattened_data<T> data =
+                    make_flattened_rows(HPX_MOVE(local_result));
+                return hpx::make_future<T>(
+                    scatter_flattened_to(current_communicator, HPX_MOVE(data),
+                        current_site, run_gen, run_step),
+                    [](flattened_data<T>&& result) {
+                        return unwrap_flattened_value(HPX_MOVE(result));
+                    });
             }
 
-            arity_arg arity = communicators.get_arity();
-            std::vector<T> data = scatter_to(communicators.get(0),
-                scatter_data(HPX_MOVE(local_result), arity), this_site_arg(0),
-                run_gen, run_step)
-                                      .get();
+            flattened_data<T> data =
+                make_flattened_rows(HPX_MOVE(local_result));
+            data = scatter_flattened_to(communicators.get(0), HPX_MOVE(data),
+                this_site_arg(0), run_gen, run_step)
+                       .get();
 
             for (std::size_t i = 1; i < communicators.size() - 1; ++i)
             {
-                data = scatter_to(communicators.get(i),
-                    scatter_data(HPX_MOVE(data), arity),
-                    this_site_arg(this_site % arity), run_gen, run_step)
+                data = scatter_flattened_to(communicators.get(i),
+                    HPX_MOVE(data), this_site_arg(0), run_gen, run_step)
                            .get();
             }
 
-            return scatter_to(communicators.back(), HPX_MOVE(data),
-                this_site_arg(0), run_gen, run_step);
+            return hpx::make_future<T>(
+                scatter_flattened_to(communicators.back(), HPX_MOVE(data),
+                    this_site_arg(0), run_gen, run_step),
+                [](flattened_data<T>&& result) {
+                    return unwrap_flattened_value(HPX_MOVE(result));
+                });
         }
     }    // namespace detail
 

--- a/libs/full/collectives/tests/unit/CMakeLists.txt
+++ b/libs/full/collectives/tests/unit/CMakeLists.txt
@@ -56,8 +56,14 @@ if(HPX_WITH_NETWORKING)
     set(${test}_PARAMETERS LOCALITIES 2)
   endforeach()
 
-  # The flat-vs-tree comparison needs a real tree: num_sites > arity (= 2).
-  set(hierarchical_flat_fallback_PARAMETERS LOCALITIES 3)
+  # Exercise the serialized intermediate gather/scatter payload through a real
+  # arity-two tree instead of collapsing to a single communicator.
+  set(gather_hierarchical_PARAMETERS LOCALITIES 3)
+  set(scatter_hierarchical_PARAMETERS LOCALITIES 3)
+
+  # The flat-vs-tree comparison needs a real tree. Five localities with arity
+  # two also exercises an uneven subtree with an intermediate payload hop.
+  set(hierarchical_flat_fallback_PARAMETERS LOCALITIES 5)
 endif()
 foreach(test ${tests})
   set(sources ${test}.cpp)

--- a/libs/full/collectives/tests/unit/gather_hierarchical.cpp
+++ b/libs/full/collectives/tests/unit/gather_hierarchical.cpp
@@ -15,6 +15,7 @@
 
 #include <cstdint>
 #include <iostream>
+#include <new>
 #include <string>
 #include <utility>
 #include <vector>
@@ -27,6 +28,70 @@ constexpr int ITERATIONS = 50;
 #else
 constexpr int ITERATIONS = 500;
 #endif
+
+struct non_default_payload
+{
+    non_default_payload() = delete;
+
+    explicit non_default_payload(std::uint32_t const value)
+      : value(value)
+    {
+    }
+
+    template <typename Archive>
+    void serialize(Archive&, unsigned int const)
+    {
+    }
+
+    template <typename Archive>
+    friend void save_construct_data(Archive& ar,
+        non_default_payload const* const payload, unsigned int const)
+    {
+        ar & payload->value;
+    }
+
+    template <typename Archive>
+    friend void load_construct_data(
+        Archive& ar, non_default_payload* const payload, unsigned int const)
+    {
+        std::uint32_t value = 0;
+        ar & value;
+        ::new (payload) non_default_payload(value);
+    }
+
+    std::uint32_t value;
+};
+
+void test_non_default_payload()
+{
+    std::uint32_t const this_locality = hpx::get_locality_id();
+    std::uint32_t const num_localities =
+        hpx::get_num_localities(hpx::launch::sync);
+
+    auto const gather_clients = create_hierarchical_communicator(
+        "/test/gather_hierarchical_non_default/", num_sites_arg(num_localities),
+        this_site_arg(this_locality), arity_arg(2), generation_arg(),
+        root_site_arg(), flat_fallback_threshold_arg(0));
+
+    non_default_payload value(this_locality + 42);
+    if (this_locality == 0)
+    {
+        auto const result = gather_here(gather_clients, HPX_MOVE(value),
+            this_site_arg(this_locality), generation_arg(1))
+                                .get();
+        HPX_TEST_EQ(result.size(), static_cast<std::size_t>(num_localities));
+        for (std::uint32_t site = 0; site != num_localities; ++site)
+        {
+            HPX_TEST_EQ(result[site].value, site + 42);
+        }
+    }
+    else
+    {
+        gather_there(gather_clients, HPX_MOVE(value),
+            this_site_arg(this_locality), generation_arg(1))
+            .get();
+    }
+}
 
 void test_multiple_use(int arity = 2)
 {
@@ -199,6 +264,7 @@ int hpx_main()
     {
         test_multiple_use();
         test_multiple_use_with_generation();
+        test_non_default_payload();
     }
 #endif
 

--- a/libs/full/collectives/tests/unit/hierarchical_flat_fallback.cpp
+++ b/libs/full/collectives/tests/unit/hierarchical_flat_fallback.cpp
@@ -117,6 +117,48 @@ void test_distributed_fallback_all_to_all()
         HPX_TEST_EQ(fb_result[i], expected[i]);
     }
 
+    std::vector<std::string> string_send_data;
+    std::vector<std::string> string_expected;
+    string_send_data.reserve(num_localities);
+    string_expected.reserve(num_localities);
+    for (std::uint32_t site = 0; site != num_localities; ++site)
+    {
+        string_send_data.push_back(
+            std::to_string(this_locality) + "->" + std::to_string(site));
+        string_expected.push_back(
+            std::to_string(site) + "->" + std::to_string(this_locality));
+    }
+
+    auto const string_fb_result =
+        all_to_all(fb_clients, std::vector<std::string>(string_send_data),
+            this_site_arg(this_locality), generation_arg(2))
+            .get();
+    HPX_TEST_EQ(string_fb_result.size(), string_expected.size());
+    for (std::size_t i = 0; i != string_expected.size(); ++i)
+    {
+        HPX_TEST_EQ(string_fb_result[i], string_expected[i]);
+    }
+
+    std::vector<bool> bool_send_data;
+    std::vector<bool> bool_expected;
+    bool_send_data.reserve(num_localities);
+    bool_expected.reserve(num_localities);
+    for (std::uint32_t site = 0; site != num_localities; ++site)
+    {
+        bool_send_data.push_back(this_locality < site);
+        bool_expected.push_back(site < this_locality);
+    }
+
+    auto const bool_fb_result =
+        all_to_all(fb_clients, std::vector<bool>(bool_send_data),
+            this_site_arg(this_locality), generation_arg(3))
+            .get();
+    HPX_TEST_EQ(bool_fb_result.size(), bool_expected.size());
+    for (std::size_t i = 0; i != bool_expected.size(); ++i)
+    {
+        HPX_TEST_EQ(bool_fb_result[i], bool_expected[i]);
+    }
+
     // Force tree path; results must match. With 2 localities and arity 2 a
     // tree is structurally impossible (arity >= num_sites dispatches flat),
     // so this leg needs at least 3.
@@ -142,7 +184,152 @@ void test_distributed_fallback_all_to_all()
         {
             HPX_TEST_EQ(tree_result[i], expected[i]);
         }
+
+        auto const string_tree_result =
+            all_to_all(tree_clients, std::vector<std::string>(string_send_data),
+                this_site_arg(this_locality), generation_arg(2))
+                .get();
+        HPX_TEST_EQ(string_tree_result.size(), string_expected.size());
+        for (std::size_t i = 0; i != string_expected.size(); ++i)
+        {
+            HPX_TEST_EQ(string_tree_result[i], string_expected[i]);
+        }
+
+        auto const bool_tree_result =
+            all_to_all(tree_clients, std::vector<bool>(bool_send_data),
+                this_site_arg(this_locality), generation_arg(3))
+                .get();
+        HPX_TEST_EQ(bool_tree_result.size(), bool_expected.size());
+        for (std::size_t i = 0; i != bool_expected.size(); ++i)
+        {
+            HPX_TEST_EQ(bool_tree_result[i], bool_expected[i]);
+        }
     }
+}
+
+void test_distributed_flattened_bool_payloads()
+{
+    std::uint32_t const this_locality = hpx::get_locality_id();
+    std::uint32_t const num_localities =
+        hpx::get_num_localities(hpx::launch::sync);
+
+    if (num_localities < 3)
+    {
+        return;
+    }
+
+    auto const gather_clients = create_hierarchical_communicator(
+        "/test/hflback_dist_bool_gather/", num_sites_arg(num_localities),
+        this_site_arg(this_locality), arity_arg(2), generation_arg(),
+        root_site_arg(0), flat_fallback_threshold_arg(0));
+
+    bool const local_value = this_locality % 2 != 0;
+    if (this_locality == 0)
+    {
+        auto const gathered = gather_here(gather_clients, bool(local_value),
+            this_site_arg(this_locality), generation_arg(1))
+                                  .get();
+        HPX_TEST_EQ(gathered.size(), static_cast<std::size_t>(num_localities));
+        for (std::uint32_t site = 0; site != num_localities; ++site)
+        {
+            HPX_TEST_EQ(gathered[site], site % 2 != 0);
+        }
+    }
+    else
+    {
+        gather_there(gather_clients, bool(local_value),
+            this_site_arg(this_locality), generation_arg(1))
+            .get();
+    }
+
+    auto const scatter_clients = create_hierarchical_communicator(
+        "/test/hflback_dist_bool_scatter/", num_sites_arg(num_localities),
+        this_site_arg(this_locality), arity_arg(2), generation_arg(),
+        root_site_arg(0), flat_fallback_threshold_arg(0));
+
+    bool result = false;
+    if (this_locality == 0)
+    {
+        std::vector<bool> values;
+        values.reserve(num_localities);
+        for (std::uint32_t site = 0; site != num_localities; ++site)
+        {
+            values.push_back(site % 2 == 0);
+        }
+        result = scatter_to(scatter_clients, HPX_MOVE(values),
+            this_site_arg(this_locality), generation_arg(1))
+                     .get();
+    }
+    else
+    {
+        result = scatter_from<bool>(
+            scatter_clients, this_site_arg(this_locality), generation_arg(1))
+                     .get();
+    }
+    HPX_TEST_EQ(result, this_locality % 2 == 0);
+}
+
+void test_local_flattened_gather_scatter()
+{
+    constexpr std::uint32_t num_sites = 5;
+    std::vector<hpx::future<void>> sites;
+    sites.reserve(num_sites);
+
+    for (std::uint32_t site = 0; site != num_sites; ++site)
+    {
+        sites.push_back(hpx::async([site]() {
+            auto const clients = create_hierarchical_communicator(
+                "/test/hflback_local_flattened_gs/", num_sites_arg(num_sites),
+                this_site_arg(site), arity_arg(2), generation_arg(),
+                root_site_arg(0), flat_fallback_threshold_arg(0));
+
+            std::string const value = "site-" + std::to_string(site);
+            if (site == 0)
+            {
+                auto const gathered = gather_here(clients, std::string(value),
+                    this_site_arg(site), generation_arg(1))
+                                          .get();
+                HPX_TEST_EQ(
+                    gathered.size(), static_cast<std::size_t>(num_sites));
+                for (std::uint32_t source = 0; source != num_sites; ++source)
+                {
+                    HPX_TEST_EQ(
+                        gathered[source], "site-" + std::to_string(source));
+                }
+            }
+            else
+            {
+                gather_there(clients, std::string(value), this_site_arg(site),
+                    generation_arg(1))
+                    .get();
+            }
+
+            std::string result;
+            if (site == 0)
+            {
+                std::vector<std::string> values;
+                values.reserve(num_sites);
+                for (std::uint32_t destination = 0; destination != num_sites;
+                    ++destination)
+                {
+                    values.push_back(
+                        "destination-" + std::to_string(destination));
+                }
+                result = scatter_to(clients, HPX_MOVE(values),
+                    this_site_arg(site), generation_arg(2))
+                             .get();
+            }
+            else
+            {
+                result = scatter_from<std::string>(
+                    clients, this_site_arg(site), generation_arg(2))
+                             .get();
+            }
+            HPX_TEST_EQ(result, "destination-" + std::to_string(site));
+        }));
+    }
+
+    hpx::wait_all(HPX_MOVE(sites));
 }
 
 // Local test (single-process, multi-thread sites), exercised from locality 0
@@ -254,11 +441,14 @@ int hpx_main()
     {
         test_distributed_fallback();
         test_distributed_fallback_all_to_all();
+        test_distributed_flattened_bool_payloads();
     }
 #endif
 
     if (hpx::get_locality_id() == 0)
     {
+        test_local_flattened_gather_scatter();
+
         // Flat legs: threshold above all site counts forces the fallback.
         for (std::uint32_t n : {2u, 4u, 8u})
         {

--- a/libs/full/collectives/tests/unit/hierarchical_helpers.cpp
+++ b/libs/full/collectives/tests/unit/hierarchical_helpers.cpp
@@ -11,15 +11,22 @@
 #include <hpx/hpx_init.hpp>
 #include <hpx/modules/testing.hpp>
 
+#include <hpx/collectives/detail/flattened_data.hpp>
 #include <hpx/modules/collectives.hpp>
 
 #include <cstddef>
+#include <cstdint>
 #include <numeric>
+#include <string>
 #include <vector>
 
 using hpx::collectives::detail::classify_site;
+using hpx::collectives::detail::flattened_data;
 using hpx::collectives::detail::get_top_level_groups;
 using hpx::collectives::detail::is_top_level_rep;
+using hpx::collectives::detail::merge_flattened_data;
+using hpx::collectives::detail::select_flattened_column;
+using hpx::collectives::detail::slice_flattened_data;
 using hpx::collectives::detail::top_level_group;
 
 void test_balanced_arity2()
@@ -261,6 +268,132 @@ void test_is_top_level_rep_exhaustive()
     }
 }
 
+void test_flattened_data_slicing()
+{
+    flattened_data<int> first{{10, 11, 20, 30, 31, 32}, {0, 2, 3, 6}};
+    auto left = slice_flattened_data(first, 0, 2);
+    HPX_TEST_EQ(left.data.size(), static_cast<std::size_t>(3));
+    HPX_TEST_EQ(left.offsets.size(), static_cast<std::size_t>(3));
+    HPX_TEST_EQ(left.data[0], 10);
+    HPX_TEST_EQ(left.data[1], 11);
+    HPX_TEST_EQ(left.data[2], 20);
+    HPX_TEST_EQ(left.offsets[0], std::uint32_t(0));
+    HPX_TEST_EQ(left.offsets[1], std::uint32_t(2));
+    HPX_TEST_EQ(left.offsets[2], std::uint32_t(3));
+
+    flattened_data<int> second{{10, 11, 20, 30, 31, 32}, {0, 2, 3, 6}};
+    auto right = slice_flattened_data(second, 1, 2);
+    HPX_TEST_EQ(right.data.size(), static_cast<std::size_t>(3));
+    HPX_TEST_EQ(right.offsets.size(), static_cast<std::size_t>(2));
+    HPX_TEST_EQ(right.data[0], 30);
+    HPX_TEST_EQ(right.data[1], 31);
+    HPX_TEST_EQ(right.data[2], 32);
+    HPX_TEST_EQ(right.offsets[0], std::uint32_t(0));
+    HPX_TEST_EQ(right.offsets[1], std::uint32_t(3));
+
+    flattened_data<int> empty_row{{1, 2, 3, 4, 5}, {0, 2, 2, 5}};
+    auto empty = slice_flattened_data(empty_row, 1, 3);
+    HPX_TEST(empty.data.empty());
+    HPX_TEST_EQ(empty.offsets.size(), static_cast<std::size_t>(2));
+    HPX_TEST_EQ(empty.offsets[0], std::uint32_t(0));
+    HPX_TEST_EQ(empty.offsets[1], std::uint32_t(0));
+}
+
+void test_flattened_data_merge()
+{
+    std::vector<flattened_data<std::string>> values;
+    values.push_back({{"a", "b", "c", "d"}, {0, 3, 4}});
+    values.push_back({{"e", "f"}, {0, 2}});
+
+    auto result = merge_flattened_data(values);
+    HPX_TEST_EQ(result.data.size(), static_cast<std::size_t>(6));
+    HPX_TEST_EQ(result.offsets.size(), static_cast<std::size_t>(4));
+    for (std::size_t i = 0; i != result.data.size(); ++i)
+    {
+        HPX_TEST_EQ(result.data[i], std::string(1, static_cast<char>('a' + i)));
+    }
+    HPX_TEST_EQ(result.offsets[0], std::uint32_t(0));
+    HPX_TEST_EQ(result.offsets[1], std::uint32_t(3));
+    HPX_TEST_EQ(result.offsets[2], std::uint32_t(4));
+    HPX_TEST_EQ(result.offsets[3], std::uint32_t(6));
+}
+
+void test_flattened_exchange_diagonal()
+{
+    std::vector<flattened_data<int>> values;
+    values.push_back({{3, 4, 103, 104, 203, 204}, {0, 0, 2, 2, 4, 4, 6}});
+    values.push_back({{300, 301, 302, 400, 401, 402}, {0, 3, 3, 6, 6}});
+
+    auto for_group_zero = select_flattened_column(values, 0);
+    HPX_TEST_EQ(for_group_zero.data.size(), static_cast<std::size_t>(6));
+    HPX_TEST_EQ(for_group_zero.offsets[0], std::uint32_t(0));
+    HPX_TEST_EQ(for_group_zero.offsets[1], std::uint32_t(0));
+    HPX_TEST_EQ(for_group_zero.offsets[2], std::uint32_t(6));
+    for (std::size_t i = 0; i != for_group_zero.data.size(); ++i)
+    {
+        HPX_TEST_EQ(for_group_zero.data[i],
+            static_cast<int>(300 + (i / 3) * 100 + i % 3));
+    }
+
+    std::vector<flattened_data<int>> second_values;
+    second_values.push_back(
+        {{3, 4, 103, 104, 203, 204}, {0, 0, 2, 2, 4, 4, 6}});
+    second_values.push_back({{300, 301, 302, 400, 401, 402}, {0, 3, 3, 6, 6}});
+    auto for_group_one = select_flattened_column(second_values, 1);
+    HPX_TEST_EQ(for_group_one.data.size(), static_cast<std::size_t>(6));
+    HPX_TEST_EQ(for_group_one.offsets[0], std::uint32_t(0));
+    HPX_TEST_EQ(for_group_one.offsets[1], std::uint32_t(6));
+    HPX_TEST_EQ(for_group_one.offsets[2], std::uint32_t(6));
+    for (std::size_t i = 0; i != for_group_one.data.size(); ++i)
+    {
+        HPX_TEST_EQ(
+            for_group_one.data[i], static_cast<int>((i / 2) * 100 + 3 + i % 2));
+    }
+}
+
+void test_flattened_vector_bool()
+{
+    std::vector<flattened_data<bool>> values;
+    values.push_back({{true, false, true}, {0, 2, 3}});
+    values.push_back({{false, false}, {0, 2}});
+
+    auto merged = merge_flattened_data(values);
+    HPX_TEST_EQ(merged.data.size(), static_cast<std::size_t>(5));
+    HPX_TEST(merged.data[0]);
+    HPX_TEST(!merged.data[1]);
+    HPX_TEST(merged.data[2]);
+    HPX_TEST(!merged.data[3]);
+    HPX_TEST(!merged.data[4]);
+
+    auto slice = slice_flattened_data(merged, 1, 3);
+    HPX_TEST_EQ(slice.data.size(), static_cast<std::size_t>(1));
+    HPX_TEST(slice.data[0]);
+}
+
+void test_flattened_data_serialization()
+{
+    flattened_data<std::string> original{{"zero", "one", "two"}, {0, 2, 3}};
+
+    std::vector<char> buffer;
+    hpx::serialization::output_archive output(buffer);
+    output << original;
+
+    flattened_data<std::string> restored;
+    hpx::serialization::input_archive input(buffer);
+    input >> restored;
+
+    HPX_TEST_EQ(restored.data.size(), original.data.size());
+    HPX_TEST_EQ(restored.offsets.size(), original.offsets.size());
+    for (std::size_t i = 0; i != original.data.size(); ++i)
+    {
+        HPX_TEST_EQ(restored.data[i], original.data[i]);
+    }
+    for (std::size_t i = 0; i != original.offsets.size(); ++i)
+    {
+        HPX_TEST_EQ(restored.offsets[i], original.offsets[i]);
+    }
+}
+
 int hpx_main()
 {
     test_balanced_arity2();
@@ -275,6 +408,11 @@ int hpx_main()
     test_matches_recursive_fill();
     test_is_top_level_rep_basic();
     test_is_top_level_rep_exhaustive();
+    test_flattened_data_slicing();
+    test_flattened_data_merge();
+    test_flattened_exchange_diagonal();
+    test_flattened_vector_bool();
+    test_flattened_data_serialization();
 
     return hpx::finalize();
 }

--- a/libs/full/collectives/tests/unit/subtree_gather_scatter.cpp
+++ b/libs/full/collectives/tests/unit/subtree_gather_scatter.cpp
@@ -61,40 +61,51 @@ void test_round_trip(std::uint32_t num_sites, int arity)
                 if (is_rep)
                 {
                     // Gather: collect subtree data.
-                    auto gathered = detail::subtree_gather_at_top_rep(
-                        comms, std::uint32_t(site), generation_arg(gather_gen));
+                    auto gathered = detail::subtree_gather_at_top_rep(comms,
+                        std::vector<std::uint32_t>{site},
+                        generation_arg(gather_gen));
 
                     // Verify: gathered should contain contiguous site ids.
                     auto groups =
                         detail::get_top_level_groups(ns, comms.get_arity());
                     auto gidx = detail::classify_site(ts, groups);
+                    HPX_TEST_NEQ(gidx, static_cast<std::ptrdiff_t>(-1));
 
-                    HPX_TEST_EQ(gathered.size(),
-                        static_cast<std::size_t>(groups[gidx].size));
-                    for (std::size_t j = 0; j != gathered.size(); ++j)
+                    std::size_t const group = static_cast<std::size_t>(gidx);
+                    std::size_t const group_left = groups[group].left;
+                    std::size_t const group_size = groups[group].size;
+
+                    HPX_TEST_EQ(gathered.offsets.size(), group_size + 1);
+                    HPX_TEST_EQ(gathered.data.size(), group_size);
+                    for (std::size_t j = 0; j != group_size; ++j)
                     {
-                        HPX_TEST_EQ(gathered[j],
-                            static_cast<std::uint32_t>(groups[gidx].left + j));
+                        HPX_TEST_EQ(gathered.offsets[j], j);
+                        HPX_TEST_EQ(gathered.data[j],
+                            static_cast<std::uint32_t>(group_left + j));
                     }
+                    HPX_TEST_EQ(gathered.offsets.back(), group_size);
 
                     // Scatter: send each site its value back.
                     auto my_val = detail::subtree_scatter_at_top_rep(
                         comms, HPX_MOVE(gathered), generation_arg(scatter_gen))
                                       .get();
-                    HPX_TEST_EQ(my_val, site);
+                    HPX_TEST_EQ(my_val.size(), static_cast<std::size_t>(1));
+                    HPX_TEST_EQ(my_val[0], site);
                 }
                 else
                 {
                     // Send our value to the rep.
-                    detail::subtree_send_to_top_rep(
-                        comms, std::uint32_t(site), generation_arg(gather_gen));
+                    detail::subtree_send_to_top_rep(comms,
+                        std::vector<std::uint32_t>{site},
+                        generation_arg(gather_gen));
 
                     // Receive our value back.
                     auto my_val =
                         detail::subtree_receive_from_top_rep<std::uint32_t>(
                             comms, generation_arg(scatter_gen))
                             .get();
-                    HPX_TEST_EQ(my_val, site);
+                    HPX_TEST_EQ(my_val.size(), static_cast<std::size_t>(1));
+                    HPX_TEST_EQ(my_val[0], site);
                 }
             }
         }));
@@ -134,37 +145,36 @@ void test_vector_payload(std::uint32_t num_sites, int arity)
 
             if (is_rep)
             {
-                // Gather: each site contributes a vector<uint32_t>.
-                // gather_data flattens one nesting level per gather step,
-                // so the result is vector<vector<uint32_t>>.
+                // Gather: each site contributes one logical row.
                 auto gathered = detail::subtree_gather_at_top_rep(
                     comms, HPX_MOVE(my_data), generation_arg(1));
 
                 auto groups =
                     detail::get_top_level_groups(ns, comms.get_arity());
                 auto gidx = detail::classify_site(ts, groups);
+                HPX_TEST_NEQ(gidx, static_cast<std::ptrdiff_t>(-1));
 
-                // gathered is vector<vector<uint32_t>> with one entry
-                // per subtree site (gather_data flattens one level per
-                // gather step, preserving inner vectors).
-                HPX_TEST_EQ(gathered.size(),
-                    static_cast<std::size_t>(groups[gidx].size));
+                std::size_t const group = static_cast<std::size_t>(gidx);
+                std::size_t const group_left = groups[group].left;
+                std::size_t const group_size = groups[group].size;
+
+                HPX_TEST_EQ(gathered.offsets.size(), group_size + 1);
+                HPX_TEST_EQ(gathered.data.size(), group_size * 3);
 
                 // Verify values.
-                for (std::size_t j = 0; j != groups[gidx].size; ++j)
+                for (std::size_t j = 0; j != group_size; ++j)
                 {
                     std::uint32_t expected_site =
-                        static_cast<std::uint32_t>(groups[gidx].left + j);
-                    HPX_TEST_EQ(
-                        gathered[j].size(), static_cast<std::size_t>(3));
-                    HPX_TEST_EQ(gathered[j][0], expected_site * 10);
-                    HPX_TEST_EQ(gathered[j][1], expected_site * 10 + 1);
-                    HPX_TEST_EQ(gathered[j][2], expected_site * 10 + 2);
+                        static_cast<std::uint32_t>(group_left + j);
+                    std::size_t const row = gathered.offsets[j];
+                    HPX_TEST_EQ(gathered.offsets[j + 1] - row,
+                        static_cast<std::size_t>(3));
+                    HPX_TEST_EQ(gathered.data[row], expected_site * 10);
+                    HPX_TEST_EQ(gathered.data[row + 1], expected_site * 10 + 1);
+                    HPX_TEST_EQ(gathered.data[row + 2], expected_site * 10 + 2);
                 }
 
-                // Scatter: gathered is already vector<vector<uint32_t>>,
-                // which is the right shape for scatter (one entry per
-                // subtree site). Pass directly.
+                // Scatter the same flat rows directly back down the subtree.
                 auto my_result = detail::subtree_scatter_at_top_rep(
                     comms, HPX_MOVE(gathered), generation_arg(2))
                                      .get();
@@ -179,9 +189,10 @@ void test_vector_payload(std::uint32_t num_sites, int arity)
                 detail::subtree_send_to_top_rep(
                     comms, HPX_MOVE(my_data), generation_arg(1));
 
-                auto my_result = detail::subtree_receive_from_top_rep<
-                    std::vector<std::uint32_t>>(comms, generation_arg(2))
-                                     .get();
+                auto my_result =
+                    detail::subtree_receive_from_top_rep<std::uint32_t>(
+                        comms, generation_arg(2))
+                        .get();
 
                 HPX_TEST_EQ(my_result.size(), static_cast<std::size_t>(3));
                 HPX_TEST_EQ(my_result[0], site * 10);


### PR DESCRIPTION
Fixes #

## Proposed Changes

- Replace nested intermediate vectors with serializable flat buffers and offset tables for hierarchical `gather`, `scatter`, and `all_to_all`
- Keep all-to-all diagonal blocks local during packing (empty segment for the local group) so they skip the inter-group round trip
- Extend unit coverage for uneven trees, bool/string payloads, serialization, non-default-constructible values, flat fallback, and flattened-data helpers

## Any background context you want to provide?

Hierarchical gather/scatter/all-to-all previously shuttled nested `vector` payloads between tree levels. Flattening to a contiguous buffer plus offset table reduces allocation churn and simplifies serialization across the communicator tree while preserving existing hierarchical generation semantics.

This PR is based directly on current `master` and does **not** include the collectives hardening work from #7359.

## Checklist

Not all points below apply to all pull requests.

- [x] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.