### PR TITLE
Move communicator basenames into owned storage

### DIFF
--- a/libs/full/collectives/include/hpx/collectives/detail/communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/communicator.hpp
@@ -63,7 +63,7 @@ namespace hpx::collectives::detail {
         HPX_EXPORT communicator_server() noexcept;
 
         HPX_EXPORT explicit communicator_server(
-            std::size_t num_sites, char const* basename);
+            std::size_t num_sites, std::string basename);
 
         communicator_server(communicator_server const&) = delete;
         communicator_server(communicator_server&&) = delete;
@@ -514,13 +514,12 @@ namespace hpx::collectives::detail {
         std::size_t const num_sites_;
         std::size_t on_ready_count_ = 0;
         char const* current_operation_ = nullptr;
-        // Owned copy for diagnostics only. create_communicator passes the
-        // caller's char const* straight into local_new; hierarchical tree
-        // construction uses name.c_str() on a stack std::string that is
+        // Owned copy for diagnostics only. Hierarchical tree construction
+        // derives communicator basenames from stack std::strings that are
         // destroyed when recursively_fill_communicators returns, while this
         // component outlives that frame. A borrowed pointer would therefore
-        // dangle on later exception paths. Flat string-literal basenames are
-        // stable, but ownership keeps every path safe without special cases.
+        // dangle on later exception paths. The constructor takes the owned
+        // name by value and moves it into place.
         std::string basename_;
         mutex_type mtx_;
         bool needs_initialization_ = true;

--- a/libs/full/collectives/src/create_communicator.cpp
+++ b/libs/full/collectives/src/create_communicator.cpp
@@ -64,14 +64,11 @@ namespace hpx::collectives {
             HPX_ASSERT(false);    // shouldn't ever be called
         }
 
-        // Copy basename: it may point at a caller-local buffer (e.g. hierarchical
-        // create_communicator(name.c_str(), ...)) that does not outlive this
-        // component. std::string(nullptr) is undefined, so guard null.
         communicator_server::communicator_server(
-            std::size_t num_sites, char const* basename)
+            std::size_t num_sites, std::string basename)
           : gate_(num_sites)
           , num_sites_(num_sites)
-          , basename_(basename != nullptr ? basename : "")
+          , basename_(HPX_MOVE(basename))
         {
             HPX_ASSERT(
                 num_sites != 0 && num_sites != static_cast<std::size_t>(-1));
@@ -247,7 +244,8 @@ namespace hpx::collectives {
         if (this_site == root_site)
         {
             // create a new communicator
-            auto c = hpx::local_new<communicator>(num_sites, basename);
+            auto c =
+                hpx::local_new<communicator>(num_sites, std::string(basename));
 
             if (init_singleton_communicator(c, num_sites, this_site, root_site))
             {
@@ -318,7 +316,8 @@ namespace hpx::collectives {
         if (this_site == root_site)
         {
             // create a new communicator
-            auto c = hpx::local_new<communicator>(num_sites, basename);
+            auto c =
+                hpx::local_new<communicator>(num_sites, std::string(basename));
 
             if (init_singleton_communicator(c, num_sites, this_site, root_site))
             {
@@ -383,7 +382,8 @@ namespace hpx::collectives {
         if (this_site == root_site)
         {
             // create a new communicator
-            auto c = hpx::local_new<communicator>(num_sites, basename);
+            auto c =
+                hpx::local_new<communicator>(num_sites, std::string(basename));
 
             if (init_singleton_communicator(c, num_sites, this_site, root_site))
             {
@@ -448,7 +448,8 @@ namespace hpx::collectives {
         if (this_site == root_site)
         {
             // create a new communicator
-            auto c = hpx::local_new<communicator>(num_sites, basename);
+            auto c =
+                hpx::local_new<communicator>(num_sites, std::string(basename));
 
             if (init_singleton_communicator(c, num_sites, this_site, root_site))
             {

--- a/libs/full/collectives/tests/unit/barrier.cpp
+++ b/libs/full/collectives/tests/unit/barrier.cpp
@@ -14,6 +14,7 @@
 #include <hpx/modules/format.hpp>
 #include <hpx/modules/testing.hpp>
 
+#include <algorithm>
 #include <atomic>
 #include <cstddef>
 #include <exception>
@@ -292,6 +293,44 @@ void collectives_communicator_validation_tests()
     }
 }
 
+void test_owned_local_communicator_basename()
+{
+    using namespace hpx::collectives;
+
+    std::string basename = "/test/barrier/collectives/owned_local_basename/";
+    std::string const original_basename = basename;
+
+    auto const first = create_local_communicator(hpx::launch::sync,
+        basename.c_str(), num_sites_arg(2), this_site_arg(0), generation_arg(),
+        root_site_arg(0));
+    auto const second = create_local_communicator(hpx::launch::sync,
+        basename.c_str(), num_sites_arg(2), this_site_arg(1), generation_arg(),
+        root_site_arg(0));
+
+    // Keep the original buffer alive but overwrite its contents. A server
+    // holding the caller's pointer would then report the overwritten name.
+    std::fill(basename.begin(), basename.end(), 'x');
+
+    auto first_barrier = barrier(first, this_site_arg(0), generation_arg());
+    auto second_barrier = barrier(second, this_site_arg(1), generation_arg());
+    first_barrier.get();
+    second_barrier.get();
+
+    bool caught_exception = false;
+    try
+    {
+        barrier(hpx::launch::sync, first, this_site_arg(0), generation_arg(1));
+    }
+    catch (hpx::exception const& e)
+    {
+        caught_exception = true;
+        HPX_TEST_EQ(e.get_error(), hpx::error::bad_parameter);
+        HPX_TEST(
+            std::string(e.what()).find(original_basename) != std::string::npos);
+    }
+    HPX_TEST(caught_exception);
+}
+
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main(hpx::program_options::variables_map& vm)
 {
@@ -300,6 +339,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
 
     collectives_barrier_generation_tests();
     collectives_communicator_validation_tests();
+    test_owned_local_communicator_basename();
 
     local_tests(vm);
 


### PR DESCRIPTION
## Proposed Changes

- Change the internal communicator server constructor to accept its basename as an owned `std::string`.
- Move the basename into the server's diagnostic storage instead of retaining or repeatedly copying a borrowed character pointer.
- Add coverage verifying that diagnostic messages preserve the original basename after the caller's buffer is modified.

## Background

Hierarchical communicator construction derives basenames from temporary strings. The server outlives those temporary buffers, so it must own the basename used by later diagnostic paths.

This follows up on the ownership change discussed during the hierarchical collectives reviews and moves the string into place at the internal server boundary. Public APIs are unchanged.

## Verification

- Built `tests.unit.modules.collectives.barrier`.
- Ran the distributed TCP barrier test successfully five consecutive times.
- Verified with clang-format 20.1.7.
- Verified DCO and whitespace checks.

## Checklist

- [x] I have fixed a bug and have added a regression test.