### PR TITLE
Tracing data parallel workloads

### DIFF
--- a/libs/core/executors/include/hpx/executors/fork_join_executor.hpp
+++ b/libs/core/executors/include/hpx/executors/fork_join_executor.hpp
@@ -695,6 +695,8 @@ namespace hpx::execution::experimental {
                             set_state(data.state_, thread_state::active);
 
                             // Process local items.
+                            HPX_TRACING_MARK_EVENT(
+                                "fork_join_executor::call_static");
                             for (; part_begin != part_end; ++part_begin)
                             {
                                 auto it = std::next(
@@ -759,6 +761,8 @@ namespace hpx::execution::experimental {
                             set_state(data.state_, thread_state::active);
 
                             // Process local items first.
+                            HPX_TRACING_MARK_EVENT(
+                                "fork_join_executor::call_dynamic");
                             hpx::optional<std::uint32_t> index;
                             while ((index = local_queue.pop_left()))
                             {
@@ -987,6 +991,8 @@ namespace hpx::execution::experimental {
             template <typename F, typename S, typename... Ts>
             decltype(auto) bulk_sync_execute(F&& f, S const& shape, Ts&&... ts)
             {
+                HPX_TRACING_MARK_EVENT("fork_join_executor::bulk_sync_execute");
+
                 // protect against nested use of this executor instance
                 if (region_data_[main_thread_].data_.state_.load(
                         std::memory_order_relaxed) != thread_state::idle)
@@ -1071,6 +1077,9 @@ namespace hpx::execution::experimental {
             template <typename F, typename S, typename... Ts>
             decltype(auto) bulk_async_execute(F&& f, S const& shape, Ts&&... ts)
             {
+                HPX_TRACING_MARK_EVENT(
+                    "fork_join_executor::bulk_async_execute");
+
                 using result_type =
                     hpx::parallel::execution::detail::bulk_execute_result_t<F,
                         S, Ts...>;

--- a/libs/core/tracing/include/hpx/tracing/macros.hpp
+++ b/libs/core/tracing/include/hpx/tracing/macros.hpp
@@ -19,6 +19,11 @@
 #if defined(HPX_HAVE_TRACY)
 #define HPX_TRACING_MARK_EVENT(name)                                           \
     hpx::tracing::mark_event HPX_PP_CAT(hpx_trace_mark_, __LINE__)(name)
+#define HPX_TRACING_ZONE(name, thread_num)                                     \
+    hpx::tracing::loop_context HPX_PP_CAT(hpx_trace_lctx_, __LINE__);          \
+    hpx::tracing::region HPX_PP_CAT(hpx_trace_rctx_, __LINE__)(                \
+        HPX_PP_CAT(hpx_trace_lctx_, __LINE__),                                 \
+        hpx::tracing::region_init_data{name, 0, false}, thread_num)
 #define HPX_TRACING_PAUSE()
 #define HPX_TRACING_RESUME()
 #elif defined(HPX_HAVE_ITTNOTIFY) && HPX_HAVE_ITTNOTIFY != 0
@@ -26,14 +31,17 @@
     static hpx::util::itt::event HPX_PP_CAT(hpx_trace_event_, __LINE__)(name); \
     hpx::util::itt::mark_event HPX_PP_CAT(hpx_trace_mark_, __LINE__)(          \
         HPX_PP_CAT(hpx_trace_event_, __LINE__))
+#define HPX_TRACING_ZONE(name, thread_num)
 #define HPX_TRACING_PAUSE() itt_pause()
 #define HPX_TRACING_RESUME() itt_resume()
 #elif defined(HPX_HAVE_APEX)
 #define HPX_TRACING_MARK_EVENT(name)
+#define HPX_TRACING_ZONE(name, thread_num)
 #define HPX_TRACING_PAUSE()
 #define HPX_TRACING_RESUME()
 #else
 #define HPX_TRACING_MARK_EVENT(name)
+#define HPX_TRACING_ZONE(name, thread_num)
 #define HPX_TRACING_PAUSE()
 #define HPX_TRACING_RESUME()
 #endif

--- a/libs/core/tracy/include/hpx/tracy/tracy_tls.hpp
+++ b/libs/core/tracy/include/hpx/tracy/tracy_tls.hpp
@@ -30,6 +30,8 @@ namespace hpx::tracy {
         HPX_CORE_EXPORT region_data start_region(
             char const*, std::size_t = 0, std::size_t = 0) noexcept;
         HPX_CORE_EXPORT char const* rename_region(char const*) noexcept;
+        HPX_CORE_EXPORT std::uint64_t push_zone(char const*) noexcept;
+        HPX_CORE_EXPORT void pop_zone(std::uint64_t) noexcept;
         HPX_CORE_EXPORT region_data stop_region(
             region_data const& prev_region) noexcept;
         // Set/clear the per-OS-thread "inside fiber" flag used to guard
@@ -112,17 +114,17 @@ namespace hpx::tracy {
     HPX_CXX_CORE_EXPORT struct mark_event
     {
         explicit mark_event(char const* name) noexcept
-          : previous_name(detail::rename_region(name))
+          : ctx_value(detail::push_zone(name))
         {
         }
 
         ~mark_event()
         {
-            detail::rename_region(previous_name);
+            detail::pop_zone(ctx_value);
         }
 
     private:
-        char const* previous_name;
+        std::uint64_t ctx_value;
     };
 
     // RAII guard that closes the running fiber zone before self_.yield() and

--- a/libs/core/tracy/include/hpx/tracy/tracy_tls.hpp
+++ b/libs/core/tracy/include/hpx/tracy/tracy_tls.hpp
@@ -118,6 +118,11 @@ namespace hpx::tracy {
         {
         }
 
+        mark_event(mark_event const&) = delete;
+        mark_event(mark_event&&) = delete;
+        mark_event& operator=(mark_event const&) = delete;
+        mark_event& operator=(mark_event&&) = delete;
+
         ~mark_event()
         {
             detail::pop_zone(ctx_value);

--- a/libs/core/tracy/src/tracy_tls.cpp
+++ b/libs/core/tracy/src/tracy_tls.cpp
@@ -261,8 +261,9 @@ namespace hpx::tracy {
 
         HPX_CORE_EXPORT std::uint64_t push_zone(char const* name) noexcept
         {
+            char const* safe_name = intern_zone_label(name, "event");
             TracyCZoneC(ctx, 0x0078D7, 1);
-            TracyCZoneName(ctx, name, std::strlen(name));
+            TracyCZoneName(ctx, safe_name, std::strlen(safe_name));
             tracy_context data;
             data.context = ctx;
             return data.value;

--- a/libs/core/tracy/src/tracy_tls.cpp
+++ b/libs/core/tracy/src/tracy_tls.cpp
@@ -259,6 +259,24 @@ namespace hpx::tracy {
             return nullptr;
         }
 
+        HPX_CORE_EXPORT std::uint64_t push_zone(char const* name) noexcept
+        {
+            TracyCZoneC(ctx, 0x0078D7, 1);
+            TracyCZoneName(ctx, name, std::strlen(name));
+            tracy_context data;
+            data.context = ctx;
+            return data.value;
+        }
+
+        HPX_CORE_EXPORT void pop_zone(std::uint64_t ctx_value) noexcept
+        {
+            if (ctx_value)
+            {
+                tracy_context data;
+                data.value = ctx_value;
+                TracyCZoneEnd(data.context);
+            }
+        }
     }    // namespace detail
 }    // namespace hpx::tracy
 


### PR DESCRIPTION

## Proposed Changes

- Swapped Tracy's `mark_event` from using `rename_region` to `push_zone`/`pop_zone` to fix crashes and thread-local state issues.
- Added tracing spans to `fork_join_executor` (`bulk_sync_execute`, `bulk_async_execute`, `call_static`, `call_dynamic`) so we can actually see data-parallel workloads in Tracy.


## Any background context you want to provide?

Before this PR, the `fork_join_executor` was a huge blind spot in the Tracy profiler because it bypasses the standard task scheduler. Worker threads crunching data in things like `hpx::for_each` would just show up as idle or unknown. 

This fixes that by adding exact spans for when the executor dispatches and crunches the data statically or dynamically, while keeping the overhead well within the 5% budget.

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.