### PR TITLE
async: add hpx::async<^^func>(target, ...) reflection overload

### DIFF
--- a/cmake/HPX_CollectStdHeaders.cmake
+++ b/cmake/HPX_CollectStdHeaders.cmake
@@ -105,6 +105,10 @@ set(STANDARD_LIBRARY_HEADERS
     "<cwctype>"
 )
 
+if(HPX_WITH_CXX26_REFLECTION)
+  list(APPEND STANDARD_LIBRARY_HEADERS "<meta>")
+endif()
+
 # Function to extract #includes from a file recursively
 function(hpx_extract_includes_from_file module)
 

--- a/libs/full/actions_base/include/hpx/actions_base/reflect_action.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/reflect_action.hpp
@@ -129,6 +129,7 @@ namespace hpx::actions {
         typename Component =
             typename detail::reflect_component_action_base<F>::component_type,
         typename Derived = void>
+        requires(std::meta::is_function(F) && std::meta::is_class_member(F))
     struct reflect_component_action
       : basic_action<Component,
             typename detail::reflect_component_action_base<F>::func_type,
@@ -162,6 +163,7 @@ namespace hpx::actions {
     };
 
     template <std::meta::info F, typename Component, typename Derived>
+        requires(std::meta::is_function(F) && std::meta::is_class_member(F))
     detail::register_action_invocation_count<
         reflect_component_action<F, Component, Derived>>
         reflect_component_action<F, Component,
@@ -180,6 +182,7 @@ namespace hpx::actions {
         typename Component =
             typename detail::reflect_component_action_base<F>::component_type,
         typename Derived = void>
+        requires(std::meta::is_function(F) && std::meta::is_class_member(F))
     struct reflect_component_direct_action
       : reflect_component_action<F, Component,
             detail::action_type_t<
@@ -198,6 +201,7 @@ namespace hpx::actions {
             invocation_count_registrar_;
     };
     template <std::meta::info F, typename Component, typename Derived>
+        requires(std::meta::is_function(F) && std::meta::is_class_member(F))
     detail::register_action_invocation_count<
         reflect_component_direct_action<F, Component, Derived>>
         reflect_component_direct_action<F, Component,
@@ -232,6 +236,7 @@ namespace hpx::actions {
     /// \tparam F  A std::meta::info reflection of a free function.
     /// \tparam Derived  Derived type for CRTP extensibility (default: void).
     template <std::meta::info F, typename Derived = void>
+        requires(std::meta::is_namespace_member(F) && std::meta::is_function(F))
     struct reflect_action
       : basic_action<hpx::actions::detail::plain_function,
             typename detail::reflect_action_base<F>::func_type,
@@ -278,6 +283,7 @@ namespace hpx::actions {
 
     /// \cond NOINTERNAL
     template <std::meta::info F, typename Derived>
+        requires(std::meta::is_namespace_member(F) && std::meta::is_function(F))
     detail::register_action_invocation_count<reflect_action<F, Derived>>
         reflect_action<F, Derived>::invocation_count_registrar_;
     /// \endcond
@@ -292,6 +298,7 @@ namespace hpx::actions {
     /// \tparam F       A std::meta::info reflection of a free function.
     /// \tparam Derived CRTP derived type (defaults to void).
     template <std::meta::info F, typename Derived = void>
+        requires(std::meta::is_namespace_member(F) && std::meta::is_function(F))
     struct reflect_direct_action
       : reflect_action<F,
             detail::action_type_t<reflect_direct_action<F, Derived>, Derived>>
@@ -308,6 +315,7 @@ namespace hpx::actions {
     };
     /// \cond NOINTERNAL
     template <std::meta::info F, typename Derived>
+        requires(std::meta::is_namespace_member(F) && std::meta::is_function(F))
     detail::register_action_invocation_count<reflect_direct_action<F, Derived>>
         reflect_direct_action<F, Derived>::invocation_count_registrar_;
     /// \endcond

--- a/libs/full/async_distributed/include/hpx/async_distributed/async.hpp
+++ b/libs/full/async_distributed/include/hpx/async_distributed/async.hpp
@@ -218,6 +218,45 @@ namespace hpx {
         return detail::async_action_dispatch<Action, std::decay_t<F>>::call(
             HPX_FORWARD(F, f), HPX_FORWARD(Ts, ts)...);
     }
+
+#if defined(HPX_HAVE_CXX26_REFLECTION)
+    /// \brief Reflection-based async overload.
+    ///
+    /// Allows calling hpx::async<^^func>(target, ...) directly without
+    /// defining an explicit action type. Internally constructs
+    /// reflect_action<F> and delegates to the existing async machinery.
+    ///
+    /// \tparam F      A std::meta::info reflection of a free function.
+    /// \tparam Target id_type, client, or distribution policy.
+    /// \tparam Ts     Additional arguments to pass to the function.
+    // clang-format off
+    HPX_CXX_EXPORT template <std::meta::info F, typename Target, typename... Ts>
+        requires(std::meta::is_namespace_member(F) && std::meta::is_function(F) &&
+            (std::is_same_v<std::decay_t<Target>, hpx::id_type> ||
+                hpx::traits::is_client_v<std::decay_t<Target>> ||
+                hpx::traits::is_distribution_policy_v<std::decay_t<Target>>))
+    HPX_FORCEINLINE auto async(Target&& target, Ts&&... ts)
+    // clang-format on
+    {
+        return hpx::async(hpx::actions::reflect_action<F>{},
+            HPX_FORWARD(Target, target), HPX_FORWARD(Ts, ts)...);
+    }
+    // clang-format off
+    HPX_CXX_EXPORT template <std::meta::info F, typename Policy,
+        typename Target, typename... Ts>
+        requires(std::meta::is_namespace_member(F) && std::meta::is_function(F) &&
+            traits::is_launch_policy_v<Policy> &&
+            (std::is_same_v<std::decay_t<Target>, hpx::id_type> ||
+                hpx::traits::is_client_v<std::decay_t<Target>> ||
+                hpx::traits::is_distribution_policy_v<std::decay_t<Target>>))
+    HPX_FORCEINLINE auto async(Policy&& policy, Target&& target, Ts&&... ts)
+    // clang-format on
+    {
+        return hpx::async(hpx::actions::reflect_action<F>{},
+            HPX_FORWARD(Policy, policy), HPX_FORWARD(Target, target),
+            HPX_FORWARD(Ts, ts)...);
+    }
+#endif    // HPX_HAVE_CXX26_REFLECTION
 }    // namespace hpx
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/libs/full/async_distributed/tests/unit/CMakeLists.txt
+++ b/libs/full/async_distributed/tests/unit/CMakeLists.txt
@@ -34,6 +34,11 @@ set(tests
 set(async_continue_PARAMETERS LOCALITIES 2)
 set(async_continue_cb_PARAMETERS LOCALITIES 2)
 set(async_remote_PARAMETERS LOCALITIES 2)
+
+if(HPX_WITH_CXX26_REFLECTION)
+  set(tests ${tests} async_remote_reflect)
+  set(async_remote_reflect_PARAMETERS LOCALITIES 2)
+endif()
 set(async_remote_client_PARAMETERS LOCALITIES 2)
 set(async_cb_remote_PARAMETERS LOCALITIES 2)
 set(async_cb_remote_client_PARAMETERS LOCALITIES 2)

--- a/libs/full/async_distributed/tests/unit/async_remote_reflect.cpp
+++ b/libs/full/async_distributed/tests/unit/async_remote_reflect.cpp
@@ -1,0 +1,88 @@
+//  Copyright (c) 2026 Priyanshi Sharma
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+#if defined(HPX_HAVE_CXX26_REFLECTION)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/actions.hpp>
+#include <hpx/include/async.hpp>
+#include <hpx/include/runtime.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <cstdint>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+// Component action test
+struct reflect_server : hpx::components::managed_component_base<reflect_server>
+{
+    hpx::id_type identity(std::int32_t i) const
+    {
+        HPX_TEST_EQ(i, std::int32_t(42));
+        return hpx::find_here();
+    }
+};
+using reflect_server_type = hpx::components::managed_component<reflect_server>;
+HPX_REGISTER_COMPONENT(reflect_server_type, reflect_server)
+
+///////////////////////////////////////////////////////////////////////////////
+hpx::id_type reflect_increment(std::int32_t i)
+{
+    HPX_TEST_EQ(i, std::int32_t(42));
+    return hpx::find_here();
+}
+
+///////////////////////////////////////////////////////////////////////////////
+void test_async_reflect(hpx::id_type const& target)
+{
+    // Test: hpx::async<^^func>(target, ...) -- reflection-based syntax
+    // reflect_increment returns hpx::find_here() so we can verify
+    // the action executed on the expected target locality.
+    {
+        hpx::future<hpx::id_type> f1 =
+            hpx::async<^^reflect_increment>(target, 42);
+        HPX_TEST_EQ(f1.get(), target);
+    }
+    {
+        hpx::future<hpx::id_type> f1 =
+            hpx::async<^^reflect_increment>(hpx::launch::async, target, 42);
+        HPX_TEST_EQ(f1.get(), target);
+    }
+}
+
+int hpx_main()
+{
+    std::vector<hpx::id_type> localities = hpx::find_all_localities();
+    for (hpx::id_type const& id : localities)
+    {
+        test_async_reflect(id);
+    }
+    // Test: reflect_component_action -- component member function
+    // Instantiate reflect_server on each locality and verify identity()
+    // returns the locality it ran on.
+    for (hpx::id_type const& id : localities)
+    {
+        hpx::future<hpx::id_type> server_id = hpx::new_<reflect_server>(id);
+        using identity_action =
+            hpx::actions::reflect_component_action<^^reflect_server::identity>;
+        hpx::future<hpx::id_type> f =
+            hpx::async<identity_action>(server_id.get(), std::int32_t(42));
+        HPX_TEST_EQ(f.get(), id);
+    }
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    HPX_TEST_EQ_MSG(
+        hpx::init(argc, argv), 0, "HPX main exited with non-zero status");
+    return hpx::util::report_errors();
+}
+
+#endif    // HPX_HAVE_CXX26_REFLECTION
+#endif    // HPX_COMPUTE_DEVICE_CODE


### PR DESCRIPTION
## Summary

Adds a new `hpx::async` overload that accepts a `std::meta::info`
reflection of a free function as a non-type template parameter,
eliminating the need to define an explicit action type:

```cpp
// Before: explicit action type required
using my_action = hpx::actions::reflect_action<^^app::compute>;
hpx::async<my_action>(target, args...);

// After: direct reflection syntax
hpx::async<^^app::compute>(target, args...);
```

## Design

The overload is constrained to accept only viable distributed targets:
- `hpx::id_type`
- Client types (`hpx::traits::is_client_v`)
- Distribution policies (`hpx::traits::is_distribution_policy_v`)

Internally constructs `reflect_action<F>{}` and delegates to the
existing `hpx::async(action, target, ...)` machinery — no changes
to dispatch internals required.

Guarded by `HPX_HAVE_CXX26_REFLECTION`.

## Testing

Added compile-time check verifying `reflect_action<F>` is default
constructible (required for the `reflect_action<F>{}` construction
in the overload). Full runtime dispatch requires a live HPX locality.

## Related

Suggested by hkaiser. Builds on PRs #7298, #7311, #7342, #7349.
As hkaiser noted, this gives the deprecated `async<Action>` syntax
a new life via reflection.