### PR TITLE
components: add reflect_client<^^Server> and HPX_REFLECT_CLIENT macro

### DIFF
--- a/libs/full/runtime_components/CMakeLists.txt
+++ b/libs/full/runtime_components/CMakeLists.txt
@@ -49,6 +49,13 @@ set(runtime_components_compat_headers
 )
 # cmake-format: on
 
+if(HPX_WITH_CXX26_REFLECTION)
+  list(APPEND runtime_components_headers
+       hpx/runtime_components/reflect_client.hpp
+       hpx/runtime_components/reflect_client_macros.hpp
+  )
+endif()
+
 set(runtime_components_sources
     component_registry.cpp console_error_sink.cpp console_logging.cpp
     server/console_error_sink_server.cpp

--- a/libs/full/runtime_components/include/hpx/runtime_components/macros.hpp
+++ b/libs/full/runtime_components/include/hpx/runtime_components/macros.hpp
@@ -309,3 +309,7 @@
         HPX_PP_CAT(__distributed_metadata_, name);                             \
     HPX_REGISTER_COMPONENT(HPX_PP_CAT(__distributed_metadata_, name))          \
     /**/
+
+#if defined(HPX_HAVE_CXX26_REFLECTION)
+#include <hpx/runtime_components/reflect_client_macros.hpp>
+#endif

--- a/libs/full/runtime_components/include/hpx/runtime_components/reflect_client.hpp
+++ b/libs/full/runtime_components/include/hpx/runtime_components/reflect_client.hpp
@@ -1,0 +1,202 @@
+//  Copyright (c) 2026 Priyanshi Sharma
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#pragma once
+
+#include <hpx/config.hpp>
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE) && defined(HPX_HAVE_CXX26_REFLECTION)
+
+#include <hpx/modules/actions_base.hpp>
+#include <hpx/modules/async_distributed.hpp>
+#include <hpx/modules/components.hpp>
+#include <hpx/modules/futures.hpp>
+#include <hpx/runtime_components/new.hpp>
+
+#include <array>
+#include <cstddef>
+#include <functional>
+#include <meta>
+#include <utility>
+#include <vector>
+
+namespace hpx::components {
+
+    namespace detail {
+
+        /// Returns true for user-defined public non-static member functions.
+        consteval bool is_client_member_fn(std::meta::info m) noexcept
+        {
+            return std::meta::is_public(m) && std::meta::is_function(m) &&
+                !std::meta::is_constructor(m) && !std::meta::is_destructor(m) &&
+                !std::meta::is_static_member(m) &&
+                !std::meta::is_special_member_function(m) &&
+                !std::meta::is_conversion_function(m);
+        }
+
+        consteval std::size_t count_client_member_fns(
+            std::meta::info cls) noexcept
+        {
+            std::size_t n = 0;
+            for (auto m : std::meta::members_of(
+                     cls, std::meta::access_context::unchecked()))
+                if (is_client_member_fn(m))
+                    ++n;
+            return n;
+        }
+
+        template <std::meta::info Cls>
+        consteval auto get_client_member_fns() noexcept
+        {
+            constexpr std::size_t N = count_client_member_fns(Cls);
+            std::array<std::meta::info, N> result{};
+            std::size_t i = 0;
+            for (auto m : std::meta::members_of(
+                     Cls, std::meta::access_context::unchecked()))
+                if (is_client_member_fn(m))
+                    result[i++] = m;
+            return result;
+        }
+
+        /// Helper alias to build std::function<future<R>(Ps...)>
+        template <typename Ret, typename... Ps>
+        using make_async_fn = std::function<Ret(Ps...)>;
+
+        /// Returns the std::function type for async dispatch of a server fn.
+        consteval std::meta::info build_async_fn_type(std::meta::info fn)
+        {
+            auto fut_ret = std::meta::substitute(^^hpx::future,
+                {
+                    std::meta::return_type_of(fn)});
+            std::vector<std::meta::info> args = {fut_ret};
+            for (auto p : std::meta::parameters_of(fn))
+                args.push_back(std::meta::type_of(p));
+            return std::meta::substitute(^^detail::make_async_fn, args);
+        }
+
+        /// Build the data member spec list for define_aggregate.
+        /// Takes the server function array and returns a vector of
+        /// data_member_spec entries (one per server fn + one for id_).
+        template <std::meta::info Server>
+        consteval ::std::vector<::std::meta::info> create_client_data_members()
+        {
+            ::std::vector<::std::meta::info> mems;
+            for (auto m : get_client_member_fns<Server>())
+                mems.push_back(
+                    ::std::meta::data_member_spec(build_async_fn_type(m),
+                        {.name = ::std::meta::identifier_of(m)}));
+            mems.push_back(::std::meta::data_member_spec(^^::hpx::id_type,
+                {
+                    .name = "id_"}));
+            return mems;
+        }
+
+        struct fn_pair
+        {
+            std::meta::info server_fn;
+            std::meta::info client_dm;
+        };
+
+        /// Count data members of Client (excluding id_).
+        template <typename Client>
+        consteval std::size_t reflect_npairs() noexcept
+        {
+            std::size_t n = 0;
+            for (auto m : std::meta::members_of(
+                     ^^Client, std::meta::access_context::unchecked()))
+                if (std::meta::has_identifier(m) &&
+                    std::meta::identifier_of(m) != "id_" &&
+                    !std::meta::is_function(m))
+                    ++n;
+            return n;
+        }
+
+        /// Build fn_pair array pairing server fns with client data members.
+        template <typename Client, std::size_t N, std::size_t M>
+        consteval auto reflect_get_pairs(
+            std::array<std::meta::info, M> const& server_fns) noexcept
+        {
+            std::array<fn_pair, N> r{};
+            std::size_t i = 0;
+            for (auto cm : std::meta::members_of(
+                     ^^Client, std::meta::access_context::unchecked()))
+            {
+                if (!std::meta::has_identifier(cm))
+                    continue;
+                if (std::meta::identifier_of(cm) == "id_")
+                    continue;
+                if (std::meta::is_function(cm))
+                    continue;
+                for (auto sm : server_fns)
+                    if (std::meta::identifier_of(sm) ==
+                        std::meta::identifier_of(cm))
+                    {
+                        r[i++] = {sm, cm};
+                        break;
+                    }
+            }
+            return r;
+        }
+
+        /// Async dispatcher for a single server member function.
+        template <std::meta::info Sfn, std::meta::info Cdm>
+        auto reflect_dispatch(hpx::id_type id)
+        {
+            return [id](auto&&... args) {
+                return hpx::async<hpx::actions::reflect_component_action<Sfn>>(
+                    id, std::forward<decltype(args)>(args)...);
+            };
+        }
+
+        /// Initialize all dispatchers in a generated client.
+        template <typename Client, std::size_t N>
+        Client reflect_make_client(
+            hpx::id_type id, std::array<fn_pair, N> const& pairs)
+        {
+            Client c;
+            c.id_ = id;
+            template for (constexpr auto p : pairs)
+                c.[:p.client_dm:] = reflect_dispatch<p.server_fn, p.client_dm>(
+                                      id);
+            return c;
+        }
+
+    }    // namespace detail
+
+    /// \brief Reflection-generated client type for a component server.
+    ///
+    /// Forward-declared here; the actual definition is injected by
+    /// HPX_CLIENT(Server, reflect_client<Server>) using consteval{} +
+    /// define_aggregate at namespace scope.
+    template <typename Server>
+    struct reflect_client;
+
+    /// \brief Instantiate a Server component and return a reflect_client.
+    ///
+    /// Requires HPX_CLIENT(Server) at namespace scope first.
+    /// Constructor arguments are forwarded to hpx::new_<Server>.
+    ///
+    /// \code
+    ///   HPX_CLIENT(compute_server)
+    ///   auto c = hpx::components::make_client<compute_server>(locality);
+    ///   auto f = c.add(42);   // async, returns future<int>
+    /// \endcode
+    template <typename Server, typename... CtorArgs>
+    reflect_client<Server> make_client(
+        hpx::id_type locality, CtorArgs&&... ctor_args)
+    {
+        constexpr auto sfns = detail::get_client_member_fns<^^Server>();
+        constexpr auto pairs = detail::reflect_get_pairs<reflect_client<Server>,
+            detail::reflect_npairs<reflect_client<Server>>(), sfns.size()>(
+            sfns);
+        hpx::id_type id =
+            hpx::new_<Server>(locality, std::forward<CtorArgs>(ctor_args)...)
+                .get();
+        return detail::reflect_make_client<reflect_client<Server>>(id, pairs);
+    }
+
+}    // namespace hpx::components
+
+#endif    // !HPX_COMPUTE_DEVICE_CODE && HPX_HAVE_CXX26_REFLECTION

--- a/libs/full/runtime_components/include/hpx/runtime_components/reflect_client_macros.hpp
+++ b/libs/full/runtime_components/include/hpx/runtime_components/reflect_client_macros.hpp
@@ -1,0 +1,37 @@
+//  Copyright (c) 2026 Priyanshi Sharma
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE) && defined(HPX_HAVE_CXX26_REFLECTION)
+
+#include <hpx/modules/preprocessor.hpp>
+#include <hpx/runtime_components/reflect_client.hpp>
+
+/// \brief Generates a reflection-based client for a component server.
+///
+/// Invoke at namespace scope after the server definition:
+/// \code
+///   HPX_CLIENT(compute_server)
+///
+///   // Instantiate component and get client:
+///   auto c = hpx::components::make_client<compute_server>(locality);
+///   auto f = c.add(42);   // async, returns future<int>
+/// \endcode
+///
+/// The generated client type is hpx::components::reflect_client<Server>.
+#define HPX_CLIENT(Server)                                                     \
+    consteval                                                                  \
+    {                                                                          \
+        ::std::meta::define_aggregate(                                         \
+            ^^::hpx::components::reflect_client<Server>,                       \
+            ::hpx::components::detail::create_client_data_members<             \
+                ^^Server>());                                                  \
+    } /**/
+
+#endif    // !HPX_COMPUTE_DEVICE_CODE && HPX_HAVE_CXX26_REFLECTION

--- a/libs/full/runtime_components/tests/unit/components/CMakeLists.txt
+++ b/libs/full/runtime_components/tests/unit/components/CMakeLists.txt
@@ -25,6 +25,11 @@ set(tests
     new_
 )
 
+if(HPX_WITH_CXX26_REFLECTION)
+  set(tests ${tests} reflect_client_test)
+  set(reflect_client_test_PARAMETERS LOCALITIES 2)
+endif()
+
 set(action_invoke_no_more_than_PARAMETERS THREADS_PER_LOCALITY 4)
 set(action_invoke_no_more_than_FLAGS DEPENDENCIES iostreams_component)
 

--- a/libs/full/runtime_components/tests/unit/components/reflect_client_test.cpp
+++ b/libs/full/runtime_components/tests/unit/components/reflect_client_test.cpp
@@ -1,0 +1,100 @@
+//  Copyright (c) 2026 Priyanshi Sharma
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+#include <hpx/config.hpp>
+#if !defined(HPX_COMPUTE_DEVICE_CODE) && defined(HPX_HAVE_CXX26_REFLECTION)
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/actions.hpp>
+#include <hpx/include/components.hpp>
+#include <hpx/include/runtime.hpp>
+#include <hpx/modules/runtime_components.hpp>
+#include <hpx/modules/testing.hpp>
+#include <cstdint>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+// Server: a simple component with two public member functions
+struct reflect_test_server
+  : hpx::components::component_base<reflect_test_server>
+{
+    /// Returns the locality this component lives on.
+    hpx::id_type identity() const
+    {
+        return hpx::find_here();
+    }
+
+    /// Returns i + 1 and verifies the argument.
+    std::int32_t increment(std::int32_t i) const
+    {
+        HPX_TEST(i >= 0);
+        return i + 1;
+    }
+};
+
+using reflect_test_server_type =
+    hpx::components::component<reflect_test_server>;
+HPX_REGISTER_COMPONENT(reflect_test_server_type, reflect_test_server)
+
+///////////////////////////////////////////////////////////////////////////////
+// Server with constructor arguments
+struct reflect_test_server2
+  : hpx::components::component_base<reflect_test_server2>
+{
+    explicit reflect_test_server2(std::int32_t base)
+      : base_(base)
+    {
+    }
+
+    std::int32_t increment(std::int32_t i) const
+    {
+        return base_ + i;
+    }
+
+    std::int32_t base_;
+};
+
+using reflect_test_server2_type =
+    hpx::components::component<reflect_test_server2>;
+HPX_REGISTER_COMPONENT(reflect_test_server2_type, reflect_test_server2)
+
+HPX_CLIENT(reflect_test_server2)
+
+///////////////////////////////////////////////////////////////////////////////
+// Generate client -- single argument, no client name needed.
+// reflect_client<reflect_test_server> is the generated client type.
+HPX_CLIENT(reflect_test_server)
+
+///////////////////////////////////////////////////////////////////////////////
+int main()
+{
+    std::vector<hpx::id_type> localities = hpx::find_all_localities();
+
+    for (hpx::id_type const& loc : localities)
+    {
+        // Instantiate component on locality and get client in one call
+        auto c = hpx::components::make_client<reflect_test_server>(loc);
+
+        // Test identity() -- verifies action ran on expected locality
+        hpx::future<hpx::id_type> f1 = c.identity();
+        HPX_TEST_EQ(f1.get(), loc);
+
+        // Test increment() -- verifies argument passing and return value
+        hpx::future<std::int32_t> f2 = c.increment(41);
+        HPX_TEST_EQ(f2.get(), std::int32_t(42));
+    }
+
+    // Test make_client with constructor arguments
+    for (hpx::id_type const& loc : localities)
+    {
+        // Pass constructor argument (base = 10) to make_client
+        auto c2 = hpx::components::make_client<reflect_test_server2>(
+            loc, std::int32_t(10));
+        hpx::future<std::int32_t> f3 = c2.increment(32);
+        HPX_TEST_EQ(f3.get(), std::int32_t(42));
+    }
+
+    return hpx::util::report_errors();
+}
+#endif    // !HPX_COMPUTE_DEVICE_CODE && HPX_HAVE_CXX26_REFLECTION


### PR DESCRIPTION
## Summary

Adds `reflect_client<^^Server>`, a reflection-based client wrapper that
eliminates manual client boilerplate for HPX components.

## Before / After

```cpp
// Before: manual client with explicit action types
struct compute_client
  : hpx::components::client_base<compute_client, compute_server>
{
    hpx::future<int> add(int x) {
        return hpx::async<compute_server::add_action>(get_id(), x);
    }
    void broadcast(int n) {
        hpx::async<compute_server::broadcast_action>(get_id(), n).get();
    }
}; 
// After: zero boilerplate
HPX_CLIENT(compute_server)

// Instantiate component and get client in one call:
auto c = hpx::components::make_client<compute_server>(locality);

// Or with constructor arguments:
auto c = hpx::components::make_client<compute_server>(locality, ctor_arg1, ...);

auto f = c.add(42);    // async, returns hpx::future<int>
int r = f.get();
```
Design

`HPX_CLIENT(Server)` at namespace scope does one thing: calls `consteval {}` + `define_aggregate` to generate `reflect_client<Server>` with typed `std::function<future<R>(Ps...)>` data members for each public member function.

`make_client<Server>(locality, ctor_args...)` in `reflect_client.hpp`:

Calls `hpx::new_<Server>(locality, ctor_args...)` to instantiate the component
Initializes each data member with an async dispatcher via `reflect_make_client`

Helper functions in `hpx::components::detail`:

`create_client_data_members<^^Server>()` — builds `data_member_spec` list
`reflect_npairs<Client>()` — counts client data members
`reflect_get_pairs<Client, N, M>(sfns)` — pairs server fns with client members
`reflect_dispatch<Sfn, Cdm>(id)` — creates typed async dispatcher
`reflect_make_client<Client>(id, pairs)` — initializes and returns client
GCC Trunk Constraint

`consteval {}` blocks inside function templates cannot access template parameters on current GCC trunk — so `HPX_CLIENT(Server)` at namespace scope remains necessary for type generation. Once this limitation is lifted, the macro can be dropped entirely.

Future Direction

Custom attributes `[[=hpx::remote_function{}]]` are already functional on GCC trunk (`annotations_of` + `extract<T>` verified). This opens the path to zero-annotation distributed HPX — no macros at all.

Related PRs

Builds on #7298, #7311, #7342, #7349, #7376.