### PR TITLE
execution: fix sync_wait notify lifetime race

### DIFF
--- a/libs/core/execution/include/hpx/execution/algorithms/detail/sync_wait_domain.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/detail/sync_wait_domain.hpp
@@ -29,9 +29,9 @@
 // --hpx:threads=1.
 //
 // sync_wait_domain customizes apply_sender(sync_wait_t, sndr) to use HPX-aware
-// waiting with hpx::spinlock + hpx::condition_variable_any. This suspends the
-// HPX task cooperatively instead of OS-blocking the worker thread, allowing
-// queued HPX work to continue running.
+// waiting with hpx::spinlock + hpx::lcos::local::detail::condition_variable.
+// This suspends the HPX task cooperatively instead of OS-blocking the worker
+// thread, allowing queued HPX work to continue running.
 //
 // Senders executing through HPX should expose this domain through
 // get_completion_domain<set_value_t> so sync_wait routes here.
@@ -212,12 +212,18 @@ namespace hpx::execution::experimental::detail {
     struct shared_state
     {
         hpx::spinlock mtx;
-        hpx::condition_variable_any cv;
+        hpx::lcos::local::detail::condition_variable cv;
         hpx::execution::experimental::run_loop loop;
         bool done = false;
         std::variant<std::monostate, ValueTuple, std::exception_ptr,
             stopped_t<ValueTuple>>
             result;
+
+        void notify_all(std::unique_lock<hpx::spinlock> l) noexcept
+        {
+            hpx::error_code ec(hpx::throwmode::lightweight);
+            cv.notify_all(HPX_MOVE(l), ec);
+        }
 
         template <typename... Vs>
         void notify_value(Vs&&... vs) noexcept
@@ -227,7 +233,7 @@ namespace hpx::execution::experimental::detail {
                 std::unique_lock<hpx::spinlock> l(mtx);
                 result.template emplace<ValueTuple>(HPX_FORWARD(Vs, vs)...);
                 done = true;
-                cv.notify_all();
+                notify_all(HPX_MOVE(l));
             }
             catch (...)
             {
@@ -235,7 +241,7 @@ namespace hpx::execution::experimental::detail {
                 result.template emplace<std::exception_ptr>(
                     std::current_exception());
                 done = true;
-                cv.notify_all();
+                notify_all(HPX_MOVE(l));
             }
         }
 
@@ -266,7 +272,7 @@ namespace hpx::execution::experimental::detail {
                 }
             }
             done = true;
-            cv.notify_all();
+            notify_all(HPX_MOVE(l));
         }
 
         void notify_stopped() noexcept
@@ -274,7 +280,7 @@ namespace hpx::execution::experimental::detail {
             std::unique_lock<hpx::spinlock> l(mtx);
             result.template emplace<stopped_t<ValueTuple>>();
             done = true;
-            cv.notify_all();
+            notify_all(HPX_MOVE(l));
         }
 
         // Wait HPX-aware: yields the calling HPX task while waiting, does not
@@ -283,7 +289,10 @@ namespace hpx::execution::experimental::detail {
         {
             {
                 std::unique_lock<hpx::spinlock> l(mtx);
-                cv.wait(l, [this] { return done; });
+                while (!done)
+                {
+                    cv.wait(l, "sync_wait_domain::wait_get_value");
+                }
             }
 
             loop.finish();

--- a/libs/core/execution/include/hpx/execution/algorithms/detail/sync_wait_domain.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/detail/sync_wait_domain.hpp
@@ -224,21 +224,17 @@ namespace hpx::execution::experimental::detail {
         {
             try
             {
-                {
-                    std::unique_lock<hpx::spinlock> l(mtx);
-                    result.template emplace<ValueTuple>(HPX_FORWARD(Vs, vs)...);
-                    done = true;
-                }
+                std::unique_lock<hpx::spinlock> l(mtx);
+                result.template emplace<ValueTuple>(HPX_FORWARD(Vs, vs)...);
+                done = true;
                 cv.notify_all();
             }
             catch (...)
             {
-                {
-                    std::unique_lock<hpx::spinlock> l(mtx);
-                    result.template emplace<std::exception_ptr>(
-                        std::current_exception());
-                    done = true;
-                }
+                std::unique_lock<hpx::spinlock> l(mtx);
+                result.template emplace<std::exception_ptr>(
+                    std::current_exception());
+                done = true;
                 cv.notify_all();
             }
         }
@@ -246,43 +242,39 @@ namespace hpx::execution::experimental::detail {
         template <typename E>
         void notify_error(E&& e) noexcept
         {
+            std::unique_lock<hpx::spinlock> l(mtx);
+            using err_t = std::decay_t<E>;
+            if constexpr (std::is_same_v<err_t, std::exception_ptr>)
             {
-                std::unique_lock<hpx::spinlock> l(mtx);
-                using err_t = std::decay_t<E>;
-                if constexpr (std::is_same_v<err_t, std::exception_ptr>)
-                {
-                    result.template emplace<std::exception_ptr>(
-                        HPX_FORWARD(E, e));
-                }
-                else if constexpr (std::is_same_v<err_t, std::error_code>)
-                {
-                    result.template emplace<std::exception_ptr>(
-                        std::make_exception_ptr(std::system_error(e)));
-                }
-                else
-                {
-                    try
-                    {
-                        throw HPX_FORWARD(E, e);
-                    }
-                    catch (...)
-                    {
-                        result.template emplace<std::exception_ptr>(
-                            std::current_exception());
-                    }
-                }
-                done = true;
+                result.template emplace<std::exception_ptr>(
+                    HPX_FORWARD(E, e));
             }
+            else if constexpr (std::is_same_v<err_t, std::error_code>)
+            {
+                result.template emplace<std::exception_ptr>(
+                    std::make_exception_ptr(std::system_error(e)));
+            }
+            else
+            {
+                try
+                {
+                    throw HPX_FORWARD(E, e);
+                }
+                catch (...)
+                {
+                    result.template emplace<std::exception_ptr>(
+                        std::current_exception());
+                }
+            }
+            done = true;
             cv.notify_all();
         }
 
         void notify_stopped() noexcept
         {
-            {
-                std::unique_lock<hpx::spinlock> l(mtx);
-                result.template emplace<stopped_t<ValueTuple>>();
-                done = true;
-            }
+            std::unique_lock<hpx::spinlock> l(mtx);
+            result.template emplace<stopped_t<ValueTuple>>();
+            done = true;
             cv.notify_all();
         }
 

--- a/libs/core/execution/include/hpx/execution/algorithms/detail/sync_wait_domain.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/detail/sync_wait_domain.hpp
@@ -246,8 +246,7 @@ namespace hpx::execution::experimental::detail {
             using err_t = std::decay_t<E>;
             if constexpr (std::is_same_v<err_t, std::exception_ptr>)
             {
-                result.template emplace<std::exception_ptr>(
-                    HPX_FORWARD(E, e));
+                result.template emplace<std::exception_ptr>(HPX_FORWARD(E, e));
             }
             else if constexpr (std::is_same_v<err_t, std::error_code>)
             {

--- a/libs/core/execution/include/hpx/execution/algorithms/detail/sync_wait_domain.hpp
+++ b/libs/core/execution/include/hpx/execution/algorithms/detail/sync_wait_domain.hpp
@@ -219,10 +219,9 @@ namespace hpx::execution::experimental::detail {
             stopped_t<ValueTuple>>
             result;
 
-        void notify_all(std::unique_lock<hpx::spinlock> l) noexcept
+        void notify_all(std::unique_lock<hpx::spinlock> l)
         {
-            hpx::error_code ec(hpx::throwmode::lightweight);
-            cv.notify_all(HPX_MOVE(l), ec);
+            cv.notify_all(HPX_MOVE(l));
         }
 
         template <typename... Vs>

--- a/libs/full/execution_distributed/tests/unit/CMakeLists.txt
+++ b/libs/full/execution_distributed/tests/unit/CMakeLists.txt
@@ -4,6 +4,10 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
+if(NOT HPX_WITH_NETWORKING)
+  return()
+endif()
+
 set(tests distributed_scheduler)
 
 set(distributed_scheduler_PARAMETERS LOCALITIES 2)


### PR DESCRIPTION
fixed race condition by #7355 

found a likely race in sync_wait_domain: the shared_state lock was released before cv.notify_all(), so the waiting HPX task could return from sync_wait and destroy the stack-owned condition variable while notify_all() was still executing. That matches the intermittent crash stack in condition_variable::notify_all().