### PR TITLE
async_cuda: preserve transform_stream environment

### DIFF
--- a/libs/core/async_cuda/include/hpx/async_cuda/transform_stream.hpp
+++ b/libs/core/async_cuda/include/hpx/async_cuda/transform_stream.hpp
@@ -327,7 +327,8 @@ namespace hpx::cuda::experimental {
             }
             // clang-format on
 
-            constexpr auto get_env() const noexcept
+            constexpr decltype(auto) get_env() const
+                noexcept(noexcept(hpx::execution::experimental::get_env(s)))
             {
                 return hpx::execution::experimental::get_env(s);
             }


### PR DESCRIPTION
## Proposed Changes

  - Preserve the wrapped sender environment in transform_stream_sender::get_env() with decltype(auto) and conditional noexcept

## Any background context you want to provide?

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
