### PR TITLE
Flatten hierarchical all-to-all exchange payloads

### DIFF
--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -654,8 +654,8 @@ namespace hpx::collectives {
                         destination_site != dest_left + dest_group_size;
                         ++destination_site)
                     {
-                        destination.emplace_back(HPX_MOVE(gathered).take(
-                            row_left + destination_site));
+                        destination.emplace_back(
+                            gathered.take(row_left + destination_site));
                     }
                     exchange_offsets.push_back(exchange_data.size());
                 }
@@ -732,8 +732,7 @@ namespace hpx::collectives {
                             std::size_t const index =
                                 received.offsets()[group] +
                                 source * my_group_size + j;
-                            scatter_data.emplace_back(
-                                HPX_MOVE(received).take(index));
+                            scatter_data.emplace_back(received.take(index));
                         }
                     }
                 }

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -347,7 +347,8 @@ namespace hpx::collectives {
                 std::size_t const diagonal_size =
                     checked_data_size_product(my_group_size_, my_group_size_);
 
-                scatter_data_ = HPX_MOVE(gathered).release_data();
+                std::vector<T> gathered_data =
+                    HPX_MOVE(gathered).release_data();
 
                 exchange_data_.reserve(exchange_size);
                 exchange_offsets_.reserve(exchange_boundaries);
@@ -372,7 +373,7 @@ namespace hpx::collectives {
                             ++destination_site)
                         {
                             destination.emplace_back(handle_bool<T>(HPX_MOVE(
-                                scatter_data_[row_left + destination_site])));
+                                gathered_data[row_left + destination_site])));
                         }
                         exchange_offsets_.push_back(exchange_data_.size());
                     }
@@ -380,10 +381,6 @@ namespace hpx::collectives {
 
                 HPX_ASSERT(exchange_data_.size() == exchange_size);
                 HPX_ASSERT(diagonal_.size() == diagonal_size);
-
-                // Every gathered element now lives in the exchange or local
-                // diagonal. Keep its allocation for the final scatter rows.
-                scatter_data_.clear();
             }
 
             [[nodiscard]] ragged_rows<T> release_exchange() &
@@ -435,7 +432,8 @@ namespace hpx::collectives {
                 // group] storage order. Thus source * my_group_size_ + j
                 // selects the value for destination j; off-diagonal data also
                 // starts at received_offsets[group].
-                scatter_data_.reserve(
+                std::vector<T> scatter_data;
+                scatter_data.reserve(
                     checked_data_size_product(my_group_size_, num_sites_));
                 for (std::size_t j = 0; j != my_group_size_; ++j)
                 {
@@ -450,7 +448,7 @@ namespace hpx::collectives {
                             {
                                 std::size_t const index =
                                     source * my_group_size_ + j;
-                                scatter_data_.emplace_back(
+                                scatter_data.emplace_back(
                                     handle_bool<T>(HPX_MOVE(diagonal_[index])));
                             }
                             else
@@ -458,16 +456,16 @@ namespace hpx::collectives {
                                 std::size_t const index =
                                     received_offsets[group] +
                                     source * my_group_size_ + j;
-                                scatter_data_.emplace_back(handle_bool<T>(
+                                scatter_data.emplace_back(handle_bool<T>(
                                     HPX_MOVE(received_data[index])));
                             }
                         }
                     }
                 }
-                HPX_ASSERT(scatter_data_.size() ==
+                HPX_ASSERT(scatter_data.size() ==
                     checked_data_size_product(my_group_size_, num_sites_));
 
-                return uniform_rows<T>(HPX_MOVE(scatter_data_), my_group_size_);
+                return uniform_rows<T>(HPX_MOVE(scatter_data), my_group_size_);
             }
 
         private:
@@ -479,7 +477,6 @@ namespace hpx::collectives {
             std::vector<T> exchange_data_;
             std::vector<std::size_t> exchange_offsets_;
             std::vector<T> diagonal_;
-            std::vector<T> scatter_data_;
         };
 
         // all_to_all: detail entry point carrying the internal generation step.
@@ -531,9 +528,18 @@ namespace hpx::collectives {
 
                 if constexpr (is_ragged_rows_v<payload_type>)
                 {
-                    std::vector<payload_type> values;
-                    values.emplace_back(HPX_FORWARD(Payload, local_result));
-                    return hpx::make_ready_future(payload_type(values, 0));
+                    // Match the communicator finalizer: the outgoing carrier
+                    // has one segment per source row, while the received
+                    // carrier has one segment per contributor. With one
+                    // destination column all source-row data is already
+                    // contiguous, so only the offsets need to be collapsed.
+                    payload_type payload(HPX_FORWARD(Payload, local_result));
+                    payload.validate_for_exchange(
+                        num_sites, "hpx::collectives::all_to_all");
+                    auto data = HPX_MOVE(payload).release_data();
+                    std::vector<std::size_t> offsets{0, data.size()};
+                    return hpx::make_ready_future(
+                        payload_type(HPX_MOVE(data), HPX_MOVE(offsets)));
                 }
                 else
                 {
@@ -775,8 +781,7 @@ namespace hpx::collectives {
             // Phase 2: Pack one flat sequence of destination-group segments
             // for each gathered row. Retain the local diagonal separately and
             // represent it by empty exchange segments, avoiding its round trip
-            // through the inter-group communicator. The constructor also
-            // preserves the gathered allocation for the final scatter rows.
+            // through the inter-group communicator.
             detail::hierarchical_all_to_all_exchange<T> exchange(
                 HPX_MOVE(gathered), group_index, num_sites_val, arity_val);
 

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -214,6 +214,7 @@ namespace hpx { namespace collectives {
 #include <hpx/assert.hpp>
 #include <hpx/collectives/argument_types.hpp>
 #include <hpx/collectives/create_communicator.hpp>
+#include <hpx/collectives/detail/flattened_data.hpp>
 #include <hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp>
 #include <hpx/collectives/detail/hierarchical_helpers.hpp>
 #include <hpx/modules/async_base.hpp>
@@ -223,7 +224,6 @@ namespace hpx { namespace collectives {
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/type_support.hpp>
 
-#include <algorithm>
 #include <cstddef>
 #include <type_traits>
 #include <utility>
@@ -247,43 +247,57 @@ namespace hpx::traits {
     template <typename Communicator>
     struct communication_operation<Communicator, communication::all_to_all_tag>
     {
-        template <typename Result, typename T>
+        template <typename Result, typename Payload>
         static Result get(Communicator& communicator, std::size_t which,
             std::size_t generation,
             hpx::collectives::detail::generation_mode num_generations,
-            std::vector<T>&& t)
+            Payload&& payload)
         {
-            return communicator.template handle_data<std::vector<T>>(
+            using payload_type = std::decay_t<Payload>;
+            return communicator.template handle_data<payload_type>(
                 communication::communicator_data<
                     communication::all_to_all_tag>::name(),
                 which, generation,
                 // step function (invoked for each get)
-                [&t](auto& data, std::size_t which) {
-                    data[which] = HPX_MOVE(t);
+                [&payload](auto& data, std::size_t which) {
+                    data[which] = HPX_FORWARD(Payload, payload);
                 },
                 // finalizer (invoked after all data has been received)
                 [](auto& data, auto&, std::size_t which) {
-                    // slice the overall data based on the locality id of the
-                    // requesting site
-                    std::vector<T> result;
-                    result.reserve(data.size());
-                    for (auto& v : data)
-                    {
-                        if (v.size() != data.size())
-                        {
-                            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
-                                "hpx::collectives::all_to_all",
-                                "each participating site must contribute "
-                                "exactly num_sites elements");
-                        }
-
-                        result.push_back(
-                            hpx::collectives::detail::handle_bool<T>(
-                                HPX_MOVE(v[which])));
-                    }
-                    return result;
+                    return finalize(data, which);
                 },
                 num_generations);
+        }
+
+    private:
+        template <typename T>
+        static std::vector<T> finalize(
+            std::vector<std::vector<T>>& data, std::size_t const which)
+        {
+            std::vector<T> result;
+            result.reserve(data.size());
+            for (auto& values : data)
+            {
+                if (values.size() != data.size())
+                {
+                    HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                        "hpx::collectives::all_to_all",
+                        "each participating site must contribute exactly "
+                        "num_sites elements");
+                }
+
+                result.push_back(hpx::collectives::detail::handle_bool<T>(
+                    HPX_MOVE(values[which])));
+            }
+            return result;
+        }
+
+        template <typename T>
+        static hpx::collectives::detail::ragged_rows<T> finalize(
+            std::vector<hpx::collectives::detail::ragged_rows<T>>& data,
+            std::size_t const which)
+        {
+            return hpx::collectives::detail::ragged_rows<T>(data, which);
         }
     };
 }    // namespace hpx::traits
@@ -297,18 +311,20 @@ namespace hpx::collectives {
         // The public overload forwards with single_step; the hierarchical
         // overload passes double_step for the flat fast path and the inter-group
         // exchange.
-        template <typename T>
-        hpx::future<std::vector<T>> all_to_all(communicator fid,
-            std::vector<T>&& local_result, this_site_arg this_site,
+        template <typename Payload>
+        hpx::future<std::decay_t<Payload>> all_to_all(communicator fid,
+            Payload&& local_result, this_site_arg this_site,
             generation_arg const generation, generation_mode num_generations)
         {
+            using payload_type = std::decay_t<Payload>;
+
             if (this_site.is_default())
             {
                 this_site = agas::get_locality_id();
             }
             if (generation == 0)
             {
-                return hpx::make_exceptional_future<std::vector<T>>(
+                return hpx::make_exceptional_future<payload_type>(
                     HPX_GET_EXCEPTION(hpx::error::bad_parameter,
                         "hpx::collectives::all_to_all",
                         "the generation number shouldn't be zero"));
@@ -317,38 +333,52 @@ namespace hpx::collectives {
             // Handle operation right away if there is only one value.
             if (auto [num_sites, comm_site] = fid.get_info(); num_sites == 1)
             {
-                if (local_result.size() != 1)
+                if constexpr (!is_ragged_rows_v<payload_type>)
                 {
-                    return hpx::make_exceptional_future<std::vector<T>>(
-                        HPX_GET_EXCEPTION(hpx::error::bad_parameter,
-                            "hpx::collectives::all_to_all",
-                            "each participating site must contribute exactly "
-                            "num_sites elements"));
+                    if (local_result.size() != 1)
+                    {
+                        return hpx::make_exceptional_future<payload_type>(
+                            HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                                "hpx::collectives::all_to_all",
+                                "each participating site must contribute "
+                                "exactly num_sites elements"));
+                    }
                 }
 
                 if (this_site != comm_site)
                 {
-                    return hpx::make_exceptional_future<std::vector<T>>(
+                    return hpx::make_exceptional_future<payload_type>(
                         HPX_GET_EXCEPTION(hpx::error::bad_parameter,
                             "hpx::collectives::all_to_all",
                             "the local site should be zero if only one site is "
                             "involved"));
                 }
-                return hpx::make_ready_future(HPX_MOVE(local_result));
+
+                if constexpr (is_ragged_rows_v<payload_type>)
+                {
+                    std::vector<payload_type> values;
+                    values.emplace_back(HPX_FORWARD(Payload, local_result));
+                    return hpx::make_ready_future(payload_type(values, 0));
+                }
+                else
+                {
+                    return hpx::make_ready_future(
+                        HPX_FORWARD(Payload, local_result));
+                }
             }
 
             auto all_to_all_data =
-                [local_result = HPX_MOVE(local_result), this_site, generation,
-                    num_generations](
-                    communicator&& c) mutable -> hpx::future<std::vector<T>> {
+                [local_result = HPX_FORWARD(Payload, local_result), this_site,
+                    generation, num_generations](
+                    communicator&& c) mutable -> hpx::future<payload_type> {
                 using action_type =
                     communicator_server::communication_get_direct_action<
                         traits::communication::all_to_all_tag,
-                        hpx::future<std::vector<T>>, generation_mode,
-                        std::vector<T>>;
+                        hpx::future<payload_type>, generation_mode,
+                        payload_type>;
 
                 // explicitly unwrap returned future
-                hpx::future<std::vector<T>> result =
+                hpx::future<payload_type> result =
                     hpx::async(action_type(), c, this_site, generation,
                         num_generations, HPX_MOVE(local_result));
 
@@ -561,7 +591,7 @@ namespace hpx::collectives {
         if (is_representative)
         {
             // Phase 1: Gather all subtree sites' data at this rep.
-            std::vector<std::vector<T>> gathered =
+            detail::uniform_rows<T> gathered =
                 detail::subtree_gather_at_top_rep(
                     communicators, HPX_MOVE(local_result), first_gen);
 
@@ -570,60 +600,151 @@ namespace hpx::collectives {
                 group_index, num_sites_val, arity_val);
             std::size_t const num_groups =
                 detail::get_top_level_group_count(num_sites_val, arity_val);
+            std::size_t const exchange_size = detail::checked_data_size_product(
+                my_group_size, num_sites_val - my_group_size);
+            std::size_t const exchange_segments =
+                detail::checked_data_size_product(my_group_size, num_groups);
+            std::size_t const exchange_boundaries =
+                detail::checked_data_size_sum(exchange_segments, 1);
+            std::size_t const diagonal_size =
+                detail::checked_data_size_product(my_group_size, my_group_size);
 
-            // Phase 2: Build exchange blocks -- pack gathered data by
-            // destination group, then perform flat all_to_all among reps.
-            std::vector<std::vector<T>> exchange_blocks(num_groups);
-            for (std::size_t group = 0; group != num_groups; ++group)
+            gathered.validate("hpx::collectives::all_to_all (hierarchical)");
+            if (gathered.num_rows() != my_group_size)
             {
-                std::size_t const dest_group_size =
-                    detail::get_top_level_group_size(
-                        group, num_sites_val, arity_val);
-                std::size_t const dest_left = detail::get_top_level_group_left(
-                    group, num_sites_val, arity_val);
+                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                    "hpx::collectives::all_to_all (hierarchical)",
+                    "the subtree gather returned an unexpected number of "
+                    "rows");
+            }
+            if (gathered.row_width() != num_sites_val)
+            {
+                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                    "hpx::collectives::all_to_all (hierarchical)",
+                    "the subtree gather returned rows with an unexpected "
+                    "number of elements");
+            }
 
-                exchange_blocks[group].reserve(my_group_size * dest_group_size);
-                for (std::size_t s = 0; s != my_group_size; ++s)
+            // Phase 2: Pack one flat sequence of destination-group segments
+            // for each gathered row. Retain the local diagonal separately and
+            // represent it by empty exchange segments, avoiding its round trip
+            // through the inter-group communicator.
+            std::vector<T> exchange_data;
+            exchange_data.reserve(exchange_size);
+            std::vector<std::size_t> exchange_offsets;
+            exchange_offsets.reserve(exchange_boundaries);
+            exchange_offsets.push_back(0);
+            std::vector<T> diagonal;
+            diagonal.reserve(diagonal_size);
+            for (std::size_t row = 0; row != my_group_size; ++row)
+            {
+                std::size_t const row_left =
+                    detail::checked_data_size_product(row, num_sites_val);
+                for (std::size_t group = 0; group != num_groups; ++group)
                 {
-                    std::move(gathered[s].begin() + dest_left,
-                        gathered[s].begin() + dest_left + dest_group_size,
-                        std::back_inserter(exchange_blocks[group]));
+                    std::size_t const dest_group_size =
+                        detail::get_top_level_group_size(
+                            group, num_sites_val, arity_val);
+                    std::size_t const dest_left =
+                        detail::get_top_level_group_left(
+                            group, num_sites_val, arity_val);
+                    auto& destination =
+                        group == group_index ? diagonal : exchange_data;
+                    for (std::size_t destination_site = dest_left;
+                        destination_site != dest_left + dest_group_size;
+                        ++destination_site)
+                    {
+                        destination.emplace_back(HPX_MOVE(gathered).take(
+                            row_left + destination_site));
+                    }
+                    exchange_offsets.push_back(exchange_data.size());
                 }
             }
+            HPX_ASSERT(exchange_data.size() == exchange_size);
+            HPX_ASSERT(diagonal.size() == diagonal_size);
+
+            detail::ragged_rows<T> exchange(
+                HPX_MOVE(exchange_data), HPX_MOVE(exchange_offsets));
 
             // The exchange touches the inter-group communicator once but must
             // advance it by two generations to stay in lock-step with the
             // subtree communicators, so request double_step.
-            std::vector<std::vector<T>> received =
-                detail::all_to_all(communicators.get(0),
-                    HPX_MOVE(exchange_blocks), communicators.site(0), first_gen,
-                    detail::generation_mode::double_step)
-                    .get();
+            hpx::future<detail::ragged_rows<T>> received_future =
+                detail::all_to_all(communicators.get(0), HPX_MOVE(exchange),
+                    communicators.site(0), first_gen,
+                    detail::generation_mode::double_step);
 
-            // Phase 3: Transpose received blocks back to per-site vectors,
-            // then scatter down the subtree.
-            std::vector<std::vector<T>> scatter_input(my_group_size);
-            for (std::size_t j = 0; j != my_group_size; ++j)
+            // Every gathered element now lives in the exchange or diagonal.
+            // Reuse the gathered allocation for the final scatter rows.
+            std::vector<T> scatter_data = HPX_MOVE(gathered).release_data();
+            scatter_data.clear();
+
+            detail::ragged_rows<T> received = received_future.get();
+            received.validate("hpx::collectives::all_to_all (hierarchical)");
+            if (received.num_segments() != num_groups)
             {
-                scatter_input[j].resize(num_sites_val);
-                for (std::size_t group = 0; group != num_groups; ++group)
+                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                    "hpx::collectives::all_to_all (hierarchical)",
+                    "the inter-group exchange returned an unexpected number "
+                    "of blocks");
+            }
+            for (std::size_t group = 0; group != num_groups; ++group)
+            {
+                std::size_t const source_group_size =
+                    detail::get_top_level_group_size(
+                        group, num_sites_val, arity_val);
+                std::size_t const expected_size = group == group_index ?
+                    0 :
+                    detail::checked_data_size_product(
+                        source_group_size, my_group_size);
+                if (received.segment_size(group) != expected_size)
                 {
-                    std::size_t const src_group_size =
-                        detail::get_top_level_group_size(
-                            group, num_sites_val, arity_val);
-                    std::size_t const src_left =
-                        detail::get_top_level_group_left(
-                            group, num_sites_val, arity_val);
-                    for (std::size_t s = 0; s != src_group_size; ++s)
-                    {
-                        scatter_input[j][src_left + s] =
-                            HPX_MOVE(received[group][s * my_group_size + j]);
-                    }
+                    HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                        "hpx::collectives::all_to_all (hierarchical)",
+                        "the inter-group exchange returned a block with an "
+                        "unexpected number of elements");
                 }
             }
 
-            return detail::subtree_scatter_at_top_rep(
-                communicators, HPX_MOVE(scatter_input), second_gen);
+            // Phase 3: Transpose the received off-diagonal blocks and the
+            // retained local diagonal into one row per subtree site.
+            scatter_data.reserve(detail::checked_data_size_product(
+                my_group_size, num_sites_val));
+            for (std::size_t j = 0; j != my_group_size; ++j)
+            {
+                for (std::size_t group = 0; group != num_groups; ++group)
+                {
+                    std::size_t const source_group_size =
+                        detail::get_top_level_group_size(
+                            group, num_sites_val, arity_val);
+                    for (std::size_t source = 0; source != source_group_size;
+                        ++source)
+                    {
+                        if (group == group_index)
+                        {
+                            std::size_t const index =
+                                source * my_group_size + j;
+                            scatter_data.emplace_back(detail::handle_bool<T>(
+                                HPX_MOVE(diagonal[index])));
+                        }
+                        else
+                        {
+                            std::size_t const index =
+                                received.offsets()[group] +
+                                source * my_group_size + j;
+                            scatter_data.emplace_back(
+                                HPX_MOVE(received).take(index));
+                        }
+                    }
+                }
+            }
+            HPX_ASSERT(scatter_data.size() ==
+                detail::checked_data_size_product(
+                    my_group_size, num_sites_val));
+
+            return detail::subtree_scatter_at_top_rep(communicators,
+                detail::uniform_rows<T>(HPX_MOVE(scatter_data), my_group_size),
+                second_gen);
         }
         else
         {
@@ -632,7 +753,7 @@ namespace hpx::collectives {
             detail::subtree_send_to_top_rep(
                 communicators, HPX_MOVE(local_result), first_gen);
 
-            return detail::subtree_receive_from_top_rep<std::vector<T>>(
+            return detail::subtree_receive_from_top_rep<T>(
                 communicators, second_gen);
         }
     }

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -225,7 +225,6 @@ namespace hpx { namespace collectives {
 #include <hpx/modules/type_support.hpp>
 
 #include <cstddef>
-#include <tuple>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -315,16 +314,18 @@ namespace hpx::collectives {
             hierarchical_all_to_all_exchange(uniform_rows<T>&& gathered,
                 std::size_t const group_index, std::size_t const num_sites,
                 std::size_t const arity)
+              : group_index_(group_index)
+              , num_sites_(num_sites)
+              , arity_(arity)
+              , my_group_size_(
+                    get_top_level_group_size(group_index, num_sites, arity))
+              , num_groups_(get_top_level_group_count(num_sites, arity))
             {
                 constexpr char const* operation =
                     "hpx::collectives::all_to_all (hierarchical)";
-                std::size_t const my_group_size =
-                    get_top_level_group_size(group_index, num_sites, arity);
-                std::size_t const num_groups =
-                    get_top_level_group_count(num_sites, arity);
 
                 gathered.validate(operation);
-                if (gathered.num_rows() != my_group_size)
+                if (gathered.num_rows() != my_group_size_)
                 {
                     HPX_THROW_EXCEPTION(hpx::error::invalid_status, operation,
                         "the subtree gather returned an unexpected number of "
@@ -338,35 +339,33 @@ namespace hpx::collectives {
                 }
 
                 std::size_t const exchange_size = checked_data_size_product(
-                    my_group_size, num_sites - my_group_size);
+                    my_group_size_, num_sites_ - my_group_size_);
                 std::size_t const exchange_segments =
-                    checked_data_size_product(my_group_size, num_groups);
+                    checked_data_size_product(my_group_size_, num_groups_);
                 std::size_t const exchange_boundaries =
                     checked_data_size_sum(exchange_segments, 1);
                 std::size_t const diagonal_size =
-                    checked_data_size_product(my_group_size, my_group_size);
+                    checked_data_size_product(my_group_size_, my_group_size_);
 
                 scatter_data_ = HPX_MOVE(gathered).release_data();
 
-                std::vector<T> exchange_data;
-                exchange_data.reserve(exchange_size);
-                std::vector<std::size_t> exchange_offsets;
-                exchange_offsets.reserve(exchange_boundaries);
-                exchange_offsets.push_back(0);
+                exchange_data_.reserve(exchange_size);
+                exchange_offsets_.reserve(exchange_boundaries);
+                exchange_offsets_.push_back(0);
                 diagonal_.reserve(diagonal_size);
 
-                for (std::size_t row = 0; row != my_group_size; ++row)
+                for (std::size_t row = 0; row != my_group_size_; ++row)
                 {
                     std::size_t const row_left =
-                        checked_data_size_product(row, num_sites);
-                    for (std::size_t group = 0; group != num_groups; ++group)
+                        checked_data_size_product(row, num_sites_);
+                    for (std::size_t group = 0; group != num_groups_; ++group)
                     {
                         std::size_t const destination_group_size =
-                            get_top_level_group_size(group, num_sites, arity);
+                            get_top_level_group_size(group, num_sites_, arity_);
                         std::size_t const destination_left =
-                            get_top_level_group_left(group, num_sites, arity);
+                            get_top_level_group_left(group, num_sites_, arity_);
                         auto& destination =
-                            group == group_index ? diagonal_ : exchange_data;
+                            group == group_index_ ? diagonal_ : exchange_data_;
                         for (std::size_t destination_site = destination_left;
                             destination_site !=
                             destination_left + destination_group_size;
@@ -375,30 +374,110 @@ namespace hpx::collectives {
                             destination.emplace_back(handle_bool<T>(HPX_MOVE(
                                 scatter_data_[row_left + destination_site])));
                         }
-                        exchange_offsets.push_back(exchange_data.size());
+                        exchange_offsets_.push_back(exchange_data_.size());
                     }
                 }
 
-                HPX_ASSERT(exchange_data.size() == exchange_size);
+                HPX_ASSERT(exchange_data_.size() == exchange_size);
                 HPX_ASSERT(diagonal_.size() == diagonal_size);
-                exchange_ = ragged_rows<T>(
-                    HPX_MOVE(exchange_data), HPX_MOVE(exchange_offsets));
 
                 // Every gathered element now lives in the exchange or local
                 // diagonal. Keep its allocation for the final scatter rows.
                 scatter_data_.clear();
             }
 
-            [[nodiscard]] std::tuple<ragged_rows<T>, std::vector<T>,
-                std::vector<T>>
-            release() &&
+            [[nodiscard]] ragged_rows<T> release_exchange() &
             {
-                return {HPX_MOVE(exchange_), HPX_MOVE(diagonal_),
-                    HPX_MOVE(scatter_data_)};
+                return ragged_rows<T>(
+                    HPX_MOVE(exchange_data_), HPX_MOVE(exchange_offsets_));
+            }
+
+            [[nodiscard]] uniform_rows<T> transpose(
+                ragged_rows<T>&& received) &&
+            {
+                constexpr char const* operation =
+                    "hpx::collectives::all_to_all (hierarchical)";
+                received.validate(operation);
+                if (received.num_segments() != num_groups_)
+                {
+                    HPX_THROW_EXCEPTION(hpx::error::invalid_status, operation,
+                        "the inter-group exchange returned an unexpected "
+                        "number of blocks");
+                }
+                for (std::size_t group = 0; group != num_groups_; ++group)
+                {
+                    std::size_t const source_group_size =
+                        get_top_level_group_size(group, num_sites_, arity_);
+                    std::size_t const expected_size = group == group_index_ ?
+                        0 :
+                        checked_data_size_product(
+                            source_group_size, my_group_size_);
+                    if (received.segment_size(group) != expected_size)
+                    {
+                        HPX_THROW_EXCEPTION(hpx::error::invalid_status,
+                            operation,
+                            "the inter-group exchange returned a block with "
+                            "an unexpected number of elements");
+                    }
+                }
+
+                std::vector<std::size_t> const received_offsets =
+                    received.offsets();
+                std::vector<T> received_data =
+                    HPX_MOVE(received).release_data();
+
+                // Create one scatter row for each destination site j in this
+                // representative's group. Within each row, source groups are
+                // visited from left to right and their sites from low to high,
+                // preserving global source-site order. Both an off-diagonal
+                // received segment and the retained local diagonal use
+                // [source site within group][destination site within this
+                // group] storage order. Thus source * my_group_size_ + j
+                // selects the value for destination j; off-diagonal data also
+                // starts at received_offsets[group].
+                scatter_data_.reserve(
+                    checked_data_size_product(my_group_size_, num_sites_));
+                for (std::size_t j = 0; j != my_group_size_; ++j)
+                {
+                    for (std::size_t group = 0; group != num_groups_; ++group)
+                    {
+                        std::size_t const source_group_size =
+                            get_top_level_group_size(group, num_sites_, arity_);
+                        for (std::size_t source = 0;
+                            source != source_group_size; ++source)
+                        {
+                            if (group == group_index_)
+                            {
+                                std::size_t const index =
+                                    source * my_group_size_ + j;
+                                scatter_data_.emplace_back(
+                                    handle_bool<T>(HPX_MOVE(diagonal_[index])));
+                            }
+                            else
+                            {
+                                std::size_t const index =
+                                    received_offsets[group] +
+                                    source * my_group_size_ + j;
+                                scatter_data_.emplace_back(handle_bool<T>(
+                                    HPX_MOVE(received_data[index])));
+                            }
+                        }
+                    }
+                }
+                HPX_ASSERT(scatter_data_.size() ==
+                    checked_data_size_product(my_group_size_, num_sites_));
+
+                return uniform_rows<T>(HPX_MOVE(scatter_data_), my_group_size_);
             }
 
         private:
-            ragged_rows<T> exchange_;
+            std::size_t group_index_;
+            std::size_t num_sites_;
+            std::size_t arity_;
+            std::size_t my_group_size_;
+            std::size_t num_groups_;
+            std::vector<T> exchange_data_;
+            std::vector<std::size_t> exchange_offsets_;
             std::vector<T> diagonal_;
             std::vector<T> scatter_data_;
         };
@@ -692,105 +771,27 @@ namespace hpx::collectives {
                     communicators, HPX_MOVE(local_result), first_gen);
 
             std::size_t const group_index = static_cast<std::size_t>(gidx);
-            std::size_t const my_group_size = detail::get_top_level_group_size(
-                group_index, num_sites_val, arity_val);
-            std::size_t const num_groups =
-                detail::get_top_level_group_count(num_sites_val, arity_val);
 
             // Phase 2: Pack one flat sequence of destination-group segments
             // for each gathered row. Retain the local diagonal separately and
             // represent it by empty exchange segments, avoiding its round trip
             // through the inter-group communicator. The constructor also
             // preserves the gathered allocation for the final scatter rows.
-            auto [exchange, diagonal, scatter_data] =
-                detail::hierarchical_all_to_all_exchange<T>(
-                    HPX_MOVE(gathered), group_index, num_sites_val, arity_val)
-                    .release();
+            detail::hierarchical_all_to_all_exchange<T> exchange(
+                HPX_MOVE(gathered), group_index, num_sites_val, arity_val);
 
             // The exchange touches the inter-group communicator once but must
             // advance it by two generations to stay in lock-step with the
             // subtree communicators, so request double_step.
             hpx::future<detail::ragged_rows<T>> received_future =
-                detail::all_to_all(communicators.get(0), HPX_MOVE(exchange),
-                    communicators.site(0), first_gen,
-                    detail::generation_mode::double_step);
+                detail::all_to_all(communicators.get(0),
+                    exchange.release_exchange(), communicators.site(0),
+                    first_gen, detail::generation_mode::double_step);
 
             detail::ragged_rows<T> received = received_future.get();
-            received.validate("hpx::collectives::all_to_all (hierarchical)");
-            if (received.num_segments() != num_groups)
-            {
-                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
-                    "hpx::collectives::all_to_all (hierarchical)",
-                    "the inter-group exchange returned an unexpected number "
-                    "of blocks");
-            }
-            for (std::size_t group = 0; group != num_groups; ++group)
-            {
-                std::size_t const source_group_size =
-                    detail::get_top_level_group_size(
-                        group, num_sites_val, arity_val);
-                std::size_t const expected_size = group == group_index ?
-                    0 :
-                    detail::checked_data_size_product(
-                        source_group_size, my_group_size);
-                if (received.segment_size(group) != expected_size)
-                {
-                    HPX_THROW_EXCEPTION(hpx::error::invalid_status,
-                        "hpx::collectives::all_to_all (hierarchical)",
-                        "the inter-group exchange returned a block with an "
-                        "unexpected number of elements");
-                }
-            }
-
-            std::vector<std::size_t> const received_offsets =
-                received.offsets();
-            std::vector<T> received_data = HPX_MOVE(received).release_data();
-
-            // Phase 3 creates one scatter row for each destination site j in
-            // this representative's group. Within each row, source groups are
-            // visited from left to right and their sites from low to high, so
-            // the appended values preserve global source-site order. Both an
-            // off-diagonal received segment and the retained local diagonal
-            // use [source site within group][destination site within this
-            // group] storage order. Thus source * my_group_size + j selects
-            // the value for destination j; off-diagonal data additionally
-            // starts at received_offsets[group].
-            scatter_data.reserve(detail::checked_data_size_product(
-                my_group_size, num_sites_val));
-            for (std::size_t j = 0; j != my_group_size; ++j)
-            {
-                for (std::size_t group = 0; group != num_groups; ++group)
-                {
-                    std::size_t const source_group_size =
-                        detail::get_top_level_group_size(
-                            group, num_sites_val, arity_val);
-                    for (std::size_t source = 0; source != source_group_size;
-                        ++source)
-                    {
-                        if (group == group_index)
-                        {
-                            std::size_t const index =
-                                source * my_group_size + j;
-                            scatter_data.emplace_back(detail::handle_bool<T>(
-                                HPX_MOVE(diagonal[index])));
-                        }
-                        else
-                        {
-                            std::size_t const index = received_offsets[group] +
-                                source * my_group_size + j;
-                            scatter_data.emplace_back(detail::handle_bool<T>(
-                                HPX_MOVE(received_data[index])));
-                        }
-                    }
-                }
-            }
-            HPX_ASSERT(scatter_data.size() ==
-                detail::checked_data_size_product(
-                    my_group_size, num_sites_val));
 
             return detail::subtree_scatter_at_top_rep(communicators,
-                detail::uniform_rows<T>(HPX_MOVE(scatter_data), my_group_size),
-                second_gen);
+                HPX_MOVE(exchange).transpose(HPX_MOVE(received)), second_gen);
         }
         else
         {

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -225,6 +225,7 @@ namespace hpx { namespace collectives {
 #include <hpx/modules/type_support.hpp>
 
 #include <cstddef>
+#include <tuple>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -306,6 +307,101 @@ namespace hpx::collectives {
 
     ///////////////////////////////////////////////////////////////////////////
     namespace detail {
+
+        template <typename T>
+        class hierarchical_all_to_all_exchange
+        {
+        public:
+            hierarchical_all_to_all_exchange(uniform_rows<T>&& gathered,
+                std::size_t const group_index, std::size_t const num_sites,
+                std::size_t const arity)
+            {
+                constexpr char const* operation =
+                    "hpx::collectives::all_to_all (hierarchical)";
+                std::size_t const my_group_size =
+                    get_top_level_group_size(group_index, num_sites, arity);
+                std::size_t const num_groups =
+                    get_top_level_group_count(num_sites, arity);
+
+                gathered.validate(operation);
+                if (gathered.num_rows() != my_group_size)
+                {
+                    HPX_THROW_EXCEPTION(hpx::error::invalid_status, operation,
+                        "the subtree gather returned an unexpected number of "
+                        "rows");
+                }
+                if (gathered.row_width() != num_sites)
+                {
+                    HPX_THROW_EXCEPTION(hpx::error::invalid_status, operation,
+                        "the subtree gather returned rows with an unexpected "
+                        "number of elements");
+                }
+
+                std::size_t const exchange_size = checked_data_size_product(
+                    my_group_size, num_sites - my_group_size);
+                std::size_t const exchange_segments =
+                    checked_data_size_product(my_group_size, num_groups);
+                std::size_t const exchange_boundaries =
+                    checked_data_size_sum(exchange_segments, 1);
+                std::size_t const diagonal_size =
+                    checked_data_size_product(my_group_size, my_group_size);
+
+                scatter_data_ = HPX_MOVE(gathered).release_data();
+
+                std::vector<T> exchange_data;
+                exchange_data.reserve(exchange_size);
+                std::vector<std::size_t> exchange_offsets;
+                exchange_offsets.reserve(exchange_boundaries);
+                exchange_offsets.push_back(0);
+                diagonal_.reserve(diagonal_size);
+
+                for (std::size_t row = 0; row != my_group_size; ++row)
+                {
+                    std::size_t const row_left =
+                        checked_data_size_product(row, num_sites);
+                    for (std::size_t group = 0; group != num_groups; ++group)
+                    {
+                        std::size_t const destination_group_size =
+                            get_top_level_group_size(group, num_sites, arity);
+                        std::size_t const destination_left =
+                            get_top_level_group_left(group, num_sites, arity);
+                        auto& destination =
+                            group == group_index ? diagonal_ : exchange_data;
+                        for (std::size_t destination_site = destination_left;
+                            destination_site !=
+                            destination_left + destination_group_size;
+                            ++destination_site)
+                        {
+                            destination.emplace_back(handle_bool<T>(HPX_MOVE(
+                                scatter_data_[row_left + destination_site])));
+                        }
+                        exchange_offsets.push_back(exchange_data.size());
+                    }
+                }
+
+                HPX_ASSERT(exchange_data.size() == exchange_size);
+                HPX_ASSERT(diagonal_.size() == diagonal_size);
+                exchange_ = ragged_rows<T>(
+                    HPX_MOVE(exchange_data), HPX_MOVE(exchange_offsets));
+
+                // Every gathered element now lives in the exchange or local
+                // diagonal. Keep its allocation for the final scatter rows.
+                scatter_data_.clear();
+            }
+
+            [[nodiscard]] std::tuple<ragged_rows<T>, std::vector<T>,
+                std::vector<T>>
+            release() &&
+            {
+                return {HPX_MOVE(exchange_), HPX_MOVE(diagonal_),
+                    HPX_MOVE(scatter_data_)};
+            }
+
+        private:
+            ragged_rows<T> exchange_;
+            std::vector<T> diagonal_;
+            std::vector<T> scatter_data_;
+        };
 
         // all_to_all: detail entry point carrying the internal generation step.
         // The public overload forwards with single_step; the hierarchical
@@ -600,71 +696,16 @@ namespace hpx::collectives {
                 group_index, num_sites_val, arity_val);
             std::size_t const num_groups =
                 detail::get_top_level_group_count(num_sites_val, arity_val);
-            std::size_t const exchange_size = detail::checked_data_size_product(
-                my_group_size, num_sites_val - my_group_size);
-            std::size_t const exchange_segments =
-                detail::checked_data_size_product(my_group_size, num_groups);
-            std::size_t const exchange_boundaries =
-                detail::checked_data_size_sum(exchange_segments, 1);
-            std::size_t const diagonal_size =
-                detail::checked_data_size_product(my_group_size, my_group_size);
-
-            gathered.validate("hpx::collectives::all_to_all (hierarchical)");
-            if (gathered.num_rows() != my_group_size)
-            {
-                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
-                    "hpx::collectives::all_to_all (hierarchical)",
-                    "the subtree gather returned an unexpected number of "
-                    "rows");
-            }
-            if (gathered.row_width() != num_sites_val)
-            {
-                HPX_THROW_EXCEPTION(hpx::error::invalid_status,
-                    "hpx::collectives::all_to_all (hierarchical)",
-                    "the subtree gather returned rows with an unexpected "
-                    "number of elements");
-            }
 
             // Phase 2: Pack one flat sequence of destination-group segments
             // for each gathered row. Retain the local diagonal separately and
             // represent it by empty exchange segments, avoiding its round trip
-            // through the inter-group communicator.
-            std::vector<T> exchange_data;
-            exchange_data.reserve(exchange_size);
-            std::vector<std::size_t> exchange_offsets;
-            exchange_offsets.reserve(exchange_boundaries);
-            exchange_offsets.push_back(0);
-            std::vector<T> diagonal;
-            diagonal.reserve(diagonal_size);
-            for (std::size_t row = 0; row != my_group_size; ++row)
-            {
-                std::size_t const row_left =
-                    detail::checked_data_size_product(row, num_sites_val);
-                for (std::size_t group = 0; group != num_groups; ++group)
-                {
-                    std::size_t const dest_group_size =
-                        detail::get_top_level_group_size(
-                            group, num_sites_val, arity_val);
-                    std::size_t const dest_left =
-                        detail::get_top_level_group_left(
-                            group, num_sites_val, arity_val);
-                    auto& destination =
-                        group == group_index ? diagonal : exchange_data;
-                    for (std::size_t destination_site = dest_left;
-                        destination_site != dest_left + dest_group_size;
-                        ++destination_site)
-                    {
-                        destination.emplace_back(
-                            gathered.take(row_left + destination_site));
-                    }
-                    exchange_offsets.push_back(exchange_data.size());
-                }
-            }
-            HPX_ASSERT(exchange_data.size() == exchange_size);
-            HPX_ASSERT(diagonal.size() == diagonal_size);
-
-            detail::ragged_rows<T> exchange(
-                HPX_MOVE(exchange_data), HPX_MOVE(exchange_offsets));
+            // through the inter-group communicator. The constructor also
+            // preserves the gathered allocation for the final scatter rows.
+            auto [exchange, diagonal, scatter_data] =
+                detail::hierarchical_all_to_all_exchange<T>(
+                    HPX_MOVE(gathered), group_index, num_sites_val, arity_val)
+                    .release();
 
             // The exchange touches the inter-group communicator once but must
             // advance it by two generations to stay in lock-step with the
@@ -673,11 +714,6 @@ namespace hpx::collectives {
                 detail::all_to_all(communicators.get(0), HPX_MOVE(exchange),
                     communicators.site(0), first_gen,
                     detail::generation_mode::double_step);
-
-            // Every gathered element now lives in the exchange or diagonal.
-            // Reuse the gathered allocation for the final scatter rows.
-            std::vector<T> scatter_data = HPX_MOVE(gathered).release_data();
-            scatter_data.clear();
 
             detail::ragged_rows<T> received = received_future.get();
             received.validate("hpx::collectives::all_to_all (hierarchical)");
@@ -706,8 +742,19 @@ namespace hpx::collectives {
                 }
             }
 
-            // Phase 3: Transpose the received off-diagonal blocks and the
-            // retained local diagonal into one row per subtree site.
+            std::vector<std::size_t> const received_offsets =
+                received.offsets();
+            std::vector<T> received_data = HPX_MOVE(received).release_data();
+
+            // Phase 3 creates one scatter row for each destination site j in
+            // this representative's group. Within each row, source groups are
+            // visited from left to right and their sites from low to high, so
+            // the appended values preserve global source-site order. Both an
+            // off-diagonal received segment and the retained local diagonal
+            // use [source site within group][destination site within this
+            // group] storage order. Thus source * my_group_size + j selects
+            // the value for destination j; off-diagonal data additionally
+            // starts at received_offsets[group].
             scatter_data.reserve(detail::checked_data_size_product(
                 my_group_size, num_sites_val));
             for (std::size_t j = 0; j != my_group_size; ++j)
@@ -729,10 +776,10 @@ namespace hpx::collectives {
                         }
                         else
                         {
-                            std::size_t const index =
-                                received.offsets()[group] +
+                            std::size_t const index = received_offsets[group] +
                                 source * my_group_size + j;
-                            scatter_data.emplace_back(received.take(index));
+                            scatter_data.emplace_back(detail::handle_bool<T>(
+                                HPX_MOVE(received_data[index])));
                         }
                     }
                 }

--- a/libs/full/collectives/include/hpx/collectives/detail/flattened_data.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/flattened_data.hpp
@@ -223,7 +223,7 @@ namespace hpx::collectives::detail {
             return HPX_MOVE(data_);
         }
 
-        [[nodiscard]] T take(std::size_t const index) &&
+        [[nodiscard]] T take(std::size_t const index) &
         {
             HPX_ASSERT(index < data_.size());
             return handle_bool<T>(HPX_MOVE(data_[index]));
@@ -391,7 +391,7 @@ namespace hpx::collectives::detail {
             return offsets_[segment + 1] - offsets_[segment];
         }
 
-        [[nodiscard]] T take(std::size_t const index) &&
+        [[nodiscard]] T take(std::size_t const index) &
         {
             HPX_ASSERT(index < data_.size());
             return handle_bool<T>(HPX_MOVE(data_[index]));

--- a/libs/full/collectives/include/hpx/collectives/detail/flattened_data.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/flattened_data.hpp
@@ -223,6 +223,18 @@ namespace hpx::collectives::detail {
             return HPX_MOVE(data_);
         }
 
+        [[nodiscard]] T take(std::size_t const index) &&
+        {
+            HPX_ASSERT(index < data_.size());
+            return handle_bool<T>(HPX_MOVE(data_[index]));
+        }
+
+        [[nodiscard]] std::vector<T> release_data() &&
+        {
+            HPX_ASSERT(is_valid());
+            return HPX_MOVE(data_);
+        }
+
         [[nodiscard]] std::vector<T> const& data() const noexcept
         {
             return data_;
@@ -273,5 +285,167 @@ namespace hpx::collectives::detail {
     HPX_CXX_EXPORT template <typename T>
     inline constexpr bool is_uniform_rows_v =
         is_uniform_rows<std::decay_t<T>>::value;
+
+    // A compact carrier for variable-sized logical segments. Hierarchical
+    // all-to-all uses one segment per source-row/destination-group pair, so
+    // prefix offsets retain the segment boundaries without nested vectors.
+    HPX_CXX_EXPORT template <typename T>
+    struct ragged_rows
+    {
+        ragged_rows() = default;
+
+        ragged_rows(std::vector<T>&& values,
+            std::vector<std::size_t>&& offsets) noexcept
+          : data_(HPX_MOVE(values))
+          , offsets_(HPX_MOVE(offsets))
+        {
+            HPX_ASSERT(is_valid());
+        }
+
+        ragged_rows(
+            std::vector<ragged_rows<T>>& values, std::size_t const column)
+        {
+            // Communicator finalizers call this under the server lock. Each
+            // site consumes a disjoint column, so moved elements are visited
+            // exactly once even though the shared carriers remain in place.
+            constexpr char const* operation =
+                "hpx::collectives::detail::ragged_rows::ragged_rows";
+            std::size_t const num_columns = values.size();
+            HPX_ASSERT(num_columns != 0 && column < num_columns);
+
+            std::size_t total_size = 0;
+            for (auto const& value : values)
+            {
+                value.validate_for_exchange(num_columns, operation);
+                std::size_t const num_source_rows =
+                    value.num_segments() / num_columns;
+                for (std::size_t row = 0; row != num_source_rows; ++row)
+                {
+                    std::size_t const segment = row * num_columns + column;
+                    total_size = checked_data_size_sum(
+                        total_size, value.segment_size(segment));
+                }
+            }
+
+            data_.reserve(total_size);
+            offsets_.reserve(
+                checked_data_size_sum(num_columns, std::size_t{1}));
+            offsets_.push_back(0);
+
+            for (auto& value : values)
+            {
+                std::size_t const num_source_rows =
+                    value.num_segments() / num_columns;
+                for (std::size_t row = 0; row != num_source_rows; ++row)
+                {
+                    std::size_t const segment = row * num_columns + column;
+                    append_data_range(data_,
+                        value.data_.begin() + value.offsets_[segment],
+                        value.data_.begin() + value.offsets_[segment + 1]);
+                }
+                offsets_.push_back(data_.size());
+            }
+
+            HPX_ASSERT(is_valid());
+        }
+
+        [[nodiscard]] bool is_valid() const noexcept
+        {
+            return !offsets_.empty() && offsets_.front() == 0 &&
+                offsets_.back() == data_.size() &&
+                std::is_sorted(offsets_.begin(), offsets_.end());
+        }
+
+        void validate(char const* const operation) const
+        {
+            if (!is_valid())
+            {
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter, operation,
+                    "the ragged hierarchical collective payload has invalid "
+                    "offsets");
+            }
+        }
+
+        void validate_for_exchange(
+            std::size_t const num_columns, char const* const operation) const
+        {
+            HPX_ASSERT(num_columns != 0);
+            validate(operation);
+            if (num_segments() % num_columns != 0)
+            {
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter, operation,
+                    "the ragged payload must contain a complete set of "
+                    "destination-group segments for every source row");
+            }
+        }
+
+        [[nodiscard]] std::size_t num_segments() const noexcept
+        {
+            return offsets_.empty() ? 0 : offsets_.size() - 1;
+        }
+
+        [[nodiscard]] std::size_t segment_size(std::size_t const segment) const
+        {
+            HPX_ASSERT(is_valid());
+            HPX_ASSERT(segment < num_segments());
+            return offsets_[segment + 1] - offsets_[segment];
+        }
+
+        [[nodiscard]] T take(std::size_t const index) &&
+        {
+            HPX_ASSERT(index < data_.size());
+            return handle_bool<T>(HPX_MOVE(data_[index]));
+        }
+
+        [[nodiscard]] std::vector<T> const& data() const noexcept
+        {
+            return data_;
+        }
+
+        [[nodiscard]] std::vector<std::size_t> const& offsets() const noexcept
+        {
+            return offsets_;
+        }
+
+    private:
+        friend class hpx::serialization::access;
+
+        std::vector<T> data_;
+        std::vector<std::size_t> offsets_;
+
+        template <typename Archive>
+        void serialize(Archive& ar, unsigned int const)
+        {
+            ar & data_ & offsets_;
+        }
+
+        template <typename Iterator>
+        static void append_data_range(
+            std::vector<T>& destination, Iterator first, Iterator const last)
+        {
+            // Inserting a range can instantiate vector's move-assignment path
+            // even at end(). Append element-wise so internal carriers require
+            // only move construction. vector<bool> additionally needs proxy
+            // conversion.
+            for (; first != last; ++first)
+            {
+                destination.emplace_back(handle_bool<T>(HPX_MOVE(*first)));
+            }
+        }
+    };
+
+    template <typename T>
+    struct is_ragged_rows : std::false_type
+    {
+    };
+
+    template <typename T>
+    struct is_ragged_rows<ragged_rows<T>> : std::true_type
+    {
+    };
+
+    HPX_CXX_EXPORT template <typename T>
+    inline constexpr bool is_ragged_rows_v =
+        is_ragged_rows<std::decay_t<T>>::value;
 
 }    // namespace hpx::collectives::detail

--- a/libs/full/collectives/include/hpx/collectives/detail/flattened_data.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/flattened_data.hpp
@@ -59,6 +59,11 @@ namespace hpx::collectives::detail {
     void append_data_range(
         std::vector<T>& destination, Iterator first, Iterator const last)
     {
+        auto const size = std::distance(first, last);
+        HPX_ASSERT(size >= 0);
+        destination.reserve(checked_data_size_sum(
+            destination.size(), static_cast<std::size_t>(size)));
+
         // Inserting a range can instantiate vector's move-assignment path
         // even at end(). Append element-wise so internal carriers require
         // only move construction. vector<bool> additionally needs proxy
@@ -96,9 +101,6 @@ namespace hpx::collectives::detail {
             std::size_t const num_rows, Iterator first, Iterator const last)
           : num_rows_(num_rows)
         {
-            auto const size = std::distance(first, last);
-            HPX_ASSERT(size >= 0);
-            data_.reserve(static_cast<std::size_t>(size));
             append_data_range(data_, first, last);
             HPX_ASSERT(is_valid());
         }
@@ -157,12 +159,12 @@ namespace hpx::collectives::detail {
             }
 
             data_.reserve(total_size);
-            num_rows_ = total_rows;
             for (auto& value : values)
             {
                 append_data_range(
                     data_, value.data_.begin(), value.data_.end());
             }
+            num_rows_ = total_rows;
 
             HPX_ASSERT(is_valid());
         }
@@ -286,7 +288,10 @@ namespace hpx::collectives::detail {
     HPX_CXX_EXPORT template <typename T>
     struct ragged_rows
     {
-        ragged_rows() = default;
+        ragged_rows()
+          : offsets_{0, 0}
+        {
+        }
 
         ragged_rows(std::vector<T>&& values,
             std::vector<std::size_t>&& offsets) noexcept
@@ -347,7 +352,7 @@ namespace hpx::collectives::detail {
 
         [[nodiscard]] bool is_valid() const noexcept
         {
-            return !offsets_.empty() && offsets_.front() == 0 &&
+            return offsets_.size() >= 2 && offsets_.front() == 0 &&
                 offsets_.back() == data_.size() &&
                 std::is_sorted(offsets_.begin(), offsets_.end());
         }

--- a/libs/full/collectives/include/hpx/collectives/detail/flattened_data.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/flattened_data.hpp
@@ -55,6 +55,20 @@ namespace hpx::collectives::detail {
         return lhs * rhs;
     }
 
+    template <typename T, typename Iterator>
+    void append_data_range(
+        std::vector<T>& destination, Iterator first, Iterator const last)
+    {
+        // Inserting a range can instantiate vector's move-assignment path
+        // even at end(). Append element-wise so internal carriers require
+        // only move construction. vector<bool> additionally needs proxy
+        // conversion.
+        for (; first != last; ++first)
+        {
+            destination.emplace_back(handle_bool<T>(HPX_MOVE(*first)));
+        }
+    }
+
     // A compact carrier for equally sized logical rows. Gather and scatter
     // preserve a uniform row width, so a row count is sufficient to derive
     // every boundary without allocating or serializing an offset table.
@@ -223,12 +237,6 @@ namespace hpx::collectives::detail {
             return HPX_MOVE(data_);
         }
 
-        [[nodiscard]] T take(std::size_t const index) &
-        {
-            HPX_ASSERT(index < data_.size());
-            return handle_bool<T>(HPX_MOVE(data_[index]));
-        }
-
         [[nodiscard]] std::vector<T> release_data() &&
         {
             HPX_ASSERT(is_valid());
@@ -255,20 +263,6 @@ namespace hpx::collectives::detail {
         void serialize(Archive& ar, unsigned int const)
         {
             ar & data_ & num_rows_;
-        }
-
-        template <typename Iterator>
-        static void append_data_range(
-            std::vector<T>& destination, Iterator first, Iterator const last)
-        {
-            // Inserting a range can instantiate vector's move-assignment path
-            // even at end(). Append element-wise so internal carriers require
-            // only move construction. vector<bool> additionally needs proxy
-            // conversion.
-            for (; first != last; ++first)
-            {
-                destination.emplace_back(handle_bool<T>(HPX_MOVE(*first)));
-            }
         }
     };
 
@@ -308,6 +302,8 @@ namespace hpx::collectives::detail {
             // Communicator finalizers call this under the server lock. Each
             // site consumes a disjoint column, so moved elements are visited
             // exactly once even though the shared carriers remain in place.
+            // The result has one segment per input contributor, containing
+            // all of that contributor's selected-column rows.
             constexpr char const* operation =
                 "hpx::collectives::detail::ragged_rows::ragged_rows";
             std::size_t const num_columns = values.size();
@@ -391,10 +387,10 @@ namespace hpx::collectives::detail {
             return offsets_[segment + 1] - offsets_[segment];
         }
 
-        [[nodiscard]] T take(std::size_t const index) &
+        [[nodiscard]] std::vector<T> release_data() &&
         {
-            HPX_ASSERT(index < data_.size());
-            return handle_bool<T>(HPX_MOVE(data_[index]));
+            HPX_ASSERT(is_valid());
+            return HPX_MOVE(data_);
         }
 
         [[nodiscard]] std::vector<T> const& data() const noexcept
@@ -417,20 +413,6 @@ namespace hpx::collectives::detail {
         void serialize(Archive& ar, unsigned int const)
         {
             ar & data_ & offsets_;
-        }
-
-        template <typename Iterator>
-        static void append_data_range(
-            std::vector<T>& destination, Iterator first, Iterator const last)
-        {
-            // Inserting a range can instantiate vector's move-assignment path
-            // even at end(). Append element-wise so internal carriers require
-            // only move construction. vector<bool> additionally needs proxy
-            // conversion.
-            for (; first != last; ++first)
-            {
-                destination.emplace_back(handle_bool<T>(HPX_MOVE(*first)));
-            }
         }
     };
 

--- a/libs/full/collectives/include/hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp
@@ -18,13 +18,13 @@
 
 #include <hpx/assert.hpp>
 #include <hpx/collectives/create_communicator.hpp>
+#include <hpx/collectives/detail/flattened_data.hpp>
 #include <hpx/collectives/gather.hpp>
 #include <hpx/collectives/scatter.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/type_support.hpp>
 
 #include <cstddef>
-#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -37,25 +37,19 @@ namespace hpx::collectives::detail {
     // its subtree using communicator levels 1..size()-1, skipping level 0
     // (the inter-group communicator).
     //
-    // Returns: flat vector of all subtree sites' data, ordered by subtree
-    //          site rank.
+    // Returns one logical row per subtree site, ordered by subtree site rank.
     //
     // For the flat fallback case (comms.size() <= 1), returns the site's
-    // own data wrapped in a single-element vector.
+    // own data wrapped in a single row.
     ///////////////////////////////////////////////////////////////////////////
     HPX_CXX_EXPORT template <typename T>
-    std::vector<std::decay_t<T>> subtree_gather_at_top_rep(
-        hierarchical_communicator const& comms, T&& local_result,
+    uniform_rows<T> subtree_gather_at_top_rep(
+        hierarchical_communicator const& comms, std::vector<T>&& local_result,
         generation_arg const generation)
     {
         HPX_ASSERT(comms.size() != 0);
 
-        using value_type = std::decay_t<T>;
-
-        // Wrap local value in a vector (same pattern as hierarchical
-        // gather_here).
-        std::vector<value_type> result;
-        result.emplace_back(HPX_FORWARD(T, local_result));
+        uniform_rows<T> result(HPX_MOVE(local_result), 1);
 
         // Walk bottom-up from leaf (size()-1) to level 1, skipping level 0
         // (the inter-group communicator). At every subtree level this site
@@ -65,8 +59,10 @@ namespace hpx::collectives::detail {
         // data is returned.
         for (std::size_t i = comms.size() - 1; i != 0; --i)
         {
-            result = gather_data(gather_here(hpx::launch::sync, comms.get(i),
-                HPX_MOVE(result), this_site_arg(0), generation));
+            result = gather_here_impl<uniform_rows<T>>(comms.get(i),
+                HPX_MOVE(result), this_site_arg(0), generation,
+                generation_mode::single_step)
+                         .get();
         }
 
         return result;
@@ -86,73 +82,73 @@ namespace hpx::collectives::detail {
     ///////////////////////////////////////////////////////////////////////////
     HPX_CXX_EXPORT template <typename T>
     void subtree_send_to_top_rep(hierarchical_communicator const& comms,
-        T&& local_result, generation_arg const generation)
+        std::vector<T>&& local_result, generation_arg const generation)
     {
         HPX_ASSERT(comms.size() != 0);
 
-        using value_type = std::decay_t<T>;
-
-        std::vector<value_type> data;
-        data.emplace_back(HPX_FORWARD(T, local_result));
+        uniform_rows<T> data(HPX_MOVE(local_result), 1);
 
         // Walk bottom-up from leaf to level 1, calling gather_here
         // (each intermediate rep gathers from its children).
         for (std::size_t i = comms.size() - 1; i != 0; --i)
         {
-            data = gather_data(gather_here(hpx::launch::sync, comms.get(i),
-                HPX_MOVE(data), this_site_arg(0), generation));
+            data =
+                gather_here_impl<uniform_rows<T>>(comms.get(i), HPX_MOVE(data),
+                    this_site_arg(0), generation, generation_mode::single_step)
+                    .get();
         }
 
         // At the topmost level (level 0 in this site's vector, which is
         // a subtree-internal communicator, NOT the inter-group one),
         // send to the subtree root via gather_there.
-        gather_there(hpx::launch::sync, comms.get(0), HPX_MOVE(data),
-            comms.site(0), generation);
+        gather_there(comms.get(0), HPX_MOVE(data), comms.site(0), generation,
+            generation_mode::single_step)
+            .get();
     }
 
     ///////////////////////////////////////////////////////////////////////////
     // subtree_scatter_at_top_rep
     //
-    // Called by a top-level representative. Scatters data from a flat vector
-    // to all sites in its subtree using communicator levels 1..size()-1,
+    // Called by a top-level representative. Scatters logical rows to all sites
+    // in its subtree using communicator levels 1..size()-1,
     // skipping level 0 (the inter-group communicator).
     //
-    // Returns: this site's portion (a T) after scattering down the tree.
+    // Returns this site's row after scattering down the tree.
     //
-    // For the flat fallback case (comms.size() <= 1), returns the first
-    // (and only) element of the input data.
+    // For the flat fallback case (comms.size() <= 1), returns the input row.
     ///////////////////////////////////////////////////////////////////////////
     HPX_CXX_EXPORT template <typename T>
-    hpx::future<T> subtree_scatter_at_top_rep(
-        hierarchical_communicator const& comms, std::vector<T>&& data,
+    hpx::future<std::vector<T>> subtree_scatter_at_top_rep(
+        hierarchical_communicator const& comms, uniform_rows<T>&& data,
         generation_arg const generation)
     {
         HPX_ASSERT(comms.size() != 0);
 
-        // Flat fallback or single-level subtree: the entire data vector
-        // belongs to this site.
+        // Flat fallback or single-level subtree: the single row belongs to
+        // this site.
         if (comms.size() == 1)
         {
-            return hpx::make_ready_future(HPX_MOVE(data[0]));
+            return hpx::make_ready_future(HPX_MOVE(data).unwrap_row());
         }
-
-        arity_arg const arity = comms.get_arity();
 
         // Walk top-down from level 1 through size()-2, partitioning and
         // scattering at each level. At each level, this site is rank 0
         // (subtree root).
         for (std::size_t i = 1; i < comms.size() - 1; ++i)
         {
-            data = scatter_to(hpx::launch::sync, comms.get(i),
-                scatter_data(HPX_MOVE(data), arity), this_site_arg(0),
-                generation);
+            data = scatter_rows_to(comms.get(i), HPX_MOVE(data),
+                this_site_arg(0), generation, generation_mode::single_step)
+                       .get();
         }
 
         // At the leaf level (size()-1), scatter asynchronously and return
-        // the future directly (no scatter_data; each element maps 1:1 to a
-        // leaf site).
-        return scatter_to(
-            comms.back(), HPX_MOVE(data), this_site_arg(0), generation);
+        // the future directly.
+        return hpx::make_future<std::vector<T>>(
+            scatter_rows_to(comms.back(), HPX_MOVE(data), this_site_arg(0),
+                generation, generation_mode::single_step),
+            [](uniform_rows<T>&& result) {
+                return HPX_MOVE(result).unwrap_row();
+            });
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -166,40 +162,47 @@ namespace hpx::collectives::detail {
     // level 0, then scatter down through intermediate levels to the leaf.
     ///////////////////////////////////////////////////////////////////////////
     HPX_CXX_EXPORT template <typename T>
-    hpx::future<T> subtree_receive_from_top_rep(
+    hpx::future<std::vector<T>> subtree_receive_from_top_rep(
         hierarchical_communicator const& comms, generation_arg const generation)
     {
         HPX_ASSERT(comms.size() != 0);
 
         auto [current_communicator, current_site] = comms[0];
 
-        // A direct leaf of the top representative receives exactly its own
-        // portion (a single T) as a future, returned directly.
+        // A direct leaf of the top representative receives exactly its own row
+        // as a future, returned directly.
         if (comms.size() == 1)
         {
-            return scatter_from<T>(
-                current_communicator, current_site, generation);
+            return hpx::make_future<std::vector<T>>(
+                scatter_rows_from<T>(current_communicator, current_site,
+                    generation, generation_mode::single_step),
+                [](uniform_rows<T>&& result) {
+                    return HPX_MOVE(result).unwrap_row();
+                });
         }
 
-        // An intermediate representative receives a vector<T> (one element
-        // per site in its subtree) to scatter further down.
-        std::vector<T> data = scatter_from<std::vector<T>>(
-            hpx::launch::sync, current_communicator, current_site, generation);
-
-        arity_arg const arity = comms.get_arity();
+        // An intermediate representative receives rows for its subtree to
+        // scatter further down.
+        uniform_rows<T> data = scatter_rows_from<T>(current_communicator,
+            current_site, generation, generation_mode::single_step)
+                                   .get();
 
         // Walk down through intermediate levels.
         for (std::size_t i = 1; i < comms.size() - 1; ++i)
         {
-            data = scatter_to(hpx::launch::sync, comms.get(i),
-                scatter_data(HPX_MOVE(data), arity), this_site_arg(0),
-                generation);
+            data = scatter_rows_to(comms.get(i), HPX_MOVE(data),
+                this_site_arg(0), generation, generation_mode::single_step)
+                       .get();
         }
 
         // At the leaf level, scatter asynchronously and return the future
-        // directly (no scatter_data; each element maps 1:1 to a leaf site).
-        return scatter_to(
-            comms.back(), HPX_MOVE(data), this_site_arg(0), generation);
+        // directly.
+        return hpx::make_future<std::vector<T>>(
+            scatter_rows_to(comms.back(), HPX_MOVE(data), this_site_arg(0),
+                generation, generation_mode::single_step),
+            [](uniform_rows<T>&& result) {
+                return HPX_MOVE(result).unwrap_row();
+            });
     }
 
 }    // namespace hpx::collectives::detail

--- a/libs/full/collectives/include/hpx/collectives/gather.hpp
+++ b/libs/full/collectives/include/hpx/collectives/gather.hpp
@@ -570,45 +570,6 @@ namespace hpx::collectives {
             detail::generation_mode::single_step);
     }
 
-    ////////////////////////////////////////////////////////////////////////////
-    namespace detail {
-
-        template <typename T>
-        std::vector<T> gather_data(std::vector<std::vector<T>>&& data)
-        {
-            if (data.size() == 1)
-            {
-                return HPX_MOVE(data.front());
-            }
-
-            std::size_t total_size = 0;
-            for (auto const& row : data)
-            {
-                total_size += row.size();
-            }
-
-            std::vector<T> result;
-            result.reserve(total_size);
-            for (auto&& row : data)
-            {
-                result.insert(result.end(),
-                    std::make_move_iterator(row.begin()),
-                    std::make_move_iterator(row.end()));
-            }
-            return result;
-        }
-
-        template <typename T>
-        hpx::future<std::vector<T>> gather_data(
-            hpx::future<std::vector<std::vector<T>>>&& f)
-        {
-            return hpx::make_future<std::vector<T>>(
-                HPX_MOVE(f), [](std::vector<std::vector<T>>&& data) {
-                    return gather_data(HPX_MOVE(data));
-                });
-        }
-    }    // namespace detail
-
     namespace detail {
 
         // gather_here over a hierarchical_communicator: detail entry carrying

--- a/libs/full/collectives/include/hpx/collectives/scatter.hpp
+++ b/libs/full/collectives/include/hpx/collectives/scatter.hpp
@@ -612,34 +612,6 @@ namespace hpx::collectives {
     ////////////////////////////////////////////////////////////////////////////
     namespace detail {
 
-        template <typename T>
-        std::vector<std::vector<T>> scatter_data(
-            std::vector<T>&& data, arity_arg arity)
-        {
-            std::vector<std::vector<T>> grouped(arity);
-            std::size_t division_steps = data.size() / arity;
-            std::size_t remainder = data.size() % arity;
-            std::size_t offset = 0;
-
-            for (std::size_t i = 0; i != arity; ++i)
-            {
-                std::size_t const current_group_size =
-                    division_steps + (i < remainder ? 1 : 0);
-                grouped[i].reserve(current_group_size);
-
-                std::size_t const current_left = offset;
-                std::size_t const current_right =
-                    current_left + current_group_size;
-                offset += current_group_size;
-
-                std::move(data.begin() + current_left,
-                    data.begin() + current_right,
-                    std::back_inserter(grouped[i]));
-            }
-
-            return grouped;
-        }
-
         // Forward declaration: the flat scatter_to detail entry is defined
         // further down, but the hierarchical scatter_from below walks its
         // sub-communicators through it.

--- a/libs/full/collectives/tests/unit/CMakeLists.txt
+++ b/libs/full/collectives/tests/unit/CMakeLists.txt
@@ -61,8 +61,9 @@ if(HPX_WITH_NETWORKING)
   # serialized intermediate payload hop.
   set(flattened_collective_payloads_PARAMETERS LOCALITIES 5)
 
-  # The flat-vs-tree comparison needs a real tree: num_sites > arity (= 2).
-  set(hierarchical_flat_fallback_PARAMETERS LOCALITIES 3)
+  # The flat-vs-tree comparison needs a real tree. Five localities with arity
+  # two also exercises an uneven subtree with an intermediate payload hop.
+  set(hierarchical_flat_fallback_PARAMETERS LOCALITIES 5)
 endif()
 foreach(test ${tests})
   set(sources ${test}.cpp)

--- a/libs/full/collectives/tests/unit/flattened_collective_payloads.cpp
+++ b/libs/full/collectives/tests/unit/flattened_collective_payloads.cpp
@@ -63,6 +63,29 @@ struct opaque_payload_traits;
 
 template <>
 struct opaque_payload_traits<
+    hpx::collectives::detail::ragged_rows<std::uint32_t>>
+{
+    using payload_type = hpx::collectives::detail::ragged_rows<std::uint32_t>;
+
+    static payload_type make(std::uint32_t const value)
+    {
+        return payload_type(
+            std::vector<std::uint32_t>{value}, std::vector<std::size_t>{0, 1});
+    }
+
+    static void check_payload(
+        payload_type const& payload, std::uint32_t const expected)
+    {
+        HPX_TEST_EQ(payload.data().size(), static_cast<std::size_t>(1));
+        HPX_TEST_EQ(payload.data()[0], expected);
+        HPX_TEST_EQ(payload.offsets().size(), static_cast<std::size_t>(2));
+        HPX_TEST_EQ(payload.offsets()[0], static_cast<std::size_t>(0));
+        HPX_TEST_EQ(payload.offsets()[1], static_cast<std::size_t>(1));
+    }
+};
+
+template <>
+struct opaque_payload_traits<
     hpx::collectives::detail::uniform_rows<std::uint32_t>>
 {
     using payload_type = hpx::collectives::detail::uniform_rows<std::uint32_t>;
@@ -82,7 +105,7 @@ struct opaque_payload_traits<
 };
 
 template <typename Payload, typename Communicator>
-void run_opaque_uniform_payload(Communicator const& communicator,
+void run_opaque_flat_payload(Communicator const& communicator,
     std::uint32_t const num_sites, std::uint32_t const this_site)
 {
     using traits = opaque_payload_traits<Payload>;
@@ -126,6 +149,22 @@ void run_opaque_uniform_payload(Communicator const& communicator,
             .get();
     }();
     traits::check_payload(scattered, this_site + 20);
+
+    std::vector<Payload> values;
+    values.reserve(num_sites);
+    for (std::uint32_t destination = 0; destination != num_sites; ++destination)
+    {
+        values.push_back(traits::make(this_site * num_sites + destination));
+    }
+    auto const exchanged = all_to_all(communicator, HPX_MOVE(values),
+        this_site_arg(this_site), generation_arg(3))
+                               .get();
+    HPX_TEST_EQ(exchanged.size(), static_cast<std::size_t>(num_sites));
+    for (std::uint32_t source = 0; source != num_sites; ++source)
+    {
+        traits::check_payload(
+            exchanged[source], source * num_sites + this_site);
+    }
 }
 
 void run_nonassignable_hierarchical_payload(char const* const basename,
@@ -174,6 +213,22 @@ void run_nonassignable_hierarchical_payload(char const* const basename,
             .get();
     }();
     HPX_TEST_EQ(scattered.value, this_site + 40);
+
+    std::vector<nonassignable_payload> values;
+    values.reserve(num_sites);
+    for (std::uint32_t destination = 0; destination != num_sites; ++destination)
+    {
+        values.emplace_back(this_site * num_sites + destination + 50);
+    }
+    auto const exchanged = all_to_all(communicators, HPX_MOVE(values),
+        this_site_arg(this_site), generation_arg(3))
+                               .get();
+    HPX_TEST_EQ(exchanged.size(), static_cast<std::size_t>(num_sites));
+    for (std::uint32_t source = 0; source != num_sites; ++source)
+    {
+        HPX_TEST_EQ(
+            exchanged[source].value, source * num_sites + this_site + 50);
+    }
 }
 
 void run_auto_generation_hierarchical_payloads(
@@ -248,23 +303,37 @@ void test_local_multisite_payload_paths()
     }
 
     constexpr std::uint32_t num_sites = 5;
+    using ragged_payload = hpx::collectives::detail::ragged_rows<std::uint32_t>;
     using uniform_payload =
         hpx::collectives::detail::uniform_rows<std::uint32_t>;
 
     run_local_sites(num_sites, [](std::uint32_t const site) {
         auto const communicator =
+            create_communicator("/test/flattened_payload_local_opaque_offsets/",
+                num_sites_arg(num_sites), this_site_arg(site), generation_arg(),
+                root_site_arg(0));
+        run_opaque_flat_payload<ragged_payload>(communicator, num_sites, site);
+    });
+    run_local_sites(num_sites, [](std::uint32_t const site) {
+        auto const communicator =
             create_communicator("/test/flattened_payload_local_opaque_rows/",
                 num_sites_arg(num_sites), this_site_arg(site), generation_arg(),
                 root_site_arg(0));
-        run_opaque_uniform_payload<uniform_payload>(
-            communicator, num_sites, site);
+        run_opaque_flat_payload<uniform_payload>(communicator, num_sites, site);
+    });
+    run_local_sites(num_sites, [](std::uint32_t const site) {
+        auto const communicators = create_hierarchical_communicator(
+            "/test/flattened_payload_local_hierarchical_opaque_offsets/",
+            num_sites_arg(num_sites), this_site_arg(site), arity_arg(2),
+            generation_arg(), root_site_arg(0), flat_fallback_threshold_arg(0));
+        run_opaque_flat_payload<ragged_payload>(communicators, num_sites, site);
     });
     run_local_sites(num_sites, [](std::uint32_t const site) {
         auto const communicators = create_hierarchical_communicator(
             "/test/flattened_payload_local_hierarchical_opaque_rows/",
             num_sites_arg(num_sites), this_site_arg(site), arity_arg(2),
             generation_arg(), root_site_arg(0), flat_fallback_threshold_arg(0));
-        run_opaque_uniform_payload<uniform_payload>(
+        run_opaque_flat_payload<uniform_payload>(
             communicators, num_sites, site);
     });
     run_local_sites(num_sites, [](std::uint32_t const site) {
@@ -313,26 +382,47 @@ void test_singleton_payload_paths()
         HPX_MOVE(opaque_values), this_site_arg(0), generation_arg(4))
                                       .get();
     traits::check_payload(opaque_scattered, 90);
+
+    auto const exchanged =
+        all_to_all(communicators, std::vector<std::string>{"all_to_all"},
+            this_site_arg(0), generation_arg(5))
+            .get();
+    HPX_TEST_EQ(exchanged.size(), static_cast<std::size_t>(1));
+    HPX_TEST_EQ(exchanged[0], std::string("all_to_all"));
 }
 
 int hpx_main()
 {
     std::uint32_t const this_site = hpx::get_locality_id();
     std::uint32_t const num_sites = hpx::get_num_localities(hpx::launch::sync);
+    using ragged_payload = hpx::collectives::detail::ragged_rows<std::uint32_t>;
     using uniform_payload =
         hpx::collectives::detail::uniform_rows<std::uint32_t>;
+
+    auto const offsets_communicator = create_communicator(
+        "/test/flattened_payload_opaque_offsets/", num_sites_arg(num_sites),
+        this_site_arg(this_site), generation_arg(), root_site_arg(0));
+    run_opaque_flat_payload<ragged_payload>(
+        offsets_communicator, num_sites, this_site);
 
     auto const communicator = create_communicator(
         "/test/flattened_payload_opaque_rows/", num_sites_arg(num_sites),
         this_site_arg(this_site), generation_arg(), root_site_arg(0));
-    run_opaque_uniform_payload<uniform_payload>(
+    run_opaque_flat_payload<uniform_payload>(
         communicator, num_sites, this_site);
+
+    auto const hierarchical_offsets = create_hierarchical_communicator(
+        "/test/flattened_payload_hierarchical_opaque_offsets/",
+        num_sites_arg(num_sites), this_site_arg(this_site), arity_arg(2),
+        generation_arg(), root_site_arg(0), flat_fallback_threshold_arg(0));
+    run_opaque_flat_payload<ragged_payload>(
+        hierarchical_offsets, num_sites, this_site);
 
     auto const hierarchical_communicators = create_hierarchical_communicator(
         "/test/flattened_payload_hierarchical_opaque_rows/",
         num_sites_arg(num_sites), this_site_arg(this_site), arity_arg(2),
         generation_arg(), root_site_arg(0), flat_fallback_threshold_arg(0));
-    run_opaque_uniform_payload<uniform_payload>(
+    run_opaque_flat_payload<uniform_payload>(
         hierarchical_communicators, num_sites, this_site);
     run_nonassignable_hierarchical_payload(
         "/test/flattened_payload_nonassignable/", num_sites, this_site);

--- a/libs/full/collectives/tests/unit/hierarchical_flat_fallback.cpp
+++ b/libs/full/collectives/tests/unit/hierarchical_flat_fallback.cpp
@@ -117,6 +117,48 @@ void test_distributed_fallback_all_to_all()
         HPX_TEST_EQ(fb_result[i], expected[i]);
     }
 
+    std::vector<std::string> string_send_data;
+    std::vector<std::string> string_expected;
+    string_send_data.reserve(num_localities);
+    string_expected.reserve(num_localities);
+    for (std::uint32_t site = 0; site != num_localities; ++site)
+    {
+        string_send_data.push_back(
+            std::to_string(this_locality) + "->" + std::to_string(site));
+        string_expected.push_back(
+            std::to_string(site) + "->" + std::to_string(this_locality));
+    }
+
+    auto const string_fb_result =
+        all_to_all(fb_clients, std::vector<std::string>(string_send_data),
+            this_site_arg(this_locality), generation_arg(2))
+            .get();
+    HPX_TEST_EQ(string_fb_result.size(), string_expected.size());
+    for (std::size_t i = 0; i != string_expected.size(); ++i)
+    {
+        HPX_TEST_EQ(string_fb_result[i], string_expected[i]);
+    }
+
+    std::vector<bool> bool_send_data;
+    std::vector<bool> bool_expected;
+    bool_send_data.reserve(num_localities);
+    bool_expected.reserve(num_localities);
+    for (std::uint32_t site = 0; site != num_localities; ++site)
+    {
+        bool_send_data.push_back(this_locality < site);
+        bool_expected.push_back(site < this_locality);
+    }
+
+    auto const bool_fb_result =
+        all_to_all(fb_clients, std::vector<bool>(bool_send_data),
+            this_site_arg(this_locality), generation_arg(3))
+            .get();
+    HPX_TEST_EQ(bool_fb_result.size(), bool_expected.size());
+    for (std::size_t i = 0; i != bool_expected.size(); ++i)
+    {
+        HPX_TEST_EQ(bool_fb_result[i], bool_expected[i]);
+    }
+
     // Force tree path; results must match. With 2 localities and arity 2 a
     // tree is structurally impossible (arity >= num_sites dispatches flat),
     // so this leg needs at least 3.
@@ -141,6 +183,26 @@ void test_distributed_fallback_all_to_all()
         for (std::size_t i = 0; i != expected.size(); ++i)
         {
             HPX_TEST_EQ(tree_result[i], expected[i]);
+        }
+
+        auto const string_tree_result =
+            all_to_all(tree_clients, std::vector<std::string>(string_send_data),
+                this_site_arg(this_locality), generation_arg(2))
+                .get();
+        HPX_TEST_EQ(string_tree_result.size(), string_expected.size());
+        for (std::size_t i = 0; i != string_expected.size(); ++i)
+        {
+            HPX_TEST_EQ(string_tree_result[i], string_expected[i]);
+        }
+
+        auto const bool_tree_result =
+            all_to_all(tree_clients, std::vector<bool>(bool_send_data),
+                this_site_arg(this_locality), generation_arg(3))
+                .get();
+        HPX_TEST_EQ(bool_tree_result.size(), bool_expected.size());
+        for (std::size_t i = 0; i != bool_expected.size(); ++i)
+        {
+            HPX_TEST_EQ(bool_tree_result[i], bool_expected[i]);
         }
     }
 }

--- a/libs/full/collectives/tests/unit/hierarchical_helpers.cpp
+++ b/libs/full/collectives/tests/unit/hierarchical_helpers.cpp
@@ -25,8 +25,10 @@ using hpx::collectives::detail::classify_site;
 using hpx::collectives::detail::get_top_level_group_count;
 using hpx::collectives::detail::get_top_level_group_left;
 using hpx::collectives::detail::get_top_level_group_size;
+using hpx::collectives::detail::is_ragged_rows_v;
 using hpx::collectives::detail::is_top_level_rep;
 using hpx::collectives::detail::is_uniform_rows_v;
+using hpx::collectives::detail::ragged_rows;
 using hpx::collectives::detail::uniform_rows;
 
 std::size_t expected_group_count(std::size_t const n, std::size_t const arity)
@@ -321,6 +323,120 @@ void test_is_uniform_rows_trait()
     static_assert(!is_uniform_rows_v<std::vector<int>>);
 }
 
+void test_is_ragged_rows_trait()
+{
+    static_assert(is_ragged_rows_v<ragged_rows<int>>);
+    static_assert(is_ragged_rows_v<ragged_rows<int> const>);
+    static_assert(is_ragged_rows_v<ragged_rows<int>&>);
+    static_assert(is_ragged_rows_v<ragged_rows<int> const&>);
+    static_assert(!is_ragged_rows_v<int>);
+    static_assert(!is_ragged_rows_v<std::vector<int>>);
+    using take_type = decltype(&ragged_rows<int>::take);
+    static_assert(
+        std::is_invocable_v<take_type, ragged_rows<int>&&, std::size_t>);
+    static_assert(
+        !std::is_invocable_v<take_type, ragged_rows<int>&, std::size_t>);
+    static_assert(std::is_nothrow_constructible_v<ragged_rows<int>,
+        std::vector<int>&&, std::vector<std::size_t>&&>);
+}
+
+void test_ragged_rows_extract_columns()
+{
+    std::vector<ragged_rows<int>> values;
+    values.emplace_back(std::vector<int>{3, 4, 103, 104, 203, 204},
+        std::vector<std::size_t>{0, 0, 2, 2, 4, 4, 6});
+    values.emplace_back(std::vector<int>{300, 301, 302, 400, 401, 402},
+        std::vector<std::size_t>{0, 3, 3, 6, 6});
+
+    ragged_rows<int> column_zero(values, 0);
+    HPX_TEST_EQ(column_zero.data().size(), static_cast<std::size_t>(6));
+    HPX_TEST_EQ(column_zero.offsets().size(), static_cast<std::size_t>(3));
+    HPX_TEST_EQ(column_zero.offsets()[0], static_cast<std::size_t>(0));
+    HPX_TEST_EQ(column_zero.offsets()[1], static_cast<std::size_t>(0));
+    HPX_TEST_EQ(column_zero.offsets()[2], static_cast<std::size_t>(6));
+    for (std::size_t i = 0; i != column_zero.data().size(); ++i)
+    {
+        HPX_TEST_EQ(column_zero.data()[i],
+            static_cast<int>(300 + (i / 3) * 100 + i % 3));
+    }
+
+    ragged_rows<int> column_one(values, 1);
+    HPX_TEST_EQ(column_one.data().size(), static_cast<std::size_t>(6));
+    HPX_TEST_EQ(column_one.offsets().size(), static_cast<std::size_t>(3));
+    HPX_TEST_EQ(column_one.offsets()[0], static_cast<std::size_t>(0));
+    HPX_TEST_EQ(column_one.offsets()[1], static_cast<std::size_t>(6));
+    HPX_TEST_EQ(column_one.offsets()[2], static_cast<std::size_t>(6));
+    for (std::size_t i = 0; i != column_one.data().size(); ++i)
+    {
+        HPX_TEST_EQ(
+            column_one.data()[i], static_cast<int>((i / 2) * 100 + 3 + i % 2));
+    }
+
+    std::vector<ragged_rows<move_only_value>> move_only_values;
+    std::vector<move_only_value> first;
+    first.emplace_back(1);
+    first.emplace_back(2);
+    move_only_values.emplace_back(
+        HPX_MOVE(first), std::vector<std::size_t>{0, 1, 2});
+    std::vector<move_only_value> second;
+    second.emplace_back(3);
+    second.emplace_back(4);
+    move_only_values.emplace_back(
+        HPX_MOVE(second), std::vector<std::size_t>{0, 1, 2});
+
+    ragged_rows<move_only_value> move_only_column(move_only_values, 1);
+    HPX_TEST_EQ(move_only_column.data().size(), static_cast<std::size_t>(2));
+    HPX_TEST_EQ(move_only_column.data()[0].value, 2);
+    HPX_TEST_EQ(move_only_column.data()[1].value, 4);
+    auto taken = HPX_MOVE(move_only_column).take(1);
+    HPX_TEST_EQ(taken.value, 4);
+}
+
+void test_ragged_rows_validation()
+{
+    ragged_rows<int> valid_empty_rows(
+        std::vector<int>{}, std::vector<std::size_t>{0, 0, 0});
+    HPX_TEST(valid_empty_rows.is_valid());
+    HPX_TEST_NO_THROW(valid_empty_rows.validate("test_ragged_rows_validation"));
+    HPX_TEST_NO_THROW(valid_empty_rows.validate_for_exchange(
+        2, "test_ragged_rows_validation"));
+
+    auto deserialize_rows = [](std::vector<int> data,
+                                std::vector<std::size_t> offsets) {
+        std::vector<char> buffer;
+        hpx::serialization::output_archive output(buffer);
+        output << data << offsets;
+
+        ragged_rows<int> rows;
+        hpx::serialization::input_archive input(buffer);
+        input >> rows;
+        return rows;
+    };
+
+    auto empty_offsets = deserialize_rows({}, {});
+    auto nonzero_first = deserialize_rows({1}, {1, 1});
+    auto decreasing = deserialize_rows({1, 2}, {0, 2, 1, 2});
+    auto wrong_end = deserialize_rows({1, 2}, {0, 1});
+    ragged_rows<int> incomplete_exchange(
+        std::vector<int>{1}, std::vector<std::size_t>{0, 1});
+
+    HPX_TEST(!empty_offsets.is_valid());
+    HPX_TEST(!nonzero_first.is_valid());
+    HPX_TEST(!decreasing.is_valid());
+    HPX_TEST(!wrong_end.is_valid());
+    HPX_TEST_THROW(
+        empty_offsets.validate("test_ragged_rows_validation"), hpx::exception);
+    HPX_TEST_THROW(
+        nonzero_first.validate("test_ragged_rows_validation"), hpx::exception);
+    HPX_TEST_THROW(
+        decreasing.validate("test_ragged_rows_validation"), hpx::exception);
+    HPX_TEST_THROW(
+        wrong_end.validate("test_ragged_rows_validation"), hpx::exception);
+    HPX_TEST_THROW(incomplete_exchange.validate_for_exchange(
+                       2, "test_ragged_rows_validation"),
+        hpx::exception);
+}
+
 void test_uniform_rows_slicing()
 {
     uniform_rows<int> first(std::vector<int>{10, 11, 20, 21, 30, 31}, 3);
@@ -506,6 +622,12 @@ void test_uniform_rows_construction()
     static_assert(
         std::is_nothrow_constructible_v<uniform_rows<int>, std::vector<int>&&>);
 
+    using take_type = decltype(&uniform_rows<int>::take);
+    static_assert(
+        std::is_invocable_v<take_type, uniform_rows<int>&&, std::size_t>);
+    static_assert(
+        !std::is_invocable_v<take_type, uniform_rows<int>&, std::size_t>);
+
     uniform_rows<int> rows(std::vector<int>{1, 2, 3});
     HPX_TEST_EQ(rows.data().size(), static_cast<std::size_t>(3));
     HPX_TEST_EQ(rows.num_rows(), static_cast<std::size_t>(3));
@@ -531,6 +653,11 @@ void test_uniform_rows_construction()
     HPX_TEST_EQ(values[0], 1);
     HPX_TEST_EQ(values[1], 2);
     HPX_TEST_EQ(values[2], 3);
+
+    uniform_rows<int> releasable(std::vector<int>{4, 5, 6, 7}, 2);
+    HPX_TEST_EQ(HPX_MOVE(releasable).take(2), 6);
+    auto released = HPX_MOVE(releasable).release_data();
+    HPX_TEST_EQ(released.size(), static_cast<std::size_t>(4));
 }
 
 void test_data_size_overflow()
@@ -564,6 +691,30 @@ void test_uniform_rows_serialization()
     HPX_TEST_EQ(restored_rows.num_rows(), rows.num_rows());
 }
 
+void test_ragged_rows_serialization()
+{
+    ragged_rows<std::string> rows(
+        std::vector<std::string>{"zero", "one", "two"},
+        std::vector<std::size_t>{0, 2, 3});
+    std::vector<char> buffer;
+    hpx::serialization::output_archive output(buffer);
+    output << rows;
+
+    ragged_rows<std::string> restored;
+    hpx::serialization::input_archive input(buffer);
+    input >> restored;
+    HPX_TEST_EQ(restored.data().size(), rows.data().size());
+    HPX_TEST_EQ(restored.offsets().size(), rows.offsets().size());
+    for (std::size_t i = 0; i != rows.data().size(); ++i)
+    {
+        HPX_TEST_EQ(restored.data()[i], rows.data()[i]);
+    }
+    for (std::size_t i = 0; i != rows.offsets().size(); ++i)
+    {
+        HPX_TEST_EQ(restored.offsets()[i], rows.offsets()[i]);
+    }
+}
+
 int hpx_main()
 {
     test_balanced_arity2();
@@ -578,7 +729,10 @@ int hpx_main()
     test_matches_recursive_fill();
     test_is_top_level_rep_basic();
     test_is_top_level_rep_exhaustive();
+    test_is_ragged_rows_trait();
     test_is_uniform_rows_trait();
+    test_ragged_rows_extract_columns();
+    test_ragged_rows_validation();
     test_uniform_rows_slicing();
     test_uniform_rows_extract_single_slice();
     test_uniform_rows_merge();
@@ -589,6 +743,7 @@ int hpx_main()
     test_uniform_rows_row_width_zero_rows();
     test_uniform_rows_construction();
     test_data_size_overflow();
+    test_ragged_rows_serialization();
     test_uniform_rows_serialization();
 
     return hpx::finalize();

--- a/libs/full/collectives/tests/unit/hierarchical_helpers.cpp
+++ b/libs/full/collectives/tests/unit/hierarchical_helpers.cpp
@@ -390,8 +390,15 @@ void test_ragged_rows_extract_columns()
 
 void test_ragged_rows_validation()
 {
+    ragged_rows<int> default_rows;
     ragged_rows<int> valid_empty_rows(
         std::vector<int>{}, std::vector<std::size_t>{0, 0, 0});
+    HPX_TEST(default_rows.is_valid());
+    HPX_TEST_EQ(default_rows.num_segments(), static_cast<std::size_t>(1));
+    HPX_TEST_EQ(default_rows.offsets().size(), static_cast<std::size_t>(2));
+    HPX_TEST_EQ(default_rows.offsets()[0], static_cast<std::size_t>(0));
+    HPX_TEST_EQ(default_rows.offsets()[1], static_cast<std::size_t>(0));
+    HPX_TEST_NO_THROW(default_rows.validate("test_ragged_rows_validation"));
     HPX_TEST(valid_empty_rows.is_valid());
     HPX_TEST_NO_THROW(valid_empty_rows.validate("test_ragged_rows_validation"));
     HPX_TEST_NO_THROW(valid_empty_rows.validate_for_exchange(
@@ -410,6 +417,7 @@ void test_ragged_rows_validation()
     };
 
     auto empty_offsets = deserialize_rows({}, {});
+    auto single_offset = deserialize_rows({}, {0});
     auto nonzero_first = deserialize_rows({1}, {1, 1});
     auto decreasing = deserialize_rows({1, 2}, {0, 2, 1, 2});
     auto wrong_end = deserialize_rows({1, 2}, {0, 1});
@@ -417,11 +425,14 @@ void test_ragged_rows_validation()
         std::vector<int>{1}, std::vector<std::size_t>{0, 1});
 
     HPX_TEST(!empty_offsets.is_valid());
+    HPX_TEST(!single_offset.is_valid());
     HPX_TEST(!nonzero_first.is_valid());
     HPX_TEST(!decreasing.is_valid());
     HPX_TEST(!wrong_end.is_valid());
     HPX_TEST_THROW(
         empty_offsets.validate("test_ragged_rows_validation"), hpx::exception);
+    HPX_TEST_THROW(
+        single_offset.validate("test_ragged_rows_validation"), hpx::exception);
     HPX_TEST_THROW(
         nonzero_first.validate("test_ragged_rows_validation"), hpx::exception);
     HPX_TEST_THROW(
@@ -682,6 +693,20 @@ void test_uniform_rows_serialization()
 
 void test_ragged_rows_serialization()
 {
+    ragged_rows<std::string> empty_rows;
+    std::vector<char> empty_buffer;
+    hpx::serialization::output_archive empty_output(empty_buffer);
+    empty_output << empty_rows;
+
+    ragged_rows<std::string> restored_empty_rows;
+    hpx::serialization::input_archive empty_input(empty_buffer);
+    empty_input >> restored_empty_rows;
+    HPX_TEST(restored_empty_rows.is_valid());
+    HPX_TEST_EQ(
+        restored_empty_rows.num_segments(), static_cast<std::size_t>(1));
+    HPX_TEST_EQ(
+        restored_empty_rows.offsets().size(), static_cast<std::size_t>(2));
+
     ragged_rows<std::string> rows(
         std::vector<std::string>{"zero", "one", "two"},
         std::vector<std::size_t>{0, 2, 3});

--- a/libs/full/collectives/tests/unit/hierarchical_helpers.cpp
+++ b/libs/full/collectives/tests/unit/hierarchical_helpers.cpp
@@ -333,9 +333,9 @@ void test_is_ragged_rows_trait()
     static_assert(!is_ragged_rows_v<std::vector<int>>);
     using take_type = decltype(&ragged_rows<int>::take);
     static_assert(
-        std::is_invocable_v<take_type, ragged_rows<int>&&, std::size_t>);
+        std::is_invocable_v<take_type, ragged_rows<int>&, std::size_t>);
     static_assert(
-        !std::is_invocable_v<take_type, ragged_rows<int>&, std::size_t>);
+        !std::is_invocable_v<take_type, ragged_rows<int>&&, std::size_t>);
     static_assert(std::is_nothrow_constructible_v<ragged_rows<int>,
         std::vector<int>&&, std::vector<std::size_t>&&>);
 }
@@ -388,7 +388,7 @@ void test_ragged_rows_extract_columns()
     HPX_TEST_EQ(move_only_column.data().size(), static_cast<std::size_t>(2));
     HPX_TEST_EQ(move_only_column.data()[0].value, 2);
     HPX_TEST_EQ(move_only_column.data()[1].value, 4);
-    auto taken = HPX_MOVE(move_only_column).take(1);
+    auto taken = move_only_column.take(1);
     HPX_TEST_EQ(taken.value, 4);
 }
 
@@ -624,9 +624,9 @@ void test_uniform_rows_construction()
 
     using take_type = decltype(&uniform_rows<int>::take);
     static_assert(
-        std::is_invocable_v<take_type, uniform_rows<int>&&, std::size_t>);
+        std::is_invocable_v<take_type, uniform_rows<int>&, std::size_t>);
     static_assert(
-        !std::is_invocable_v<take_type, uniform_rows<int>&, std::size_t>);
+        !std::is_invocable_v<take_type, uniform_rows<int>&&, std::size_t>);
 
     uniform_rows<int> rows(std::vector<int>{1, 2, 3});
     HPX_TEST_EQ(rows.data().size(), static_cast<std::size_t>(3));
@@ -655,7 +655,7 @@ void test_uniform_rows_construction()
     HPX_TEST_EQ(values[2], 3);
 
     uniform_rows<int> releasable(std::vector<int>{4, 5, 6, 7}, 2);
-    HPX_TEST_EQ(HPX_MOVE(releasable).take(2), 6);
+    HPX_TEST_EQ(releasable.take(2), 6);
     auto released = HPX_MOVE(releasable).release_data();
     HPX_TEST_EQ(released.size(), static_cast<std::size_t>(4));
 }

--- a/libs/full/collectives/tests/unit/hierarchical_helpers.cpp
+++ b/libs/full/collectives/tests/unit/hierarchical_helpers.cpp
@@ -331,11 +331,6 @@ void test_is_ragged_rows_trait()
     static_assert(is_ragged_rows_v<ragged_rows<int> const&>);
     static_assert(!is_ragged_rows_v<int>);
     static_assert(!is_ragged_rows_v<std::vector<int>>);
-    using take_type = decltype(&ragged_rows<int>::take);
-    static_assert(
-        std::is_invocable_v<take_type, ragged_rows<int>&, std::size_t>);
-    static_assert(
-        !std::is_invocable_v<take_type, ragged_rows<int>&&, std::size_t>);
     static_assert(std::is_nothrow_constructible_v<ragged_rows<int>,
         std::vector<int>&&, std::vector<std::size_t>&&>);
 }
@@ -388,8 +383,9 @@ void test_ragged_rows_extract_columns()
     HPX_TEST_EQ(move_only_column.data().size(), static_cast<std::size_t>(2));
     HPX_TEST_EQ(move_only_column.data()[0].value, 2);
     HPX_TEST_EQ(move_only_column.data()[1].value, 4);
-    auto taken = move_only_column.take(1);
-    HPX_TEST_EQ(taken.value, 4);
+    auto move_only_data = HPX_MOVE(move_only_column).release_data();
+    HPX_TEST_EQ(move_only_data.size(), static_cast<std::size_t>(2));
+    HPX_TEST_EQ(move_only_data[1].value, 4);
 }
 
 void test_ragged_rows_validation()
@@ -622,12 +618,6 @@ void test_uniform_rows_construction()
     static_assert(
         std::is_nothrow_constructible_v<uniform_rows<int>, std::vector<int>&&>);
 
-    using take_type = decltype(&uniform_rows<int>::take);
-    static_assert(
-        std::is_invocable_v<take_type, uniform_rows<int>&, std::size_t>);
-    static_assert(
-        !std::is_invocable_v<take_type, uniform_rows<int>&&, std::size_t>);
-
     uniform_rows<int> rows(std::vector<int>{1, 2, 3});
     HPX_TEST_EQ(rows.data().size(), static_cast<std::size_t>(3));
     HPX_TEST_EQ(rows.num_rows(), static_cast<std::size_t>(3));
@@ -655,7 +645,6 @@ void test_uniform_rows_construction()
     HPX_TEST_EQ(values[2], 3);
 
     uniform_rows<int> releasable(std::vector<int>{4, 5, 6, 7}, 2);
-    HPX_TEST_EQ(releasable.take(2), 6);
     auto released = HPX_MOVE(releasable).release_data();
     HPX_TEST_EQ(released.size(), static_cast<std::size_t>(4));
 }

--- a/libs/full/collectives/tests/unit/subtree_gather_scatter.cpp
+++ b/libs/full/collectives/tests/unit/subtree_gather_scatter.cpp
@@ -61,8 +61,9 @@ void test_round_trip(std::uint32_t num_sites, int arity)
                 if (is_rep)
                 {
                     // Gather: collect subtree data.
-                    auto gathered = detail::subtree_gather_at_top_rep(
-                        comms, std::uint32_t(site), generation_arg(gather_gen));
+                    auto gathered = detail::subtree_gather_at_top_rep(comms,
+                        std::vector<std::uint32_t>{site},
+                        generation_arg(gather_gen));
 
                     // Verify: gathered should contain contiguous site ids.
                     std::ptrdiff_t const gidx =
@@ -77,10 +78,11 @@ void test_round_trip(std::uint32_t num_sites, int arity)
                         detail::get_top_level_group_size(
                             group, ns, comms.get_arity());
 
-                    HPX_TEST_EQ(gathered.size(), group_size);
-                    for (std::size_t j = 0; j != gathered.size(); ++j)
+                    HPX_TEST_EQ(gathered.num_rows(), group_size);
+                    HPX_TEST_EQ(gathered.data().size(), group_size);
+                    for (std::size_t j = 0; j != group_size; ++j)
                     {
-                        HPX_TEST_EQ(gathered[j],
+                        HPX_TEST_EQ(gathered.data()[j],
                             static_cast<std::uint32_t>(group_left + j));
                     }
 
@@ -88,20 +90,23 @@ void test_round_trip(std::uint32_t num_sites, int arity)
                     auto my_val = detail::subtree_scatter_at_top_rep(
                         comms, HPX_MOVE(gathered), generation_arg(scatter_gen))
                                       .get();
-                    HPX_TEST_EQ(my_val, site);
+                    HPX_TEST_EQ(my_val.size(), static_cast<std::size_t>(1));
+                    HPX_TEST_EQ(my_val[0], site);
                 }
                 else
                 {
                     // Send our value to the rep.
-                    detail::subtree_send_to_top_rep(
-                        comms, std::uint32_t(site), generation_arg(gather_gen));
+                    detail::subtree_send_to_top_rep(comms,
+                        std::vector<std::uint32_t>{site},
+                        generation_arg(gather_gen));
 
                     // Receive our value back.
                     auto my_val =
                         detail::subtree_receive_from_top_rep<std::uint32_t>(
                             comms, generation_arg(scatter_gen))
                             .get();
-                    HPX_TEST_EQ(my_val, site);
+                    HPX_TEST_EQ(my_val.size(), static_cast<std::size_t>(1));
+                    HPX_TEST_EQ(my_val[0], site);
                 }
             }
         }));
@@ -141,9 +146,7 @@ void test_vector_payload(std::uint32_t num_sites, int arity)
 
             if (is_rep)
             {
-                // Gather: each site contributes a vector<uint32_t>.
-                // gather_data flattens one nesting level per gather step,
-                // so the result is vector<vector<uint32_t>>.
+                // Gather: each site contributes one logical row.
                 auto gathered = detail::subtree_gather_at_top_rep(
                     comms, HPX_MOVE(my_data), generation_arg(1));
 
@@ -157,26 +160,23 @@ void test_vector_payload(std::uint32_t num_sites, int arity)
                 std::size_t const group_size = detail::get_top_level_group_size(
                     group, ns, comms.get_arity());
 
-                // gathered is vector<vector<uint32_t>> with one entry
-                // per subtree site (gather_data flattens one level per
-                // gather step, preserving inner vectors).
-                HPX_TEST_EQ(gathered.size(), group_size);
+                HPX_TEST_EQ(gathered.num_rows(), group_size);
+                HPX_TEST_EQ(gathered.data().size(), group_size * 3);
 
                 // Verify values.
                 for (std::size_t j = 0; j != group_size; ++j)
                 {
                     std::uint32_t expected_site =
                         static_cast<std::uint32_t>(group_left + j);
+                    std::size_t const row = j * 3;
+                    HPX_TEST_EQ(gathered.data()[row], expected_site * 10);
                     HPX_TEST_EQ(
-                        gathered[j].size(), static_cast<std::size_t>(3));
-                    HPX_TEST_EQ(gathered[j][0], expected_site * 10);
-                    HPX_TEST_EQ(gathered[j][1], expected_site * 10 + 1);
-                    HPX_TEST_EQ(gathered[j][2], expected_site * 10 + 2);
+                        gathered.data()[row + 1], expected_site * 10 + 1);
+                    HPX_TEST_EQ(
+                        gathered.data()[row + 2], expected_site * 10 + 2);
                 }
 
-                // Scatter: gathered is already vector<vector<uint32_t>>,
-                // which is the right shape for scatter (one entry per
-                // subtree site). Pass directly.
+                // Scatter the same flat rows directly back down the subtree.
                 auto my_result = detail::subtree_scatter_at_top_rep(
                     comms, HPX_MOVE(gathered), generation_arg(2))
                                      .get();
@@ -191,9 +191,10 @@ void test_vector_payload(std::uint32_t num_sites, int arity)
                 detail::subtree_send_to_top_rep(
                     comms, HPX_MOVE(my_data), generation_arg(1));
 
-                auto my_result = detail::subtree_receive_from_top_rep<
-                    std::vector<std::uint32_t>>(comms, generation_arg(2))
-                                     .get();
+                auto my_result =
+                    detail::subtree_receive_from_top_rep<std::uint32_t>(
+                        comms, generation_arg(2))
+                        .get();
 
                 HPX_TEST_EQ(my_result.size(), static_cast<std::size_t>(3));
                 HPX_TEST_EQ(my_result[0], site * 10);


### PR DESCRIPTION
## Proposed Changes

- replace nested intermediate all-to-all payloads with flat uniform/ragged carriers
- pack exchange data in storage order, reuse scratch storage, and avoid default-initializing overwritten output slots
- keep the local diagonal block out of the inter-group exchange

## Background context

This follows the hierarchical gather/scatter payload flattening. The all-to-all representative path previously materialized multiple nested `std::vector<std::vector<T>>` stages while gathering, exchanging, and scattering data.

The new ragged carrier stores payload data in one flat vector with a prefix-offset table. The intermediate subtree hops use uniform rows, while the inter-group transpose uses ragged segments.

Coverage includes uneven trees, flat fallback, serialization, singleton communicators, move-only/non-assignable payloads, `std::vector<bool>`, strings, and nested flat-carrier value types.

## Checklist

- [x] I have added tests for the changes.
- [x] I have verified traditional C++20 and C++ modules builds.