### PR TITLE
Flatten hierarchical gather and scatter payloads

### DIFF
--- a/libs/full/collectives/CMakeLists.txt
+++ b/libs/full/collectives/CMakeLists.txt
@@ -23,6 +23,7 @@ set(collectives_headers
     hpx/collectives/create_communicator.hpp
     hpx/collectives/detail/channel_communicator.hpp
     hpx/collectives/detail/communicator.hpp
+    hpx/collectives/detail/flattened_data.hpp
     hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
     hpx/collectives/detail/hierarchical_helpers.hpp
     hpx/collectives/detail/hierarchical_scan_helpers.hpp
@@ -83,6 +84,7 @@ add_hpx_module(
   HEADERS ${collectives_headers}
   MACRO_HEADERS ${collectives_macros_headers}
   ADD_TO_GLOBAL_HEADER
+    "hpx/collectives/detail/flattened_data.hpp"
     "hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp"
     "hpx/collectives/detail/hierarchical_helpers.hpp"
     "hpx/collectives/detail/hierarchical_scan_helpers.hpp"

--- a/libs/full/collectives/include/hpx/collectives/detail/flattened_data.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/flattened_data.hpp
@@ -23,42 +23,6 @@
 
 namespace hpx::collectives::detail {
 
-    // A compact carrier for equally sized logical rows. Gather and scatter
-    // preserve a uniform row width, so a row count is sufficient to derive
-    // every boundary without allocating or serializing an offset table.
-    HPX_CXX_EXPORT template <typename T>
-    struct uniform_rows
-    {
-        std::vector<T> data;
-        std::size_t num_rows = 0;
-
-        template <typename Archive>
-        void serialize(Archive& ar, unsigned int const)
-        {
-            ar & data & num_rows;
-        }
-    };
-
-    template <typename T>
-    struct is_uniform_rows : std::false_type
-    {
-    };
-
-    template <typename T>
-    struct is_uniform_rows<uniform_rows<T>> : std::true_type
-    {
-    };
-
-    template <typename T>
-    inline constexpr bool is_uniform_rows_v =
-        is_uniform_rows<std::decay_t<T>>::value;
-
-    // Distinguishes the internal row scatter protocol from an ordinary scatter
-    // whose user value type happens to be uniform_rows<T>.
-    struct uniform_scatter_tag
-    {
-    };
-
     HPX_CXX_EXPORT [[nodiscard]] inline std::size_t checked_data_size_sum(
         std::size_t const lhs, std::size_t const rhs)
     {
@@ -89,178 +53,213 @@ namespace hpx::collectives::detail {
         return lhs * rhs;
     }
 
+    // A compact carrier for equally sized logical rows. Gather and scatter
+    // preserve a uniform row width, so a row count is sufficient to derive
+    // every boundary without allocating or serializing an offset table.
     HPX_CXX_EXPORT template <typename T>
-    [[nodiscard]] bool is_valid_uniform_rows(
-        uniform_rows<T> const& value) noexcept
+    struct uniform_rows
     {
-        return value.num_rows == 0 ? value.data.empty() :
-                                     value.data.size() % value.num_rows == 0;
-    }
+        uniform_rows() = default;
 
-    HPX_CXX_EXPORT template <typename T>
-    void validate_uniform_rows(
-        uniform_rows<T> const& value, char const* const operation)
-    {
-        if (!is_valid_uniform_rows(value))
+        uniform_rows(std::vector<T>&& values, std::size_t const num_rows)
+          : data(HPX_MOVE(values))
+          , num_rows(num_rows)
         {
-            HPX_THROW_EXCEPTION(hpx::error::bad_parameter, operation,
-                "the uniform-row hierarchical collective payload has an "
-                "invalid row count");
         }
-    }
 
-    template <typename T>
-    [[nodiscard]] std::size_t uniform_row_width(uniform_rows<T> const& value)
-    {
-        HPX_ASSERT(is_valid_uniform_rows(value));
-        return value.num_rows == 0 ? 0 : value.data.size() / value.num_rows;
-    }
-
-    template <typename T, typename Iterator>
-    void append_data_range(
-        std::vector<T>& destination, Iterator first, Iterator const last)
-    {
-        // Inserting a range can instantiate vector's move-assignment path even
-        // at end(). Append element-wise so the internal carriers require only
-        // move construction. vector<bool> additionally needs proxy conversion.
-        for (; first != last; ++first)
+        explicit uniform_rows(std::vector<T>&& values)
+          : data(HPX_MOVE(values))
+          , num_rows(data.size())
         {
+        }
+
+        explicit uniform_rows(T const& value)
+          : num_rows(1)
+        {
+            data.emplace_back(value);
+        }
+
+        explicit uniform_rows(T&& value)
+          : num_rows(1)
+        {
+            data.emplace_back(HPX_MOVE(value));
+        }
+
+        explicit uniform_rows(std::vector<uniform_rows<T>>&& values)
+        {
+            constexpr char const* operation =
+                "hpx::collectives::detail::uniform_rows::uniform_rows";
+
+            if (values.size() == 1)
+            {
+                values.front().validate(operation);
+                data = HPX_MOVE(values.front().data);
+                num_rows = values.front().num_rows;
+                return;
+            }
+
+            std::size_t total_size = 0;
+            std::size_t total_rows = 0;
+            std::size_t expected_row_width = 0;
+            bool have_row_width = false;
+
+            for (auto const& value : values)
+            {
+                value.validate(operation);
+                total_size =
+                    checked_data_size_sum(total_size, value.data.size());
+                total_rows = checked_data_size_sum(total_rows, value.num_rows);
+
+                if (value.num_rows != 0)
+                {
+                    std::size_t const current_row_width = value.row_width();
+                    if (have_row_width &&
+                        current_row_width != expected_row_width)
+                    {
+                        HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                            operation,
+                            "all uniform hierarchical collective rows must "
+                            "have the same width");
+                    }
+                    expected_row_width = current_row_width;
+                    have_row_width = true;
+                }
+            }
+
+            data.reserve(total_size);
+            num_rows = total_rows;
+            for (auto& value : values)
+            {
+                append_data_range(data, value.data.begin(), value.data.end());
+            }
+
+            HPX_ASSERT(is_valid());
+        }
+
+        [[nodiscard]] bool is_valid() const noexcept
+        {
+            return num_rows == 0 ? data.empty() : data.size() % num_rows == 0;
+        }
+
+        void validate(char const* const operation) const
+        {
+            if (!is_valid())
+            {
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter, operation,
+                    "the uniform-row hierarchical collective payload has an "
+                    "invalid row count");
+            }
+        }
+
+        [[nodiscard]] std::size_t row_width() const
+        {
+            HPX_ASSERT(is_valid());
+            return num_rows == 0 ? 0 : data.size() / num_rows;
+        }
+
+        [[nodiscard]] uniform_rows extract(
+            std::size_t const slice, std::size_t const num_slices) &
+        {
+            // Communicator finalizers invoke this under the server lock. Each
+            // site consumes a disjoint row range from this carrier.
+            HPX_ASSERT(is_valid());
+            HPX_ASSERT(num_slices != 0 && slice < num_slices);
+
+            std::size_t const division_steps = num_rows / num_slices;
+            std::size_t const remainder = num_rows % num_slices;
+            std::size_t const first_row =
+                slice * division_steps + (std::min) (slice, remainder);
+            std::size_t const row_count =
+                division_steps + (slice < remainder ? 1 : 0);
+            std::size_t const width = row_width();
+            std::size_t const first =
+                checked_data_size_product(first_row, width);
+            std::size_t const count =
+                checked_data_size_product(row_count, width);
+            std::size_t const last = checked_data_size_sum(first, count);
+
+            uniform_rows result;
+            result.data.reserve(count);
+            result.num_rows = row_count;
+            append_data_range(
+                result.data, data.begin() + first, data.begin() + last);
+
+            HPX_ASSERT(result.is_valid());
+            return result;
+        }
+
+        [[nodiscard]] T unwrap_value() &&
+        {
+            HPX_ASSERT(is_valid());
+            HPX_ASSERT(num_rows == 1 && data.size() == 1);
+
             if constexpr (std::is_same_v<T, bool>)
             {
-                destination.push_back(static_cast<bool>(*first));
+                return static_cast<bool>(data.front());
             }
             else
             {
-                destination.emplace_back(HPX_MOVE(*first));
+                return HPX_MOVE(data.front());
             }
         }
-    }
 
-    template <typename T>
-    [[nodiscard]] uniform_rows<T> make_uniform_rows(std::vector<T>&& values)
-    {
-        uniform_rows<T> result;
-        result.data = HPX_MOVE(values);
-        result.num_rows = result.data.size();
-        return result;
-    }
-
-    template <typename T>
-    [[nodiscard]] uniform_rows<T> make_uniform_row(std::vector<T>&& values)
-    {
-        uniform_rows<T> result;
-        result.data = HPX_MOVE(values);
-        result.num_rows = 1;
-        return result;
-    }
-
-    template <typename T>
-    [[nodiscard]] uniform_rows<std::decay_t<T>> make_uniform_value(T&& value)
-    {
-        uniform_rows<std::decay_t<T>> result;
-        result.data.emplace_back(HPX_FORWARD(T, value));
-        result.num_rows = 1;
-        return result;
-    }
-
-    HPX_CXX_EXPORT template <typename T>
-    [[nodiscard]] uniform_rows<T> merge_uniform_rows(
-        std::vector<uniform_rows<T>>&& values)
-    {
-        std::size_t total_size = 0;
-        std::size_t total_rows = 0;
-        std::size_t row_width = 0;
-        bool have_row_width = false;
-
-        for (auto const& value : values)
+        [[nodiscard]] std::vector<T> unwrap_row() &&
         {
-            validate_uniform_rows(
-                value, "hpx::collectives::detail::merge_uniform_rows");
-            total_size = checked_data_size_sum(total_size, value.data.size());
-            total_rows = checked_data_size_sum(total_rows, value.num_rows);
+            HPX_ASSERT(is_valid());
+            HPX_ASSERT(num_rows == 1);
+            return HPX_MOVE(data);
+        }
 
-            if (value.num_rows != 0)
+        std::vector<T> data;
+        std::size_t num_rows = 0;
+
+        template <typename Archive>
+        void serialize(Archive& ar, unsigned int const)
+        {
+            ar & data & num_rows;
+        }
+
+    private:
+        template <typename Iterator>
+        static void append_data_range(
+            std::vector<T>& destination, Iterator first, Iterator const last)
+        {
+            // Inserting a range can instantiate vector's move-assignment path
+            // even at end(). Append element-wise so internal carriers require
+            // only move construction. vector<bool> additionally needs proxy
+            // conversion.
+            for (; first != last; ++first)
             {
-                std::size_t const current_width = uniform_row_width(value);
-                if (have_row_width && current_width != row_width)
+                if constexpr (std::is_same_v<T, bool>)
                 {
-                    HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
-                        "hpx::collectives::detail::merge_uniform_rows",
-                        "all uniform hierarchical collective rows must "
-                        "have the same width");
+                    destination.push_back(static_cast<bool>(*first));
                 }
-                row_width = current_width;
-                have_row_width = true;
+                else
+                {
+                    destination.emplace_back(HPX_MOVE(*first));
+                }
             }
         }
-
-        uniform_rows<T> result;
-        result.data.reserve(total_size);
-        result.num_rows = total_rows;
-        for (auto& value : values)
-        {
-            append_data_range(
-                result.data, value.data.begin(), value.data.end());
-        }
-
-        HPX_ASSERT(is_valid_uniform_rows(result));
-        return result;
-    }
-
-    HPX_CXX_EXPORT template <typename T>
-    [[nodiscard]] uniform_rows<T> extract_uniform_rows(uniform_rows<T>& value,
-        std::size_t const slice, std::size_t const num_slices)
-    {
-        // Communicator finalizers invoke this under the server lock. Each site
-        // consumes a disjoint row range from value.
-        HPX_ASSERT(is_valid_uniform_rows(value));
-        HPX_ASSERT(num_slices != 0 && slice < num_slices);
-
-        std::size_t const division_steps = value.num_rows / num_slices;
-        std::size_t const remainder = value.num_rows % num_slices;
-        std::size_t const first_row =
-            slice * division_steps + (std::min) (slice, remainder);
-        std::size_t const row_count =
-            division_steps + (slice < remainder ? 1 : 0);
-        std::size_t const row_width = uniform_row_width(value);
-        std::size_t const first =
-            checked_data_size_product(first_row, row_width);
-        std::size_t const count =
-            checked_data_size_product(row_count, row_width);
-        std::size_t const last = checked_data_size_sum(first, count);
-
-        uniform_rows<T> result;
-        result.data.reserve(count);
-        result.num_rows = row_count;
-        append_data_range(
-            result.data, value.data.begin() + first, value.data.begin() + last);
-
-        HPX_ASSERT(is_valid_uniform_rows(result));
-        return result;
-    }
+    };
 
     template <typename T>
-    [[nodiscard]] T unwrap_uniform_value(uniform_rows<T>&& value)
+    struct is_uniform_rows : std::false_type
     {
-        HPX_ASSERT(is_valid_uniform_rows(value));
-        HPX_ASSERT(value.num_rows == 1 && value.data.size() == 1);
-
-        if constexpr (std::is_same_v<T, bool>)
-        {
-            return static_cast<bool>(value.data.front());
-        }
-        else
-        {
-            return HPX_MOVE(value.data.front());
-        }
-    }
+    };
 
     template <typename T>
-    [[nodiscard]] std::vector<T> unwrap_uniform_row(uniform_rows<T>&& value)
+    struct is_uniform_rows<uniform_rows<T>> : std::true_type
     {
-        HPX_ASSERT(is_valid_uniform_rows(value));
-        HPX_ASSERT(value.num_rows == 1);
-        return HPX_MOVE(value.data);
-    }
+    };
+
+    template <typename T>
+    inline constexpr bool is_uniform_rows_v =
+        is_uniform_rows<std::decay_t<T>>::value;
+
+    // Distinguishes the internal row scatter protocol from an ordinary scatter
+    // whose user value type happens to be uniform_rows<T>.
+    struct uniform_scatter_tag
+    {
+    };
 
 }    // namespace hpx::collectives::detail

--- a/libs/full/collectives/include/hpx/collectives/detail/flattened_data.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/flattened_data.hpp
@@ -65,39 +65,40 @@ namespace hpx::collectives::detail {
 
         uniform_rows(
             std::vector<T>&& values, std::size_t const num_rows) noexcept
-          : data(HPX_MOVE(values))
-          , num_rows(num_rows)
+          : data_(HPX_MOVE(values))
+          , num_rows_(num_rows)
         {
+            HPX_ASSERT(is_valid());
         }
 
         explicit uniform_rows(std::vector<T>&& values) noexcept
-          : data(HPX_MOVE(values))
-          , num_rows(data.size())
+          : data_(HPX_MOVE(values))
+          , num_rows_(data_.size())
         {
         }
 
         template <typename Iterator>
         uniform_rows(
             std::size_t const num_rows, Iterator first, Iterator const last)
-          : num_rows(num_rows)
+          : num_rows_(num_rows)
         {
             auto const size = std::distance(first, last);
             HPX_ASSERT(size >= 0);
-            data.reserve(static_cast<std::size_t>(size));
-            append_data_range(data, first, last);
+            data_.reserve(static_cast<std::size_t>(size));
+            append_data_range(data_, first, last);
             HPX_ASSERT(is_valid());
         }
 
         explicit uniform_rows(T const& value)
-          : num_rows(1)
+          : num_rows_(1)
         {
-            data.emplace_back(value);
+            data_.emplace_back(value);
         }
 
         explicit uniform_rows(T&& value)
-          : num_rows(1)
+          : num_rows_(1)
         {
-            data.emplace_back(HPX_MOVE(value));
+            data_.emplace_back(HPX_MOVE(value));
         }
 
         explicit uniform_rows(std::vector<uniform_rows<T>>&& values)
@@ -108,8 +109,8 @@ namespace hpx::collectives::detail {
             if (values.size() == 1)
             {
                 values.front().validate(operation);
-                data = HPX_MOVE(values.front().data);
-                num_rows = values.front().num_rows;
+                data_ = HPX_MOVE(values.front().data_);
+                num_rows_ = values.front().num_rows_;
                 return;
             }
 
@@ -122,10 +123,10 @@ namespace hpx::collectives::detail {
             {
                 value.validate(operation);
                 total_size =
-                    checked_data_size_sum(total_size, value.data.size());
-                total_rows = checked_data_size_sum(total_rows, value.num_rows);
+                    checked_data_size_sum(total_size, value.data_.size());
+                total_rows = checked_data_size_sum(total_rows, value.num_rows_);
 
-                if (value.num_rows != 0)
+                if (value.num_rows_ != 0)
                 {
                     std::size_t const current_row_width = value.row_width();
                     if (have_row_width &&
@@ -141,11 +142,12 @@ namespace hpx::collectives::detail {
                 }
             }
 
-            data.reserve(total_size);
-            num_rows = total_rows;
+            data_.reserve(total_size);
+            num_rows_ = total_rows;
             for (auto& value : values)
             {
-                append_data_range(data, value.data.begin(), value.data.end());
+                append_data_range(
+                    data_, value.data_.begin(), value.data_.end());
             }
 
             HPX_ASSERT(is_valid());
@@ -153,7 +155,8 @@ namespace hpx::collectives::detail {
 
         [[nodiscard]] bool is_valid() const noexcept
         {
-            return num_rows == 0 ? data.empty() : data.size() % num_rows == 0;
+            return num_rows_ == 0 ? data_.empty() :
+                                    data_.size() % num_rows_ == 0;
         }
 
         void validate(char const* const operation) const
@@ -169,11 +172,11 @@ namespace hpx::collectives::detail {
         [[nodiscard]] std::size_t row_width() const
         {
             HPX_ASSERT(is_valid());
-            return num_rows == 0 ? 0 : data.size() / num_rows;
+            return num_rows_ == 0 ? 0 : data_.size() / num_rows_;
         }
 
         [[nodiscard]] uniform_rows extract(
-            std::size_t const slice, std::size_t const num_slices) &
+            std::size_t const slice, std::size_t const num_slices) &&
         {
             // This deliberately moves the selected elements out of the
             // carrier. Communicator finalizers invoke this under the server
@@ -181,8 +184,8 @@ namespace hpx::collectives::detail {
             HPX_ASSERT(is_valid());
             HPX_ASSERT(num_slices != 0 && slice < num_slices);
 
-            std::size_t const division_steps = num_rows / num_slices;
-            std::size_t const remainder = num_rows % num_slices;
+            std::size_t const division_steps = num_rows_ / num_slices;
+            std::size_t const remainder = num_rows_ % num_slices;
             std::size_t const first_row =
                 slice * division_steps + (std::min) (slice, remainder);
             std::size_t const row_count =
@@ -195,41 +198,53 @@ namespace hpx::collectives::detail {
             std::size_t const last = checked_data_size_sum(first, count);
 
             return uniform_rows(
-                row_count, data.begin() + first, data.begin() + last);
+                row_count, data_.begin() + first, data_.begin() + last);
         }
 
         [[nodiscard]] T unwrap_value() &&
         {
             HPX_ASSERT(is_valid());
-            HPX_ASSERT(num_rows == 1 && data.size() == 1);
+            HPX_ASSERT(num_rows_ == 1 && data_.size() == 1);
 
-            return handle_bool<T>(HPX_MOVE(data.front()));
+            return handle_bool<T>(HPX_MOVE(data_.front()));
         }
 
         [[nodiscard]] std::vector<T> unwrap_row() &&
         {
             HPX_ASSERT(is_valid());
-            HPX_ASSERT(num_rows == 1);
-            return HPX_MOVE(data);
+            HPX_ASSERT(num_rows_ == 1);
+            return HPX_MOVE(data_);
         }
 
         [[nodiscard]] std::vector<T> unwrap_values() &&
         {
             HPX_ASSERT(is_valid());
-            HPX_ASSERT(num_rows == data.size());
-            return HPX_MOVE(data);
+            HPX_ASSERT(num_rows_ == data_.size());
+            return HPX_MOVE(data_);
         }
 
-        std::vector<T> data;
-        std::size_t num_rows = 0;
+        [[nodiscard]] std::vector<T> const& data() const noexcept
+        {
+            return data_;
+        }
+
+        [[nodiscard]] std::size_t num_rows() const noexcept
+        {
+            return num_rows_;
+        }
+
+    private:
+        friend class hpx::serialization::access;
+
+        std::vector<T> data_;
+        std::size_t num_rows_ = 0;
 
         template <typename Archive>
         void serialize(Archive& ar, unsigned int const)
         {
-            ar & data & num_rows;
+            ar & data_ & num_rows_;
         }
 
-    private:
         template <typename Iterator>
         static void append_data_range(
             std::vector<T>& destination, Iterator first, Iterator const last)

--- a/libs/full/collectives/include/hpx/collectives/detail/flattened_data.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/flattened_data.hpp
@@ -11,11 +11,13 @@
 #include <hpx/config.hpp>
 
 #include <hpx/assert.hpp>
+#include <hpx/collectives/detail/hierarchical_helpers.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/serialization.hpp>
 
 #include <algorithm>
 #include <cstddef>
+#include <iterator>
 #include <limits>
 #include <type_traits>
 #include <utility>
@@ -61,16 +63,29 @@ namespace hpx::collectives::detail {
     {
         uniform_rows() = default;
 
-        uniform_rows(std::vector<T>&& values, std::size_t const num_rows)
+        uniform_rows(
+            std::vector<T>&& values, std::size_t const num_rows) noexcept
           : data(HPX_MOVE(values))
           , num_rows(num_rows)
         {
         }
 
-        explicit uniform_rows(std::vector<T>&& values)
+        explicit uniform_rows(std::vector<T>&& values) noexcept
           : data(HPX_MOVE(values))
           , num_rows(data.size())
         {
+        }
+
+        template <typename Iterator>
+        uniform_rows(
+            std::size_t const num_rows, Iterator first, Iterator const last)
+          : num_rows(num_rows)
+        {
+            auto const size = std::distance(first, last);
+            HPX_ASSERT(size >= 0);
+            data.reserve(static_cast<std::size_t>(size));
+            append_data_range(data, first, last);
+            HPX_ASSERT(is_valid());
         }
 
         explicit uniform_rows(T const& value)
@@ -160,8 +175,9 @@ namespace hpx::collectives::detail {
         [[nodiscard]] uniform_rows extract(
             std::size_t const slice, std::size_t const num_slices) &
         {
-            // Communicator finalizers invoke this under the server lock. Each
-            // site consumes a disjoint row range from this carrier.
+            // This deliberately moves the selected elements out of the
+            // carrier. Communicator finalizers invoke this under the server
+            // lock, and each site consumes a disjoint row range exactly once.
             HPX_ASSERT(is_valid());
             HPX_ASSERT(num_slices != 0 && slice < num_slices);
 
@@ -178,14 +194,8 @@ namespace hpx::collectives::detail {
                 checked_data_size_product(row_count, width);
             std::size_t const last = checked_data_size_sum(first, count);
 
-            uniform_rows result;
-            result.data.reserve(count);
-            result.num_rows = row_count;
-            append_data_range(
-                result.data, data.begin() + first, data.begin() + last);
-
-            HPX_ASSERT(result.is_valid());
-            return result;
+            return uniform_rows(
+                row_count, data.begin() + first, data.begin() + last);
         }
 
         [[nodiscard]] T unwrap_value() &&
@@ -193,14 +203,7 @@ namespace hpx::collectives::detail {
             HPX_ASSERT(is_valid());
             HPX_ASSERT(num_rows == 1 && data.size() == 1);
 
-            if constexpr (std::is_same_v<T, bool>)
-            {
-                return static_cast<bool>(data.front());
-            }
-            else
-            {
-                return HPX_MOVE(data.front());
-            }
+            return handle_bool<T>(HPX_MOVE(data.front()));
         }
 
         [[nodiscard]] std::vector<T> unwrap_row() &&
@@ -237,14 +240,7 @@ namespace hpx::collectives::detail {
             // conversion.
             for (; first != last; ++first)
             {
-                if constexpr (std::is_same_v<T, bool>)
-                {
-                    destination.push_back(static_cast<bool>(*first));
-                }
-                else
-                {
-                    destination.emplace_back(HPX_MOVE(*first));
-                }
+                destination.emplace_back(handle_bool<T>(HPX_MOVE(*first)));
             }
         }
     };

--- a/libs/full/collectives/include/hpx/collectives/detail/flattened_data.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/flattened_data.hpp
@@ -25,7 +25,7 @@
 
 namespace hpx::collectives::detail {
 
-    [[nodiscard]] inline std::size_t checked_data_size_sum(
+    HPX_CXX_EXPORT [[nodiscard]] inline std::size_t checked_data_size_sum(
         std::size_t const lhs, std::size_t const rhs)
     {
         constexpr std::size_t max_size =
@@ -40,7 +40,7 @@ namespace hpx::collectives::detail {
         return lhs + rhs;
     }
 
-    [[nodiscard]] inline std::size_t checked_data_size_product(
+    HPX_CXX_EXPORT [[nodiscard]] inline std::size_t checked_data_size_product(
         std::size_t const lhs, std::size_t const rhs)
     {
         constexpr std::size_t max_size =
@@ -58,7 +58,7 @@ namespace hpx::collectives::detail {
     // A compact carrier for equally sized logical rows. Gather and scatter
     // preserve a uniform row width, so a row count is sufficient to derive
     // every boundary without allocating or serializing an offset table.
-    template <typename T>
+    HPX_CXX_EXPORT template <typename T>
     struct uniform_rows
     {
         uniform_rows() = default;
@@ -270,7 +270,7 @@ namespace hpx::collectives::detail {
     {
     };
 
-    template <typename T>
+    HPX_CXX_EXPORT template <typename T>
     inline constexpr bool is_uniform_rows_v =
         is_uniform_rows<std::decay_t<T>>::value;
 

--- a/libs/full/collectives/include/hpx/collectives/detail/flattened_data.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/flattened_data.hpp
@@ -259,10 +259,4 @@ namespace hpx::collectives::detail {
     inline constexpr bool is_uniform_rows_v =
         is_uniform_rows<std::decay_t<T>>::value;
 
-    // Distinguishes the internal row scatter protocol from an ordinary scatter
-    // whose user value type happens to be uniform_rows<T>.
-    struct uniform_scatter_tag
-    {
-    };
-
 }    // namespace hpx::collectives::detail

--- a/libs/full/collectives/include/hpx/collectives/detail/flattened_data.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/flattened_data.hpp
@@ -25,7 +25,7 @@
 
 namespace hpx::collectives::detail {
 
-    HPX_CXX_EXPORT [[nodiscard]] inline std::size_t checked_data_size_sum(
+    [[nodiscard]] inline std::size_t checked_data_size_sum(
         std::size_t const lhs, std::size_t const rhs)
     {
         constexpr std::size_t max_size =
@@ -40,7 +40,7 @@ namespace hpx::collectives::detail {
         return lhs + rhs;
     }
 
-    HPX_CXX_EXPORT [[nodiscard]] inline std::size_t checked_data_size_product(
+    [[nodiscard]] inline std::size_t checked_data_size_product(
         std::size_t const lhs, std::size_t const rhs)
     {
         constexpr std::size_t max_size =
@@ -58,7 +58,7 @@ namespace hpx::collectives::detail {
     // A compact carrier for equally sized logical rows. Gather and scatter
     // preserve a uniform row width, so a row count is sufficient to derive
     // every boundary without allocating or serializing an offset table.
-    HPX_CXX_EXPORT template <typename T>
+    template <typename T>
     struct uniform_rows
     {
         uniform_rows() = default;

--- a/libs/full/collectives/include/hpx/collectives/detail/flattened_data.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/flattened_data.hpp
@@ -210,6 +210,13 @@ namespace hpx::collectives::detail {
             return HPX_MOVE(data);
         }
 
+        [[nodiscard]] std::vector<T> unwrap_values() &&
+        {
+            HPX_ASSERT(is_valid());
+            HPX_ASSERT(num_rows == data.size());
+            return HPX_MOVE(data);
+        }
+
         std::vector<T> data;
         std::size_t num_rows = 0;
 

--- a/libs/full/collectives/include/hpx/collectives/detail/flattened_data.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/flattened_data.hpp
@@ -1,0 +1,266 @@
+//  Copyright (c) 2026 Anshuman Agrawal
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file detail/flattened_data.hpp
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#include <hpx/assert.hpp>
+#include <hpx/modules/errors.hpp>
+#include <hpx/modules/serialization.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <limits>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace hpx::collectives::detail {
+
+    // A compact carrier for equally sized logical rows. Gather and scatter
+    // preserve a uniform row width, so a row count is sufficient to derive
+    // every boundary without allocating or serializing an offset table.
+    HPX_CXX_EXPORT template <typename T>
+    struct uniform_rows
+    {
+        std::vector<T> data;
+        std::size_t num_rows = 0;
+
+        template <typename Archive>
+        void serialize(Archive& ar, unsigned int const)
+        {
+            ar & data & num_rows;
+        }
+    };
+
+    template <typename T>
+    struct is_uniform_rows : std::false_type
+    {
+    };
+
+    template <typename T>
+    struct is_uniform_rows<uniform_rows<T>> : std::true_type
+    {
+    };
+
+    template <typename T>
+    inline constexpr bool is_uniform_rows_v =
+        is_uniform_rows<std::decay_t<T>>::value;
+
+    // Distinguishes the internal row scatter protocol from an ordinary scatter
+    // whose user value type happens to be uniform_rows<T>.
+    struct uniform_scatter_tag
+    {
+    };
+
+    HPX_CXX_EXPORT [[nodiscard]] inline std::size_t checked_data_size_sum(
+        std::size_t const lhs, std::size_t const rhs)
+    {
+        constexpr std::size_t max_size =
+            (std::numeric_limits<std::size_t>::max)();
+        if (rhs > max_size - lhs)
+        {
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "hpx::collectives::detail::checked_data_size_sum",
+                "the hierarchical collective payload size "
+                "overflows size_t");
+        }
+        return lhs + rhs;
+    }
+
+    HPX_CXX_EXPORT [[nodiscard]] inline std::size_t checked_data_size_product(
+        std::size_t const lhs, std::size_t const rhs)
+    {
+        constexpr std::size_t max_size =
+            (std::numeric_limits<std::size_t>::max)();
+        if (rhs != 0 && lhs > max_size / rhs)
+        {
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "hpx::collectives::detail::checked_data_size_product",
+                "the hierarchical collective payload size "
+                "overflows size_t");
+        }
+        return lhs * rhs;
+    }
+
+    HPX_CXX_EXPORT template <typename T>
+    [[nodiscard]] bool is_valid_uniform_rows(
+        uniform_rows<T> const& value) noexcept
+    {
+        return value.num_rows == 0 ? value.data.empty() :
+                                     value.data.size() % value.num_rows == 0;
+    }
+
+    HPX_CXX_EXPORT template <typename T>
+    void validate_uniform_rows(
+        uniform_rows<T> const& value, char const* const operation)
+    {
+        if (!is_valid_uniform_rows(value))
+        {
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter, operation,
+                "the uniform-row hierarchical collective payload has an "
+                "invalid row count");
+        }
+    }
+
+    template <typename T>
+    [[nodiscard]] std::size_t uniform_row_width(uniform_rows<T> const& value)
+    {
+        HPX_ASSERT(is_valid_uniform_rows(value));
+        return value.num_rows == 0 ? 0 : value.data.size() / value.num_rows;
+    }
+
+    template <typename T, typename Iterator>
+    void append_data_range(
+        std::vector<T>& destination, Iterator first, Iterator const last)
+    {
+        // Inserting a range can instantiate vector's move-assignment path even
+        // at end(). Append element-wise so the internal carriers require only
+        // move construction. vector<bool> additionally needs proxy conversion.
+        for (; first != last; ++first)
+        {
+            if constexpr (std::is_same_v<T, bool>)
+            {
+                destination.push_back(static_cast<bool>(*first));
+            }
+            else
+            {
+                destination.emplace_back(HPX_MOVE(*first));
+            }
+        }
+    }
+
+    template <typename T>
+    [[nodiscard]] uniform_rows<T> make_uniform_rows(std::vector<T>&& values)
+    {
+        uniform_rows<T> result;
+        result.data = HPX_MOVE(values);
+        result.num_rows = result.data.size();
+        return result;
+    }
+
+    template <typename T>
+    [[nodiscard]] uniform_rows<T> make_uniform_row(std::vector<T>&& values)
+    {
+        uniform_rows<T> result;
+        result.data = HPX_MOVE(values);
+        result.num_rows = 1;
+        return result;
+    }
+
+    template <typename T>
+    [[nodiscard]] uniform_rows<std::decay_t<T>> make_uniform_value(T&& value)
+    {
+        uniform_rows<std::decay_t<T>> result;
+        result.data.emplace_back(HPX_FORWARD(T, value));
+        result.num_rows = 1;
+        return result;
+    }
+
+    HPX_CXX_EXPORT template <typename T>
+    [[nodiscard]] uniform_rows<T> merge_uniform_rows(
+        std::vector<uniform_rows<T>>&& values)
+    {
+        std::size_t total_size = 0;
+        std::size_t total_rows = 0;
+        std::size_t row_width = 0;
+        bool have_row_width = false;
+
+        for (auto const& value : values)
+        {
+            validate_uniform_rows(
+                value, "hpx::collectives::detail::merge_uniform_rows");
+            total_size = checked_data_size_sum(total_size, value.data.size());
+            total_rows = checked_data_size_sum(total_rows, value.num_rows);
+
+            if (value.num_rows != 0)
+            {
+                std::size_t const current_width = uniform_row_width(value);
+                if (have_row_width && current_width != row_width)
+                {
+                    HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                        "hpx::collectives::detail::merge_uniform_rows",
+                        "all uniform hierarchical collective rows must "
+                        "have the same width");
+                }
+                row_width = current_width;
+                have_row_width = true;
+            }
+        }
+
+        uniform_rows<T> result;
+        result.data.reserve(total_size);
+        result.num_rows = total_rows;
+        for (auto& value : values)
+        {
+            append_data_range(
+                result.data, value.data.begin(), value.data.end());
+        }
+
+        HPX_ASSERT(is_valid_uniform_rows(result));
+        return result;
+    }
+
+    HPX_CXX_EXPORT template <typename T>
+    [[nodiscard]] uniform_rows<T> extract_uniform_rows(uniform_rows<T>& value,
+        std::size_t const slice, std::size_t const num_slices)
+    {
+        // Communicator finalizers invoke this under the server lock. Each site
+        // consumes a disjoint row range from value.
+        HPX_ASSERT(is_valid_uniform_rows(value));
+        HPX_ASSERT(num_slices != 0 && slice < num_slices);
+
+        std::size_t const division_steps = value.num_rows / num_slices;
+        std::size_t const remainder = value.num_rows % num_slices;
+        std::size_t const first_row =
+            slice * division_steps + (std::min) (slice, remainder);
+        std::size_t const row_count =
+            division_steps + (slice < remainder ? 1 : 0);
+        std::size_t const row_width = uniform_row_width(value);
+        std::size_t const first =
+            checked_data_size_product(first_row, row_width);
+        std::size_t const count =
+            checked_data_size_product(row_count, row_width);
+        std::size_t const last = checked_data_size_sum(first, count);
+
+        uniform_rows<T> result;
+        result.data.reserve(count);
+        result.num_rows = row_count;
+        append_data_range(
+            result.data, value.data.begin() + first, value.data.begin() + last);
+
+        HPX_ASSERT(is_valid_uniform_rows(result));
+        return result;
+    }
+
+    template <typename T>
+    [[nodiscard]] T unwrap_uniform_value(uniform_rows<T>&& value)
+    {
+        HPX_ASSERT(is_valid_uniform_rows(value));
+        HPX_ASSERT(value.num_rows == 1 && value.data.size() == 1);
+
+        if constexpr (std::is_same_v<T, bool>)
+        {
+            return static_cast<bool>(value.data.front());
+        }
+        else
+        {
+            return HPX_MOVE(value.data.front());
+        }
+    }
+
+    template <typename T>
+    [[nodiscard]] std::vector<T> unwrap_uniform_row(uniform_rows<T>&& value)
+    {
+        HPX_ASSERT(is_valid_uniform_rows(value));
+        HPX_ASSERT(value.num_rows == 1);
+        return HPX_MOVE(value.data);
+    }
+
+}    // namespace hpx::collectives::detail

--- a/libs/full/collectives/include/hpx/collectives/gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/gather.hpp
@@ -412,6 +412,7 @@ namespace hpx { namespace collectives {
 
 #include <hpx/collectives/argument_types.hpp>
 #include <hpx/collectives/create_communicator.hpp>
+#include <hpx/collectives/detail/flattened_data.hpp>
 #include <hpx/collectives/detail/hierarchical_helpers.hpp>
 
 #include <cstddef>
@@ -442,17 +443,40 @@ namespace hpx::traits {
             std::size_t generation,
             hpx::collectives::detail::generation_mode num_generations, T&& t)
         {
-            return communicator.template handle_data<std::decay_t<T>>(
-                communication::communicator_data<
-                    communication::gather_tag>::name(),
-                which, generation,
-                // step function (invoked once for get)
-                [&t](auto& data, std::size_t which) {
-                    data[which] = HPX_FORWARD(T, t);
-                },
-                // finalizer (invoked once after all data has been received)
-                [](auto& data, bool&, std::size_t) { return HPX_MOVE(data); },
-                num_generations);
+            using payload_type = std::decay_t<T>;
+            constexpr bool uniform_result =
+                hpx::collectives::detail::is_uniform_rows_v<payload_type> &&
+                std::is_same_v<typename Result::result_type, payload_type>;
+
+            if constexpr (uniform_result)
+            {
+                return communicator.template handle_data<payload_type>(
+                    communication::communicator_data<
+                        communication::gather_tag>::name(),
+                    which, generation,
+                    [&t](auto& data, std::size_t which) {
+                        data[which] = HPX_FORWARD(T, t);
+                    },
+                    [](auto& data, bool&, std::size_t) {
+                        return hpx::collectives::detail::merge_uniform_rows(
+                            HPX_MOVE(data));
+                    },
+                    num_generations);
+            }
+            else
+            {
+                return communicator.template handle_data<payload_type>(
+                    communication::communicator_data<
+                        communication::gather_tag>::name(),
+                    which, generation,
+                    [&t](auto& data, std::size_t which) {
+                        data[which] = HPX_FORWARD(T, t);
+                    },
+                    [](auto& data, bool&, std::size_t) {
+                        return HPX_MOVE(data);
+                    },
+                    num_generations);
+            }
         }
 
         template <typename Result, typename T>
@@ -460,7 +484,8 @@ namespace hpx::traits {
             std::size_t generation,
             hpx::collectives::detail::generation_mode num_generations, T&& t)
         {
-            return communicator.template handle_data<std::decay_t<T>>(
+            using payload_type = std::decay_t<T>;
+            return communicator.template handle_data<payload_type>(
                 communication::communicator_data<
                     communication::gather_tag>::name(),
                 which, generation,
@@ -484,12 +509,18 @@ namespace hpx::collectives {
         // step. The public overload forwards with single_step; the hierarchical
         // gather_here walks its sub-communicators through this entry with the
         // mapped step.
-        template <typename T>
-        hpx::future<std::vector<std::decay_t<T>>> gather_here(communicator fid,
-            T&& local_result, this_site_arg this_site,
-            generation_arg generation, generation_mode num_generations)
+        template <typename Result, typename T>
+        hpx::future<Result> gather_here_impl(communicator fid, T&& local_result,
+            this_site_arg this_site, generation_arg generation,
+            generation_mode num_generations)
         {
-            using arg_type = std::decay_t<T>;
+            using payload_type = std::decay_t<T>;
+            constexpr bool uniform_result = is_uniform_rows_v<Result>;
+
+            if constexpr (uniform_result)
+            {
+                static_assert(std::is_same_v<Result, payload_type>);
+            }
 
             if (this_site.is_default())
             {
@@ -497,10 +528,9 @@ namespace hpx::collectives {
             }
             if (generation == 0)
             {
-                return hpx::make_exceptional_future<std::vector<arg_type>>(
-                    HPX_GET_EXCEPTION(hpx::error::bad_parameter,
-                        "hpx::collectives::gather_here",
-                        "the generation number shouldn't be zero"));
+                return hpx::make_exceptional_future<Result>(HPX_GET_EXCEPTION(
+                    hpx::error::bad_parameter, "hpx::collectives::gather_here",
+                    "the generation number shouldn't be zero"));
             }
 
             // Handle operation right away if there is only one value.
@@ -508,30 +538,38 @@ namespace hpx::collectives {
             {
                 if (this_site != comm_site)
                 {
-                    return hpx::make_exceptional_future<std::vector<arg_type>>(
+                    return hpx::make_exceptional_future<Result>(
                         HPX_GET_EXCEPTION(hpx::error::bad_parameter,
                             "hpx::collectives::gather_here",
                             "the local site should be zero if only one site is "
                             "involved"));
                 }
 
-                std::vector<arg_type> result;
-                result.emplace_back(HPX_FORWARD(T, local_result));
+                Result result;
+                if constexpr (uniform_result)
+                {
+                    validate_uniform_rows(
+                        local_result, "hpx::collectives::gather_here");
+                    result = HPX_FORWARD(T, local_result);
+                }
+                else
+                {
+                    result.emplace_back(HPX_FORWARD(T, local_result));
+                }
                 return hpx::make_ready_future(HPX_MOVE(result));
             }
 
             auto gather_here_data =
                 [local_result = HPX_FORWARD(T, local_result), this_site,
-                    generation, num_generations](communicator&& c) mutable
-                -> hpx::future<std::vector<arg_type>> {
+                    generation, num_generations](
+                    communicator&& c) mutable -> hpx::future<Result> {
                 using action_type =
                     communicator_server::communication_get_direct_action<
-                        traits::communication::gather_tag,
-                        hpx::future<std::vector<arg_type>>, generation_mode,
-                        arg_type>;
+                        traits::communication::gather_tag, hpx::future<Result>,
+                        generation_mode, payload_type>;
 
                 // explicitly unwrap returned future
-                hpx::future<std::vector<arg_type>> result =
+                hpx::future<Result> result =
                     hpx::async(action_type(), c, this_site, generation,
                         num_generations, HPX_MOVE(local_result));
 
@@ -556,8 +594,9 @@ namespace hpx::collectives {
         T&& local_result, this_site_arg this_site = this_site_arg(),
         generation_arg generation = generation_arg())
     {
-        return detail::gather_here(HPX_MOVE(fid), HPX_FORWARD(T, local_result),
-            this_site, generation, detail::generation_mode::single_step);
+        return detail::gather_here_impl<std::vector<std::decay_t<T>>>(
+            HPX_MOVE(fid), HPX_FORWARD(T, local_result), this_site, generation,
+            detail::generation_mode::single_step);
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -630,17 +669,23 @@ namespace hpx::collectives {
             auto const [run_gen, run_step] =
                 hierarchical_run_params(generation, num_generations);
 
-            std::vector<std::decay_t<T>> result;
-            result.emplace_back(HPX_FORWARD(T, local_result));
+            using value_type = std::decay_t<T>;
+            uniform_rows<value_type> result =
+                make_uniform_value(HPX_FORWARD(T, local_result));
             for (std::size_t i = communicators.size() - 1; i != 0; --i)
             {
-                result = gather_data(gather_here(communicators.get(i),
-                    HPX_MOVE(result), this_site_arg(0), run_gen, run_step)
-                        .get());
+                result = gather_here_impl<uniform_rows<value_type>>(
+                    communicators.get(i), HPX_MOVE(result), this_site_arg(0),
+                    run_gen, run_step)
+                             .get();
             }
 
-            return gather_data(gather_here(communicators.get(0),
-                HPX_MOVE(result), this_site_arg(0), run_gen, run_step));
+            return hpx::make_future<std::vector<value_type>>(
+                gather_here_impl<uniform_rows<value_type>>(communicators.get(0),
+                    HPX_MOVE(result), this_site_arg(0), run_gen, run_step),
+                [](uniform_rows<value_type>&& data) {
+                    return HPX_MOVE(data.data);
+                });
         }
     }    // namespace detail
 
@@ -804,13 +849,15 @@ namespace hpx::collectives {
             auto const [run_gen, run_step] =
                 hierarchical_run_params(generation, num_generations);
 
-            std::vector<std::decay_t<T>> data;
-            data.emplace_back(HPX_FORWARD(T, local_result));
+            using value_type = std::decay_t<T>;
+            uniform_rows<value_type> data =
+                make_uniform_value(HPX_FORWARD(T, local_result));
             for (std::size_t i = communicators.size() - 1; i != 0; --i)
             {
-                data = gather_data(gather_here(communicators.get(i),
-                    HPX_MOVE(data), this_site_arg(0), run_gen, run_step)
-                        .get());
+                data = gather_here_impl<uniform_rows<value_type>>(
+                    communicators.get(i), HPX_MOVE(data), this_site_arg(0),
+                    run_gen, run_step)
+                           .get();
             }
 
             return gather_there(communicators.get(0), HPX_MOVE(data),

--- a/libs/full/collectives/include/hpx/collectives/gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/gather.hpp
@@ -444,9 +444,10 @@ namespace hpx::traits {
             hpx::collectives::detail::generation_mode num_generations, T&& t)
         {
             using payload_type = std::decay_t<T>;
+            using result_type = typename Result::result_type;
             constexpr bool uniform_result =
                 hpx::collectives::detail::is_uniform_rows_v<payload_type> &&
-                std::is_same_v<typename Result::result_type, payload_type>;
+                std::is_same_v<result_type, payload_type>;
 
             if constexpr (uniform_result)
             {
@@ -458,8 +459,7 @@ namespace hpx::traits {
                         data[which] = HPX_FORWARD(T, t);
                     },
                     [](auto& data, bool&, std::size_t) {
-                        return hpx::collectives::detail::merge_uniform_rows(
-                            HPX_MOVE(data));
+                        return result_type(HPX_MOVE(data));
                     },
                     num_generations);
             }
@@ -548,8 +548,7 @@ namespace hpx::collectives {
                 Result result;
                 if constexpr (uniform_result)
                 {
-                    validate_uniform_rows(
-                        local_result, "hpx::collectives::gather_here");
+                    local_result.validate("hpx::collectives::gather_here");
                     result = HPX_FORWARD(T, local_result);
                 }
                 else
@@ -670,8 +669,7 @@ namespace hpx::collectives {
                 hierarchical_run_params(generation, num_generations);
 
             using value_type = std::decay_t<T>;
-            uniform_rows<value_type> result =
-                make_uniform_value(HPX_FORWARD(T, local_result));
+            uniform_rows<value_type> result(HPX_FORWARD(T, local_result));
             for (std::size_t i = communicators.size() - 1; i != 0; --i)
             {
                 result = gather_here_impl<uniform_rows<value_type>>(
@@ -684,7 +682,7 @@ namespace hpx::collectives {
                 gather_here_impl<uniform_rows<value_type>>(communicators.get(0),
                     HPX_MOVE(result), this_site_arg(0), run_gen, run_step),
                 [](uniform_rows<value_type>&& data) {
-                    return HPX_MOVE(data.data);
+                    return HPX_MOVE(data).unwrap_row();
                 });
         }
     }    // namespace detail
@@ -850,8 +848,7 @@ namespace hpx::collectives {
                 hierarchical_run_params(generation, num_generations);
 
             using value_type = std::decay_t<T>;
-            uniform_rows<value_type> data =
-                make_uniform_value(HPX_FORWARD(T, local_result));
+            uniform_rows<value_type> data(HPX_FORWARD(T, local_result));
             for (std::size_t i = communicators.size() - 1; i != 0; --i)
             {
                 data = gather_here_impl<uniform_rows<value_type>>(

--- a/libs/full/collectives/include/hpx/collectives/gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/gather.hpp
@@ -652,7 +652,7 @@ namespace hpx::collectives {
                 gather_here_impl<uniform_rows<value_type>>(communicators.get(0),
                     HPX_MOVE(result), this_site_arg(0), run_gen, run_step),
                 [](uniform_rows<value_type>&& data) {
-                    return HPX_MOVE(data).unwrap_row();
+                    return HPX_MOVE(data).unwrap_values();
                 });
         }
     }    // namespace detail

--- a/libs/full/collectives/include/hpx/collectives/gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/gather.hpp
@@ -452,9 +452,11 @@ namespace hpx::traits {
                 communication::communicator_data<
                     communication::gather_tag>::name(),
                 which, generation,
+                // step function (invoked once for get)
                 [&t](auto& data, std::size_t which) {
                     data[which] = HPX_FORWARD(T, t);
                 },
+                // finalizer (invoked once after all data has been received)
                 [](auto& data, bool&, std::size_t) -> result_type {
                     return result_type(HPX_MOVE(data));
                 },

--- a/libs/full/collectives/include/hpx/collectives/gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/gather.hpp
@@ -445,38 +445,20 @@ namespace hpx::traits {
         {
             using payload_type = std::decay_t<T>;
             using result_type = typename Result::result_type;
-            constexpr bool uniform_result =
-                hpx::collectives::detail::is_uniform_rows_v<payload_type> &&
-                std::is_same_v<result_type, payload_type>;
+            static_assert(std::is_constructible_v<result_type,
+                std::vector<payload_type>&&>);
 
-            if constexpr (uniform_result)
-            {
-                return communicator.template handle_data<payload_type>(
-                    communication::communicator_data<
-                        communication::gather_tag>::name(),
-                    which, generation,
-                    [&t](auto& data, std::size_t which) {
-                        data[which] = HPX_FORWARD(T, t);
-                    },
-                    [](auto& data, bool&, std::size_t) {
-                        return result_type(HPX_MOVE(data));
-                    },
-                    num_generations);
-            }
-            else
-            {
-                return communicator.template handle_data<payload_type>(
-                    communication::communicator_data<
-                        communication::gather_tag>::name(),
-                    which, generation,
-                    [&t](auto& data, std::size_t which) {
-                        data[which] = HPX_FORWARD(T, t);
-                    },
-                    [](auto& data, bool&, std::size_t) {
-                        return HPX_MOVE(data);
-                    },
-                    num_generations);
-            }
+            return communicator.template handle_data<payload_type>(
+                communication::communicator_data<
+                    communication::gather_tag>::name(),
+                which, generation,
+                [&t](auto& data, std::size_t which) {
+                    data[which] = HPX_FORWARD(T, t);
+                },
+                [](auto& data, bool&, std::size_t) -> result_type {
+                    return result_type(HPX_MOVE(data));
+                },
+                num_generations);
         }
 
         template <typename Result, typename T>
@@ -515,12 +497,8 @@ namespace hpx::collectives {
             generation_mode num_generations)
         {
             using payload_type = std::decay_t<T>;
-            constexpr bool uniform_result = is_uniform_rows_v<Result>;
-
-            if constexpr (uniform_result)
-            {
-                static_assert(std::is_same_v<Result, payload_type>);
-            }
+            static_assert(
+                std::is_constructible_v<Result, std::vector<payload_type>&&>);
 
             if (this_site.is_default())
             {
@@ -545,17 +523,9 @@ namespace hpx::collectives {
                             "involved"));
                 }
 
-                Result result;
-                if constexpr (uniform_result)
-                {
-                    local_result.validate("hpx::collectives::gather_here");
-                    result = HPX_FORWARD(T, local_result);
-                }
-                else
-                {
-                    result.emplace_back(HPX_FORWARD(T, local_result));
-                }
-                return hpx::make_ready_future(HPX_MOVE(result));
+                std::vector<payload_type> values;
+                values.emplace_back(HPX_FORWARD(T, local_result));
+                return hpx::make_ready_future(Result(HPX_MOVE(values)));
             }
 
             auto gather_here_data =

--- a/libs/full/collectives/include/hpx/collectives/scatter.hpp
+++ b/libs/full/collectives/include/hpx/collectives/scatter.hpp
@@ -397,6 +397,7 @@ namespace hpx { namespace collectives {
 
 #include <hpx/collectives/argument_types.hpp>
 #include <hpx/collectives/create_communicator.hpp>
+#include <hpx/collectives/detail/flattened_data.hpp>
 #include <hpx/collectives/detail/hierarchical_helpers.hpp>
 
 #include <cstddef>
@@ -428,14 +429,10 @@ namespace hpx::traits {
             hpx::collectives::detail::generation_mode num_generations)
         {
             using data_type = typename Result::result_type;
-
             return communicator.template handle_data<data_type>(
                 communication::communicator_data<
                     communication::scatter_tag>::name(),
-                which, generation,
-                // step function (invoked once for get)
-                nullptr,
-                // finalizer (invoked after all sites have checked in)
+                which, generation, nullptr,
                 [](auto& data, bool&, std::size_t which) {
                     return hpx::collectives::detail::handle_bool<data_type>(
                         HPX_MOVE(data[which]));
@@ -443,24 +440,68 @@ namespace hpx::traits {
                 num_generations);
         }
 
-        template <typename Result, typename T>
+        template <typename Result>
+        static Result get(Communicator& communicator, std::size_t which,
+            std::size_t generation,
+            hpx::collectives::detail::generation_mode num_generations,
+            hpx::collectives::detail::uniform_scatter_tag)
+        {
+            using data_type = typename Result::result_type;
+            static_assert(
+                hpx::collectives::detail::is_uniform_rows_v<data_type>);
+
+            std::size_t const num_sites = communicator.num_sites_;
+            return communicator.template handle_data<data_type>(
+                communication::communicator_data<
+                    communication::scatter_tag>::name(),
+                which, generation, nullptr,
+                [num_sites](auto& data, bool&, std::size_t which) {
+                    return hpx::collectives::detail::extract_uniform_rows(
+                        data[0], which, num_sites);
+                },
+                num_generations, 1);
+        }
+
+        template <typename Result, typename Payload>
         static Result set(Communicator& communicator, std::size_t which,
             std::size_t generation,
             hpx::collectives::detail::generation_mode num_generations,
-            std::vector<T>&& t)
+            Payload&& t)
         {
-            return communicator.template handle_data<T>(
-                communication::communicator_data<
-                    communication::scatter_tag>::name(),
-                which, generation,
-                // step function (invoked once for set)
-                [&t](auto& data, std::size_t) { data = HPX_MOVE(t); },
-                // finalizer (invoked after all sites have checked in)
-                [](auto& data, bool&, std::size_t which) {
-                    return hpx::collectives::detail::handle_bool<T>(
-                        HPX_MOVE(data[which]));
-                },
-                num_generations);
+            using payload_type = std::decay_t<Payload>;
+            if constexpr (hpx::collectives::detail::is_uniform_rows_v<
+                              payload_type>)
+            {
+                std::size_t const num_sites = communicator.num_sites_;
+                return communicator.template handle_data<payload_type>(
+                    communication::communicator_data<
+                        communication::scatter_tag>::name(),
+                    which, generation,
+                    [&t](auto& data, std::size_t) {
+                        data[0] = HPX_FORWARD(Payload, t);
+                    },
+                    [num_sites](auto& data, bool&, std::size_t which) {
+                        return hpx::collectives::detail::extract_uniform_rows(
+                            data[0], which, num_sites);
+                    },
+                    num_generations, 1);
+            }
+            else
+            {
+                using data_type = typename payload_type::value_type;
+                return communicator.template handle_data<data_type>(
+                    communication::communicator_data<
+                        communication::scatter_tag>::name(),
+                    which, generation,
+                    [&t](auto& data, std::size_t) {
+                        data = HPX_FORWARD(Payload, t);
+                    },
+                    [](auto& data, bool&, std::size_t which) {
+                        return hpx::collectives::detail::handle_bool<data_type>(
+                            HPX_MOVE(data[which]));
+                    },
+                    num_generations);
+            }
         }
     };
 }    // namespace hpx::traits
@@ -475,9 +516,10 @@ namespace hpx::collectives {
         // step. The public overload forwards with single_step; the hierarchical
         // scatter_from walks its sub-communicators through this entry with the
         // mapped step.
-        template <typename T>
-        hpx::future<T> scatter_from(communicator fid, this_site_arg this_site,
-            generation_arg const generation, generation_mode num_generations)
+        template <typename T, bool UseUniformRows = false>
+        hpx::future<T> scatter_from_impl(communicator fid,
+            this_site_arg this_site, generation_arg const generation,
+            generation_mode num_generations)
         {
             if (this_site.is_default())
             {
@@ -492,14 +534,29 @@ namespace hpx::collectives {
 
             auto scatter_from_data = [this_site, generation, num_generations](
                                          communicator&& c) -> hpx::future<T> {
-                using action_type =
-                    communicator_server::communication_get_direct_action<
-                        traits::communication::scatter_tag, hpx::future<T>,
-                        generation_mode>;
-
-                // explicitly unwrap returned future
-                hpx::future<T> result = hpx::async(
-                    action_type(), c, this_site, generation, num_generations);
+                // Explicitly unwrap the returned future. Only the internal
+                // uniform-row protocol adds a tag to the action signature.
+                hpx::future<T> result = [&]() {
+                    if constexpr (UseUniformRows)
+                    {
+                        using action_type = communicator_server::
+                            communication_get_direct_action<
+                                traits::communication::scatter_tag,
+                                hpx::future<T>, generation_mode,
+                                uniform_scatter_tag>;
+                        return hpx::async(action_type(), c, this_site,
+                            generation, num_generations, uniform_scatter_tag{});
+                    }
+                    else
+                    {
+                        using action_type = communicator_server::
+                            communication_get_direct_action<
+                                traits::communication::scatter_tag,
+                                hpx::future<T>, generation_mode>;
+                        return hpx::async(action_type(), c, this_site,
+                            generation, num_generations);
+                    }
+                }();
 
                 if (!result.is_ready())
                 {
@@ -513,6 +570,16 @@ namespace hpx::collectives {
 
             return fid.then(hpx::launch::sync, HPX_MOVE(scatter_from_data));
         }
+
+        template <typename T>
+        hpx::future<uniform_rows<T>> scatter_rows_from(communicator fid,
+            this_site_arg this_site, generation_arg const generation,
+            generation_mode num_generations)
+        {
+            return scatter_from_impl<uniform_rows<T>, true>(
+                HPX_MOVE(fid), this_site, generation, num_generations);
+        }
+
     }    // namespace detail
 
     HPX_CXX_EXPORT template <typename T>
@@ -520,8 +587,8 @@ namespace hpx::collectives {
         this_site_arg this_site = this_site_arg(),
         generation_arg const generation = generation_arg())
     {
-        return detail::scatter_from<T>(HPX_MOVE(fid), this_site, generation,
-            detail::generation_mode::single_step);
+        return detail::scatter_from_impl<T>(HPX_MOVE(fid), this_site,
+            generation, detail::generation_mode::single_step);
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -558,10 +625,62 @@ namespace hpx::collectives {
         // Forward declaration: the flat scatter_to detail entry is defined
         // further down, but the hierarchical scatter_from below walks its
         // sub-communicators through it.
+        template <typename Result, typename Payload>
+        hpx::future<Result> scatter_to_impl(communicator fid,
+            Payload&& local_result, this_site_arg this_site,
+            generation_arg generation, generation_mode num_generations);
+
         template <typename T>
-        hpx::future<T> scatter_to(communicator fid,
-            std::vector<T>&& local_result, this_site_arg this_site,
-            generation_arg const generation, generation_mode num_generations);
+        hpx::future<uniform_rows<T>> scatter_rows_to(communicator fid,
+            uniform_rows<T>&& local_result, this_site_arg this_site,
+            generation_arg generation, generation_mode num_generations);
+
+        // Ordinary communicator storage requires default construction at the
+        // leaf; retain the uniform carrier for payloads without it.
+        template <typename T>
+        hpx::future<T> scatter_leaf_from(communicator fid,
+            this_site_arg this_site, generation_arg generation,
+            generation_mode num_generations)
+        {
+            if constexpr (std::is_default_constructible_v<T>)
+            {
+                return scatter_from_impl<T>(
+                    HPX_MOVE(fid), this_site, generation, num_generations);
+            }
+            else
+            {
+                return hpx::make_future<T>(
+                    scatter_rows_from<T>(
+                        HPX_MOVE(fid), this_site, generation, num_generations),
+                    [](uniform_rows<T>&& result) {
+                        return unwrap_uniform_value(HPX_MOVE(result));
+                    });
+            }
+        }
+
+        template <typename T>
+        hpx::future<T> scatter_leaf_to(communicator fid,
+            uniform_rows<T>&& local_result, this_site_arg this_site,
+            generation_arg generation, generation_mode num_generations)
+        {
+            HPX_ASSERT(local_result.num_rows == local_result.data.size());
+
+            if constexpr (std::is_default_constructible_v<T>)
+            {
+                return scatter_to_impl<T>(HPX_MOVE(fid),
+                    HPX_MOVE(local_result.data), this_site, generation,
+                    num_generations);
+            }
+            else
+            {
+                return hpx::make_future<T>(
+                    scatter_rows_to(HPX_MOVE(fid), HPX_MOVE(local_result),
+                        this_site, generation, num_generations),
+                    [](uniform_rows<T>&& result) {
+                        return unwrap_uniform_value(HPX_MOVE(result));
+                    });
+            }
+        }
 
         // scatter_from over a hierarchical_communicator: detail entry carrying
         // the internal generation step. The public overload forwards with
@@ -594,23 +713,22 @@ namespace hpx::collectives {
             auto [current_communicator, current_site] = communicators[0];
             if (communicators.size() == 1)
             {
-                return scatter_from<T>(
+                return scatter_leaf_from<T>(
                     current_communicator, current_site, run_gen, run_step);
             }
 
-            std::vector<T> data = scatter_from<std::vector<T>>(
+            uniform_rows<T> data = scatter_rows_from<T>(
                 current_communicator, current_site, run_gen, run_step)
-                                      .get();
+                                       .get();
 
             for (std::size_t i = 1; i < communicators.size() - 1; ++i)
             {
-                data = scatter_to(communicators.get(i),
-                    scatter_data(HPX_MOVE(data), communicators.get_arity()),
+                data = scatter_rows_to(communicators.get(i), HPX_MOVE(data),
                     this_site_arg(0), run_gen, run_step)
                            .get();
             }
 
-            return scatter_to(communicators.back(), HPX_MOVE(data),
+            return scatter_leaf_to(communicators.back(), HPX_MOVE(data),
                 this_site_arg(0), run_gen, run_step);
         }
     }    // namespace detail
@@ -690,27 +808,44 @@ namespace hpx::collectives {
         // The public overload forwards with single_step; the hierarchical
         // scatter_to walks its sub-communicators through this entry with the
         // mapped step.
-        template <typename T>
-        hpx::future<T> scatter_to(communicator fid,
-            std::vector<T>&& local_result, this_site_arg this_site,
+        template <typename Result, typename Payload>
+        hpx::future<Result> scatter_to_impl(communicator fid,
+            Payload&& local_result, this_site_arg this_site,
             generation_arg const generation, generation_mode num_generations)
         {
+            using payload_type = std::decay_t<Payload>;
+            constexpr bool uniform_payload = is_uniform_rows_v<payload_type>;
+
             if (this_site.is_default())
             {
                 this_site = agas::get_locality_id();
             }
             if (generation == 0)
             {
-                return hpx::make_exceptional_future<T>(HPX_GET_EXCEPTION(
+                return hpx::make_exceptional_future<Result>(HPX_GET_EXCEPTION(
                     hpx::error::bad_parameter, "hpx::collectives::scatter_to",
                     "the generation number shouldn't be zero"));
             }
 
             auto [num_sites, comm_site] = fid.get_info();
 
-            if (local_result.size() != num_sites)
+            if constexpr (uniform_payload)
             {
-                return hpx::make_exceptional_future<T>(HPX_GET_EXCEPTION(
+                static_assert(std::is_same_v<Result, payload_type>);
+                validate_uniform_rows(
+                    local_result, "hpx::collectives::scatter_to");
+                if (local_result.num_rows < num_sites)
+                {
+                    return hpx::make_exceptional_future<Result>(
+                        HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                            "hpx::collectives::scatter_to",
+                            "the uniform-row payload must contain at least one "
+                            "row per participating site"));
+                }
+            }
+            else if (local_result.size() != num_sites)
+            {
+                return hpx::make_exceptional_future<Result>(HPX_GET_EXCEPTION(
                     hpx::error::bad_parameter, "hpx::collectives::scatter_to",
                     "the number of values to scatter must be equal to the "
                     "number of participating sites"));
@@ -721,14 +856,19 @@ namespace hpx::collectives {
             {
                 if (this_site != comm_site)
                 {
-                    return hpx::make_exceptional_future<T>(
+                    return hpx::make_exceptional_future<Result>(
                         HPX_GET_EXCEPTION(hpx::error::bad_parameter,
                             "hpx::collectives::scatter_to",
                             "the local site should be zero if only one site is "
                             "involved"));
                 }
 
-                if constexpr (std::is_same_v<T, bool>)
+                if constexpr (uniform_payload)
+                {
+                    return hpx::make_ready_future(
+                        HPX_FORWARD(Payload, local_result));
+                }
+                else if constexpr (std::is_same_v<Result, bool>)
                 {
                     return hpx::make_ready_future(
                         static_cast<bool>(local_result[0]));
@@ -740,17 +880,18 @@ namespace hpx::collectives {
             }
 
             auto scatter_to_data =
-                [local_result = HPX_MOVE(local_result), this_site, generation,
-                    num_generations](
-                    communicator&& c) mutable -> hpx::future<T> {
+                [local_result = HPX_FORWARD(Payload, local_result), this_site,
+                    generation, num_generations](
+                    communicator&& c) mutable -> hpx::future<Result> {
                 using action_type =
                     communicator_server::communication_set_direct_action<
-                        traits::communication::scatter_tag, hpx::future<T>,
-                        generation_mode, std::vector<T>>;
+                        traits::communication::scatter_tag, hpx::future<Result>,
+                        generation_mode, payload_type>;
 
                 // explicitly unwrap returned future
-                hpx::future<T> result = hpx::async(action_type(), c, this_site,
-                    generation, num_generations, HPX_MOVE(local_result));
+                hpx::future<Result> result =
+                    hpx::async(action_type(), c, this_site, generation,
+                        num_generations, HPX_MOVE(local_result));
 
                 if (!result.is_ready())
                 {
@@ -764,6 +905,15 @@ namespace hpx::collectives {
 
             return fid.then(hpx::launch::sync, HPX_MOVE(scatter_to_data));
         }
+
+        template <typename T>
+        hpx::future<uniform_rows<T>> scatter_rows_to(communicator fid,
+            uniform_rows<T>&& local_result, this_site_arg this_site,
+            generation_arg const generation, generation_mode num_generations)
+        {
+            return scatter_to_impl<uniform_rows<T>>(HPX_MOVE(fid),
+                HPX_MOVE(local_result), this_site, generation, num_generations);
+        }
     }    // namespace detail
 
     ///////////////////////////////////////////////////////////////////////////
@@ -773,7 +923,7 @@ namespace hpx::collectives {
         this_site_arg this_site = this_site_arg(),
         generation_arg const generation = generation_arg())
     {
-        return detail::scatter_to(HPX_MOVE(fid), HPX_MOVE(local_result),
+        return detail::scatter_to_impl<T>(HPX_MOVE(fid), HPX_MOVE(local_result),
             this_site, generation, detail::generation_mode::single_step);
     }
 
@@ -792,6 +942,16 @@ namespace hpx::collectives {
             if (this_site.is_default())
             {
                 this_site = agas::get_locality_id();
+            }
+
+            if (!is_valid_hierarchical_run_generation(
+                    generation, num_generations))
+            {
+                return hpx::make_exceptional_future<T>(
+                    HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                        "hpx::collectives::scatter_to (hierarchical)",
+                        "the generation number is too large for the internal "
+                        "generation mapping"));
             }
 
             std::size_t const num_sites_val =
@@ -814,41 +974,30 @@ namespace hpx::collectives {
                         "number of participating sites"));
             }
 
-            if (!is_valid_hierarchical_run_generation(
-                    generation, num_generations))
-            {
-                return hpx::make_exceptional_future<T>(
-                    HPX_GET_EXCEPTION(hpx::error::bad_parameter,
-                        "hpx::collectives::scatter_to (hierarchical)",
-                        "the generation number is too large for the internal "
-                        "generation mapping"));
-            }
-
             auto const [run_gen, run_step] =
                 hierarchical_run_params(generation, num_generations);
 
             auto [current_communicator, current_site] = communicators[0];
             if (communicators.size() == 1)
             {
-                return scatter_to(current_communicator, HPX_MOVE(local_result),
-                    current_site, run_gen, run_step);
+                return scatter_leaf_to(current_communicator,
+                    make_uniform_rows(HPX_MOVE(local_result)), current_site,
+                    run_gen, run_step);
             }
 
-            arity_arg arity = communicators.get_arity();
-            std::vector<T> data = scatter_to(communicators.get(0),
-                scatter_data(HPX_MOVE(local_result), arity), this_site_arg(0),
-                run_gen, run_step)
-                                      .get();
+            uniform_rows<T> data = make_uniform_rows(HPX_MOVE(local_result));
+            data = scatter_rows_to(communicators.get(0), HPX_MOVE(data),
+                this_site_arg(0), run_gen, run_step)
+                       .get();
 
             for (std::size_t i = 1; i < communicators.size() - 1; ++i)
             {
-                data = scatter_to(communicators.get(i),
-                    scatter_data(HPX_MOVE(data), arity),
-                    this_site_arg(this_site % arity), run_gen, run_step)
+                data = scatter_rows_to(communicators.get(i), HPX_MOVE(data),
+                    this_site_arg(0), run_gen, run_step)
                            .get();
             }
 
-            return scatter_to(communicators.back(), HPX_MOVE(data),
+            return scatter_leaf_to(communicators.back(), HPX_MOVE(data),
                 this_site_arg(0), run_gen, run_step);
         }
     }    // namespace detail

--- a/libs/full/collectives/include/hpx/collectives/scatter.hpp
+++ b/libs/full/collectives/include/hpx/collectives/scatter.hpp
@@ -883,14 +883,10 @@ namespace hpx::collectives {
                     return hpx::make_ready_future(
                         HPX_FORWARD(Payload, local_result));
                 }
-                else if constexpr (std::is_same_v<Result, bool>)
-                {
-                    return hpx::make_ready_future(
-                        static_cast<bool>(local_result[0]));
-                }
                 else
                 {
-                    return hpx::make_ready_future(HPX_MOVE(local_result[0]));
+                    return hpx::make_ready_future(
+                        handle_bool<Result>(HPX_MOVE(local_result[0])));
                 }
             }
 
@@ -1001,11 +997,7 @@ namespace hpx::collectives {
             }
 
             uniform_rows<T> data(HPX_MOVE(local_result));
-            data = scatter_rows_to(communicators.get(0), HPX_MOVE(data),
-                this_site_arg(0), run_gen, run_step)
-                       .get();
-
-            for (std::size_t i = 1; i < communicators.size() - 1; ++i)
+            for (std::size_t i = 0; i < communicators.size() - 1; ++i)
             {
                 data = scatter_rows_to(communicators.get(i), HPX_MOVE(data),
                     this_site_arg(0), run_gen, run_step)

--- a/libs/full/collectives/include/hpx/collectives/scatter.hpp
+++ b/libs/full/collectives/include/hpx/collectives/scatter.hpp
@@ -472,7 +472,7 @@ namespace hpx::traits {
                 nullptr,
                 // finalizer (invoked after all sites have checked in)
                 [num_sites](auto& data, bool&, std::size_t which) {
-                    return data[0].extract(which, num_sites);
+                    return HPX_MOVE(data[0]).extract(which, num_sites);
                 },
                 num_generations, 1);
         }
@@ -498,7 +498,7 @@ namespace hpx::traits {
                     },
                     // finalizer (invoked after all sites have checked in)
                     [num_sites](auto& data, bool&, std::size_t which) {
-                        return data[0].extract(which, num_sites);
+                        return HPX_MOVE(data[0]).extract(which, num_sites);
                     },
                     num_generations, 1);
             }
@@ -681,13 +681,11 @@ namespace hpx::collectives {
             uniform_rows<T>&& local_result, this_site_arg this_site,
             generation_arg generation, generation_mode num_generations)
         {
-            HPX_ASSERT(local_result.num_rows == local_result.data.size());
-
             if constexpr (std::is_default_constructible_v<T>)
             {
                 return scatter_to_impl<T>(HPX_MOVE(fid),
-                    HPX_MOVE(local_result.data), this_site, generation,
-                    num_generations);
+                    HPX_MOVE(local_result).unwrap_values(), this_site,
+                    generation, num_generations);
             }
             else
             {
@@ -851,7 +849,7 @@ namespace hpx::collectives {
             {
                 static_assert(std::is_same_v<Result, payload_type>);
                 local_result.validate("hpx::collectives::scatter_to");
-                if (local_result.num_rows < num_sites)
+                if (local_result.num_rows() < num_sites)
                 {
                     return hpx::make_exceptional_future<Result>(
                         HPX_GET_EXCEPTION(hpx::error::bad_parameter,

--- a/libs/full/collectives/include/hpx/collectives/scatter.hpp
+++ b/libs/full/collectives/include/hpx/collectives/scatter.hpp
@@ -405,6 +405,16 @@ namespace hpx { namespace collectives {
 #include <utility>
 #include <vector>
 
+namespace hpx::collectives::detail {
+
+    // Distinguishes the internal row scatter protocol from an ordinary scatter
+    // whose user value type happens to be uniform_rows<T>.
+    struct uniform_scatter_tag
+    {
+    };
+
+}    // namespace hpx::collectives::detail
+
 namespace hpx::traits {
 
     ///////////////////////////////////////////////////////////////////////////
@@ -432,7 +442,10 @@ namespace hpx::traits {
             return communicator.template handle_data<data_type>(
                 communication::communicator_data<
                     communication::scatter_tag>::name(),
-                which, generation, nullptr,
+                which, generation,
+                // step function (invoked once for get)
+                nullptr,
+                // finalizer (invoked after all sites have checked in)
                 [](auto& data, bool&, std::size_t which) {
                     return hpx::collectives::detail::handle_bool<data_type>(
                         HPX_MOVE(data[which]));
@@ -454,7 +467,10 @@ namespace hpx::traits {
             return communicator.template handle_data<data_type>(
                 communication::communicator_data<
                     communication::scatter_tag>::name(),
-                which, generation, nullptr,
+                which, generation,
+                // step function (invoked once for get)
+                nullptr,
+                // finalizer (invoked after all sites have checked in)
                 [num_sites](auto& data, bool&, std::size_t which) {
                     return data[0].extract(which, num_sites);
                 },
@@ -476,9 +492,11 @@ namespace hpx::traits {
                     communication::communicator_data<
                         communication::scatter_tag>::name(),
                     which, generation,
+                    // step function (invoked once for set)
                     [&t](auto& data, std::size_t) {
                         data[0] = HPX_FORWARD(Payload, t);
                     },
+                    // finalizer (invoked after all sites have checked in)
                     [num_sites](auto& data, bool&, std::size_t which) {
                         return data[0].extract(which, num_sites);
                     },
@@ -491,9 +509,11 @@ namespace hpx::traits {
                     communication::communicator_data<
                         communication::scatter_tag>::name(),
                     which, generation,
+                    // step function (invoked once for set)
                     [&t](auto& data, std::size_t) {
                         data = HPX_FORWARD(Payload, t);
                     },
+                    // finalizer (invoked after all sites have checked in)
                     [](auto& data, bool&, std::size_t which) {
                         return hpx::collectives::detail::handle_bool<data_type>(
                             HPX_MOVE(data[which]));

--- a/libs/full/collectives/include/hpx/collectives/scatter.hpp
+++ b/libs/full/collectives/include/hpx/collectives/scatter.hpp
@@ -456,8 +456,7 @@ namespace hpx::traits {
                     communication::scatter_tag>::name(),
                 which, generation, nullptr,
                 [num_sites](auto& data, bool&, std::size_t which) {
-                    return hpx::collectives::detail::extract_uniform_rows(
-                        data[0], which, num_sites);
+                    return data[0].extract(which, num_sites);
                 },
                 num_generations, 1);
         }
@@ -481,8 +480,7 @@ namespace hpx::traits {
                         data[0] = HPX_FORWARD(Payload, t);
                     },
                     [num_sites](auto& data, bool&, std::size_t which) {
-                        return hpx::collectives::detail::extract_uniform_rows(
-                            data[0], which, num_sites);
+                        return data[0].extract(which, num_sites);
                     },
                     num_generations, 1);
             }
@@ -653,7 +651,7 @@ namespace hpx::collectives {
                     scatter_rows_from<T>(
                         HPX_MOVE(fid), this_site, generation, num_generations),
                     [](uniform_rows<T>&& result) {
-                        return unwrap_uniform_value(HPX_MOVE(result));
+                        return HPX_MOVE(result).unwrap_value();
                     });
             }
         }
@@ -677,7 +675,7 @@ namespace hpx::collectives {
                     scatter_rows_to(HPX_MOVE(fid), HPX_MOVE(local_result),
                         this_site, generation, num_generations),
                     [](uniform_rows<T>&& result) {
-                        return unwrap_uniform_value(HPX_MOVE(result));
+                        return HPX_MOVE(result).unwrap_value();
                     });
             }
         }
@@ -832,8 +830,7 @@ namespace hpx::collectives {
             if constexpr (uniform_payload)
             {
                 static_assert(std::is_same_v<Result, payload_type>);
-                validate_uniform_rows(
-                    local_result, "hpx::collectives::scatter_to");
+                local_result.validate("hpx::collectives::scatter_to");
                 if (local_result.num_rows < num_sites)
                 {
                     return hpx::make_exceptional_future<Result>(
@@ -981,11 +978,11 @@ namespace hpx::collectives {
             if (communicators.size() == 1)
             {
                 return scatter_leaf_to(current_communicator,
-                    make_uniform_rows(HPX_MOVE(local_result)), current_site,
+                    uniform_rows<T>(HPX_MOVE(local_result)), current_site,
                     run_gen, run_step);
             }
 
-            uniform_rows<T> data = make_uniform_rows(HPX_MOVE(local_result));
+            uniform_rows<T> data(HPX_MOVE(local_result));
             data = scatter_rows_to(communicators.get(0), HPX_MOVE(data),
                 this_site_arg(0), run_gen, run_step)
                        .get();

--- a/libs/full/collectives/tests/unit/CMakeLists.txt
+++ b/libs/full/collectives/tests/unit/CMakeLists.txt
@@ -38,6 +38,7 @@ if(HPX_WITH_NETWORKING)
       exclusive_scan_
       exclusive_scan_hierarchical
       exclusive_scan_sync
+      flattened_collective_payloads
       gather
       gather_hierarchical
       gather_sync
@@ -55,6 +56,10 @@ if(HPX_WITH_NETWORKING)
   foreach(test ${tests})
     set(${test}_PARAMETERS LOCALITIES 2)
   endforeach()
+
+  # Five localities with arity two force an uneven, three-level tree and a
+  # serialized intermediate payload hop.
+  set(flattened_collective_payloads_PARAMETERS LOCALITIES 5)
 
   # The flat-vs-tree comparison needs a real tree: num_sites > arity (= 2).
   set(hierarchical_flat_fallback_PARAMETERS LOCALITIES 3)

--- a/libs/full/collectives/tests/unit/flattened_collective_payloads.cpp
+++ b/libs/full/collectives/tests/unit/flattened_collective_payloads.cpp
@@ -1,0 +1,321 @@
+//  Copyright (c) 2026 Anshuman Agrawal
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/modules/collectives.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <new>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace hpx::collectives;
+
+struct nonassignable_payload
+{
+    nonassignable_payload() = delete;
+    nonassignable_payload(nonassignable_payload const&) = default;
+    nonassignable_payload& operator=(nonassignable_payload const&) = delete;
+    nonassignable_payload(nonassignable_payload&&) = default;
+    nonassignable_payload& operator=(nonassignable_payload&&) = delete;
+
+    explicit nonassignable_payload(std::uint32_t const value)
+      : value(value)
+    {
+    }
+
+    template <typename Archive>
+    void serialize(Archive&, unsigned int const)
+    {
+    }
+
+    template <typename Archive>
+    friend void save_construct_data(Archive& ar,
+        nonassignable_payload const* const payload, unsigned int const)
+    {
+        ar & payload->value;
+    }
+
+    template <typename Archive>
+    friend void load_construct_data(
+        Archive& ar, nonassignable_payload* const payload, unsigned int const)
+    {
+        std::uint32_t value = 0;
+        ar & value;
+        ::new (payload) nonassignable_payload(value);
+    }
+
+    std::uint32_t value;
+};
+
+template <typename Payload>
+struct opaque_payload_traits;
+
+template <>
+struct opaque_payload_traits<
+    hpx::collectives::detail::uniform_rows<std::uint32_t>>
+{
+    using payload_type = hpx::collectives::detail::uniform_rows<std::uint32_t>;
+
+    static payload_type make(std::uint32_t const value)
+    {
+        return {{value}, 0};
+    }
+
+    static void check_payload(
+        payload_type const& payload, std::uint32_t const expected)
+    {
+        HPX_TEST_EQ(payload.data.size(), static_cast<std::size_t>(1));
+        HPX_TEST_EQ(payload.data[0], expected);
+        HPX_TEST_EQ(payload.num_rows, static_cast<std::size_t>(0));
+    }
+};
+
+template <typename Payload>
+void run_opaque_uniform_payload(char const* const basename,
+    std::uint32_t const num_sites, std::uint32_t const this_site)
+{
+    using traits = opaque_payload_traits<Payload>;
+
+    auto const communicator =
+        create_communicator(basename, num_sites_arg(num_sites),
+            this_site_arg(this_site), generation_arg(), root_site_arg(0));
+
+    Payload local_value = traits::make(this_site + 10);
+    if (this_site == 0)
+    {
+        auto const gathered = gather_here(communicator, HPX_MOVE(local_value),
+            this_site_arg(this_site), generation_arg(1))
+                                  .get();
+        HPX_TEST_EQ(gathered.size(), static_cast<std::size_t>(num_sites));
+        for (std::uint32_t source = 0; source != num_sites; ++source)
+        {
+            traits::check_payload(gathered[source], source + 10);
+        }
+    }
+    else
+    {
+        gather_there(communicator, HPX_MOVE(local_value),
+            this_site_arg(this_site), generation_arg(1))
+            .get();
+    }
+
+    Payload scattered = [&]() {
+        if (this_site == 0)
+        {
+            std::vector<Payload> values;
+            values.reserve(num_sites);
+            for (std::uint32_t destination = 0; destination != num_sites;
+                ++destination)
+            {
+                values.push_back(traits::make(destination + 20));
+            }
+            return scatter_to(communicator, HPX_MOVE(values),
+                this_site_arg(this_site), generation_arg(2))
+                .get();
+        }
+
+        return scatter_from<Payload>(
+            communicator, this_site_arg(this_site), generation_arg(2))
+            .get();
+    }();
+    traits::check_payload(scattered, this_site + 20);
+}
+
+void run_nonassignable_hierarchical_payload(char const* const basename,
+    std::uint32_t const num_sites, std::uint32_t const this_site)
+{
+    auto const communicators = create_hierarchical_communicator(basename,
+        num_sites_arg(num_sites), this_site_arg(this_site), arity_arg(2),
+        generation_arg(), root_site_arg(0), flat_fallback_threshold_arg(0));
+
+    nonassignable_payload local_value(this_site + 30);
+    if (this_site == 0)
+    {
+        auto const gathered = gather_here(communicators, HPX_MOVE(local_value),
+            this_site_arg(this_site), generation_arg(1))
+                                  .get();
+        HPX_TEST_EQ(gathered.size(), static_cast<std::size_t>(num_sites));
+        for (std::uint32_t source = 0; source != num_sites; ++source)
+        {
+            HPX_TEST_EQ(gathered[source].value, source + 30);
+        }
+    }
+    else
+    {
+        gather_there(communicators, HPX_MOVE(local_value),
+            this_site_arg(this_site), generation_arg(1))
+            .get();
+    }
+
+    nonassignable_payload scattered = [&]() {
+        if (this_site == 0)
+        {
+            std::vector<nonassignable_payload> values;
+            values.reserve(num_sites);
+            for (std::uint32_t destination = 0; destination != num_sites;
+                ++destination)
+            {
+                values.emplace_back(destination + 40);
+            }
+            return scatter_to(communicators, HPX_MOVE(values),
+                this_site_arg(this_site), generation_arg(2))
+                .get();
+        }
+
+        return scatter_from<nonassignable_payload>(
+            communicators, this_site_arg(this_site), generation_arg(2))
+            .get();
+    }();
+    HPX_TEST_EQ(scattered.value, this_site + 40);
+}
+
+void run_auto_generation_hierarchical_payloads(
+    std::uint32_t const num_sites, std::uint32_t const this_site)
+{
+    auto const gather_communicators =
+        create_hierarchical_communicator("/test/flattened_payload_auto_gather/",
+            num_sites_arg(num_sites), this_site_arg(this_site), arity_arg(2),
+            generation_arg(), root_site_arg(0), flat_fallback_threshold_arg(0));
+
+    if (this_site == 0)
+    {
+        auto const gathered =
+            gather_here(gather_communicators, this_site + 60).get();
+        HPX_TEST_EQ(gathered.size(), static_cast<std::size_t>(num_sites));
+        for (std::uint32_t source = 0; source != num_sites; ++source)
+        {
+            HPX_TEST_EQ(gathered[source], source + 60);
+        }
+    }
+    else
+    {
+        gather_there(gather_communicators, this_site + 60).get();
+    }
+
+    // Use a distinct basename so this exercises automatic generation without
+    // depending on communicator cleanup from the preceding gather.
+    auto const scatter_communicators = create_hierarchical_communicator(
+        "/test/flattened_payload_auto_scatter/", num_sites_arg(num_sites),
+        this_site_arg(this_site), arity_arg(2), generation_arg(),
+        root_site_arg(0), flat_fallback_threshold_arg(0));
+
+    std::uint32_t const scattered = [&]() {
+        if (this_site == 0)
+        {
+            std::vector<std::uint32_t> values;
+            values.reserve(num_sites);
+            for (std::uint32_t destination = 0; destination != num_sites;
+                ++destination)
+            {
+                values.push_back(destination + 70);
+            }
+            return scatter_to(scatter_communicators, HPX_MOVE(values)).get();
+        }
+
+        return scatter_from<std::uint32_t>(scatter_communicators).get();
+    }();
+    HPX_TEST_EQ(scattered, this_site + 70);
+}
+
+template <typename F>
+void run_local_sites(std::uint32_t const num_sites, F&& f)
+{
+    std::vector<hpx::future<void>> sites;
+    sites.reserve(num_sites);
+    for (std::uint32_t site = 0; site != num_sites; ++site)
+    {
+        sites.push_back(hpx::async([site, f]() mutable { f(site); }));
+    }
+
+    for (auto& site : sites)
+    {
+        site.get();
+    }
+}
+
+void test_local_multisite_payload_paths()
+{
+    if (hpx::get_locality_id() != 0)
+    {
+        return;
+    }
+
+    constexpr std::uint32_t num_sites = 5;
+    using uniform_payload =
+        hpx::collectives::detail::uniform_rows<std::uint32_t>;
+
+    run_local_sites(num_sites, [](std::uint32_t const site) {
+        run_opaque_uniform_payload<uniform_payload>(
+            "/test/flattened_payload_local_opaque_rows/", num_sites, site);
+    });
+    run_local_sites(num_sites, [](std::uint32_t const site) {
+        run_nonassignable_hierarchical_payload(
+            "/test/flattened_payload_local_nonassignable/", num_sites, site);
+    });
+}
+
+void test_singleton_payload_paths()
+{
+    if (hpx::get_locality_id() != 0)
+    {
+        return;
+    }
+
+    auto const communicators =
+        create_hierarchical_communicator("/test/flattened_payload_singleton/",
+            num_sites_arg(1), this_site_arg(0), arity_arg(2), generation_arg(),
+            root_site_arg(0), flat_fallback_threshold_arg(0));
+
+    auto const gathered = gather_here(communicators, std::string("gather"),
+        this_site_arg(0), generation_arg(1))
+                              .get();
+    HPX_TEST_EQ(gathered.size(), static_cast<std::size_t>(1));
+    HPX_TEST_EQ(gathered[0], std::string("gather"));
+
+    auto const scattered =
+        scatter_to(communicators, std::vector<std::string>{"scatter"},
+            this_site_arg(0), generation_arg(2))
+            .get();
+    HPX_TEST_EQ(scattered, std::string("scatter"));
+}
+
+int hpx_main()
+{
+    std::uint32_t const this_site = hpx::get_locality_id();
+    std::uint32_t const num_sites = hpx::get_num_localities(hpx::launch::sync);
+
+    run_opaque_uniform_payload<
+        hpx::collectives::detail::uniform_rows<std::uint32_t>>(
+        "/test/flattened_payload_opaque_rows/", num_sites, this_site);
+    run_nonassignable_hierarchical_payload(
+        "/test/flattened_payload_nonassignable/", num_sites, this_site);
+    run_auto_generation_hierarchical_payloads(num_sites, this_site);
+    test_local_multisite_payload_paths();
+    test_singleton_payload_paths();
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> const cfg = {"hpx.run_hpx_main!=1"};
+
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ(hpx::init(argc, argv, init_args), 0);
+    return hpx::util::report_errors();
+}
+
+#endif

--- a/libs/full/collectives/tests/unit/flattened_collective_payloads.cpp
+++ b/libs/full/collectives/tests/unit/flattened_collective_payloads.cpp
@@ -69,7 +69,7 @@ struct opaque_payload_traits<
 
     static payload_type make(std::uint32_t const value)
     {
-        return {{value}, 0};
+        return payload_type(std::vector<std::uint32_t>{value}, 0);
     }
 
     static void check_payload(

--- a/libs/full/collectives/tests/unit/flattened_collective_payloads.cpp
+++ b/libs/full/collectives/tests/unit/flattened_collective_payloads.cpp
@@ -69,15 +69,15 @@ struct opaque_payload_traits<
 
     static payload_type make(std::uint32_t const value)
     {
-        return payload_type(std::vector<std::uint32_t>{value}, 0);
+        return payload_type(std::vector<std::uint32_t>{value}, 1);
     }
 
     static void check_payload(
         payload_type const& payload, std::uint32_t const expected)
     {
-        HPX_TEST_EQ(payload.data.size(), static_cast<std::size_t>(1));
-        HPX_TEST_EQ(payload.data[0], expected);
-        HPX_TEST_EQ(payload.num_rows, static_cast<std::size_t>(0));
+        HPX_TEST_EQ(payload.data().size(), static_cast<std::size_t>(1));
+        HPX_TEST_EQ(payload.data()[0], expected);
+        HPX_TEST_EQ(payload.num_rows(), static_cast<std::size_t>(1));
     }
 };
 

--- a/libs/full/collectives/tests/unit/flattened_collective_payloads.cpp
+++ b/libs/full/collectives/tests/unit/flattened_collective_payloads.cpp
@@ -4,6 +4,8 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#define HPX_HAVE_FORCE_NO_CXX_MODULES
+
 #include <hpx/config.hpp>
 
 #if !defined(HPX_COMPUTE_DEVICE_CODE)

--- a/libs/full/collectives/tests/unit/flattened_collective_payloads.cpp
+++ b/libs/full/collectives/tests/unit/flattened_collective_payloads.cpp
@@ -81,15 +81,11 @@ struct opaque_payload_traits<
     }
 };
 
-template <typename Payload>
-void run_opaque_uniform_payload(char const* const basename,
+template <typename Payload, typename Communicator>
+void run_opaque_uniform_payload(Communicator const& communicator,
     std::uint32_t const num_sites, std::uint32_t const this_site)
 {
     using traits = opaque_payload_traits<Payload>;
-
-    auto const communicator =
-        create_communicator(basename, num_sites_arg(num_sites),
-            this_site_arg(this_site), generation_arg(), root_site_arg(0));
 
     Payload local_value = traits::make(this_site + 10);
     if (this_site == 0)
@@ -256,8 +252,20 @@ void test_local_multisite_payload_paths()
         hpx::collectives::detail::uniform_rows<std::uint32_t>;
 
     run_local_sites(num_sites, [](std::uint32_t const site) {
+        auto const communicator =
+            create_communicator("/test/flattened_payload_local_opaque_rows/",
+                num_sites_arg(num_sites), this_site_arg(site), generation_arg(),
+                root_site_arg(0));
         run_opaque_uniform_payload<uniform_payload>(
-            "/test/flattened_payload_local_opaque_rows/", num_sites, site);
+            communicator, num_sites, site);
+    });
+    run_local_sites(num_sites, [](std::uint32_t const site) {
+        auto const communicators = create_hierarchical_communicator(
+            "/test/flattened_payload_local_hierarchical_opaque_rows/",
+            num_sites_arg(num_sites), this_site_arg(site), arity_arg(2),
+            generation_arg(), root_site_arg(0), flat_fallback_threshold_arg(0));
+        run_opaque_uniform_payload<uniform_payload>(
+            communicators, num_sites, site);
     });
     run_local_sites(num_sites, [](std::uint32_t const site) {
         run_nonassignable_hierarchical_payload(
@@ -288,16 +296,44 @@ void test_singleton_payload_paths()
             this_site_arg(0), generation_arg(2))
             .get();
     HPX_TEST_EQ(scattered, std::string("scatter"));
+
+    using uniform_payload =
+        hpx::collectives::detail::uniform_rows<std::uint32_t>;
+    using traits = opaque_payload_traits<uniform_payload>;
+
+    auto const opaque_gathered = gather_here(
+        communicators, traits::make(80), this_site_arg(0), generation_arg(3))
+                                     .get();
+    HPX_TEST_EQ(opaque_gathered.size(), static_cast<std::size_t>(1));
+    traits::check_payload(opaque_gathered[0], 80);
+
+    std::vector<uniform_payload> opaque_values;
+    opaque_values.push_back(traits::make(90));
+    auto const opaque_scattered = scatter_to(communicators,
+        HPX_MOVE(opaque_values), this_site_arg(0), generation_arg(4))
+                                      .get();
+    traits::check_payload(opaque_scattered, 90);
 }
 
 int hpx_main()
 {
     std::uint32_t const this_site = hpx::get_locality_id();
     std::uint32_t const num_sites = hpx::get_num_localities(hpx::launch::sync);
+    using uniform_payload =
+        hpx::collectives::detail::uniform_rows<std::uint32_t>;
 
-    run_opaque_uniform_payload<
-        hpx::collectives::detail::uniform_rows<std::uint32_t>>(
-        "/test/flattened_payload_opaque_rows/", num_sites, this_site);
+    auto const communicator = create_communicator(
+        "/test/flattened_payload_opaque_rows/", num_sites_arg(num_sites),
+        this_site_arg(this_site), generation_arg(), root_site_arg(0));
+    run_opaque_uniform_payload<uniform_payload>(
+        communicator, num_sites, this_site);
+
+    auto const hierarchical_communicators = create_hierarchical_communicator(
+        "/test/flattened_payload_hierarchical_opaque_rows/",
+        num_sites_arg(num_sites), this_site_arg(this_site), arity_arg(2),
+        generation_arg(), root_site_arg(0), flat_fallback_threshold_arg(0));
+    run_opaque_uniform_payload<uniform_payload>(
+        hierarchical_communicators, num_sites, this_site);
     run_nonassignable_hierarchical_payload(
         "/test/flattened_payload_nonassignable/", num_sites, this_site);
     run_auto_generation_hierarchical_payloads(num_sites, this_site);

--- a/libs/full/collectives/tests/unit/flattened_collective_payloads.cpp
+++ b/libs/full/collectives/tests/unit/flattened_collective_payloads.cpp
@@ -4,8 +4,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#define HPX_HAVE_FORCE_NO_CXX_MODULES
-
 #include <hpx/config.hpp>
 
 #if !defined(HPX_COMPUTE_DEVICE_CODE)

--- a/libs/full/collectives/tests/unit/hierarchical_helpers.cpp
+++ b/libs/full/collectives/tests/unit/hierarchical_helpers.cpp
@@ -21,13 +21,9 @@
 using hpx::collectives::detail::checked_data_size_product;
 using hpx::collectives::detail::checked_data_size_sum;
 using hpx::collectives::detail::classify_site;
-using hpx::collectives::detail::extract_uniform_rows;
 using hpx::collectives::detail::get_top_level_groups;
 using hpx::collectives::detail::is_top_level_rep;
-using hpx::collectives::detail::is_valid_uniform_rows;
-using hpx::collectives::detail::merge_uniform_rows;
 using hpx::collectives::detail::uniform_rows;
-using hpx::collectives::detail::validate_uniform_rows;
 
 void test_balanced_arity2()
 {
@@ -270,8 +266,8 @@ void test_is_top_level_rep_exhaustive()
 
 void test_uniform_rows_slicing()
 {
-    uniform_rows<int> first{{10, 11, 20, 21, 30, 31}, 3};
-    auto left = extract_uniform_rows(first, 0, 2);
+    uniform_rows<int> first(std::vector<int>{10, 11, 20, 21, 30, 31}, 3);
+    auto left = first.extract(0, 2);
     HPX_TEST_EQ(left.data.size(), static_cast<std::size_t>(4));
     HPX_TEST_EQ(left.num_rows, static_cast<std::size_t>(2));
     HPX_TEST_EQ(left.data[0], 10);
@@ -279,15 +275,15 @@ void test_uniform_rows_slicing()
     HPX_TEST_EQ(left.data[2], 20);
     HPX_TEST_EQ(left.data[3], 21);
 
-    uniform_rows<int> second{{10, 11, 20, 21, 30, 31}, 3};
-    auto right = extract_uniform_rows(second, 1, 2);
+    uniform_rows<int> second(std::vector<int>{10, 11, 20, 21, 30, 31}, 3);
+    auto right = second.extract(1, 2);
     HPX_TEST_EQ(right.data.size(), static_cast<std::size_t>(2));
     HPX_TEST_EQ(right.num_rows, static_cast<std::size_t>(1));
     HPX_TEST_EQ(right.data[0], 30);
     HPX_TEST_EQ(right.data[1], 31);
 
-    uniform_rows<int> empty_rows{{}, 3};
-    auto empty = extract_uniform_rows(empty_rows, 1, 3);
+    uniform_rows<int> empty_rows(std::vector<int>{}, 3);
+    auto empty = empty_rows.extract(1, 3);
     HPX_TEST(empty.data.empty());
     HPX_TEST_EQ(empty.num_rows, static_cast<std::size_t>(1));
 }
@@ -295,10 +291,10 @@ void test_uniform_rows_slicing()
 void test_uniform_rows_merge()
 {
     std::vector<uniform_rows<std::string>> values;
-    values.push_back({{"a", "b", "c", "d"}, 2});
-    values.push_back({{"e", "f"}, 1});
+    values.emplace_back(std::vector<std::string>{"a", "b", "c", "d"}, 2);
+    values.emplace_back(std::vector<std::string>{"e", "f"}, 1);
 
-    auto result = merge_uniform_rows(HPX_MOVE(values));
+    uniform_rows<std::string> result(HPX_MOVE(values));
     HPX_TEST_EQ(result.data.size(), static_cast<std::size_t>(6));
     HPX_TEST_EQ(result.num_rows, static_cast<std::size_t>(3));
     for (std::size_t i = 0; i != result.data.size(); ++i)
@@ -307,19 +303,26 @@ void test_uniform_rows_merge()
     }
 
     std::vector<uniform_rows<int>> mismatched;
-    mismatched.push_back({{1, 2}, 1});
-    mismatched.push_back({{3, 4, 5}, 1});
+    mismatched.emplace_back(std::vector<int>{1, 2}, 1);
+    mismatched.emplace_back(std::vector<int>{3, 4, 5}, 1);
     HPX_TEST_THROW(
-        (void) merge_uniform_rows(HPX_MOVE(mismatched)), hpx::exception);
+        (void) uniform_rows<int>(HPX_MOVE(mismatched)), hpx::exception);
+
+    std::vector<uniform_rows<int>> singleton;
+    singleton.emplace_back(std::vector<int>{1, 2, 3, 4}, 2);
+    int const* const original_data = singleton.front().data.data();
+    uniform_rows<int> singleton_result(HPX_MOVE(singleton));
+    HPX_TEST_EQ(singleton_result.data.data(), original_data);
+    HPX_TEST_EQ(singleton_result.num_rows, static_cast<std::size_t>(2));
 }
 
 void test_uniform_rows_vector_bool()
 {
     std::vector<uniform_rows<bool>> values;
-    values.push_back({{true, false, true, true}, 2});
-    values.push_back({{false, false}, 1});
+    values.emplace_back(std::vector<bool>{true, false, true, true}, 2);
+    values.emplace_back(std::vector<bool>{false, false}, 1);
 
-    auto merged = merge_uniform_rows(HPX_MOVE(values));
+    uniform_rows<bool> merged(HPX_MOVE(values));
     HPX_TEST_EQ(merged.data.size(), static_cast<std::size_t>(6));
     HPX_TEST_EQ(merged.num_rows, static_cast<std::size_t>(3));
     HPX_TEST(merged.data[0]);
@@ -329,7 +332,7 @@ void test_uniform_rows_vector_bool()
     HPX_TEST(!merged.data[4]);
     HPX_TEST(!merged.data[5]);
 
-    auto slice = extract_uniform_rows(merged, 1, 3);
+    auto slice = merged.extract(1, 3);
     HPX_TEST_EQ(slice.data.size(), static_cast<std::size_t>(2));
     HPX_TEST_EQ(slice.num_rows, static_cast<std::size_t>(1));
     HPX_TEST(slice.data[0]);
@@ -338,23 +341,43 @@ void test_uniform_rows_vector_bool()
 
 void test_uniform_rows_validation()
 {
-    uniform_rows<int> valid_empty_rows{{}, 3};
-    uniform_rows<int> valid_no_rows{{}, 0};
-    uniform_rows<int> rows_with_no_width{{1}, 0};
-    uniform_rows<int> nonuniform_width{{1, 2, 3}, 2};
+    uniform_rows<int> valid_empty_rows(std::vector<int>{}, 3);
+    uniform_rows<int> valid_no_rows(std::vector<int>{}, 0);
+    uniform_rows<int> rows_with_no_width(std::vector<int>{1}, 0);
+    uniform_rows<int> nonuniform_width(std::vector<int>{1, 2, 3}, 2);
 
-    HPX_TEST(is_valid_uniform_rows(valid_empty_rows));
-    HPX_TEST(is_valid_uniform_rows(valid_no_rows));
-    HPX_TEST(!is_valid_uniform_rows(rows_with_no_width));
-    HPX_TEST(!is_valid_uniform_rows(nonuniform_width));
-    HPX_TEST_NO_THROW(validate_uniform_rows(
-        valid_empty_rows, "test_uniform_rows_validation"));
-    HPX_TEST_THROW(validate_uniform_rows(
-                       rows_with_no_width, "test_uniform_rows_validation"),
+    HPX_TEST(valid_empty_rows.is_valid());
+    HPX_TEST(valid_no_rows.is_valid());
+    HPX_TEST(!rows_with_no_width.is_valid());
+    HPX_TEST(!nonuniform_width.is_valid());
+    HPX_TEST_NO_THROW(
+        valid_empty_rows.validate("test_uniform_rows_validation"));
+    HPX_TEST_THROW(rows_with_no_width.validate("test_uniform_rows_validation"),
         hpx::exception);
-    HPX_TEST_THROW(
-        validate_uniform_rows(nonuniform_width, "test_uniform_rows_validation"),
+    HPX_TEST_THROW(nonuniform_width.validate("test_uniform_rows_validation"),
         hpx::exception);
+}
+
+void test_uniform_rows_construction()
+{
+    uniform_rows<int> rows(std::vector<int>{1, 2, 3});
+    HPX_TEST_EQ(rows.data.size(), static_cast<std::size_t>(3));
+    HPX_TEST_EQ(rows.num_rows, static_cast<std::size_t>(3));
+    HPX_TEST_EQ(rows.row_width(), static_cast<std::size_t>(1));
+
+    std::string value = "value";
+    uniform_rows<std::string> copied_value(value);
+    HPX_TEST_EQ(HPX_MOVE(copied_value).unwrap_value(), value);
+
+    uniform_rows<std::string> moved_value(std::string("moved"));
+    HPX_TEST_EQ(HPX_MOVE(moved_value).unwrap_value(), std::string("moved"));
+
+    uniform_rows<std::string> row(
+        std::vector<std::string>{"first", "second"}, 1);
+    auto unwrapped = HPX_MOVE(row).unwrap_row();
+    HPX_TEST_EQ(unwrapped.size(), static_cast<std::size_t>(2));
+    HPX_TEST_EQ(unwrapped[0], std::string("first"));
+    HPX_TEST_EQ(unwrapped[1], std::string("second"));
 }
 
 void test_data_size_overflow()
@@ -371,7 +394,8 @@ void test_data_size_overflow()
 
 void test_uniform_rows_serialization()
 {
-    uniform_rows<std::string> rows{{"zero", "one", "two", "three"}, 2};
+    uniform_rows<std::string> rows(
+        std::vector<std::string>{"zero", "one", "two", "three"}, 2);
     std::vector<char> rows_buffer;
     hpx::serialization::output_archive rows_output(rows_buffer);
     rows_output << rows;
@@ -405,6 +429,7 @@ int hpx_main()
     test_uniform_rows_merge();
     test_uniform_rows_vector_bool();
     test_uniform_rows_validation();
+    test_uniform_rows_construction();
     test_data_size_overflow();
     test_uniform_rows_serialization();
 

--- a/libs/full/collectives/tests/unit/hierarchical_helpers.cpp
+++ b/libs/full/collectives/tests/unit/hierarchical_helpers.cpp
@@ -378,6 +378,13 @@ void test_uniform_rows_construction()
     HPX_TEST_EQ(unwrapped.size(), static_cast<std::size_t>(2));
     HPX_TEST_EQ(unwrapped[0], std::string("first"));
     HPX_TEST_EQ(unwrapped[1], std::string("second"));
+
+    uniform_rows<int> scalar_rows(std::vector<int>{1, 2, 3});
+    auto values = HPX_MOVE(scalar_rows).unwrap_values();
+    HPX_TEST_EQ(values.size(), static_cast<std::size_t>(3));
+    HPX_TEST_EQ(values[0], 1);
+    HPX_TEST_EQ(values[1], 2);
+    HPX_TEST_EQ(values[2], 3);
 }
 
 void test_data_size_overflow()

--- a/libs/full/collectives/tests/unit/hierarchical_helpers.cpp
+++ b/libs/full/collectives/tests/unit/hierarchical_helpers.cpp
@@ -9,18 +9,25 @@
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 #include <hpx/hpx.hpp>
 #include <hpx/hpx_init.hpp>
+#include <hpx/modules/collectives.hpp>
+#include <hpx/modules/serialization.hpp>
 #include <hpx/modules/testing.hpp>
 
-#include <hpx/modules/collectives.hpp>
-
 #include <cstddef>
-#include <numeric>
+#include <limits>
+#include <string>
 #include <vector>
 
+using hpx::collectives::detail::checked_data_size_product;
+using hpx::collectives::detail::checked_data_size_sum;
 using hpx::collectives::detail::classify_site;
+using hpx::collectives::detail::extract_uniform_rows;
 using hpx::collectives::detail::get_top_level_groups;
 using hpx::collectives::detail::is_top_level_rep;
-using hpx::collectives::detail::top_level_group;
+using hpx::collectives::detail::is_valid_uniform_rows;
+using hpx::collectives::detail::merge_uniform_rows;
+using hpx::collectives::detail::uniform_rows;
+using hpx::collectives::detail::validate_uniform_rows;
 
 void test_balanced_arity2()
 {
@@ -261,6 +268,125 @@ void test_is_top_level_rep_exhaustive()
     }
 }
 
+void test_uniform_rows_slicing()
+{
+    uniform_rows<int> first{{10, 11, 20, 21, 30, 31}, 3};
+    auto left = extract_uniform_rows(first, 0, 2);
+    HPX_TEST_EQ(left.data.size(), static_cast<std::size_t>(4));
+    HPX_TEST_EQ(left.num_rows, static_cast<std::size_t>(2));
+    HPX_TEST_EQ(left.data[0], 10);
+    HPX_TEST_EQ(left.data[1], 11);
+    HPX_TEST_EQ(left.data[2], 20);
+    HPX_TEST_EQ(left.data[3], 21);
+
+    uniform_rows<int> second{{10, 11, 20, 21, 30, 31}, 3};
+    auto right = extract_uniform_rows(second, 1, 2);
+    HPX_TEST_EQ(right.data.size(), static_cast<std::size_t>(2));
+    HPX_TEST_EQ(right.num_rows, static_cast<std::size_t>(1));
+    HPX_TEST_EQ(right.data[0], 30);
+    HPX_TEST_EQ(right.data[1], 31);
+
+    uniform_rows<int> empty_rows{{}, 3};
+    auto empty = extract_uniform_rows(empty_rows, 1, 3);
+    HPX_TEST(empty.data.empty());
+    HPX_TEST_EQ(empty.num_rows, static_cast<std::size_t>(1));
+}
+
+void test_uniform_rows_merge()
+{
+    std::vector<uniform_rows<std::string>> values;
+    values.push_back({{"a", "b", "c", "d"}, 2});
+    values.push_back({{"e", "f"}, 1});
+
+    auto result = merge_uniform_rows(HPX_MOVE(values));
+    HPX_TEST_EQ(result.data.size(), static_cast<std::size_t>(6));
+    HPX_TEST_EQ(result.num_rows, static_cast<std::size_t>(3));
+    for (std::size_t i = 0; i != result.data.size(); ++i)
+    {
+        HPX_TEST_EQ(result.data[i], std::string(1, static_cast<char>('a' + i)));
+    }
+
+    std::vector<uniform_rows<int>> mismatched;
+    mismatched.push_back({{1, 2}, 1});
+    mismatched.push_back({{3, 4, 5}, 1});
+    HPX_TEST_THROW(
+        (void) merge_uniform_rows(HPX_MOVE(mismatched)), hpx::exception);
+}
+
+void test_uniform_rows_vector_bool()
+{
+    std::vector<uniform_rows<bool>> values;
+    values.push_back({{true, false, true, true}, 2});
+    values.push_back({{false, false}, 1});
+
+    auto merged = merge_uniform_rows(HPX_MOVE(values));
+    HPX_TEST_EQ(merged.data.size(), static_cast<std::size_t>(6));
+    HPX_TEST_EQ(merged.num_rows, static_cast<std::size_t>(3));
+    HPX_TEST(merged.data[0]);
+    HPX_TEST(!merged.data[1]);
+    HPX_TEST(merged.data[2]);
+    HPX_TEST(merged.data[3]);
+    HPX_TEST(!merged.data[4]);
+    HPX_TEST(!merged.data[5]);
+
+    auto slice = extract_uniform_rows(merged, 1, 3);
+    HPX_TEST_EQ(slice.data.size(), static_cast<std::size_t>(2));
+    HPX_TEST_EQ(slice.num_rows, static_cast<std::size_t>(1));
+    HPX_TEST(slice.data[0]);
+    HPX_TEST(slice.data[1]);
+}
+
+void test_uniform_rows_validation()
+{
+    uniform_rows<int> valid_empty_rows{{}, 3};
+    uniform_rows<int> valid_no_rows{{}, 0};
+    uniform_rows<int> rows_with_no_width{{1}, 0};
+    uniform_rows<int> nonuniform_width{{1, 2, 3}, 2};
+
+    HPX_TEST(is_valid_uniform_rows(valid_empty_rows));
+    HPX_TEST(is_valid_uniform_rows(valid_no_rows));
+    HPX_TEST(!is_valid_uniform_rows(rows_with_no_width));
+    HPX_TEST(!is_valid_uniform_rows(nonuniform_width));
+    HPX_TEST_NO_THROW(validate_uniform_rows(
+        valid_empty_rows, "test_uniform_rows_validation"));
+    HPX_TEST_THROW(validate_uniform_rows(
+                       rows_with_no_width, "test_uniform_rows_validation"),
+        hpx::exception);
+    HPX_TEST_THROW(
+        validate_uniform_rows(nonuniform_width, "test_uniform_rows_validation"),
+        hpx::exception);
+}
+
+void test_data_size_overflow()
+{
+    constexpr std::size_t max_size = (std::numeric_limits<std::size_t>::max)();
+
+    HPX_TEST_EQ(checked_data_size_sum(max_size - 1, 1), max_size);
+    HPX_TEST_EQ(checked_data_size_product(max_size, 1), max_size);
+    HPX_TEST_EQ(checked_data_size_product(max_size, 0), std::size_t{0});
+    HPX_TEST_THROW((void) checked_data_size_sum(max_size, 1), hpx::exception);
+    HPX_TEST_THROW(
+        (void) checked_data_size_product(max_size, 2), hpx::exception);
+}
+
+void test_uniform_rows_serialization()
+{
+    uniform_rows<std::string> rows{{"zero", "one", "two", "three"}, 2};
+    std::vector<char> rows_buffer;
+    hpx::serialization::output_archive rows_output(rows_buffer);
+    rows_output << rows;
+
+    uniform_rows<std::string> restored_rows;
+    hpx::serialization::input_archive rows_input(rows_buffer);
+    rows_input >> restored_rows;
+    HPX_TEST_EQ(restored_rows.data.size(), rows.data.size());
+    for (std::size_t i = 0; i != rows.data.size(); ++i)
+    {
+        HPX_TEST_EQ(restored_rows.data[i], rows.data[i]);
+    }
+    HPX_TEST_EQ(restored_rows.num_rows, rows.num_rows);
+}
+
 int hpx_main()
 {
     test_balanced_arity2();
@@ -275,6 +401,12 @@ int hpx_main()
     test_matches_recursive_fill();
     test_is_top_level_rep_basic();
     test_is_top_level_rep_exhaustive();
+    test_uniform_rows_slicing();
+    test_uniform_rows_merge();
+    test_uniform_rows_vector_bool();
+    test_uniform_rows_validation();
+    test_data_size_overflow();
+    test_uniform_rows_serialization();
 
     return hpx::finalize();
 }

--- a/libs/full/collectives/tests/unit/hierarchical_helpers.cpp
+++ b/libs/full/collectives/tests/unit/hierarchical_helpers.cpp
@@ -24,6 +24,7 @@ using hpx::collectives::detail::checked_data_size_sum;
 using hpx::collectives::detail::classify_site;
 using hpx::collectives::detail::get_top_level_groups;
 using hpx::collectives::detail::is_top_level_rep;
+using hpx::collectives::detail::is_uniform_rows_v;
 using hpx::collectives::detail::uniform_rows;
 
 struct move_only_value
@@ -286,6 +287,16 @@ void test_is_top_level_rep_exhaustive()
     }
 }
 
+void test_is_uniform_rows_trait()
+{
+    static_assert(is_uniform_rows_v<uniform_rows<int>>);
+    static_assert(is_uniform_rows_v<uniform_rows<int> const>);
+    static_assert(is_uniform_rows_v<uniform_rows<int>&>);
+    static_assert(is_uniform_rows_v<uniform_rows<int> const&>);
+    static_assert(!is_uniform_rows_v<int>);
+    static_assert(!is_uniform_rows_v<std::vector<int>>);
+}
+
 void test_uniform_rows_slicing()
 {
     uniform_rows<int> first(std::vector<int>{10, 11, 20, 21, 30, 31}, 3);
@@ -320,6 +331,18 @@ void test_uniform_rows_slicing()
     HPX_TEST_EQ(middle.data()[0].value, 20);
 }
 
+void test_uniform_rows_extract_single_slice()
+{
+    uniform_rows<int> rows(std::vector<int>{1, 2, 3, 4}, 2);
+    auto slice = HPX_MOVE(rows).extract(0, 1);
+    HPX_TEST_EQ(slice.num_rows(), static_cast<std::size_t>(2));
+    HPX_TEST_EQ(slice.data().size(), static_cast<std::size_t>(4));
+    HPX_TEST_EQ(slice.data()[0], 1);
+    HPX_TEST_EQ(slice.data()[1], 2);
+    HPX_TEST_EQ(slice.data()[2], 3);
+    HPX_TEST_EQ(slice.data()[3], 4);
+}
+
 void test_uniform_rows_merge()
 {
     std::vector<uniform_rows<std::string>> values;
@@ -347,6 +370,37 @@ void test_uniform_rows_merge()
     uniform_rows<int> singleton_result(HPX_MOVE(singleton));
     HPX_TEST_EQ(singleton_result.data().data(), original_data);
     HPX_TEST_EQ(singleton_result.num_rows(), static_cast<std::size_t>(2));
+}
+
+void test_uniform_rows_merge_move_only()
+{
+    std::vector<uniform_rows<move_only_value>> values;
+
+    std::vector<move_only_value> first_row;
+    first_row.emplace_back(1);
+    first_row.emplace_back(2);
+    values.emplace_back(HPX_MOVE(first_row), 1);
+
+    std::vector<move_only_value> second_row;
+    second_row.emplace_back(3);
+    second_row.emplace_back(4);
+    values.emplace_back(HPX_MOVE(second_row), 1);
+
+    uniform_rows<move_only_value> merged(HPX_MOVE(values));
+    HPX_TEST_EQ(merged.data().size(), static_cast<std::size_t>(4));
+    HPX_TEST_EQ(merged.num_rows(), static_cast<std::size_t>(2));
+    HPX_TEST_EQ(merged.data()[0].value, 1);
+    HPX_TEST_EQ(merged.data()[1].value, 2);
+    HPX_TEST_EQ(merged.data()[2].value, 3);
+    HPX_TEST_EQ(merged.data()[3].value, 4);
+}
+
+void test_uniform_rows_empty_merge()
+{
+    std::vector<uniform_rows<int>> empty_values;
+    uniform_rows<int> result(HPX_MOVE(empty_values));
+    HPX_TEST_EQ(result.num_rows(), static_cast<std::size_t>(0));
+    HPX_TEST(result.data().empty());
 }
 
 void test_uniform_rows_vector_bool()
@@ -399,7 +453,6 @@ void test_uniform_rows_validation()
     HPX_TEST(valid_no_rows.is_valid());
     HPX_TEST(valid_rows.is_valid());
     HPX_TEST_EQ(valid_empty_rows.row_width(), static_cast<std::size_t>(0));
-    HPX_TEST_EQ(valid_no_rows.row_width(), static_cast<std::size_t>(0));
     HPX_TEST_EQ(valid_rows.row_width(), static_cast<std::size_t>(2));
     HPX_TEST(!rows_with_no_width.is_valid());
     HPX_TEST(!nonuniform_width.is_valid());
@@ -409,6 +462,12 @@ void test_uniform_rows_validation()
         hpx::exception);
     HPX_TEST_THROW(nonuniform_width.validate("test_uniform_rows_validation"),
         hpx::exception);
+}
+
+void test_uniform_rows_row_width_zero_rows()
+{
+    uniform_rows<int> zero_rows(std::vector<int>{}, 0);
+    HPX_TEST_EQ(zero_rows.row_width(), static_cast<std::size_t>(0));
 }
 
 void test_uniform_rows_construction()
@@ -495,10 +554,15 @@ int hpx_main()
     test_matches_recursive_fill();
     test_is_top_level_rep_basic();
     test_is_top_level_rep_exhaustive();
+    test_is_uniform_rows_trait();
     test_uniform_rows_slicing();
+    test_uniform_rows_extract_single_slice();
     test_uniform_rows_merge();
+    test_uniform_rows_merge_move_only();
+    test_uniform_rows_empty_merge();
     test_uniform_rows_vector_bool();
     test_uniform_rows_validation();
+    test_uniform_rows_row_width_zero_rows();
     test_uniform_rows_construction();
     test_data_size_overflow();
     test_uniform_rows_serialization();

--- a/libs/full/collectives/tests/unit/hierarchical_helpers.cpp
+++ b/libs/full/collectives/tests/unit/hierarchical_helpers.cpp
@@ -289,25 +289,25 @@ void test_is_top_level_rep_exhaustive()
 void test_uniform_rows_slicing()
 {
     uniform_rows<int> first(std::vector<int>{10, 11, 20, 21, 30, 31}, 3);
-    auto left = first.extract(0, 2);
-    HPX_TEST_EQ(left.data.size(), static_cast<std::size_t>(4));
-    HPX_TEST_EQ(left.num_rows, static_cast<std::size_t>(2));
-    HPX_TEST_EQ(left.data[0], 10);
-    HPX_TEST_EQ(left.data[1], 11);
-    HPX_TEST_EQ(left.data[2], 20);
-    HPX_TEST_EQ(left.data[3], 21);
+    auto left = HPX_MOVE(first).extract(0, 2);
+    HPX_TEST_EQ(left.data().size(), static_cast<std::size_t>(4));
+    HPX_TEST_EQ(left.num_rows(), static_cast<std::size_t>(2));
+    HPX_TEST_EQ(left.data()[0], 10);
+    HPX_TEST_EQ(left.data()[1], 11);
+    HPX_TEST_EQ(left.data()[2], 20);
+    HPX_TEST_EQ(left.data()[3], 21);
 
     uniform_rows<int> second(std::vector<int>{10, 11, 20, 21, 30, 31}, 3);
-    auto right = second.extract(1, 2);
-    HPX_TEST_EQ(right.data.size(), static_cast<std::size_t>(2));
-    HPX_TEST_EQ(right.num_rows, static_cast<std::size_t>(1));
-    HPX_TEST_EQ(right.data[0], 30);
-    HPX_TEST_EQ(right.data[1], 31);
+    auto right = HPX_MOVE(second).extract(1, 2);
+    HPX_TEST_EQ(right.data().size(), static_cast<std::size_t>(2));
+    HPX_TEST_EQ(right.num_rows(), static_cast<std::size_t>(1));
+    HPX_TEST_EQ(right.data()[0], 30);
+    HPX_TEST_EQ(right.data()[1], 31);
 
     uniform_rows<int> empty_rows(std::vector<int>{}, 3);
-    auto empty = empty_rows.extract(1, 3);
-    HPX_TEST(empty.data.empty());
-    HPX_TEST_EQ(empty.num_rows, static_cast<std::size_t>(1));
+    auto empty = HPX_MOVE(empty_rows).extract(1, 3);
+    HPX_TEST(empty.data().empty());
+    HPX_TEST_EQ(empty.num_rows(), static_cast<std::size_t>(1));
 
     std::vector<move_only_value> move_only_values;
     move_only_values.reserve(3);
@@ -315,10 +315,9 @@ void test_uniform_rows_slicing()
     move_only_values.emplace_back(20);
     move_only_values.emplace_back(30);
     uniform_rows<move_only_value> move_only_rows(HPX_MOVE(move_only_values), 3);
-    auto middle = move_only_rows.extract(1, 3);
-    HPX_TEST_EQ(middle.data.size(), static_cast<std::size_t>(1));
-    HPX_TEST_EQ(middle.data[0].value, 20);
-    HPX_TEST_EQ(move_only_rows.data[1].value, -1);
+    auto middle = HPX_MOVE(move_only_rows).extract(1, 3);
+    HPX_TEST_EQ(middle.data().size(), static_cast<std::size_t>(1));
+    HPX_TEST_EQ(middle.data()[0].value, 20);
 }
 
 void test_uniform_rows_merge()
@@ -328,11 +327,12 @@ void test_uniform_rows_merge()
     values.emplace_back(std::vector<std::string>{"e", "f"}, 1);
 
     uniform_rows<std::string> result(HPX_MOVE(values));
-    HPX_TEST_EQ(result.data.size(), static_cast<std::size_t>(6));
-    HPX_TEST_EQ(result.num_rows, static_cast<std::size_t>(3));
-    for (std::size_t i = 0; i != result.data.size(); ++i)
+    HPX_TEST_EQ(result.data().size(), static_cast<std::size_t>(6));
+    HPX_TEST_EQ(result.num_rows(), static_cast<std::size_t>(3));
+    for (std::size_t i = 0; i != result.data().size(); ++i)
     {
-        HPX_TEST_EQ(result.data[i], std::string(1, static_cast<char>('a' + i)));
+        HPX_TEST_EQ(
+            result.data()[i], std::string(1, static_cast<char>('a' + i)));
     }
 
     std::vector<uniform_rows<int>> mismatched;
@@ -343,10 +343,10 @@ void test_uniform_rows_merge()
 
     std::vector<uniform_rows<int>> singleton;
     singleton.emplace_back(std::vector<int>{1, 2, 3, 4}, 2);
-    int const* const original_data = singleton.front().data.data();
+    int const* const original_data = singleton.front().data().data();
     uniform_rows<int> singleton_result(HPX_MOVE(singleton));
-    HPX_TEST_EQ(singleton_result.data.data(), original_data);
-    HPX_TEST_EQ(singleton_result.num_rows, static_cast<std::size_t>(2));
+    HPX_TEST_EQ(singleton_result.data().data(), original_data);
+    HPX_TEST_EQ(singleton_result.num_rows(), static_cast<std::size_t>(2));
 }
 
 void test_uniform_rows_vector_bool()
@@ -356,20 +356,20 @@ void test_uniform_rows_vector_bool()
     values.emplace_back(std::vector<bool>{false, false}, 1);
 
     uniform_rows<bool> merged(HPX_MOVE(values));
-    HPX_TEST_EQ(merged.data.size(), static_cast<std::size_t>(6));
-    HPX_TEST_EQ(merged.num_rows, static_cast<std::size_t>(3));
-    HPX_TEST(merged.data[0]);
-    HPX_TEST(!merged.data[1]);
-    HPX_TEST(merged.data[2]);
-    HPX_TEST(merged.data[3]);
-    HPX_TEST(!merged.data[4]);
-    HPX_TEST(!merged.data[5]);
+    HPX_TEST_EQ(merged.data().size(), static_cast<std::size_t>(6));
+    HPX_TEST_EQ(merged.num_rows(), static_cast<std::size_t>(3));
+    HPX_TEST(merged.data()[0]);
+    HPX_TEST(!merged.data()[1]);
+    HPX_TEST(merged.data()[2]);
+    HPX_TEST(merged.data()[3]);
+    HPX_TEST(!merged.data()[4]);
+    HPX_TEST(!merged.data()[5]);
 
-    auto slice = merged.extract(1, 3);
-    HPX_TEST_EQ(slice.data.size(), static_cast<std::size_t>(2));
-    HPX_TEST_EQ(slice.num_rows, static_cast<std::size_t>(1));
-    HPX_TEST(slice.data[0]);
-    HPX_TEST(slice.data[1]);
+    auto slice = HPX_MOVE(merged).extract(1, 3);
+    HPX_TEST_EQ(slice.data().size(), static_cast<std::size_t>(2));
+    HPX_TEST_EQ(slice.num_rows(), static_cast<std::size_t>(1));
+    HPX_TEST(slice.data()[0]);
+    HPX_TEST(slice.data()[1]);
 
     uniform_rows<bool> value(true);
     HPX_TEST(HPX_MOVE(value).unwrap_value());
@@ -379,11 +379,28 @@ void test_uniform_rows_validation()
 {
     uniform_rows<int> valid_empty_rows(std::vector<int>{}, 3);
     uniform_rows<int> valid_no_rows(std::vector<int>{}, 0);
-    uniform_rows<int> rows_with_no_width(std::vector<int>{1}, 0);
-    uniform_rows<int> nonuniform_width(std::vector<int>{1, 2, 3}, 2);
+    uniform_rows<int> valid_rows(std::vector<int>{1, 2, 3, 4}, 2);
+
+    auto deserialize_rows = [](std::vector<int> data, std::size_t num_rows) {
+        std::vector<char> buffer;
+        hpx::serialization::output_archive output(buffer);
+        output << data << num_rows;
+
+        uniform_rows<int> rows;
+        hpx::serialization::input_archive input(buffer);
+        input >> rows;
+        return rows;
+    };
+
+    auto rows_with_no_width = deserialize_rows(std::vector<int>{1}, 0);
+    auto nonuniform_width = deserialize_rows(std::vector<int>{1, 2, 3}, 2);
 
     HPX_TEST(valid_empty_rows.is_valid());
     HPX_TEST(valid_no_rows.is_valid());
+    HPX_TEST(valid_rows.is_valid());
+    HPX_TEST_EQ(valid_empty_rows.row_width(), static_cast<std::size_t>(0));
+    HPX_TEST_EQ(valid_no_rows.row_width(), static_cast<std::size_t>(0));
+    HPX_TEST_EQ(valid_rows.row_width(), static_cast<std::size_t>(2));
     HPX_TEST(!rows_with_no_width.is_valid());
     HPX_TEST(!nonuniform_width.is_valid());
     HPX_TEST_NO_THROW(
@@ -396,14 +413,19 @@ void test_uniform_rows_validation()
 
 void test_uniform_rows_construction()
 {
+    using extract_type = decltype(&uniform_rows<int>::extract);
+    static_assert(std::is_invocable_v<extract_type, uniform_rows<int>&&,
+        std::size_t, std::size_t>);
+    static_assert(!std::is_invocable_v<extract_type, uniform_rows<int>&,
+        std::size_t, std::size_t>);
     static_assert(std::is_nothrow_constructible_v<uniform_rows<int>,
         std::vector<int>&&, std::size_t>);
     static_assert(
         std::is_nothrow_constructible_v<uniform_rows<int>, std::vector<int>&&>);
 
     uniform_rows<int> rows(std::vector<int>{1, 2, 3});
-    HPX_TEST_EQ(rows.data.size(), static_cast<std::size_t>(3));
-    HPX_TEST_EQ(rows.num_rows, static_cast<std::size_t>(3));
+    HPX_TEST_EQ(rows.data().size(), static_cast<std::size_t>(3));
+    HPX_TEST_EQ(rows.num_rows(), static_cast<std::size_t>(3));
     HPX_TEST_EQ(rows.row_width(), static_cast<std::size_t>(1));
 
     std::string value = "value";
@@ -451,12 +473,12 @@ void test_uniform_rows_serialization()
     uniform_rows<std::string> restored_rows;
     hpx::serialization::input_archive rows_input(rows_buffer);
     rows_input >> restored_rows;
-    HPX_TEST_EQ(restored_rows.data.size(), rows.data.size());
-    for (std::size_t i = 0; i != rows.data.size(); ++i)
+    HPX_TEST_EQ(restored_rows.data().size(), rows.data().size());
+    for (std::size_t i = 0; i != rows.data().size(); ++i)
     {
-        HPX_TEST_EQ(restored_rows.data[i], rows.data[i]);
+        HPX_TEST_EQ(restored_rows.data()[i], rows.data()[i]);
     }
-    HPX_TEST_EQ(restored_rows.num_rows, rows.num_rows);
+    HPX_TEST_EQ(restored_rows.num_rows(), rows.num_rows());
 }
 
 int hpx_main()

--- a/libs/full/collectives/tests/unit/hierarchical_helpers.cpp
+++ b/libs/full/collectives/tests/unit/hierarchical_helpers.cpp
@@ -16,6 +16,7 @@
 #include <cstddef>
 #include <limits>
 #include <string>
+#include <type_traits>
 #include <vector>
 
 using hpx::collectives::detail::checked_data_size_product;
@@ -24,6 +25,27 @@ using hpx::collectives::detail::classify_site;
 using hpx::collectives::detail::get_top_level_groups;
 using hpx::collectives::detail::is_top_level_rep;
 using hpx::collectives::detail::uniform_rows;
+
+struct move_only_value
+{
+    explicit move_only_value(int const value)
+      : value(value)
+    {
+    }
+
+    move_only_value(move_only_value const&) = delete;
+    move_only_value& operator=(move_only_value const&) = delete;
+
+    move_only_value(move_only_value&& other) noexcept
+      : value(other.value)
+    {
+        other.value = -1;
+    }
+
+    move_only_value& operator=(move_only_value&&) = delete;
+
+    int value;
+};
 
 void test_balanced_arity2()
 {
@@ -286,6 +308,17 @@ void test_uniform_rows_slicing()
     auto empty = empty_rows.extract(1, 3);
     HPX_TEST(empty.data.empty());
     HPX_TEST_EQ(empty.num_rows, static_cast<std::size_t>(1));
+
+    std::vector<move_only_value> move_only_values;
+    move_only_values.reserve(3);
+    move_only_values.emplace_back(10);
+    move_only_values.emplace_back(20);
+    move_only_values.emplace_back(30);
+    uniform_rows<move_only_value> move_only_rows(HPX_MOVE(move_only_values), 3);
+    auto middle = move_only_rows.extract(1, 3);
+    HPX_TEST_EQ(middle.data.size(), static_cast<std::size_t>(1));
+    HPX_TEST_EQ(middle.data[0].value, 20);
+    HPX_TEST_EQ(move_only_rows.data[1].value, -1);
 }
 
 void test_uniform_rows_merge()
@@ -337,6 +370,9 @@ void test_uniform_rows_vector_bool()
     HPX_TEST_EQ(slice.num_rows, static_cast<std::size_t>(1));
     HPX_TEST(slice.data[0]);
     HPX_TEST(slice.data[1]);
+
+    uniform_rows<bool> value(true);
+    HPX_TEST(HPX_MOVE(value).unwrap_value());
 }
 
 void test_uniform_rows_validation()
@@ -360,6 +396,11 @@ void test_uniform_rows_validation()
 
 void test_uniform_rows_construction()
 {
+    static_assert(std::is_nothrow_constructible_v<uniform_rows<int>,
+        std::vector<int>&&, std::size_t>);
+    static_assert(
+        std::is_nothrow_constructible_v<uniform_rows<int>, std::vector<int>&&>);
+
     uniform_rows<int> rows(std::vector<int>{1, 2, 3});
     HPX_TEST_EQ(rows.data.size(), static_cast<std::size_t>(3));
     HPX_TEST_EQ(rows.num_rows, static_cast<std::size_t>(3));

--- a/libs/full/collectives/tests/unit/hierarchical_helpers.cpp
+++ b/libs/full/collectives/tests/unit/hierarchical_helpers.cpp
@@ -4,6 +4,8 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+#define HPX_HAVE_FORCE_NO_CXX_MODULES
+
 #include <hpx/config.hpp>
 
 #if !defined(HPX_COMPUTE_DEVICE_CODE)

--- a/libs/full/collectives/tests/unit/hierarchical_helpers.cpp
+++ b/libs/full/collectives/tests/unit/hierarchical_helpers.cpp
@@ -4,8 +4,6 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-#define HPX_HAVE_FORCE_NO_CXX_MODULES
-
 #include <hpx/config.hpp>
 
 #if !defined(HPX_COMPUTE_DEVICE_CODE)


### PR DESCRIPTION
## Proposed Changes

- Replace nested intermediate vectors in hierarchical gather and scatter with a serializable uniform-row carrier that stores values contiguously.
- Merge gather rows directly and partition scatter rows by range, avoiding per-child owned vectors at intermediate tree levels.
- Validate carrier shape and size arithmetic, preserve the ordinary leaf payload path where possible, and add coverage for edge-case payload types.

## Any background context you want to provide?

Gather and scatter carry equally sized logical rows between hierarchical levels. A contiguous data buffer plus a row count is therefore sufficient to recover every row boundary without allocating or serializing an offset table.

This changes the internal payload exchanged between hierarchical levels. The public collective APIs, results, and ordering remain unchanged. Hierarchical all-to-all is intentionally left for a separate follow-up.

## Testing

- Relevant distributed TCP collective tests: 7/7 passed locally with C++20.
- Targeted TCP suite: 24/24 passed with GCC 14.3/C++20 on Rostam.
- `clang-format` 20.1.7 (`--dry-run --Werror`) and `git diff --check` passed.
- Tests cover serialization, uneven trees, explicit and automatic generations, singleton runs, `vector<bool>`, carrier-shaped user values, and non-default-constructible payloads.

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.