### PR TITLE
Add supervision infrastructure for lifecycle events and observers

### DIFF
--- a/libs/core/errors/include/hpx/errors/error.hpp
+++ b/libs/core/errors/include/hpx/errors/error.hpp
@@ -140,8 +140,13 @@ namespace hpx {
         migration_needs_retry = 56,    ///< migration failed because of global
                                        ///< race, retry
 
+        stale_state = 57,    ///< The queried state may be stale, e.g. because
+                             ///< no state has been recorded yet or a
+                             ///< preceding notification has not yet been
+                             ///< delivered
+
         /// \cond NOINTERNAL
-        last_error = 57,
+        last_error = 58,
 
         system_error_flag = 0x4000L,
 

--- a/libs/core/errors/include/hpx/errors/error_code.hpp
+++ b/libs/core/errors/include/hpx/errors/error_code.hpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2025 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c) 2011      Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -61,6 +61,9 @@ namespace hpx {
     /// \cond NOINTERNAL
     HPX_CXX_CORE_EXPORT [[nodiscard]] HPX_CORE_EXPORT std::error_category const&
     get_lightweight_hpx_category() noexcept;
+
+    HPX_CXX_CORE_EXPORT [[nodiscard]] HPX_CORE_EXPORT std::error_category const&
+    get_lightweight_hpx_rethrow_category() noexcept;
 
     HPX_CXX_CORE_EXPORT [[nodiscard]] HPX_CORE_EXPORT std::error_category const&
     get_hpx_category(throwmode mode) noexcept;
@@ -237,6 +240,8 @@ namespace hpx {
             exception_ = std::exception_ptr();
         }
 
+        void assign(error e, std::string const& msg, throwmode mode);
+
         /// Copy constructor for error_code
         ///
         /// \note This function maintains the error category of the left hand
@@ -316,6 +321,9 @@ namespace hpx {
     {
         return error_code(mode);
     }
+
+    HPX_CXX_CORE_EXPORT HPX_CORE_EXPORT throwmode get_throwmode(
+        error_code const& ec);
 }    // namespace hpx
 
 #include <hpx/config/warnings_suffix.hpp>

--- a/libs/core/errors/include/hpx/errors/exception.hpp
+++ b/libs/core/errors/include/hpx/errors/exception.hpp
@@ -269,8 +269,11 @@ namespace hpx {
         hpx::error_code const& e)
     {
         // if this is a lightweight error_code, return canned response
-        if (e.category() == hpx::get_lightweight_hpx_category())
+        if (e.category() == hpx::get_lightweight_hpx_category() ||
+            e.category() == hpx::get_lightweight_hpx_rethrow_category())
+        {
             return e.message();
+        }
 
         return get_error_what<hpx::error_code>(e);
     }

--- a/libs/core/errors/src/error_code.cpp
+++ b/libs/core/errors/src/error_code.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2025 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c) 2011      Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -108,8 +108,7 @@ namespace hpx {
                 if (value >= hpx::error::success &&
                     value < hpx::error::last_error)
                 {
-                    return std::string("HPX(") + error_names[value] +
-                        ")";    //-V108
+                    return std::string("HPX(") + error_names[value] + ")";
                 }
                 if (value & hpx::error::system_error_flag)
                 {
@@ -162,6 +161,13 @@ namespace hpx {
         return lightweight_hpx_category;
     }
 
+    std::error_category const& get_lightweight_hpx_rethrow_category() noexcept
+    {
+        static detail::lightweight_hpx_category_rethrow
+            lightweight_hpx_category_rethrow;
+        return lightweight_hpx_category_rethrow;
+    }
+
     std::error_category const& get_hpx_category(throwmode mode) noexcept
     {
         switch (mode)
@@ -170,14 +176,33 @@ namespace hpx {
             return get_hpx_rethrow_category();
 
         case throwmode::lightweight:
-        case throwmode::lightweight_rethrow:
             return get_lightweight_hpx_category();
 
+        case throwmode::lightweight_rethrow:
+            return get_lightweight_hpx_rethrow_category();
+
         case throwmode::plain:
-        default:
             break;
         }
         return get_hpx_category();
+    }
+
+    throwmode get_throwmode(error_code const& ec)
+    {
+        std::error_category const& category = ec.category();
+        if (category == get_lightweight_hpx_rethrow_category())
+        {
+            return throwmode::lightweight_rethrow;
+        }
+        if (category == get_lightweight_hpx_category())
+        {
+            return throwmode::lightweight;
+        }
+        if (category == get_hpx_rethrow_category())
+        {
+            return throwmode::rethrow;
+        }
+        return throwmode::plain;
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -257,6 +282,21 @@ namespace hpx {
     {
     }
 
+    void error_code::assign(
+        error e, std::string const& msg, throwmode const mode)
+    {
+        exception_ = {};
+
+        this->std::error_code::assign(
+            static_cast<int>(e), get_hpx_category(mode));
+
+        if (e != hpx::error::success && e != hpx::error::no_success &&
+            !(mode & throwmode::lightweight))
+        {
+            exception_ = detail::get_exception(e, msg, mode);
+        }
+    }
+
     ///////////////////////////////////////////////////////////////////////////
     std::string error_code::get_message() const
     {
@@ -277,11 +317,13 @@ namespace hpx {
     ///////////////////////////////////////////////////////////////////////////
     error_code::error_code(error_code const& rhs)
       : std::error_code(rhs.value() == hpx::error::success ?
-                make_success_code(
-                    (category() == get_lightweight_hpx_category()) ?
+                static_cast<std::error_code const&>(make_success_code(
+                    (rhs.category() == get_lightweight_hpx_rethrow_category()) ?
+                        hpx::throwmode::lightweight_rethrow :
+                        (rhs.category() == get_lightweight_hpx_category()) ?
                         hpx::throwmode::lightweight :
-                        hpx::throwmode::plain) :
-                rhs)
+                        hpx::throwmode::plain)) :
+                static_cast<std::error_code const&>(rhs))
       , exception_(rhs.exception_)
     {
     }
@@ -295,7 +337,9 @@ namespace hpx {
             {
                 // if the rhs is a success code, we maintain our throw mode
                 this->std::error_code::operator=(make_success_code(
-                    (category() == get_lightweight_hpx_category()) ?
+                    (category() == get_lightweight_hpx_rethrow_category()) ?
+                        hpx::throwmode::lightweight_rethrow :
+                        (category() == get_lightweight_hpx_category()) ?
                         hpx::throwmode::lightweight :
                         hpx::throwmode::plain));
             }

--- a/libs/core/errors/src/error_code.cpp
+++ b/libs/core/errors/src/error_code.cpp
@@ -75,6 +75,7 @@ namespace hpx {
         /* 54 */ "out_of_range",
         /* 55 */ "length_error",
         /* 56 */ "migration_needs_retry",
+        /* 57 */ "stale_state",
 
         /*    */ ""};
     /// \endcond

--- a/libs/core/errors/src/exception.cpp
+++ b/libs/core/errors/src/exception.cpp
@@ -249,7 +249,9 @@ namespace hpx::detail {
 
     inline bool is_of_lightweight_hpx_category(hpx::exception const& e) noexcept
     {
-        return e.get_error_code().category() == get_lightweight_hpx_category();
+        std::error_category const& category = e.get_error_code().category();
+        return category == get_lightweight_hpx_category() ||
+            category == get_lightweight_hpx_rethrow_category();
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/libs/core/errors/src/exception.cpp
+++ b/libs/core/errors/src/exception.cpp
@@ -249,7 +249,8 @@ namespace hpx::detail {
 
     inline bool is_of_lightweight_hpx_category(hpx::exception const& e) noexcept
     {
-        std::error_category const& category = e.get_error_code().category();
+        hpx::error_code const& code = e.get_error_code();
+        std::error_category const& category = code.category();
         return category == get_lightweight_hpx_category() ||
             category == get_lightweight_hpx_rethrow_category();
     }

--- a/libs/core/errors/src/throw_exception.cpp
+++ b/libs/core/errors/src/throw_exception.cpp
@@ -58,14 +58,13 @@ namespace hpx::detail {
         {
             hpx::detail::throw_exception(errcode, msg, func, file, line);
         }
-        else
-        {
-            ec = make_error_code(static_cast<hpx::error>(errcode), msg,
-                func.c_str(), file.c_str(), line,
-                (ec.category() == hpx::get_lightweight_hpx_category()) ?
-                    hpx::throwmode::lightweight :
-                    hpx::throwmode::plain);
-        }
+
+        ec = make_error_code(static_cast<hpx::error>(errcode), msg,
+            func.c_str(), file.c_str(), line,
+            (ec.category() == hpx::get_lightweight_hpx_category() ||
+                ec.category() == hpx::get_lightweight_hpx_rethrow_category()) ?
+                hpx::throwmode::lightweight :
+                hpx::throwmode::plain);
     }
 
     void throws_bad_alloc_if(
@@ -75,14 +74,13 @@ namespace hpx::detail {
         {
             throw hpx::bad_alloc_exception();
         }
-        else
-        {
-            ec = make_error_code(hpx::error::out_of_memory, "out of memory",
-                func, file, line,
-                (ec.category() == hpx::get_lightweight_hpx_category()) ?
-                    hpx::throwmode::lightweight :
-                    hpx::throwmode::plain);
-        }
+
+        ec = make_error_code(hpx::error::out_of_memory, "out of memory", func,
+            file, line,
+            (ec.category() == hpx::get_lightweight_hpx_category() ||
+                ec.category() == hpx::get_lightweight_hpx_rethrow_category()) ?
+                hpx::throwmode::lightweight :
+                hpx::throwmode::plain);
     }
 
     void rethrows_if(
@@ -92,15 +90,13 @@ namespace hpx::detail {
         {
             hpx::detail::rethrow_exception(e, func);
         }
-        else
-        {
-            ec = make_error_code(e.get_error(), e.what(), func.c_str(),
-                hpx::get_error_file_name(e).c_str(),
-                hpx::get_error_line_number(e),
-                (ec.category() == hpx::get_lightweight_hpx_category()) ?
-                    hpx::throwmode::lightweight_rethrow :
-                    hpx::throwmode::rethrow);
-        }
+
+        ec = make_error_code(e.get_error(), e.what(), func.c_str(),
+            hpx::get_error_file_name(e).c_str(), hpx::get_error_line_number(e),
+            (ec.category() == hpx::get_lightweight_hpx_category() ||
+                ec.category() == hpx::get_lightweight_hpx_rethrow_category()) ?
+                hpx::throwmode::lightweight_rethrow :
+                hpx::throwmode::rethrow);
     }
 
     [[noreturn]] void throw_thread_interrupted_exception()

--- a/libs/core/serialization/CMakeLists.txt
+++ b/libs/core/serialization/CMakeLists.txt
@@ -123,6 +123,7 @@ set(serialization_headers
     hpx/serialization/complex.hpp
     hpx/serialization/datapar.hpp
     hpx/serialization/deque.hpp
+    hpx/serialization/error_code.hpp
     hpx/serialization/exception_ptr.hpp
     hpx/serialization/list.hpp
     hpx/serialization/macros.hpp

--- a/libs/core/serialization/include/hpx/serialization/error_code.hpp
+++ b/libs/core/serialization/include/hpx/serialization/error_code.hpp
@@ -1,0 +1,129 @@
+//  Copyright (c) 2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/modules/errors.hpp>
+#include <hpx/serialization/serialization_fwd.hpp>
+#include <hpx/serialization/serialize.hpp>
+
+#include <cstdint>
+#include <string>
+#include <system_error>
+
+namespace hpx::serialization {
+
+    namespace detail {
+
+        // Discriminates the error_category carried by a hpx::error_code so that
+        // it can be reconstructed exactly on the receiving side instead of
+        // always being coerced into an HPX category.
+        enum class error_category_kind : std::uint8_t
+        {
+            hpx = 0,
+            generic = 1,
+            system = 2
+        };
+
+        inline error_category_kind get_error_category_kind(
+            std::error_category const& category)
+        {
+            if (category == hpx::get_hpx_category() ||
+                category == hpx::get_hpx_rethrow_category() ||
+                category == hpx::get_lightweight_hpx_category() ||
+                category == hpx::get_lightweight_hpx_rethrow_category())
+            {
+                return error_category_kind::hpx;
+            }
+            if (category == std::generic_category())
+            {
+                return error_category_kind::generic;
+            }
+            if (category == std::system_category())
+            {
+                return error_category_kind::system;
+            }
+
+            HPX_THROW_EXCEPTION(hpx::error::serialization_error,
+                "hpx::serialization::detail::get_error_category_kind",
+                "cannot serialize hpx::error_code with unsupported error "
+                "category '{}'",
+                category.name());
+        }
+
+        inline std::string strip_hpx_error_message(std::string const& message)
+        {
+            if (auto const pos = message.rfind(": HPX(");
+                pos != std::string::npos)
+            {
+                return message.substr(0, pos);
+            }
+            return message;
+        }
+    }    // namespace detail
+
+    HPX_CXX_CORE_EXPORT inline void serialize(
+        output_archive& ar, hpx::error_code const& ec, unsigned)
+    {
+        detail::error_category_kind const kind =
+            detail::get_error_category_kind(ec.category());
+        ar << kind;
+
+        int const value = ec.value();
+        ar << value;
+
+        std::string const message = ec.get_message();
+        ar << message;
+
+        throwmode const mode = hpx::get_throwmode(ec);
+        ar << mode;
+    }
+
+    HPX_CXX_CORE_EXPORT inline void serialize(
+        input_archive& ar, hpx::error_code& ec, unsigned)
+    {
+        detail::error_category_kind kind;
+        ar >> kind;
+
+        int value;
+        ar >> value;
+
+        std::string message;
+        ar >> message;
+
+        throwmode mode;
+        ar >> mode;
+
+        switch (kind)
+        {
+        case detail::error_category_kind::hpx:
+            // The message may have ': HPX(...)' appended to it.  Remove it as
+            // the constructor below re-adds it to the message.
+            ec.assign(static_cast<hpx::error>(value),
+                detail::strip_hpx_error_message(message), mode);
+            break;
+
+        case detail::error_category_kind::generic:
+            ec.clear();
+            ec.std::error_code::assign(value, std::generic_category());
+            break;
+
+        case detail::error_category_kind::system:
+            ec.clear();
+            ec.std::error_code::assign(value, std::system_category());
+            break;
+
+        default:
+            HPX_THROW_EXCEPTION(hpx::error::serialization_error,
+                "hpx::serialization::serialize<input_archive, "
+                "hpx::error_code>",
+                "invalid error_category_kind ({}) encountered while "
+                "deserializing hpx::error_code",
+                static_cast<int>(kind));
+        }
+    }
+}    // namespace hpx::serialization

--- a/libs/core/serialization/tests/unit/CMakeLists.txt
+++ b/libs/core/serialization/tests/unit/CMakeLists.txt
@@ -12,6 +12,7 @@ set(tests
     serialization_complex
     serialization_custom_constructor
     serialization_deque
+    serialization_error_code
     serialization_list
     serialization_map
     serialization_multimap

--- a/libs/core/serialization/tests/unit/serialization_error_code.cpp
+++ b/libs/core/serialization/tests/unit/serialization_error_code.cpp
@@ -24,8 +24,6 @@ void test_hpx_category()
     hpx::error_code ec2;
     iarchive >> ec2;
 
-    auto msg1 = ec.get_message();
-    auto msg2 = ec2.get_message();
     HPX_TEST_EQ(ec.value(), ec2.value());
     HPX_TEST(ec.category() == ec2.category());
     HPX_TEST_EQ(ec.get_message(), ec2.get_message());

--- a/libs/core/serialization/tests/unit/serialization_error_code.cpp
+++ b/libs/core/serialization/tests/unit/serialization_error_code.cpp
@@ -1,0 +1,81 @@
+//  Copyright (c) 2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/modules/errors.hpp>
+#include <hpx/modules/serialization.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <system_error>
+#include <vector>
+
+void test_hpx_category()
+{
+    hpx::error_code const ec(
+        hpx::error::bad_parameter, "some message", hpx::throwmode::plain);
+
+    std::vector<char> buffer;
+    hpx::serialization::output_archive oarchive(buffer);
+    oarchive << ec;
+
+    hpx::serialization::input_archive iarchive(buffer);
+    hpx::error_code ec2;
+    iarchive >> ec2;
+
+    auto msg1 = ec.get_message();
+    auto msg2 = ec2.get_message();
+    HPX_TEST_EQ(ec.value(), ec2.value());
+    HPX_TEST(ec.category() == ec2.category());
+    HPX_TEST_EQ(ec.get_message(), ec2.get_message());
+}
+
+void test_generic_category_large_value()
+{
+    hpx::error_code ec;
+    static_cast<std::error_code&>(ec) =
+        std::error_code(100000, std::generic_category());
+
+    std::vector<char> buffer;
+    hpx::serialization::output_archive oarchive(buffer);
+    oarchive << ec;
+
+    hpx::serialization::input_archive iarchive(buffer);
+    hpx::error_code ec2;
+    iarchive >> ec2;
+
+    HPX_TEST_EQ(ec.value(), ec2.value());
+    HPX_TEST(ec.category() == ec2.category());
+    HPX_TEST(ec2.category() == std::generic_category());
+    HPX_TEST_EQ(ec.get_message(), ec2.get_message());
+}
+
+void test_system_category_large_value()
+{
+    hpx::error_code ec;
+    static_cast<std::error_code&>(ec) =
+        std::error_code(100001, std::system_category());
+
+    std::vector<char> buffer;
+    hpx::serialization::output_archive oarchive(buffer);
+    oarchive << ec;
+
+    hpx::serialization::input_archive iarchive(buffer);
+    hpx::error_code ec2;
+    iarchive >> ec2;
+
+    HPX_TEST_EQ(ec.value(), ec2.value());
+    HPX_TEST(ec.category() == ec2.category());
+    HPX_TEST(ec2.category() == std::system_category());
+    HPX_TEST_EQ(ec.get_message(), ec2.get_message());
+}
+
+int main()
+{
+    test_hpx_category();
+    test_generic_category_large_value();
+    test_system_category_large_value();
+
+    return hpx::util::report_errors();
+}

--- a/libs/core/serialization/tests/unit/serialization_error_code.cpp
+++ b/libs/core/serialization/tests/unit/serialization_error_code.cpp
@@ -29,6 +29,24 @@ void test_hpx_category()
     HPX_TEST_EQ(ec.get_message(), ec2.get_message());
 }
 
+void test_hpx_category_stale_state()
+{
+    hpx::error_code const ec(
+        hpx::error::stale_state, "some message", hpx::throwmode::plain);
+
+    std::vector<char> buffer;
+    hpx::serialization::output_archive oarchive(buffer);
+    oarchive << ec;
+
+    hpx::serialization::input_archive iarchive(buffer);
+    hpx::error_code ec2;
+    iarchive >> ec2;
+
+    HPX_TEST_EQ(ec.value(), ec2.value());
+    HPX_TEST(ec.category() == ec2.category());
+    HPX_TEST_EQ(ec.get_message(), ec2.get_message());
+}
+
 void test_generic_category_large_value()
 {
     hpx::error_code ec;
@@ -72,6 +90,7 @@ void test_system_category_large_value()
 int main()
 {
     test_hpx_category();
+    test_hpx_category_stale_state();
     test_generic_category_large_value();
     test_system_category_large_value();
 

--- a/libs/full/CMakeLists.txt
+++ b/libs/full/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright (c) 2020-2021 The STE||AR-Group
+# Copyright (c) 2020-2026 The STE||AR-Group
 #
 # SPDX-License-Identifier: BSL-1.0
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -45,6 +45,7 @@ set(_hpx_full_modules
     runtime_distributed
     segmented_algorithms
     statistics
+    supervision
 )
 # cmake-format: on
 

--- a/libs/full/actions_base/include/hpx/actions_base/preassigned_action_id.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/preassigned_action_id.hpp
@@ -183,6 +183,10 @@ namespace hpx::actions {
         supervision_manager_unregister_observer_action_id,
         supervision_manager_query_state_action_id,
 
+        // supervision agent
+        supervision_invoke_if_active_action_id,
+        supervision_deactivate_and_wait_action_id,
+
         last_action_id
     };
     /// \endcond

--- a/libs/full/actions_base/include/hpx/actions_base/preassigned_action_id.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/preassigned_action_id.hpp
@@ -177,6 +177,12 @@ namespace hpx::actions {
         // typed continuations...
         typed_continuation_hpx_agas_response,
 
+        // supervision_manager
+        supervision_manager_publish_event_action_id,
+        supervision_manager_register_observer_action_id,
+        supervision_manager_unregister_observer_action_id,
+        supervision_manager_query_state_action_id,
+
         last_action_id
     };
     /// \endcond

--- a/libs/full/agas/include/hpx/agas/addressing_service.hpp
+++ b/libs/full/agas/include/hpx/agas/addressing_service.hpp
@@ -170,6 +170,7 @@ namespace hpx::agas {
             naming::gid_type const& id, naming::address& addr) const;
 
         void register_server_instances();
+        void unregister_server_instances(hpx::error_code& ec = hpx::throws);
 
         // FIXME: document (add comments)
         void garbage_collect_non_blocking(error_code& ec = throws);

--- a/libs/full/agas/src/addressing_service.cpp
+++ b/libs/full/agas/src/addressing_service.cpp
@@ -2019,6 +2019,43 @@ namespace hpx::agas {
         symbol_ns_.register_server_instance(locality_id);
     }
 
+    void addressing_service::unregister_server_instances(hpx::error_code& ec)
+    {
+        // unregister root server
+        hpx::error_code first_ec;
+
+        hpx::error_code local_ec;
+        symbol_ns_.unregister_server_instance(local_ec);
+        if (local_ec && !first_ec)
+            first_ec = local_ec;
+
+        local_ec = hpx::error_code();
+        component_ns_->unregister_server_instance(local_ec);
+        if (local_ec && !first_ec)
+            first_ec = local_ec;
+
+        local_ec = hpx::error_code();
+        primary_ns_.unregister_server_instance(local_ec);
+        if (local_ec && !first_ec)
+            first_ec = local_ec;
+
+        local_ec = hpx::error_code();
+        locality_ns_->unregister_server_instance(local_ec);
+        if (local_ec && !first_ec)
+            first_ec = local_ec;
+
+        if (first_ec)
+        {
+            HPX_THROWS_IF(ec, hpx::error::internal_server_error,
+                "addressing_service::unregister_server_instances",
+                first_ec.message());
+        }
+        else if (&ec != &hpx::throws)
+        {
+            ec = hpx::make_success_code();
+        }
+    }
+
     void addressing_service::garbage_collect_non_blocking(error_code& ec)
     {
         std::unique_lock<mutex_type> l(refcnt_requests_mtx_, std::try_to_lock);

--- a/libs/full/components_base/include/hpx/components_base/component_type.hpp
+++ b/libs/full/components_base/include/hpx/components_base/component_type.hpp
@@ -65,6 +65,9 @@ namespace hpx::components {
         // AGAS symbolic naming services.
         agas_symbol_namespace = 11,
 
+        // Supervision manager
+        supervision_manager = 12,
+
         last,
         first_dynamic = last,
     };

--- a/libs/full/init_runtime/CMakeLists.txt
+++ b/libs/full/init_runtime/CMakeLists.txt
@@ -43,6 +43,7 @@ if(HPX_WITH_DISTRIBUTED_RUNTIME)
       hpx_performance_counters
       hpx_runtime_components
       hpx_runtime_distributed
+      hpx_supervision
   )
 endif()
 

--- a/libs/full/init_runtime/src/pre_main.cpp
+++ b/libs/full/init_runtime/src/pre_main.cpp
@@ -1,4 +1,4 @@
-//  Copyright (c) 2007-2022 Hartmut Kaiser
+//  Copyright (c) 2007-2026 Hartmut Kaiser
 //  Copyright (c)      2011 Bryce Lelbach
 //
 //  SPDX-License-Identifier: BSL-1.0
@@ -21,6 +21,7 @@
 #include <hpx/modules/runtime_configuration.hpp>
 #include <hpx/modules/runtime_distributed.hpp>
 #include <hpx/modules/runtime_local.hpp>
+#include <hpx/modules/supervision.hpp>
 
 #include <hpx/init_runtime/pre_main.hpp>
 
@@ -50,6 +51,11 @@ namespace hpx::detail {
         agas_client.register_server_instances();
         lbt_ << "(2nd stage) pre_main: registered AGAS client-side "
                 "performance counter types";
+
+        auto const& supervision_manager =
+            supervision::get_supervision_manager();
+        supervision_manager.register_server_instance();
+        lbt_ << "(2nd stage) pre_main: registered supervision infrastructure";
 
         get_runtime_distributed().register_counter_types();
         lbt_ << "(2nd stage) pre_main: registered runtime performance "

--- a/libs/full/modules.rst
+++ b/libs/full/modules.rst
@@ -1,5 +1,5 @@
 ..
-    Copyright (c) 2018-2021 The STE||AR-Group
+    Copyright (c) 2018-2026 The STE||AR-Group
 
     SPDX-License-Identifier: BSL-1.0
     Distributed under the Boost Software License, Version 1.0. (See accompanying
@@ -46,3 +46,4 @@ Main |hpx| modules
    /libs/full/runtime_distributed/docs/index.rst
    /libs/full/segmented_algorithms/docs/index.rst
    /libs/full/statistics/docs/index.rst
+   /libs/full/supervision/docs/index.rst

--- a/libs/full/runtime_distributed/CMakeLists.txt
+++ b/libs/full/runtime_distributed/CMakeLists.txt
@@ -81,5 +81,6 @@ add_hpx_module(
     hpx_performance_counters
     hpx_plugin_factories
     hpx_runtime_components
+    hpx_supervision
   CMAKE_SUBDIRS examples tests
 )

--- a/libs/full/runtime_distributed/include/hpx/runtime_distributed.hpp
+++ b/libs/full/runtime_distributed/include/hpx/runtime_distributed.hpp
@@ -16,6 +16,7 @@
 #include <hpx/modules/performance_counters.hpp>
 #include <hpx/modules/runtime_components.hpp>
 #include <hpx/modules/runtime_local.hpp>
+#include <hpx/modules/supervision.hpp>
 #include <hpx/modules/threading_base.hpp>
 
 #include <hpx/runtime_distributed/applier.hpp>
@@ -236,6 +237,8 @@ namespace hpx {
         ///        runtime.
         agas::addressing_service& get_agas_client();
 
+        supervision::supervision_manager& get_supervision_manager();
+
 #if defined(HPX_HAVE_NETWORKING)
         /// \brief Allow access to the parcel handler instance used by the HPX
         ///        runtime.
@@ -404,6 +407,8 @@ namespace hpx {
 #endif
         agas::addressing_service agas_client_;
         applier::applier applier_;
+
+        supervision::supervision_manager supervision_manager_;
 
         // locality basename -> used cores
         using used_cores_map_type = std::map<std::string, std::uint32_t>;

--- a/libs/full/runtime_distributed/src/runtime_distributed.cpp
+++ b/libs/full/runtime_distributed/src/runtime_distributed.cpp
@@ -25,6 +25,7 @@
 #include <hpx/modules/runtime_configuration.hpp>
 #include <hpx/modules/runtime_local.hpp>
 #include <hpx/modules/static_reinit.hpp>
+#include <hpx/modules/supervision.hpp>
 #include <hpx/modules/thread_pools.hpp>
 #include <hpx/modules/thread_support.hpp>
 #include <hpx/modules/threading_base.hpp>
@@ -178,6 +179,7 @@ namespace hpx {
       , parcel_handler_(rtcfg_)
 #endif
       , agas_client_(rtcfg_)
+      , supervision_manager_(rtcfg)
       , pre_main_(pre_main)
       , post_main_(post_main)
     {
@@ -861,6 +863,12 @@ namespace hpx {
     agas::addressing_service& runtime_distributed::get_agas_client()
     {
         return agas_client_;
+    }
+
+    supervision::supervision_manager&
+    runtime_distributed::get_supervision_manager()
+    {
+        return supervision_manager_;
     }
 
 #if defined(HPX_HAVE_NETWORKING)
@@ -1832,6 +1840,13 @@ namespace hpx::naming {
     }
 }    // namespace hpx::naming
 
+namespace hpx::supervision {
+
+    supervision::supervision_manager& get_supervision_manager()
+    {
+        return get_runtime_distributed().get_supervision_manager();
+    }
+}    // namespace hpx::supervision
 ///////////////////////////////////////////////////////////////////////////////
 #if defined(HPX_HAVE_NETWORKING)
 namespace hpx::parcelset {

--- a/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
+++ b/libs/full/runtime_distributed/src/server/runtime_support_server.cpp
@@ -654,6 +654,12 @@ namespace hpx { namespace components { namespace server {
                 naming::gid_type const here = agas_client.get_local_locality();
 
                 // unregister fixed components
+                auto const& supervision_manager =
+                    supervision::get_supervision_manager();
+                supervision_manager.unregister_server_instance(ec);
+
+                agas_client.unregister_server_instances(ec);
+
                 agas_client.unbind_local(
                     appl.get_runtime_support_raw_gid(), ec);
 
@@ -958,7 +964,8 @@ namespace hpx { namespace components { namespace server {
         if (it == plugins_.end() || !(*it).second.first)
         {
             l.unlock();
-            if (ec.category() != hpx::get_lightweight_hpx_category())
+            if (ec.category() != hpx::get_lightweight_hpx_category() &&
+                ec.category() != hpx::get_lightweight_hpx_rethrow_category())
             {
                 // we don't know anything about this component
                 HPX_THROWS_IF(ec, hpx::error::bad_plugin_type,
@@ -1020,7 +1027,8 @@ namespace hpx { namespace components { namespace server {
         if (it == plugins_.end() || !(*it).second.first)
         {
             l.unlock();
-            if (ec.category() != hpx::get_lightweight_hpx_category())
+            if (ec.category() != hpx::get_lightweight_hpx_category() &&
+                ec.category() != hpx::get_lightweight_hpx_rethrow_category())
             {
                 // we don't know anything about this component
                 HPX_THROWS_IF(ec, hpx::error::bad_plugin_type,

--- a/libs/full/supervision/CMakeLists.txt
+++ b/libs/full/supervision/CMakeLists.txt
@@ -1,0 +1,41 @@
+# Copyright (c) 2026 The STE||AR-Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+if(NOT HPX_WITH_DISTRIBUTED_RUNTIME)
+  return()
+endif()
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+set(supervision_headers
+    hpx/supervision.hpp hpx/supervision/supervision_manager.hpp
+    hpx/supervision/supervision_fwd.hpp hpx/supervision/server/agent.hpp
+    hpx/supervision/server/supervision_manager.hpp
+)
+
+set(supervision_sources supervision.cpp server/supervision_manager_server.cpp
+                        server/agent_server.cpp supervision_manager.cpp
+)
+
+include(HPX_AddModule)
+add_hpx_module(
+  full supervision
+  GLOBAL_HEADER_GEN ON
+  GLOBAL_HEADER_MODULE_GEN ON
+  SOURCES ${supervision_sources}
+  HEADERS ${supervision_headers}
+  DEPENDENCIES hpx_core
+  MODULE_DEPENDENCIES
+    hpx_actions
+    hpx_actions_base
+    hpx_async_distributed
+    hpx_components
+    hpx_components_base
+    hpx_naming
+    hpx_naming_base
+    hpx_runtime_components
+  CMAKE_SUBDIRS examples tests
+)

--- a/libs/full/supervision/CMakeLists.txt
+++ b/libs/full/supervision/CMakeLists.txt
@@ -11,8 +11,11 @@ endif()
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 set(supervision_headers
-    hpx/supervision.hpp hpx/supervision/supervision_manager.hpp
-    hpx/supervision/supervision_fwd.hpp hpx/supervision/server/agent.hpp
+    hpx/supervision.hpp
+    hpx/supervision/supervision_manager.hpp
+    hpx/supervision/supervision_api.hpp
+    hpx/supervision/supervision_fwd.hpp
+    hpx/supervision/server/agent.hpp
     hpx/supervision/server/supervision_manager.hpp
 )
 
@@ -27,6 +30,7 @@ add_hpx_module(
   GLOBAL_HEADER_MODULE_GEN ON
   SOURCES ${supervision_sources}
   HEADERS ${supervision_headers}
+  EXCLUDE_FROM_GLOBAL_HEADER "hpx/supervision.hpp"
   DEPENDENCIES hpx_core
   MODULE_DEPENDENCIES
     hpx_actions

--- a/libs/full/supervision/docs/index.rst
+++ b/libs/full/supervision/docs/index.rst
@@ -25,14 +25,18 @@ call:
 Publishing events
 ------------------
 
-.. cpp:function:: hpx::future<void> hpx::supervision::publish_event(hpx::id_type const& locality, hpx::id_type const& target, hpx::supervision::event ev)
-.. cpp:function:: void hpx::supervision::publish_event(hpx::launch::sync_policy, hpx::id_type const& locality, hpx::id_type const& target, hpx::supervision::event ev, hpx::error_code& ec = hpx::throws)
-.. cpp:function:: void hpx::supervision::publish_event(hpx::id_type const& target, hpx::supervision::event ev, hpx::error_code& ec = hpx::throws)
+.. cpp:function:: hpx::future<hpx::supervision::publish_result> hpx::supervision::publish_event(hpx::id_type const& locality, hpx::id_type const& target, hpx::supervision::event ev)
+.. cpp:function:: hpx::supervision::publish_result hpx::supervision::publish_event(hpx::launch::sync_policy, hpx::id_type const& locality, hpx::id_type const& target, hpx::supervision::event ev, hpx::error_code& ec = hpx::throws)
+.. cpp:function:: hpx::supervision::publish_result hpx::supervision::publish_event(hpx::id_type const& target, hpx::supervision::event ev, hpx::error_code& ec = hpx::throws)
 
     Publish a lifecycle event for ``target``. Events are visible immediately
     to local observers; remote observers are notified within roughly one to
-    two parcel round-trips. Not idempotent - each call creates a distinct,
-    timestamped record.
+    two parcel round-trips. Publishing non-terminal events is not idempotent
+    - each call creates a distinct, timestamped record. ``event::completed``
+    and ``event::failed`` are latched: the first terminal publication for a
+    target returns ``publish_result::applied``; every later terminal
+    publication for that target is a no-op that returns
+    ``publish_result::already_terminal``.
 
 Querying lifecycle state
 -------------------------

--- a/libs/full/supervision/docs/index.rst
+++ b/libs/full/supervision/docs/index.rst
@@ -1,0 +1,70 @@
+..
+    Copyright (c) 2026 The STE||AR-Group
+
+    SPDX-License-Identifier: BSL-1.0
+    Distributed under the Boost Software License, Version 1.0. (See accompanying
+    file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+.. _modules_supervision:
+
+===========
+supervision
+===========
+
+The supervision module provides lifecycle event publication, state querying,
+and observer registration for actors/components running on local or remote
+localities.
+
+Overview
+========
+
+Four core operations are exposed, each with a local (synchronous) call and
+a remote (locality-qualified, future-returning or ``launch::sync_policy``)
+call:
+
+Publishing events
+------------------
+
+.. cpp:function:: hpx::future<void> hpx::supervision::publish_event(hpx::id_type const& locality, hpx::id_type const& target, hpx::supervision::event ev)
+.. cpp:function:: void hpx::supervision::publish_event(hpx::launch::sync_policy, hpx::id_type const& locality, hpx::id_type const& target, hpx::supervision::event ev, hpx::error_code& ec = hpx::throws)
+.. cpp:function:: void hpx::supervision::publish_event(hpx::id_type const& target, hpx::supervision::event ev, hpx::error_code& ec = hpx::throws)
+
+    Publish a lifecycle event for ``target``. Events are visible immediately
+    to local observers; remote observers are notified within roughly one to
+    two parcel round-trips. Not idempotent - each call creates a distinct,
+    timestamped record.
+
+Querying lifecycle state
+-------------------------
+
+.. cpp:function:: hpx::future<hpx::supervision::lifecycle_state> hpx::supervision::query_state(hpx::id_type const& locality, hpx::id_type const& target)
+.. cpp:function:: hpx::supervision::lifecycle_state hpx::supervision::query_state(hpx::launch::sync_policy, hpx::id_type const& locality, hpx::id_type const& target, hpx::error_code& ec = hpx::throws)
+.. cpp:function:: hpx::supervision::lifecycle_state hpx::supervision::query_state(hpx::id_type const& target, hpx::error_code& ec = hpx::throws)
+
+    Query the most recently observed lifecycle state for ``target``. Includes
+    a sequence number for gap detection and a staleness error code for remote
+    queries whose result may lag the latest event.
+
+Registering observers
+----------------------
+
+.. cpp:function:: hpx::future<hpx::id_type> hpx::supervision::register_observer(hpx::id_type const& locality, hpx::id_type const& target, hpx::supervision::lifecycle_callback const& callback)
+.. cpp:function:: hpx::id_type hpx::supervision::register_observer(hpx::launch::sync_policy, hpx::id_type const& locality, hpx::id_type const& target, hpx::supervision::lifecycle_callback const& callback, hpx::error_code& ec = hpx::throws)
+.. cpp:function:: hpx::id_type hpx::supervision::register_observer(hpx::id_type const& target, hpx::supervision::lifecycle_callback const& callback, hpx::error_code& ec = hpx::throws)
+
+    Register ``callback`` to be invoked on lifecycle events of ``target``,
+    returning an observer handle usable with ``unregister_observer``. Local
+    callbacks fire synchronously within the publish call; remote callbacks
+    fire via a retried parcel.
+
+Unregistering observers
+------------------------
+
+.. cpp:function:: hpx::future<void> hpx::supervision::unregister_observer(hpx::id_type const& locality, hpx::id_type const& observer_handle)
+.. cpp:function:: void hpx::supervision::unregister_observer(hpx::launch::sync_policy, hpx::id_type const& locality, hpx::id_type const& observer_handle, hpx::error_code& ec = hpx::throws)
+.. cpp:function:: void hpx::supervision::unregister_observer(hpx::id_type const& observer_handle, hpx::error_code& ec = hpx::throws)
+
+    Unregister a previously registered observer.
+
+See the :ref:`API reference <modules_supervision_api>` of this module for
+more details.

--- a/libs/full/supervision/docs/index.rst
+++ b/libs/full/supervision/docs/index.rst
@@ -25,9 +25,9 @@ call:
 Publishing events
 ------------------
 
-.. cpp:function:: hpx::future<hpx::supervision::publish_result> hpx::supervision::publish_event(hpx::id_type const& locality, hpx::id_type const& target, hpx::supervision::event ev)
-.. cpp:function:: hpx::supervision::publish_result hpx::supervision::publish_event(hpx::launch::sync_policy, hpx::id_type const& locality, hpx::id_type const& target, hpx::supervision::event ev, hpx::error_code& ec = hpx::throws)
-.. cpp:function:: hpx::supervision::publish_result hpx::supervision::publish_event(hpx::id_type const& target, hpx::supervision::event ev, hpx::error_code& ec = hpx::throws)
+.. cpp:function:: hpx::future<hpx::supervision::publish_result> hpx::supervision::publish_event(hpx::id_type const& locality, hpx::id_type const& target, hpx::supervision::event ev, std::uint64_t epoch = 0)
+.. cpp:function:: hpx::supervision::publish_result hpx::supervision::publish_event(hpx::launch::sync_policy, hpx::id_type const& locality, hpx::id_type const& target, hpx::supervision::event ev, std::uint64_t epoch = 0, hpx::error_code& ec = hpx::throws)
+.. cpp:function:: hpx::supervision::publish_result hpx::supervision::publish_event(hpx::id_type const& target, hpx::supervision::event ev, std::uint64_t epoch = 0, hpx::error_code& ec = hpx::throws)
 
     Publish a lifecycle event for ``target``. Events are visible immediately
     to local observers; remote observers are notified within roughly one to
@@ -52,14 +52,17 @@ Querying lifecycle state
 Registering observers
 ----------------------
 
-.. cpp:function:: hpx::future<hpx::id_type> hpx::supervision::register_observer(hpx::id_type const& locality, hpx::id_type const& target, hpx::supervision::lifecycle_callback const& callback)
-.. cpp:function:: hpx::id_type hpx::supervision::register_observer(hpx::launch::sync_policy, hpx::id_type const& locality, hpx::id_type const& target, hpx::supervision::lifecycle_callback const& callback, hpx::error_code& ec = hpx::throws)
-.. cpp:function:: hpx::id_type hpx::supervision::register_observer(hpx::id_type const& target, hpx::supervision::lifecycle_callback const& callback, hpx::error_code& ec = hpx::throws)
+.. cpp:function:: hpx::future<hpx::id_type> hpx::supervision::register_observer(hpx::id_type const& locality, hpx::id_type const& target, hpx::supervision::lifecycle_callback const& callback, std::optional<std::uint64_t> epoch_filter = std::nullopt)
+.. cpp:function:: hpx::id_type hpx::supervision::register_observer(hpx::launch::sync_policy, hpx::id_type const& locality, hpx::id_type const& target, hpx::supervision::lifecycle_callback const& callback, std::optional<std::uint64_t> epoch_filter = std::nullopt, hpx::error_code& ec = hpx::throws)
+.. cpp:function:: hpx::id_type hpx::supervision::register_observer(hpx::id_type const& target, hpx::supervision::lifecycle_callback const& callback, std::optional<std::uint64_t> epoch_filter = std::nullopt, hpx::error_code& ec = hpx::throws)
 
     Register ``callback`` to be invoked on lifecycle events of ``target``,
     returning an observer handle usable with ``unregister_observer``. Local
     callbacks fire synchronously within the publish call; remote callbacks
-    fire via a retried parcel.
+    fire via a retried parcel. If ``epoch_filter`` is set, the observer only
+    receives notifications (including the initial state snapshot delivered
+    at registration time) whose epoch matches; by default the observer
+    receives notifications for every epoch.
 
 Unregistering observers
 ------------------------

--- a/libs/full/supervision/examples/CMakeLists.txt
+++ b/libs/full/supervision/examples/CMakeLists.txt
@@ -1,0 +1,16 @@
+# Copyright (c) 2020-2023 The STE||AR-Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+if(HPX_WITH_EXAMPLES)
+  add_hpx_pseudo_target(examples.modules.supervision)
+  add_hpx_pseudo_dependencies(examples.modules examples.modules.supervision)
+  if(HPX_WITH_TESTS AND HPX_WITH_TESTS_EXAMPLES)
+    add_hpx_pseudo_target(tests.examples.modules.supervision)
+    add_hpx_pseudo_dependencies(
+      tests.examples.modules tests.examples.modules.supervision
+    )
+  endif()
+endif()

--- a/libs/full/supervision/include/hpx/supervision.hpp
+++ b/libs/full/supervision/include/hpx/supervision.hpp
@@ -1,0 +1,10 @@
+//  Copyright (c) 2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/modules/supervision.hpp>

--- a/libs/full/supervision/include/hpx/supervision/server/agent.hpp
+++ b/libs/full/supervision/include/hpx/supervision/server/agent.hpp
@@ -1,0 +1,47 @@
+//  Copyright (c) 2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/modules/actions.hpp>
+#include <hpx/modules/actions_base.hpp>
+#include <hpx/modules/async_distributed.hpp>
+#include <hpx/modules/components_base.hpp>
+
+#include <hpx/supervision/supervision_fwd.hpp>
+
+#include <functional>
+
+namespace hpx::supervision::server {
+
+    class HPX_EXPORT agent_component
+      : public hpx::components::component_base<agent_component>
+    {
+    public:
+        agent_component() = default;
+
+        explicit agent_component(lifecycle_callback f) noexcept
+          : f_(HPX_MOVE(f))
+        {
+        }
+
+        void invoke(lifecycle_event_notification const& notify) const;
+
+        HPX_DEFINE_COMPONENT_ACTION(agent_component, invoke, invoke_action)
+
+    private:
+        lifecycle_callback f_;
+    };
+
+    // Create a local agent wrapping the given function
+    HPX_EXPORT hpx::id_type create_agent(lifecycle_callback f);
+
+}    // namespace hpx::supervision::server
+
+HPX_REGISTER_ACTION_DECLARATION(
+    hpx::supervision::server::agent_component::invoke_action,
+    agent_component_invoke_action)

--- a/libs/full/supervision/include/hpx/supervision/server/agent.hpp
+++ b/libs/full/supervision/include/hpx/supervision/server/agent.hpp
@@ -11,9 +11,11 @@
 #include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/components_base.hpp>
+#include <hpx/modules/synchronization.hpp>
 
-#include <hpx/supervision/supervision_fwd.hpp>
+#include <hpx/supervision/supervision_api.hpp>
 
+#include <cstddef>
 #include <functional>
 
 namespace hpx::supervision::server {
@@ -29,12 +31,23 @@ namespace hpx::supervision::server {
         {
         }
 
-        void invoke(lifecycle_event_notification const& notify) const;
+        void invoke_if_active(lifecycle_event_notification const& notify);
+        HPX_DEFINE_COMPONENT_ACTION(
+            agent_component, invoke_if_active, invoke_if_active_action)
 
-        HPX_DEFINE_COMPONENT_ACTION(agent_component, invoke, invoke_action)
+        void deactivate_and_wait();
+        HPX_DEFINE_COMPONENT_ACTION(
+            agent_component, deactivate_and_wait, deactivate_and_wait_action)
 
     private:
+        void finish_delivery();
+
         lifecycle_callback f_;
+
+        hpx::spinlock mtx_;
+        hpx::lcos::local::detail::condition_variable cv_;
+        bool active_ = true;
+        std::size_t in_flight_ = 0;
     };
 
     // Create a local agent wrapping the given function
@@ -43,5 +56,9 @@ namespace hpx::supervision::server {
 }    // namespace hpx::supervision::server
 
 HPX_REGISTER_ACTION_DECLARATION(
-    hpx::supervision::server::agent_component::invoke_action,
-    agent_component_invoke_action)
+    hpx::supervision::server::agent_component::invoke_if_active_action,
+    agent_component_invoke_if_active_action)
+
+HPX_REGISTER_ACTION_DECLARATION(
+    hpx::supervision::server::agent_component::deactivate_and_wait_action,
+    agent_component_deactivate_and_wait_action)

--- a/libs/full/supervision/include/hpx/supervision/server/agent.hpp
+++ b/libs/full/supervision/include/hpx/supervision/server/agent.hpp
@@ -31,13 +31,24 @@ namespace hpx::supervision::server {
         {
         }
 
-        void invoke_if_active(lifecycle_event_notification const& notify);
-        HPX_DEFINE_COMPONENT_ACTION(
-            agent_component, invoke_if_active, invoke_if_active_action)
+        bool invoke_if_active(lifecycle_event_notification const& notify);
+
+        struct invoke_if_active_action
+          : hpx::actions::make_action_t<
+                decltype(&agent_component::invoke_if_active),
+                &agent_component::invoke_if_active, invoke_if_active_action>
+        {
+        };
 
         void deactivate_and_wait();
-        HPX_DEFINE_COMPONENT_ACTION(
-            agent_component, deactivate_and_wait, deactivate_and_wait_action)
+
+        struct deactivate_and_wait_action
+          : hpx::actions::make_action_t<
+                decltype(&agent_component::deactivate_and_wait),
+                &agent_component::deactivate_and_wait,
+                deactivate_and_wait_action>
+        {
+        };
 
     private:
         void finish_delivery();

--- a/libs/full/supervision/include/hpx/supervision/server/supervision_manager.hpp
+++ b/libs/full/supervision/include/hpx/supervision/server/supervision_manager.hpp
@@ -15,7 +15,7 @@
 #include <hpx/modules/naming_base.hpp>
 #include <hpx/modules/synchronization.hpp>
 
-#include <hpx/supervision/supervision_fwd.hpp>
+#include <hpx/supervision/supervision_api.hpp>
 
 #include <cstdint>
 #include <map>
@@ -24,6 +24,13 @@
 #include <vector>
 
 namespace hpx::supervision::server {
+
+    namespace detail {
+
+        // Testing infrastructure support
+        HPX_CXX_EXPORT HPX_EXPORT void set_register_observer_snapshot_hook(
+            std::function<void()> hook);
+    }    // namespace detail
 
     ////////////////////////////////////////////////////////////////////////////
     // Base name used to register the component
@@ -36,8 +43,8 @@ namespace hpx::supervision::server {
         using base_type = components::fixed_component_base<supervision_manager>;
 
         supervision_manager()
-          : base_type(supervision::supervision_manager_msb,
-                supervision::supervision_manager_lsb)
+          : base_type(supervision::detail::supervision_manager_msb,
+                supervision::detail::supervision_manager_lsb)
         {
         }
 
@@ -63,9 +70,11 @@ namespace hpx::supervision::server {
         HPX_DEFINE_COMPONENT_ACTION(supervision_manager, query_state)
 
     protected:
-        hpx::future<void> fire_event(
-            hpx::id_type const& target, hpx::id_type const& agent) const;
-        hpx::future<void> fire_events(hpx::id_type const& target);
+        hpx::future<void> fire_events(hpx::id_type const& target,
+            lifecycle_event_notification const& notification);
+        hpx::future<void> fire_event(hpx::id_type const& target,
+            hpx::id_type const& agent,
+            lifecycle_event_notification notification) const;
 
         void record_error(
             hpx::id_type const& target, hpx::error_code const& ec);

--- a/libs/full/supervision/include/hpx/supervision/server/supervision_manager.hpp
+++ b/libs/full/supervision/include/hpx/supervision/server/supervision_manager.hpp
@@ -11,6 +11,7 @@
 #include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/components_base.hpp>
+#include <hpx/modules/datastructures.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/naming_base.hpp>
 #include <hpx/modules/synchronization.hpp>
@@ -20,6 +21,7 @@
 #include <cstdint>
 #include <map>
 #include <mutex>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -36,6 +38,16 @@ namespace hpx::supervision::server {
     // Base name used to register the component
     HPX_CXX_EXPORT inline constexpr char const* const supervision_manager_name =
         "supervision_manager/";
+
+    // An observer registered for a target, optionally scoped to a single
+    // epoch: if epoch_filter is engaged, only notifications whose epoch
+    // matches are delivered to agent, notifications for any other epoch are
+    // skipped for this observer.
+    struct observer_entry
+    {
+        hpx::id_type agent;
+        std::optional<std::uint64_t> epoch_filter;
+    };
 
     struct supervision_manager
       : hpx::components::fixed_component_base<supervision_manager>
@@ -55,29 +67,59 @@ namespace hpx::supervision::server {
         void unregister_server_instance(error_code& ec = throws) const;
 
         // Supervision API implementation
-        publish_result publish_event(hpx::id_type const& target, event ev);
+        publish_result publish_event(
+            hpx::id_type const& target, event ev, std::uint64_t epoch);
+
+        struct publish_event_action
+          : hpx::actions::make_action_t<
+                decltype(&supervision_manager::publish_event),
+                &supervision_manager::publish_event, publish_event_action>
+        {
+        };
 
         lifecycle_state query_state(hpx::id_type const& target);
 
-        hpx::id_type register_observer(
-            hpx::id_type const& target, hpx::id_type const& agent);
+        struct query_state_action
+          : hpx::actions::make_action_t<
+                decltype(&supervision_manager::query_state),
+                &supervision_manager::query_state, query_state_action>
+        {
+        };
+
+        hpx::id_type register_observer(hpx::id_type const& target,
+            hpx::id_type const& agent,
+            std::optional<std::uint64_t> epoch_filter = std::nullopt);
+
+        struct register_observer_action
+          : hpx::actions::make_action_t<
+                decltype(&supervision_manager::register_observer),
+                &supervision_manager::register_observer,
+                register_observer_action>
+        {
+        };
 
         void unregister_observer(hpx::id_type const& observer_handle);
 
-        HPX_DEFINE_COMPONENT_ACTION(supervision_manager, publish_event)
-        HPX_DEFINE_COMPONENT_ACTION(supervision_manager, register_observer)
-        HPX_DEFINE_COMPONENT_ACTION(supervision_manager, unregister_observer)
-        HPX_DEFINE_COMPONENT_ACTION(supervision_manager, query_state)
+        struct unregister_observer_action
+          : hpx::actions::make_action_t<
+                decltype(&supervision_manager::unregister_observer),
+                &supervision_manager::unregister_observer,
+                unregister_observer_action>
+        {
+        };
 
     protected:
         hpx::future<void> fire_events(hpx::id_type const& target,
             lifecycle_event_notification const& notification);
         hpx::future<void> fire_event(hpx::id_type const& target,
             hpx::id_type const& agent,
-            lifecycle_event_notification notification) const;
+            lifecycle_event_notification notification);
 
-        void record_error(
-            hpx::id_type const& target, hpx::error_code const& ec);
+        void record_error(hpx::id_type const& target,
+            std::uint64_t expected_sequence_number, hpx::error_code const& ec);
+
+        void unregister_observer_target(
+            hpx::id_type const& target, hpx::id_type const& observer_handle);
 
     private:
         mutable hpx::spinlock mtx_;
@@ -85,8 +127,11 @@ namespace hpx::supervision::server {
 
         // registered events: targets -> states
         std::map<hpx::id_type, lifecycle_state> states_;
-        // registered observers: targets -> agents
-        std::map<hpx::id_type, std::vector<hpx::id_type>> observers_;
+        // current epoch per target: targets -> epoch
+        std::map<hpx::id_type, std::uint64_t> current_epoch_;
+        // registered observers: targets -> observer entries (agent +
+        // optional epoch filter)
+        std::map<hpx::id_type, std::vector<observer_entry>> observers_;
         // inverse lookup for agents: agents -> targets
         std::map<hpx::id_type, std::vector<hpx::id_type>> agents_;
     };

--- a/libs/full/supervision/include/hpx/supervision/server/supervision_manager.hpp
+++ b/libs/full/supervision/include/hpx/supervision/server/supervision_manager.hpp
@@ -1,0 +1,97 @@
+//  Copyright (c) 2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/modules/actions.hpp>
+#include <hpx/modules/actions_base.hpp>
+#include <hpx/modules/async_distributed.hpp>
+#include <hpx/modules/components_base.hpp>
+#include <hpx/modules/errors.hpp>
+#include <hpx/modules/naming_base.hpp>
+#include <hpx/modules/synchronization.hpp>
+
+#include <hpx/supervision/supervision_fwd.hpp>
+
+#include <cstdint>
+#include <map>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace hpx::supervision::server {
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Base name used to register the component
+    HPX_CXX_EXPORT inline constexpr char const* const supervision_manager_name =
+        "supervision_manager/";
+
+    struct supervision_manager
+      : hpx::components::fixed_component_base<supervision_manager>
+    {
+        using base_type = components::fixed_component_base<supervision_manager>;
+
+        supervision_manager()
+          : base_type(supervision::supervision_manager_msb,
+                supervision::supervision_manager_lsb)
+        {
+        }
+
+        void finalize() const;
+
+        void register_server_instance(char const* service_name,
+            std::uint32_t locality_id, error_code& ec = throws);
+        void unregister_server_instance(error_code& ec = throws) const;
+
+        // Supervision API implementation
+        void publish_event(hpx::id_type const& target, event ev);
+
+        lifecycle_state query_state(hpx::id_type const& target);
+
+        hpx::id_type register_observer(
+            hpx::id_type const& target, hpx::id_type const& agent);
+
+        void unregister_observer(hpx::id_type const& observer_handle);
+
+        HPX_DEFINE_COMPONENT_ACTION(supervision_manager, publish_event)
+        HPX_DEFINE_COMPONENT_ACTION(supervision_manager, register_observer)
+        HPX_DEFINE_COMPONENT_ACTION(supervision_manager, unregister_observer)
+        HPX_DEFINE_COMPONENT_ACTION(supervision_manager, query_state)
+
+    protected:
+        hpx::future<void> fire_event(
+            hpx::id_type const& target, hpx::id_type const& agent) const;
+        hpx::future<void> fire_events(hpx::id_type const& target);
+
+        void record_error(
+            hpx::id_type const& target, hpx::error_code const& ec);
+
+    private:
+        mutable hpx::spinlock mtx_;
+        std::string instance_name_;
+
+        // registered events: targets -> states
+        std::map<hpx::id_type, lifecycle_state> states_;
+        // registered observers: targets -> agents
+        std::map<hpx::id_type, std::vector<hpx::id_type>> observers_;
+        // inverse lookup for agents: agents -> targets
+        std::map<hpx::id_type, std::vector<hpx::id_type>> agents_;
+    };
+}    // namespace hpx::supervision::server
+
+HPX_REGISTER_ACTION_DECLARATION(
+    hpx::supervision::server::supervision_manager::publish_event_action,
+    supervision_publish_event_action)
+HPX_REGISTER_ACTION_DECLARATION(
+    hpx::supervision::server::supervision_manager::register_observer_action,
+    supervision_register_observer_action)
+HPX_REGISTER_ACTION_DECLARATION(
+    hpx::supervision::server::supervision_manager::unregister_observer_action,
+    supervision_unregister_observer_action)
+HPX_REGISTER_ACTION_DECLARATION(
+    hpx::supervision::server::supervision_manager::query_state_action,
+    supervision_query_state_action)

--- a/libs/full/supervision/include/hpx/supervision/server/supervision_manager.hpp
+++ b/libs/full/supervision/include/hpx/supervision/server/supervision_manager.hpp
@@ -55,7 +55,7 @@ namespace hpx::supervision::server {
         void unregister_server_instance(error_code& ec = throws) const;
 
         // Supervision API implementation
-        void publish_event(hpx::id_type const& target, event ev);
+        publish_result publish_event(hpx::id_type const& target, event ev);
 
         lifecycle_state query_state(hpx::id_type const& target);
 

--- a/libs/full/supervision/include/hpx/supervision/supervision_api.hpp
+++ b/libs/full/supervision/include/hpx/supervision/supervision_api.hpp
@@ -21,6 +21,7 @@
 
 #include <chrono>
 #include <cstdint>
+#include <optional>
 
 namespace hpx::supervision {
 
@@ -45,20 +46,30 @@ namespace hpx::supervision {
         losing_locality,
     };
 
+    // is_terminal() is declared in supervision_fwd.hpp; its definition is
+    // deferred to here since it needs the full definition of `event`.
+    HPX_CXX_EXPORT constexpr bool is_terminal(event const ev) noexcept
+    {
+        return ev == event::completed || ev == event::failed;
+    }
+
     /// \brief Outcome of a call to \a publish_event().
     ///
     /// \c event::completed and \c event::failed are terminal: once either
-    /// has been recorded for a target, later terminal publications for the same
-    /// target become no-ops, reported via \c already_terminal. Non-terminal
-    /// transitions remain invalid.
-    enum class publish_result : std::uint8_t
-    {
+    /// has been recorded for a target within a given epoch, later terminal
+    /// publications for the same target/epoch become no-ops, reported via
+    /// \c already_terminal. Non-terminal transitions remain invalid.
+    HPX_CXX_EXPORT enum class publish_result : std::uint8_t {
         /// The event was recorded and observers (if any) were notified.
         applied,
-        /// The target had already reached the same terminal event
-        /// (\c completed or \c failed); the call was a no-op and no
-        /// observers were notified.
+        /// The target had already reached a terminal event (\c completed
+        /// or \c failed) within the current epoch; the call was a no-op
+        /// and no observers were notified.
         already_terminal,
+        /// \a epoch was lower than the target's current epoch; the call was
+        /// a stale/out-of-order publication, rejected as a no-op without
+        /// mutating state or notifying observers.
+        stale_epoch,
     };
 
     /// \brief Publish a lifecycle event for a target actor on a possibly
@@ -75,12 +86,23 @@ namespace hpx::supervision {
     ///                 is published.
     /// \param ev       [in] The lifecycle event to publish for \a target.
     ///
+    /// \param epoch    [in] The epoch this publication belongs to. Publications
+    ///                 are compared against the target's current epoch:
+    ///                 publications for a lower epoch are rejected as stale
+    ///                 no-ops, publications for a higher epoch reset the
+    ///                 target's sequence number and become the new current
+    ///                 epoch, and publications for the current epoch are
+    ///                 applied normally (subject to terminal-state latching).
+    ///
     /// \returns        A future that becomes ready once the event has been
     ///                 recorded by the supervision manager on \a locality,
-    ///                 holding \c publish_result::applied, or
+    ///                 holding \c publish_result::applied,
     ///                 \c publish_result::already_terminal if \a target had
     ///                 already reached a terminal event (\c completed or
-    ///                 \c failed).    ///
+    ///                 \c failed) within \a epoch, or
+    ///                 \c publish_result::stale_epoch if \a epoch is lower
+    ///                 than the target's current epoch.
+    ///
     /// \throws         hpx::exception if \a locality does not represent a
     ///                 locality, or if \a target does not represent a
     ///                 valid target. The returned future becomes
@@ -96,10 +118,10 @@ namespace hpx::supervision {
     ///                 actor's registration.
     HPX_CXX_EXPORT HPX_EXPORT hpx::future<publish_result> publish_event(
         hpx::id_type const& locality, hpx::id_type const& target,
-        hpx::supervision::event ev);
+        hpx::supervision::event ev, std::uint64_t epoch = 0);
 
-    /// \brief Publish a lifecycle event for a target actor on a possibly
-    ///        remote locality, blocking until the operation has completed.
+    /// \brief Publish a lifecycle event for a target actor on a possibly remote
+    ///        locality, blocking until the operation has completed.
     ///
     /// This is the synchronous equivalent of
     /// \a publish_event(hpx::id_type const&, hpx::id_type const&, event).
@@ -109,34 +131,39 @@ namespace hpx::supervision {
     /// \param target   [in] The actor (or component) for which the event
     ///                 is published.
     /// \param ev       [in] The lifecycle event to publish for \a target.
+    /// \param epoch    [in] The epoch this publication belongs to. See the
+    ///                 asynchronous remote overload for the epoch-scoped
+    ///                 semantics.
     /// \param ec       [in,out] this represents the error status on exit,
     ///                 if this is pre-initialized to \a hpx::throws the
     ///                 function will throw on error instead.
     ///
     /// \throws         hpx::exception if \a locality does not represent a
-    ///                 locality, or if \a target does not represent a
-    ///                 valid target, unless \a ec was initialized to
+    ///                 locality, or if \a target does not represent a valid
+    ///                 target, unless \a ec was not pre-initialized to
     ///                 \a hpx::throws. As long as \a ec is not
-    ///                 pre-initialized to \a hpx::throws this function
-    ///                 doesn't throw but returns the result code using
-    ///                 the parameter \a ec.
+    ///                 pre-initialized to \a hpx::throws this function doesn't
+    ///                 throw but returns the result code using the parameter \a
+    ///                 ec.
     ///
-    /// \returns        \c publish_result::applied, or
+    /// \returns        \c publish_result::applied,
     ///                 \c publish_result::already_terminal if \a target had
     ///                 already reached a terminal event (\c completed or
-    ///                 \c failed).
+    ///                 \c failed) within \a epoch, or
+    ///                 \c publish_result::stale_epoch if \a epoch is lower
+    ///                 than the target's current epoch.
     ///
     /// \note           Publishing non-terminal events is not idempotent:
     ///                 publishing the same event twice creates two distinct
     ///                 records with different timestamps. \c event::completed
     ///                 and \c event::failed are latched: the first terminal
-    ///                 publication for a target wins, and every later
-    ///                 terminal publication for that target is a no-op that
-    ///                 returns \c publish_result::already_terminal.
+    ///                 publication for a target wins, and every later terminal
+    ///                 publication for that target is a no-op that returns \c
+    ///                 publish_result::already_terminal.
     HPX_CXX_EXPORT HPX_EXPORT publish_result publish_event(
         hpx::launch::sync_policy, hpx::id_type const& locality,
         hpx::id_type const& target, hpx::supervision::event ev,
-        hpx::error_code& ec = hpx::throws);
+        std::uint64_t epoch = 0, hpx::error_code& ec = hpx::throws);
 
     /// \brief Publish a lifecycle event for a target actor on the local
     ///        locality.
@@ -149,6 +176,9 @@ namespace hpx::supervision {
     /// \param target [in] The actor (or component) for which the event is
     ///               published. Must be local to the calling locality.
     /// \param ev     [in] The lifecycle event to publish for \a target.
+    /// \param epoch  [in] The epoch this publication belongs to. See the
+    ///               asynchronous remote overload for the epoch-scoped
+    ///               semantics.
     /// \param ec     [in,out] this represents the error status on exit, if
     ///               this is pre-initialized to \a hpx::throws the
     ///               function will throw on error instead.
@@ -157,10 +187,12 @@ namespace hpx::supervision {
     ///               valid target, unless \a ec was not pre-initialized to
     ///               \a hpx::throws.
     ///
-    /// \returns      \c publish_result::applied, or
+    /// \returns      \c publish_result::applied,
     ///               \c publish_result::already_terminal if \a target had
     ///               already reached a terminal event (\c completed or
-    ///               \c failed).
+    ///               \c failed) within \a epoch, or
+    ///               \c publish_result::stale_epoch if \a epoch is lower
+    ///               than the target's current epoch.
     ///
     /// \note         Publishing non-terminal events is not idempotent:
     ///               publishing the same event twice creates two distinct
@@ -173,7 +205,7 @@ namespace hpx::supervision {
     ///               synchronously as part of this call.
     HPX_CXX_EXPORT HPX_EXPORT publish_result publish_event(
         hpx::id_type const& target, hpx::supervision::event ev,
-        hpx::error_code& ec = throws);
+        std::uint64_t epoch = 0, hpx::error_code& ec = throws);
 
     /// \brief Snapshot of the most recently observed lifecycle event for a
     ///        supervised actor.
@@ -215,6 +247,12 @@ namespace hpx::supervision {
         /// \ref last_event. Enables callers to detect gaps caused by dropped or
         /// undelivered notifications.
         std::uint64_t event_sequence_number = 0;
+
+        /// The epoch \ref last_event was published under. A publication for a
+        /// higher epoch than previously seen resets \ref event_sequence_number
+        /// and becomes the target's new current epoch; a publication for a
+        /// lower epoch is rejected as stale.
+        std::uint64_t epoch = 0;
 
         /// Error code describing the outcome of the query, or a staleness
         /// indicator when the query was served from a remote/observer-side
@@ -352,6 +390,9 @@ namespace hpx::supervision {
         /// notifications (e.g., due to network failure).
         std::uint64_t event_sequence_number = 0;
 
+        /// The epoch \ref event was published under.
+        std::uint64_t epoch = 0;
+
         /// Error code describing the outcome of delivering this notification.
         /// A successful delivery yields \c hpx::make_success_code(); a non-success
         /// code may indicate staleness or a delivery failure that the observer
@@ -364,27 +405,37 @@ namespace hpx::supervision {
     ///        actor.
     ///
     /// The callback is invoked with the \ref lifecycle_event_notification
-    /// describing the event that occurred, and a \c hpx::error_code that
-    /// reports the outcome of delivering the notification (e.g. staleness or
-    /// delivery failures for remote observers).
+    /// describing the event that occurred. Delivery status (e.g. staleness
+    /// or delivery failures for remote observers) is reported via
+    /// \c notification.ec.
     ///
-    /// \note The callback must not throw. Any exception thrown from the
-    ///       callback is logged and does not affect observer registration.
+    /// \returns `true` if the observer should stay registered, `false`
+    ///          otherwise (i.e., `false` will unregister the observer and no
+    ///          further callbacks will be invoked for the given observer).
+    ///
+    /// \note Any exception thrown from the callback is logged and does not
+    ///       affect observer registration.
     /// \note The callback must not block indefinitely; local observers are
     ///       invoked synchronously from within the call that publishes the
     ///       event.
-    HPX_CXX_EXPORT using lifecycle_callback = std::function<void(
-        lifecycle_event_notification const&, hpx::error_code&)>;
+    HPX_CXX_EXPORT using lifecycle_callback =
+        std::function<bool(lifecycle_event_notification const&)>;
 #endif
 
     /// \brief Register a callback to observe lifecycle events published by
     ///        a target actor running on a possibly remote locality.
     ///
-    /// \param locality [in] The locality on which the callback should be
-    ///                 registered.
-    /// \param target   [in] The actor (or component) to observe.
-    /// \param callback [in] The callback invoked whenever \a target
-    ///                 publishes a lifecycle event.
+    /// \param locality     [in] The locality on which the callback should
+    ///                     be registered.
+    /// \param target       [in] The actor (or component) to observe.
+    /// \param callback     [in] The callback invoked whenever \a target
+    ///                     publishes a lifecycle event.
+    /// \param epoch_filter [in] If set, restricts notifications to events
+    ///                     published under this epoch; events published
+    ///                     under any other epoch are silently skipped for
+    ///                     this observer. If \c std::nullopt (the
+    ///                     default), the observer is notified regardless
+    ///                     of epoch.
     ///
     /// \returns        A future holding the global id of the observer
     ///                 handle. This handle must be passed to
@@ -410,7 +461,8 @@ namespace hpx::supervision {
     ///                 registration.
     HPX_CXX_EXPORT HPX_EXPORT hpx::future<hpx::id_type> register_observer(
         hpx::id_type const& locality, hpx::id_type const& target,
-        lifecycle_callback const& callback);
+        lifecycle_callback const& callback,
+        std::optional<std::uint64_t> epoch_filter = std::nullopt);
 
     /// \brief Register a callback to observe lifecycle events published by
     ///        a target actor running on a possibly remote locality, blocking
@@ -420,14 +472,18 @@ namespace hpx::supervision {
     /// \a register_observer(hpx::id_type const&, hpx::id_type const&,
     /// lifecycle_callback const&).
     ///
-    /// \param locality [in] The locality on which the callback should be
-    ///                 registered.
-    /// \param target   [in] The actor (or component) to observe.
-    /// \param callback [in] The callback invoked whenever \a target
-    ///                 publishes a lifecycle event.
-    /// \param ec       [in,out] this represents the error status on exit,
-    ///                 if this is pre-initialized to \a hpx::throws the
-    ///                 function will throw on error instead.
+    /// \param locality     [in] The locality on which the callback should
+    ///                     be registered.
+    /// \param target       [in] The actor (or component) to observe.
+    /// \param callback     [in] The callback invoked whenever \a target
+    ///                     publishes a lifecycle event.
+    /// \param epoch_filter [in] If set, restricts notifications to events
+    ///                     published under this epoch; see the
+    ///                     asynchronous overload for details.
+    /// \param ec           [in,out] this represents the error status on
+    ///                     exit, if this is pre-initialized to
+    ///                     \a hpx::throws the function will throw on error
+    ///                     instead.
     ///
     /// \returns        The global id of the observer handle. This handle
     ///                 must be passed to \a unregister_observer() in order
@@ -440,18 +496,26 @@ namespace hpx::supervision {
     HPX_CXX_EXPORT HPX_EXPORT hpx::id_type register_observer(
         hpx::launch::sync_policy, hpx::id_type const& locality,
         hpx::id_type const& target, lifecycle_callback const& callback,
+        std::optional<std::uint64_t> epoch_filter = std::nullopt,
         hpx::error_code& ec = hpx::throws);
 
     /// \brief Register a callback to observe lifecycle events published by
     ///        a target actor on the local locality.
     ///
-    /// \param target   [in] The actor (or component) to observe. Must be
-    ///                 local to the calling locality.
-    /// \param callback [in] The callback invoked whenever \a target
-    ///                 publishes a lifecycle event.
-    /// \param ec       [in,out] this represents the error status on exit,
-    ///                 if this is pre-initialized to \a hpx::throws the
-    ///                 function will throw on error instead.
+    /// \param target       [in] The actor (or component) to observe. Must
+    ///                     be local to the calling locality.
+    /// \param callback     [in] The callback invoked whenever \a target
+    ///                     publishes a lifecycle event.
+    /// \param epoch_filter [in] If set, restricts notifications to events
+    ///                     published under this epoch; events published
+    ///                     under any other epoch are silently skipped for
+    ///                     this observer. If \c std::nullopt (the
+    ///                     default), the observer is notified regardless
+    ///                     of epoch.
+    /// \param ec           [in,out] this represents the error status on
+    ///                     exit, if this is pre-initialized to
+    ///                     \a hpx::throws the function will throw on error
+    ///                     instead.
     ///
     /// \returns        The global id of the observer handle. This handle
     ///                 must be passed to \a unregister_observer() in order
@@ -468,6 +532,7 @@ namespace hpx::supervision {
     ///                 affect the observer registration.
     HPX_CXX_EXPORT HPX_EXPORT hpx::id_type register_observer(
         hpx::id_type const& target, lifecycle_callback const& callback,
+        std::optional<std::uint64_t> epoch_filter = std::nullopt,
         hpx::error_code& ec = hpx::throws);
 
     /// \brief Unregister a previously registered observer on a possibly

--- a/libs/full/supervision/include/hpx/supervision/supervision_api.hpp
+++ b/libs/full/supervision/include/hpx/supervision/supervision_api.hpp
@@ -1,0 +1,493 @@
+//  Copyright (c) 2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file hpx/supervision/supervision_api.hpp
+/// \page hpx::supervision::publish_event, hpx::supervision::query_state, hpx::supervision::register_observer, hpx::supervision::unregister_observer
+/// \headerfile hpx/supervision.hpp
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/modules/async_base.hpp>
+#include <hpx/modules/errors.hpp>
+#include <hpx/modules/futures.hpp>
+#include <hpx/modules/naming_base.hpp>
+#include <hpx/modules/serialization.hpp>
+
+#include <hpx/supervision/supervision_fwd.hpp>
+
+#include <chrono>
+#include <cstdint>
+
+namespace hpx::supervision {
+
+    ////////////////////////////////////////////////////////////////////////////
+    // supervision API
+
+    HPX_CXX_EXPORT enum class event : std::uint8_t {
+        /// Sentinel value; no lifecycle event has been recorded yet.
+        unknown,
+        /// The actor/component has been initialized and is ready to run.
+        started,
+        /// The actor/component is actively executing.
+        running,
+        /// A graceful pause has been initiated for the actor/component.
+        suspending,
+        /// The actor/component has reached normal completion.
+        completed,
+        /// The actor/component has terminated abnormally.
+        failed,
+        /// The locality hosting the actor/component is becoming unavailable
+        /// (e.g. due to node failure or planned decommissioning).
+        losing_locality,
+    };
+
+    /// \brief Publish a lifecycle event for a target actor on a possibly
+    ///        remote locality.
+    ///
+    /// The function \a publish_event() asynchronously notifies the
+    /// supervision manager running on \a locality that \a target has
+    /// reached the lifecycle state \a ev. Registered observers of
+    /// \a target are notified as a result.
+    ///
+    /// \param locality [in] The locality on which the supervision manager
+    ///                 responsible for \a target is running.
+    /// \param target   [in] The actor (or component) for which the event
+    ///                 is published.
+    /// \param ev       [in] The lifecycle event to publish for \a target.
+    ///
+    /// \returns        A future that becomes ready once the event has been
+    ///                 recorded by the supervision manager on \a locality.
+    ///
+    /// \throws         hpx::exception if \a locality does not represent a
+    ///                 locality, or if \a target does not represent a
+    ///                 valid target. The returned future becomes
+    ///                 exceptional if the operation fails.
+    ///
+    /// \note           Publishing is not idempotent: publishing the same
+    ///                 event twice creates two distinct records with
+    ///                 different timestamps.
+    /// \note           Events are immediately visible to observers on the
+    ///                 same locality as \a target; remote observers become
+    ///                 aware of the event within about 1-2 parcel
+    ///                 round-trips to the AGAS authority managing the
+    ///                 actor's registration.
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future<void> publish_event(
+        hpx::id_type const& locality, hpx::id_type const& target,
+        hpx::supervision::event ev);
+
+    /// \brief Publish a lifecycle event for a target actor on a possibly
+    ///        remote locality, blocking until the operation has completed.
+    ///
+    /// This is the synchronous equivalent of
+    /// \a publish_event(hpx::id_type const&, hpx::id_type const&, event).
+    ///
+    /// \param locality [in] The locality on which the supervision manager
+    ///                 responsible for \a target is running.
+    /// \param target   [in] The actor (or component) for which the event
+    ///                 is published.
+    /// \param ev       [in] The lifecycle event to publish for \a target.
+    /// \param ec       [in,out] this represents the error status on exit,
+    ///                 if this is pre-initialized to \a hpx::throws the
+    ///                 function will throw on error instead.
+    ///
+    /// \throws         hpx::exception if \a locality does not represent a
+    ///                 locality, or if \a target does not represent a
+    ///                 valid target, unless \a ec was initialized to
+    ///                 \a hpx::throws. As long as \a ec is not
+    ///                 pre-initialized to \a hpx::throws this function
+    ///                 doesn't throw but returns the result code using
+    ///                 the parameter \a ec.
+    ///
+    /// \note           Publishing is not idempotent: publishing the same
+    ///                 event twice creates two distinct records with
+    ///                 different timestamps.
+    HPX_CXX_EXPORT HPX_EXPORT void publish_event(hpx::launch::sync_policy,
+        hpx::id_type const& locality, hpx::id_type const& target,
+        hpx::supervision::event ev, hpx::error_code& ec = hpx::throws);
+
+    /// \brief Publish a lifecycle event for a target actor on the local
+    ///        locality.
+    ///
+    /// This overload publishes \a ev directly through the local
+    /// supervision manager without going through AGAS or a remote parcel.
+    /// It is intended to be called from within an actor or action running
+    /// on the same locality as \a target.
+    ///
+    /// \param target [in] The actor (or component) for which the event is
+    ///               published. Must be local to the calling locality.
+    /// \param ev     [in] The lifecycle event to publish for \a target.
+    /// \param ec     [in,out] this represents the error status on exit, if
+    ///               this is pre-initialized to \a hpx::throws the
+    ///               function will throw on error instead.
+    ///
+    /// \throws       hpx::exception if \a target does not represent a
+    ///               valid target, unless \a ec was not pre-initialized to
+    ///               \a hpx::throws.
+    ///
+    /// \note         Publishing is not idempotent: publishing the same
+    ///               event twice creates two distinct records with
+    ///               different timestamps.
+    /// \note         Local observers of \a target are notified
+    ///               synchronously as part of this call.
+    HPX_CXX_EXPORT HPX_EXPORT void publish_event(hpx::id_type const& target,
+        hpx::supervision::event ev, hpx::error_code& ec = throws);
+
+    /// \brief Snapshot of the most recently observed lifecycle event for a
+    ///        supervised actor.
+    ///
+    /// A `lifecycle_state` value is returned by \ref hpx::supervision::query_state
+    /// and represents the last event recorded in the runtime's event log for the
+    /// queried actor.
+    ///
+    /// \par Semantics:
+    /// - Reflects the last event observed locally, i.e. the most recent value in
+    ///   the runtime's event log for \ref actor.
+    /// - If \ref actor is remote, the query is forwarded to the actor's home
+    ///   locality and completes with a latency of roughly one parcel round-trip.
+    /// - If the query originates from a remote caller, \ref ec may carry a
+    ///   staleness error code indicating that the returned state could be stale
+    ///   because the corresponding notification parcel has not yet been
+    ///   delivered to the caller's locality.
+    /// - \ref event_sequence_number allows callers to detect gaps, e.g. when an
+    ///   observer callback was skipped due to a network failure.
+    ///
+    /// \see hpx::supervision::event
+    /// \see hpx::supervision::query_state
+    /// \see hpx::supervision::lifecycle_event_notification
+    HPX_CXX_EXPORT struct lifecycle_state
+    {
+        /// The global id of the actor this state describes.
+        hpx::id_type actor;
+
+        /// The most recently observed lifecycle event for \ref actor. Defaults
+        /// to \c hpx::supervision::event::unknown if no event has been recorded
+        /// yet.
+        event last_event = supervision::event::unknown;
+
+        /// The time at which \ref last_event was recorded, as observed by the
+        /// runtime managing \ref actor's registration.
+        std::chrono::steady_clock::time_point timestamp;
+
+        /// Monotonically increasing sequence number associated with
+        /// \ref last_event. Enables callers to detect gaps caused by dropped or
+        /// undelivered notifications.
+        std::uint64_t event_sequence_number = 0;
+
+        /// Error code describing the outcome of the query, or a staleness
+        /// indicator when the query was served from a remote/observer-side
+        /// cache. A successful query yields \c hpx::make_success_code().
+        hpx::error_code ec = hpx::make_success_code();
+    };
+
+    /// \brief Query the last known lifecycle state of a target actor on a
+    ///        possibly remote locality.
+    ///
+    /// The function \a query_state() asynchronously retrieves the most
+    /// recently published lifecycle event for \a target, as observed by
+    /// the supervision manager running on \a locality.
+    ///
+    /// \param locality [in] The locality on which the supervision manager
+    ///                 responsible for \a target is running.
+    /// \param target   [in] The actor (or component) whose state is
+    ///                 queried.
+    ///
+    /// \returns        A future holding the last event recorded for
+    ///                 \a target (i.e., the most recent value in the
+    ///                 runtime's event log), together with its timestamp
+    ///                 and sequence number.
+    ///
+    /// \throws         hpx::exception if \a locality does not represent a
+    ///                 locality, or if \a target does not represent a
+    ///                 valid target. The returned future becomes
+    ///                 exceptional if the operation fails.
+    ///
+    /// \note           If \a target is not local to \a locality, the query
+    ///                 is forwarded to the actor's home locality, adding
+    ///                 about one parcel round-trip of latency.
+    /// \note           The returned \a lifecycle_state::ec may carry a
+    ///                 staleness error code, indicating that the returned
+    ///                 state may be stale if a preceding observer parcel
+    ///                 has not yet been delivered.
+    /// \note           The \a lifecycle_state::event_sequence_number
+    ///                 allows clients to detect gaps, e.g. if an observer
+    ///                 callback was skipped due to a network failure.
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future<lifecycle_state> query_state(
+        hpx::id_type const& locality, hpx::id_type const& target);
+
+    /// \brief Query the last known lifecycle state of a target actor on a
+    ///        possibly remote locality, blocking until the result is available.
+    ///
+    /// This is the synchronous equivalent of
+    /// \a query_state(hpx::id_type const&, hpx::id_type const&).
+    ///
+    /// \param locality [in] The locality on which the supervision manager
+    ///                 responsible for \a target is running.
+    /// \param target   [in] The actor (or component) whose state is
+    ///                 queried.
+    /// \param ec       [in,out] this represents the error status on exit,
+    ///                 if this is pre-initialized to \a hpx::throws the
+    ///                 function will throw on error instead.
+    ///
+    /// \returns        The last event recorded for \a target, together
+    ///                 with its timestamp and sequence number.
+    ///
+    /// \throws         hpx::exception if \a locality does not represent a
+    ///                 locality, or if \a target does not represent a
+    ///                 valid target, unless \a ec was not pre-initialized to
+    ///                 \a hpx::throws.
+    ///
+    /// \note           The returned \a lifecycle_state::ec may carry a
+    ///                 staleness error code, indicating that the returned
+    ///                 state may be stale if a preceding observer parcel
+    ///                 has not yet been delivered.
+    HPX_CXX_EXPORT HPX_EXPORT lifecycle_state query_state(
+        hpx::launch::sync_policy, hpx::id_type const& locality,
+        hpx::id_type const& target, hpx::error_code& ec = hpx::throws);
+
+    /// \brief Query the last known lifecycle state of a target actor on
+    ///        the local locality.
+    ///
+    /// \param target [in] The actor (or component) whose state is
+    ///               queried. Must be local to the calling locality.
+    /// \param ec     [in,out] this represents the error status on exit, if
+    ///               this is pre-initialized to \a hpx::throws the
+    ///               function will throw on error instead.
+    ///
+    /// \returns      The last event recorded locally for \a target,
+    ///               together with its timestamp and sequence number.
+    ///
+    /// \throws       hpx::exception if \a target does not represent a
+    ///               valid target, unless \a ec was not pre-initialized to
+    ///               \a hpx::throws.
+    HPX_CXX_EXPORT HPX_EXPORT lifecycle_state query_state(
+        hpx::id_type const& target, hpx::error_code& ec = hpx::throws);
+
+    /// \brief Payload delivered to a registered lifecycle observer callback
+    ///        whenever a supervised actor publishes a lifecycle event.
+    ///
+    /// A `lifecycle_event_notification` is constructed by the supervision
+    /// manager each time \ref hpx::supervision::publish_event is invoked for
+    /// a target actor that has one or more registered observers (see
+    /// \ref hpx::supervision::register_observer). It is delivered synchronously
+    /// to local observers within the publishing call, and asynchronously via a
+    /// dedicated parcel to remote observers.
+    ///
+    /// \note Instances are serializable so that they may be transmitted to
+    ///       remote observers across localities.
+    ///
+    /// \see hpx::supervision::event
+    /// \see hpx::supervision::lifecycle_callback
+    /// \see hpx::supervision::register_observer
+    /// \see hpx::supervision::publish_event
+    HPX_CXX_EXPORT struct lifecycle_event_notification
+    {
+        /// The global id of the actor that published the event.
+        hpx::id_type actor;
+
+        /// The lifecycle event that was published. Defaults to
+        /// \c hpx::supervision::event::unknown if no event has been recorded.
+        supervision::event event = supervision::event::unknown;
+
+        /// The time at which the event was published, as observed by the
+        /// runtime managing \ref actor's registration.
+        std::chrono::steady_clock::time_point event_time;
+
+        /// Monotonically increasing sequence number assigned to this event.
+        /// Allows observers to detect gaps caused by dropped or undelivered
+        /// notifications (e.g., due to network failure).
+        std::uint64_t event_sequence_number = 0;
+
+        /// Error code describing the outcome of delivering this notification.
+        /// A successful delivery yields \c hpx::make_success_code(); a non-success
+        /// code may indicate staleness or a delivery failure that the observer
+        /// callback should account for.
+        hpx::error_code ec = hpx::make_success_code();
+    };
+
+#if defined(DOXYGEN)
+    /// \brief Callback type used to observe lifecycle events for a supervised
+    ///        actor.
+    ///
+    /// The callback is invoked with the \ref lifecycle_event_notification
+    /// describing the event that occurred, and a \c hpx::error_code that
+    /// reports the outcome of delivering the notification (e.g. staleness or
+    /// delivery failures for remote observers).
+    ///
+    /// \note The callback must not throw. Any exception thrown from the
+    ///       callback is logged and does not affect observer registration.
+    /// \note The callback must not block indefinitely; local observers are
+    ///       invoked synchronously from within the call that publishes the
+    ///       event.
+    HPX_CXX_EXPORT using lifecycle_callback = std::function<void(
+        lifecycle_event_notification const&, hpx::error_code&)>;
+#endif
+
+    /// \brief Register a callback to observe lifecycle events published by
+    ///        a target actor running on a possibly remote locality.
+    ///
+    /// \param locality [in] The locality on which the callback should be
+    ///                 registered.
+    /// \param target   [in] The actor (or component) to observe.
+    /// \param callback [in] The callback invoked whenever \a target
+    ///                 publishes a lifecycle event.
+    ///
+    /// \returns        A future holding the global id of the observer
+    ///                 handle. This handle must be passed to
+    ///                 \a unregister_observer() in order to stop receiving
+    ///                 notifications.
+    ///
+    /// \throws         hpx::exception if \a locality does not represent a
+    ///                 locality, or if \a target does not represent a
+    ///                 valid target. The returned future becomes
+    ///                 exceptional if the operation fails.
+    ///
+    /// \note           If \a locality is the locality \a target is running
+    ///                 on, the callback is invoked synchronously from
+    ///                 within the publish call (best effort; the callback
+    ///                 must not block indefinitely).
+    /// \note           If \a locality differs from the locality \a target
+    ///                 is running on, the callback is invoked
+    ///                 asynchronously via a dedicated parcel, with retry
+    ///                 semantics (e.g., 3 attempts over 500 ms before
+    ///                 logging failure).
+    /// \note           The callback must not throw; exceptions thrown from
+    ///                 it are logged and do not affect the observer
+    ///                 registration.
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future<hpx::id_type> register_observer(
+        hpx::id_type const& locality, hpx::id_type const& target,
+        lifecycle_callback const& callback);
+
+    /// \brief Register a callback to observe lifecycle events published by
+    ///        a target actor running on a possibly remote locality, blocking
+    ///        until the registration has completed.
+    ///
+    /// This is the synchronous equivalent of
+    /// \a register_observer(hpx::id_type const&, hpx::id_type const&,
+    /// lifecycle_callback const&).
+    ///
+    /// \param locality [in] The locality on which the callback should be
+    ///                 registered.
+    /// \param target   [in] The actor (or component) to observe.
+    /// \param callback [in] The callback invoked whenever \a target
+    ///                 publishes a lifecycle event.
+    /// \param ec       [in,out] this represents the error status on exit,
+    ///                 if this is pre-initialized to \a hpx::throws the
+    ///                 function will throw on error instead.
+    ///
+    /// \returns        The global id of the observer handle. This handle
+    ///                 must be passed to \a unregister_observer() in order
+    ///                 to stop receiving notifications.
+    ///
+    /// \throws         hpx::exception if \a locality does not represent a
+    ///                 locality, or if \a target does not represent a
+    ///                 valid target, unless \a ec was not pre-initialized to
+    ///                 \a hpx::throws.
+    HPX_CXX_EXPORT HPX_EXPORT hpx::id_type register_observer(
+        hpx::launch::sync_policy, hpx::id_type const& locality,
+        hpx::id_type const& target, lifecycle_callback const& callback,
+        hpx::error_code& ec = hpx::throws);
+
+    /// \brief Register a callback to observe lifecycle events published by
+    ///        a target actor on the local locality.
+    ///
+    /// \param target   [in] The actor (or component) to observe. Must be
+    ///                 local to the calling locality.
+    /// \param callback [in] The callback invoked whenever \a target
+    ///                 publishes a lifecycle event.
+    /// \param ec       [in,out] this represents the error status on exit,
+    ///                 if this is pre-initialized to \a hpx::throws the
+    ///                 function will throw on error instead.
+    ///
+    /// \returns        The global id of the observer handle. This handle
+    ///                 must be passed to \a unregister_observer() in order
+    ///                 to stop receiving notifications.
+    ///
+    /// \throws         hpx::exception if \a target does not represent a
+    ///                 valid target, unless \a ec was initialized to
+    ///                 \a hpx::throws.
+    ///
+    /// \note           The callback is invoked synchronously from within
+    ///                 the publish call (best effort; the callback must
+    ///                 not block indefinitely) and must not throw;
+    ///                 exceptions thrown from it are logged and do not
+    ///                 affect the observer registration.
+    HPX_CXX_EXPORT HPX_EXPORT hpx::id_type register_observer(
+        hpx::id_type const& target, lifecycle_callback const& callback,
+        hpx::error_code& ec = hpx::throws);
+
+    /// \brief Unregister a previously registered observer on a possibly
+    ///        remote locality.
+    ///
+    /// \param locality        [in] The locality on which the observer was
+    ///                        registered.
+    /// \param observer_handle [in] The handle returned by a prior call to
+    ///                        \a register_observer().
+    ///
+    /// \returns               A future that becomes ready once the
+    ///                        observer has been unregistered.
+    ///
+    /// \throws                hpx::exception if \a locality does not
+    ///                        represent a locality, or if
+    ///                        \a observer_handle does not represent a
+    ///                        valid observer handle. The returned future
+    ///                        becomes exceptional if the operation
+    ///                        fails.
+    ///
+    /// \note                  Once the returned future has become ready,
+    ///                        no orphaned callbacks fire after
+    ///                        unregistration completes.
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future<void> unregister_observer(
+        hpx::id_type const& locality, hpx::id_type const& observer_handle);
+
+    /// \brief Unregister a previously registered observer on a possibly
+    ///        remote locality, blocking until the operation has completed.
+    ///
+    /// This is the synchronous equivalent of
+    /// \a unregister_observer(hpx::id_type const&, hpx::id_type const&).
+    ///
+    /// \param locality        [in] The locality on which the observer was
+    ///                        registered.
+    /// \param observer_handle [in] The handle returned by a prior call to
+    ///                        \a register_observer().
+    /// \param ec              [in,out] this represents the error status on
+    ///                        exit, if this pre-initialized to
+    ///                        \a hpx::throws the function will throw on
+    ///                        error instead.
+    ///
+    /// \throws                hpx::exception if \a locality does not
+    ///                        represent a locality, or if
+    ///                        \a observer_handle does not represent a
+    ///                        valid observer handle, unless \a ec was
+    ///                        initialized not to \a hpx::throws.
+    ///
+    /// \note                  No orphaned callbacks fire after
+    ///                        unregistration completes.
+    HPX_CXX_EXPORT HPX_EXPORT void unregister_observer(hpx::launch::sync_policy,
+        hpx::id_type const& locality, hpx::id_type const& observer_handle,
+        hpx::error_code& ec = hpx::throws);
+
+    /// \brief Unregister a previously registered observer on the local
+    ///        locality.
+    ///
+    /// \param observer_handle [in] The handle returned by a prior call to
+    ///                        \a register_observer(). Must be local to the
+    ///                        calling locality.
+    /// \param ec              [in,out] this represents the error status on
+    ///                        exit, if this is pre-initialized to
+    ///                        \a hpx::throws the function will throw on
+    ///                        error instead.
+    ///
+    /// \throws                hpx::exception if \a observer_handle does
+    ///                        not represent a valid observer handle,
+    ///                        unless \a ec was not pre-initialized to
+    ///                        \a hpx::throws.
+    ///
+    /// \note                  No orphaned callbacks fire after
+    ///                        unregistration completes.
+    HPX_CXX_EXPORT HPX_EXPORT void unregister_observer(
+        hpx::id_type const& observer_handle, hpx::error_code& ec = hpx::throws);
+}    // namespace hpx::supervision

--- a/libs/full/supervision/include/hpx/supervision/supervision_api.hpp
+++ b/libs/full/supervision/include/hpx/supervision/supervision_api.hpp
@@ -45,6 +45,22 @@ namespace hpx::supervision {
         losing_locality,
     };
 
+    /// \brief Outcome of a call to \a publish_event().
+    ///
+    /// \c event::completed and \c event::failed are terminal: once either
+    /// has been recorded for a target, later terminal publications for the same
+    /// target become no-ops, reported via \c already_terminal. Non-terminal
+    /// transitions remain invalid.
+    enum class publish_result : std::uint8_t
+    {
+        /// The event was recorded and observers (if any) were notified.
+        applied,
+        /// The target had already reached the same terminal event
+        /// (\c completed or \c failed); the call was a no-op and no
+        /// observers were notified.
+        already_terminal,
+    };
+
     /// \brief Publish a lifecycle event for a target actor on a possibly
     ///        remote locality.
     ///
@@ -60,8 +76,11 @@ namespace hpx::supervision {
     /// \param ev       [in] The lifecycle event to publish for \a target.
     ///
     /// \returns        A future that becomes ready once the event has been
-    ///                 recorded by the supervision manager on \a locality.
-    ///
+    ///                 recorded by the supervision manager on \a locality,
+    ///                 holding \c publish_result::applied, or
+    ///                 \c publish_result::already_terminal if \a target had
+    ///                 already reached a terminal event (\c completed or
+    ///                 \c failed).    ///
     /// \throws         hpx::exception if \a locality does not represent a
     ///                 locality, or if \a target does not represent a
     ///                 valid target. The returned future becomes
@@ -75,7 +94,7 @@ namespace hpx::supervision {
     ///                 aware of the event within about 1-2 parcel
     ///                 round-trips to the AGAS authority managing the
     ///                 actor's registration.
-    HPX_CXX_EXPORT HPX_EXPORT hpx::future<void> publish_event(
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future<publish_result> publish_event(
         hpx::id_type const& locality, hpx::id_type const& target,
         hpx::supervision::event ev);
 
@@ -102,12 +121,22 @@ namespace hpx::supervision {
     ///                 doesn't throw but returns the result code using
     ///                 the parameter \a ec.
     ///
-    /// \note           Publishing is not idempotent: publishing the same
-    ///                 event twice creates two distinct records with
-    ///                 different timestamps.
-    HPX_CXX_EXPORT HPX_EXPORT void publish_event(hpx::launch::sync_policy,
-        hpx::id_type const& locality, hpx::id_type const& target,
-        hpx::supervision::event ev, hpx::error_code& ec = hpx::throws);
+    /// \returns        \c publish_result::applied, or
+    ///                 \c publish_result::already_terminal if \a target had
+    ///                 already reached a terminal event (\c completed or
+    ///                 \c failed).
+    ///
+    /// \note           Publishing non-terminal events is not idempotent:
+    ///                 publishing the same event twice creates two distinct
+    ///                 records with different timestamps. \c event::completed
+    ///                 and \c event::failed are latched: the first terminal
+    ///                 publication for a target wins, and every later
+    ///                 terminal publication for that target is a no-op that
+    ///                 returns \c publish_result::already_terminal.
+    HPX_CXX_EXPORT HPX_EXPORT publish_result publish_event(
+        hpx::launch::sync_policy, hpx::id_type const& locality,
+        hpx::id_type const& target, hpx::supervision::event ev,
+        hpx::error_code& ec = hpx::throws);
 
     /// \brief Publish a lifecycle event for a target actor on the local
     ///        locality.
@@ -128,13 +157,23 @@ namespace hpx::supervision {
     ///               valid target, unless \a ec was not pre-initialized to
     ///               \a hpx::throws.
     ///
-    /// \note         Publishing is not idempotent: publishing the same
-    ///               event twice creates two distinct records with
-    ///               different timestamps.
+    /// \returns      \c publish_result::applied, or
+    ///               \c publish_result::already_terminal if \a target had
+    ///               already reached a terminal event (\c completed or
+    ///               \c failed).
+    ///
+    /// \note         Publishing non-terminal events is not idempotent:
+    ///               publishing the same event twice creates two distinct
+    ///               records with different timestamps. \c event::completed
+    ///               and \c event::failed are latched: the first terminal
+    ///               publication for a target wins, and every later
+    ///               terminal publication for that target is a no-op that
+    ///               returns \c publish_result::already_terminal.
     /// \note         Local observers of \a target are notified
     ///               synchronously as part of this call.
-    HPX_CXX_EXPORT HPX_EXPORT void publish_event(hpx::id_type const& target,
-        hpx::supervision::event ev, hpx::error_code& ec = throws);
+    HPX_CXX_EXPORT HPX_EXPORT publish_result publish_event(
+        hpx::id_type const& target, hpx::supervision::event ev,
+        hpx::error_code& ec = throws);
 
     /// \brief Snapshot of the most recently observed lifecycle event for a
     ///        supervised actor.
@@ -182,6 +221,18 @@ namespace hpx::supervision {
         /// cache. A successful query yields \c hpx::make_success_code().
         hpx::error_code ec = hpx::make_success_code();
     };
+
+    /// \brief Determine whether transitioning from lifecycle event \a from
+    ///        to lifecycle event \a to is permitted by the supervision
+    ///        lifecycle state machine.
+    ///
+    /// \a completed and \a failed are terminal states and have no outgoing
+    /// transitions. \a losing_locality is only reachable from \a started,
+    /// \a running, or \a suspending, and may only transition to \a failed.
+    /// A missing prior event is represented as \a event::unknown, from
+    /// which the only valid transition is to \a started.
+    HPX_CXX_EXPORT HPX_EXPORT bool is_valid_transition(
+        event from, event to) noexcept;
 
     /// \brief Query the last known lifecycle state of a target actor on a
     ///        possibly remote locality.

--- a/libs/full/supervision/include/hpx/supervision/supervision_fwd.hpp
+++ b/libs/full/supervision/include/hpx/supervision/supervision_fwd.hpp
@@ -4,34 +4,28 @@
 //  Distributed under the Boost Software License, Version 1.0. (See accompanying
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-/// \file hpx/supervision/supervision_fwd.hpp
-/// \page hpx::supervision::publish_event, hpx::supervision::query_state, hpx::supervision::register_observer, hpx::supervision::unregister_observer
-/// \headerfile hpx/supervision.hpp
-
 #pragma once
 
 #include <hpx/config.hpp>
-#include <hpx/modules/async_base.hpp>
 #include <hpx/modules/errors.hpp>
-#include <hpx/modules/futures.hpp>
-#include <hpx/modules/naming_base.hpp>
 #include <hpx/modules/serialization.hpp>
 
-#include <chrono>
 #include <cstdint>
+#include <functional>
 
 namespace hpx::supervision {
 
-    /// \cond NOINTERNAL
-    ///
     ////////////////////////////////////////////////////////////////////////////
     HPX_CXX_EXPORT inline constexpr char const* const service_name =
         "/0/supervision/";
 
-    HPX_CXX_EXPORT inline constexpr std::uint64_t supervision_manager_msb =
-        0x100000011ULL;
-    HPX_CXX_EXPORT inline constexpr std::uint64_t supervision_manager_lsb =
-        0x000000011ULL;
+    namespace detail {
+
+        HPX_CXX_EXPORT inline constexpr std::uint64_t supervision_manager_msb =
+            0x100000011ULL;
+        HPX_CXX_EXPORT inline constexpr std::uint64_t supervision_manager_lsb =
+            0x000000011ULL;
+    }    // namespace detail
 
     ////////////////////////////////////////////////////////////////////////////
     HPX_CXX_EXPORT class HPX_EXPORT supervision_manager;
@@ -42,488 +36,27 @@ namespace hpx::supervision {
     }    // namespace server
 
     HPX_CXX_EXPORT HPX_EXPORT supervision_manager& get_supervision_manager();
-    /// \endcond
 
     ////////////////////////////////////////////////////////////////////////////
-    // supervision API
+    HPX_CXX_EXPORT enum class event : std::uint8_t;
+    HPX_CXX_EXPORT struct lifecycle_state;
 
-    enum class event : std::uint8_t
-    {
-        /// Sentinel value; no lifecycle event has been recorded yet.
-        unknown,
-        /// The actor/component has been initialized and is ready to run.
-        started,
-        /// The actor/component is actively executing.
-        running,
-        /// A graceful pause has been initiated for the actor/component.
-        suspending,
-        /// The actor/component has reached normal completion.
-        completed,
-        /// The actor/component has terminated abnormally.
-        failed,
-        /// The locality hosting the actor/component is becoming unavailable
-        /// (e.g. due to node failure or planned decommissioning).
-        losing_locality,
-    };
-
-    /// \brief Publish a lifecycle event for a target actor on a possibly
-    ///        remote locality.
-    ///
-    /// The function \a publish_event() asynchronously notifies the
-    /// supervision manager running on \a locality that \a target has
-    /// reached the lifecycle state \a ev. Registered observers of
-    /// \a target are notified as a result.
-    ///
-    /// \param locality [in] The locality on which the supervision manager
-    ///                 responsible for \a target is running.
-    /// \param target   [in] The actor (or component) for which the event
-    ///                 is published.
-    /// \param ev       [in] The lifecycle event to publish for \a target.
-    ///
-    /// \returns        A future that becomes ready once the event has been
-    ///                 recorded by the supervision manager on \a locality.
-    ///
-    /// \throws         hpx::exception if \a locality does not represent a
-    ///                 locality, or if \a target does not represent a
-    ///                 valid target. The returned future becomes
-    ///                 exceptional if the operation fails.
-    ///
-    /// \note           Publishing is not idempotent: publishing the same
-    ///                 event twice creates two distinct records with
-    ///                 different timestamps.
-    /// \note           Events are immediately visible to observers on the
-    ///                 same locality as \a target; remote observers become
-    ///                 aware of the event within about 1-2 parcel
-    ///                 round-trips to the AGAS authority managing the
-    ///                 actor's registration.
-    HPX_CXX_EXPORT HPX_EXPORT hpx::future<void> publish_event(
-        hpx::id_type const& locality, hpx::id_type const& target,
-        hpx::supervision::event ev);
-
-    /// \brief Publish a lifecycle event for a target actor on a possibly
-    ///        remote locality, blocking until the operation has completed.
-    ///
-    /// This is the synchronous equivalent of
-    /// \a publish_event(hpx::id_type const&, hpx::id_type const&, event).
-    ///
-    /// \param locality [in] The locality on which the supervision manager
-    ///                 responsible for \a target is running.
-    /// \param target   [in] The actor (or component) for which the event
-    ///                 is published.
-    /// \param ev       [in] The lifecycle event to publish for \a target.
-    /// \param ec       [in,out] this represents the error status on exit,
-    ///                 if this is pre-initialized to \a hpx::throws the
-    ///                 function will throw on error instead.
-    ///
-    /// \throws         hpx::exception if \a locality does not represent a
-    ///                 locality, or if \a target does not represent a
-    ///                 valid target, unless \a ec was initialized to
-    ///                 \a hpx::throws. As long as \a ec is not
-    ///                 pre-initialized to \a hpx::throws this function
-    ///                 doesn't throw but returns the result code using
-    ///                 the parameter \a ec.
-    ///
-    /// \note           Publishing is not idempotent: publishing the same
-    ///                 event twice creates two distinct records with
-    ///                 different timestamps.
-    HPX_CXX_EXPORT HPX_EXPORT void publish_event(hpx::launch::sync_policy,
-        hpx::id_type const& locality, hpx::id_type const& target,
-        hpx::supervision::event ev, hpx::error_code& ec = hpx::throws);
-
-    /// \brief Publish a lifecycle event for a target actor on the local
-    ///        locality.
-    ///
-    /// This overload publishes \a ev directly through the local
-    /// supervision manager without going through AGAS or a remote parcel.
-    /// It is intended to be called from within an actor or action running
-    /// on the same locality as \a target.
-    ///
-    /// \param target [in] The actor (or component) for which the event is
-    ///               published. Must be local to the calling locality.
-    /// \param ev     [in] The lifecycle event to publish for \a target.
-    /// \param ec     [in,out] this represents the error status on exit, if
-    ///               this is pre-initialized to \a hpx::throws the
-    ///               function will throw on error instead.
-    ///
-    /// \throws       hpx::exception if \a target does not represent a
-    ///               valid target, unless \a ec was not pre-initialized to
-    ///               \a hpx::throws.
-    ///
-    /// \note         Publishing is not idempotent: publishing the same
-    ///               event twice creates two distinct records with
-    ///               different timestamps.
-    /// \note         Local observers of \a target are notified
-    ///               synchronously as part of this call.
-    HPX_CXX_EXPORT HPX_EXPORT void publish_event(hpx::id_type const& target,
-        hpx::supervision::event ev, hpx::error_code& ec = throws);
-
-    /// \brief Snapshot of the most recently observed lifecycle event for a
-    ///        supervised actor.
-    ///
-    /// A `lifecycle_state` value is returned by \ref hpx::supervision::query_state
-    /// and represents the last event recorded in the runtime's event log for the
-    /// queried actor.
-    ///
-    /// \par Semantics:
-    /// - Reflects the last event observed locally, i.e. the most recent value in
-    ///   the runtime's event log for \ref actor.
-    /// - If \ref actor is remote, the query is forwarded to the actor's home
-    ///   locality and completes with a latency of roughly one parcel round-trip.
-    /// - If the query originates from a remote caller, \ref ec may carry a
-    ///   staleness error code indicating that the returned state could be stale
-    ///   because the corresponding notification parcel has not yet been
-    ///   delivered to the caller's locality.
-    /// - \ref event_sequence_number allows callers to detect gaps, e.g. when an
-    ///   observer callback was skipped due to a network failure.
-    ///
-    /// \see hpx::supervision::event
-    /// \see hpx::supervision::query_state
-    /// \see hpx::supervision::lifecycle_event_notification
-    struct lifecycle_state
-    {
-        /// The global id of the actor this state describes.
-        hpx::id_type actor;
-
-        /// The most recently observed lifecycle event for \ref actor. Defaults
-        /// to \c hpx::supervision::event::unknown if no event has been recorded
-        /// yet.
-        event last_event = supervision::event::unknown;
-
-        /// The time at which \ref last_event was recorded, as observed by the
-        /// runtime managing \ref actor's registration.
-        std::chrono::steady_clock::time_point timestamp;
-
-        /// Monotonically increasing sequence number associated with
-        /// \ref last_event. Enables callers to detect gaps caused by dropped or
-        /// undelivered notifications.
-        std::uint64_t event_sequence_number = 0;
-
-        /// Error code describing the outcome of the query, or a staleness
-        /// indicator when the query was served from a remote/observer-side
-        /// cache. A successful query yields \c hpx::make_success_code().
-        hpx::error_code ec = hpx::make_success_code();
-    };
-
-    /// \cond NOINTERNAL
     HPX_CXX_EXPORT HPX_EXPORT void serialize(
         hpx::serialization::output_archive& ar, lifecycle_state const&,
         unsigned int);
     HPX_CXX_EXPORT HPX_EXPORT void serialize(
         hpx::serialization::input_archive& ar, lifecycle_state&, unsigned int);
-    /// \endcond
 
-    /// \brief Query the last known lifecycle state of a target actor on a
-    ///        possibly remote locality.
-    ///
-    /// The function \a query_state() asynchronously retrieves the most
-    /// recently published lifecycle event for \a target, as observed by
-    /// the supervision manager running on \a locality.
-    ///
-    /// \param locality [in] The locality on which the supervision manager
-    ///                 responsible for \a target is running.
-    /// \param target   [in] The actor (or component) whose state is
-    ///                 queried.
-    ///
-    /// \returns        A future holding the last event recorded for
-    ///                 \a target (i.e., the most recent value in the
-    ///                 runtime's event log), together with its timestamp
-    ///                 and sequence number.
-    ///
-    /// \throws         hpx::exception if \a locality does not represent a
-    ///                 locality, or if \a target does not represent a
-    ///                 valid target. The returned future becomes
-    ///                 exceptional if the operation fails.
-    ///
-    /// \note           If \a target is not local to \a locality, the query
-    ///                 is forwarded to the actor's home locality, adding
-    ///                 about one parcel round-trip of latency.
-    /// \note           The returned \a lifecycle_state::ec may carry a
-    ///                 staleness error code, indicating that the returned
-    ///                 state may be stale if a preceding observer parcel
-    ///                 has not yet been delivered.
-    /// \note           The \a lifecycle_state::event_sequence_number
-    ///                 allows clients to detect gaps, e.g. if an observer
-    ///                 callback was skipped due to a network failure.
-    HPX_CXX_EXPORT HPX_EXPORT hpx::future<lifecycle_state> query_state(
-        hpx::id_type const& locality, hpx::id_type const& target);
+    HPX_CXX_EXPORT struct lifecycle_event_notification;
 
-    /// \brief Query the last known lifecycle state of a target actor on a
-    ///        possibly remote locality, blocking until the result is available.
-    ///
-    /// This is the synchronous equivalent of
-    /// \a query_state(hpx::id_type const&, hpx::id_type const&).
-    ///
-    /// \param locality [in] The locality on which the supervision manager
-    ///                 responsible for \a target is running.
-    /// \param target   [in] The actor (or component) whose state is
-    ///                 queried.
-    /// \param ec       [in,out] this represents the error status on exit,
-    ///                 if this is pre-initialized to \a hpx::throws the
-    ///                 function will throw on error instead.
-    ///
-    /// \returns        The last event recorded for \a target, together
-    ///                 with its timestamp and sequence number.
-    ///
-    /// \throws         hpx::exception if \a locality does not represent a
-    ///                 locality, or if \a target does not represent a
-    ///                 valid target, unless \a ec was not pre-initialized to
-    ///                 \a hpx::throws.
-    ///
-    /// \note           The returned \a lifecycle_state::ec may carry a
-    ///                 staleness error code, indicating that the returned
-    ///                 state may be stale if a preceding observer parcel
-    ///                 has not yet been delivered.
-    HPX_CXX_EXPORT HPX_EXPORT lifecycle_state query_state(
-        hpx::launch::sync_policy, hpx::id_type const& locality,
-        hpx::id_type const& target, hpx::error_code& ec = hpx::throws);
-
-    /// \brief Query the last known lifecycle state of a target actor on
-    ///        the local locality.
-    ///
-    /// \param target [in] The actor (or component) whose state is
-    ///               queried. Must be local to the calling locality.
-    /// \param ec     [in,out] this represents the error status on exit, if
-    ///               this is pre-initialized to \a hpx::throws the
-    ///               function will throw on error instead.
-    ///
-    /// \returns      The last event recorded locally for \a target,
-    ///               together with its timestamp and sequence number.
-    ///
-    /// \throws       hpx::exception if \a target does not represent a
-    ///               valid target, unless \a ec was not pre-initialized to
-    ///               \a hpx::throws.
-    HPX_CXX_EXPORT HPX_EXPORT lifecycle_state query_state(
-        hpx::id_type const& target, hpx::error_code& ec = hpx::throws);
-
-    /// \brief Payload delivered to a registered lifecycle observer callback
-    ///        whenever a supervised actor publishes a lifecycle event.
-    ///
-    /// A `lifecycle_event_notification` is constructed by the supervision
-    /// manager each time \ref hpx::supervision::publish_event is invoked for
-    /// a target actor that has one or more registered observers (see
-    /// \ref hpx::supervision::register_observer). It is delivered synchronously
-    /// to local observers within the publishing call, and asynchronously via a
-    /// dedicated parcel to remote observers.
-    ///
-    /// \note Instances are serializable so that they may be transmitted to
-    ///       remote observers across localities.
-    ///
-    /// \see hpx::supervision::event
-    /// \see hpx::supervision::lifecycle_callback
-    /// \see hpx::supervision::register_observer
-    /// \see hpx::supervision::publish_event
-    struct lifecycle_event_notification
-    {
-        /// The global id of the actor that published the event.
-        hpx::id_type actor;
-
-        /// The lifecycle event that was published. Defaults to
-        /// \c hpx::supervision::event::unknown if no event has been recorded.
-        supervision::event event = supervision::event::unknown;
-
-        /// The time at which the event was published, as observed by the
-        /// runtime managing \ref actor's registration.
-        std::chrono::steady_clock::time_point event_time;
-
-        /// Monotonically increasing sequence number assigned to this event.
-        /// Allows observers to detect gaps caused by dropped or undelivered
-        /// notifications (e.g., due to network failure).
-        std::uint64_t event_sequence_number = 0;
-
-        /// Error code describing the outcome of delivering this notification.
-        /// A successful delivery yields \c hpx::make_success_code(); a non-success
-        /// code may indicate staleness or a delivery failure that the observer
-        /// callback should account for.
-        hpx::error_code ec = hpx::make_success_code();
-    };
-
-    /// \cond NOINTERNAL
     HPX_CXX_EXPORT HPX_EXPORT void serialize(
         hpx::serialization::output_archive& ar,
         lifecycle_event_notification const&, unsigned int);
     HPX_CXX_EXPORT HPX_EXPORT void serialize(
         hpx::serialization::input_archive& ar, lifecycle_event_notification&,
         unsigned int);
-    /// \endcond
 
-    /// \brief Callback type used to observe lifecycle events for a supervised
-    ///        actor.
-    ///
-    /// The callback is invoked with the \ref lifecycle_event_notification
-    /// describing the event that occurred, and a \c hpx::error_code that
-    /// reports the outcome of delivering the notification (e.g. staleness or
-    /// delivery failures for remote observers).
-    ///
-    /// \note The callback must not throw. Any exception thrown from the
-    ///       callback is logged and does not affect observer registration.
-    /// \note The callback must not block indefinitely; local observers are
-    ///       invoked synchronously from within the call that publishes the
-    ///       event.
-    using lifecycle_callback = std::function<void(
+    HPX_CXX_EXPORT using lifecycle_callback = std::function<void(
         lifecycle_event_notification const&, hpx::error_code&)>;
 
-    /// \brief Register a callback to observe lifecycle events published by
-    ///        a target actor running on a possibly remote locality.
-    ///
-    /// \param locality [in] The locality on which the callback should be
-    ///                 registered.
-    /// \param target   [in] The actor (or component) to observe.
-    /// \param callback [in] The callback invoked whenever \a target
-    ///                 publishes a lifecycle event.
-    ///
-    /// \returns        A future holding the global id of the observer
-    ///                 handle. This handle must be passed to
-    ///                 \a unregister_observer() in order to stop receiving
-    ///                 notifications.
-    ///
-    /// \throws         hpx::exception if \a locality does not represent a
-    ///                 locality, or if \a target does not represent a
-    ///                 valid target. The returned future becomes
-    ///                 exceptional if the operation fails.
-    ///
-    /// \note           If \a locality is the locality \a target is running
-    ///                 on, the callback is invoked synchronously from
-    ///                 within the publish call (best effort; the callback
-    ///                 must not block indefinitely).
-    /// \note           If \a locality differs from the locality \a target
-    ///                 is running on, the callback is invoked
-    ///                 asynchronously via a dedicated parcel, with retry
-    ///                 semantics (e.g., 3 attempts over 500 ms before
-    ///                 logging failure).
-    /// \note           The callback must not throw; exceptions thrown from
-    ///                 it are logged and do not affect the observer
-    ///                 registration.
-    HPX_CXX_EXPORT HPX_EXPORT hpx::future<hpx::id_type> register_observer(
-        hpx::id_type const& locality, hpx::id_type const& target,
-        lifecycle_callback const& callback);
-
-    /// \brief Register a callback to observe lifecycle events published by
-    ///        a target actor running on a possibly remote locality, blocking
-    ///        until the registration has completed.
-    ///
-    /// This is the synchronous equivalent of
-    /// \a register_observer(hpx::id_type const&, hpx::id_type const&,
-    /// lifecycle_callback const&).
-    ///
-    /// \param locality [in] The locality on which the callback should be
-    ///                 registered.
-    /// \param target   [in] The actor (or component) to observe.
-    /// \param callback [in] The callback invoked whenever \a target
-    ///                 publishes a lifecycle event.
-    /// \param ec       [in,out] this represents the error status on exit,
-    ///                 if this is pre-initialized to \a hpx::throws the
-    ///                 function will throw on error instead.
-    ///
-    /// \returns        The global id of the observer handle. This handle
-    ///                 must be passed to \a unregister_observer() in order
-    ///                 to stop receiving notifications.
-    ///
-    /// \throws         hpx::exception if \a locality does not represent a
-    ///                 locality, or if \a target does not represent a
-    ///                 valid target, unless \a ec was not pre-initialized to
-    ///                 \a hpx::throws.
-    HPX_CXX_EXPORT HPX_EXPORT hpx::id_type register_observer(
-        hpx::launch::sync_policy, hpx::id_type const& locality,
-        hpx::id_type const& target, lifecycle_callback const& callback,
-        hpx::error_code& ec = hpx::throws);
-
-    /// \brief Register a callback to observe lifecycle events published by
-    ///        a target actor on the local locality.
-    ///
-    /// \param target   [in] The actor (or component) to observe. Must be
-    ///                 local to the calling locality.
-    /// \param callback [in] The callback invoked whenever \a target
-    ///                 publishes a lifecycle event.
-    /// \param ec       [in,out] this represents the error status on exit,
-    ///                 if this is pre-initialized to \a hpx::throws the
-    ///                 function will throw on error instead.
-    ///
-    /// \returns        The global id of the observer handle. This handle
-    ///                 must be passed to \a unregister_observer() in order
-    ///                 to stop receiving notifications.
-    ///
-    /// \throws         hpx::exception if \a target does not represent a
-    ///                 valid target, unless \a ec was initialized to
-    ///                 \a hpx::throws.
-    ///
-    /// \note           The callback is invoked synchronously from within
-    ///                 the publish call (best effort; the callback must
-    ///                 not block indefinitely) and must not throw;
-    ///                 exceptions thrown from it are logged and do not
-    ///                 affect the observer registration.
-    HPX_CXX_EXPORT HPX_EXPORT hpx::id_type register_observer(
-        hpx::id_type const& target, lifecycle_callback const& callback,
-        hpx::error_code& ec = hpx::throws);
-
-    /// \brief Unregister a previously registered observer on a possibly
-    ///        remote locality.
-    ///
-    /// \param locality        [in] The locality on which the observer was
-    ///                        registered.
-    /// \param observer_handle [in] The handle returned by a prior call to
-    ///                        \a register_observer().
-    ///
-    /// \returns               A future that becomes ready once the
-    ///                        observer has been unregistered.
-    ///
-    /// \throws                hpx::exception if \a locality does not
-    ///                        represent a locality, or if
-    ///                        \a observer_handle does not represent a
-    ///                        valid observer handle. The returned future
-    ///                        becomes exceptional if the operation
-    ///                        fails.
-    ///
-    /// \note                  Once the returned future has become ready,
-    ///                        no orphaned callbacks fire after
-    ///                        unregistration completes.
-    HPX_CXX_EXPORT HPX_EXPORT hpx::future<void> unregister_observer(
-        hpx::id_type const& locality, hpx::id_type const& observer_handle);
-
-    /// \brief Unregister a previously registered observer on a possibly
-    ///        remote locality, blocking until the operation has completed.
-    ///
-    /// This is the synchronous equivalent of
-    /// \a unregister_observer(hpx::id_type const&, hpx::id_type const&).
-    ///
-    /// \param locality        [in] The locality on which the observer was
-    ///                        registered.
-    /// \param observer_handle [in] The handle returned by a prior call to
-    ///                        \a register_observer().
-    /// \param ec              [in,out] this represents the error status on
-    ///                        exit, if this pre-initialized to
-    ///                        \a hpx::throws the function will throw on
-    ///                        error instead.
-    ///
-    /// \throws                hpx::exception if \a locality does not
-    ///                        represent a locality, or if
-    ///                        \a observer_handle does not represent a
-    ///                        valid observer handle, unless \a ec was
-    ///                        initialized not to \a hpx::throws.
-    ///
-    /// \note                  No orphaned callbacks fire after
-    ///                        unregistration completes.
-    HPX_CXX_EXPORT HPX_EXPORT void unregister_observer(hpx::launch::sync_policy,
-        hpx::id_type const& locality, hpx::id_type const& observer_handle,
-        hpx::error_code& ec = hpx::throws);
-
-    /// \brief Unregister a previously registered observer on the local
-    ///        locality.
-    ///
-    /// \param observer_handle [in] The handle returned by a prior call to
-    ///                        \a register_observer(). Must be local to the
-    ///                        calling locality.
-    /// \param ec              [in,out] this represents the error status on
-    ///                        exit, if this is pre-initialized to
-    ///                        \a hpx::throws the function will throw on
-    ///                        error instead.
-    ///
-    /// \throws                hpx::exception if \a observer_handle does
-    ///                        not represent a valid observer handle,
-    ///                        unless \a ec was not pre-initialized to
-    ///                        \a hpx::throws.
-    ///
-    /// \note                  No orphaned callbacks fire after
-    ///                        unregistration completes.
-    HPX_CXX_EXPORT HPX_EXPORT void unregister_observer(
-        hpx::id_type const& observer_handle, hpx::error_code& ec = hpx::throws);
 }    // namespace hpx::supervision

--- a/libs/full/supervision/include/hpx/supervision/supervision_fwd.hpp
+++ b/libs/full/supervision/include/hpx/supervision/supervision_fwd.hpp
@@ -1,0 +1,529 @@
+//  Copyright (c) 2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file hpx/supervision/supervision_fwd.hpp
+/// \page hpx::supervision::publish_event, hpx::supervision::query_state, hpx::supervision::register_observer, hpx::supervision::unregister_observer
+/// \headerfile hpx/supervision.hpp
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/modules/async_base.hpp>
+#include <hpx/modules/errors.hpp>
+#include <hpx/modules/futures.hpp>
+#include <hpx/modules/naming_base.hpp>
+#include <hpx/modules/serialization.hpp>
+
+#include <chrono>
+#include <cstdint>
+
+namespace hpx::supervision {
+
+    /// \cond NOINTERNAL
+    ///
+    ////////////////////////////////////////////////////////////////////////////
+    HPX_CXX_EXPORT inline constexpr char const* const service_name =
+        "/0/supervision/";
+
+    HPX_CXX_EXPORT inline constexpr std::uint64_t supervision_manager_msb =
+        0x100000011ULL;
+    HPX_CXX_EXPORT inline constexpr std::uint64_t supervision_manager_lsb =
+        0x000000011ULL;
+
+    ////////////////////////////////////////////////////////////////////////////
+    HPX_CXX_EXPORT class HPX_EXPORT supervision_manager;
+
+    namespace server {
+
+        HPX_CXX_EXPORT struct HPX_EXPORT supervision_manager;
+    }    // namespace server
+
+    HPX_CXX_EXPORT HPX_EXPORT supervision_manager& get_supervision_manager();
+    /// \endcond
+
+    ////////////////////////////////////////////////////////////////////////////
+    // supervision API
+
+    enum class event : std::uint8_t
+    {
+        /// Sentinel value; no lifecycle event has been recorded yet.
+        unknown,
+        /// The actor/component has been initialized and is ready to run.
+        started,
+        /// The actor/component is actively executing.
+        running,
+        /// A graceful pause has been initiated for the actor/component.
+        suspending,
+        /// The actor/component has reached normal completion.
+        completed,
+        /// The actor/component has terminated abnormally.
+        failed,
+        /// The locality hosting the actor/component is becoming unavailable
+        /// (e.g. due to node failure or planned decommissioning).
+        losing_locality,
+    };
+
+    /// \brief Publish a lifecycle event for a target actor on a possibly
+    ///        remote locality.
+    ///
+    /// The function \a publish_event() asynchronously notifies the
+    /// supervision manager running on \a locality that \a target has
+    /// reached the lifecycle state \a ev. Registered observers of
+    /// \a target are notified as a result.
+    ///
+    /// \param locality [in] The locality on which the supervision manager
+    ///                 responsible for \a target is running.
+    /// \param target   [in] The actor (or component) for which the event
+    ///                 is published.
+    /// \param ev       [in] The lifecycle event to publish for \a target.
+    ///
+    /// \returns        A future that becomes ready once the event has been
+    ///                 recorded by the supervision manager on \a locality.
+    ///
+    /// \throws         hpx::exception if \a locality does not represent a
+    ///                 locality, or if \a target does not represent a
+    ///                 valid target. The returned future becomes
+    ///                 exceptional if the operation fails.
+    ///
+    /// \note           Publishing is not idempotent: publishing the same
+    ///                 event twice creates two distinct records with
+    ///                 different timestamps.
+    /// \note           Events are immediately visible to observers on the
+    ///                 same locality as \a target; remote observers become
+    ///                 aware of the event within about 1-2 parcel
+    ///                 round-trips to the AGAS authority managing the
+    ///                 actor's registration.
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future<void> publish_event(
+        hpx::id_type const& locality, hpx::id_type const& target,
+        hpx::supervision::event ev);
+
+    /// \brief Publish a lifecycle event for a target actor on a possibly
+    ///        remote locality, blocking until the operation has completed.
+    ///
+    /// This is the synchronous equivalent of
+    /// \a publish_event(hpx::id_type const&, hpx::id_type const&, event).
+    ///
+    /// \param locality [in] The locality on which the supervision manager
+    ///                 responsible for \a target is running.
+    /// \param target   [in] The actor (or component) for which the event
+    ///                 is published.
+    /// \param ev       [in] The lifecycle event to publish for \a target.
+    /// \param ec       [in,out] this represents the error status on exit,
+    ///                 if this is pre-initialized to \a hpx::throws the
+    ///                 function will throw on error instead.
+    ///
+    /// \throws         hpx::exception if \a locality does not represent a
+    ///                 locality, or if \a target does not represent a
+    ///                 valid target, unless \a ec was initialized to
+    ///                 \a hpx::throws. As long as \a ec is not
+    ///                 pre-initialized to \a hpx::throws this function
+    ///                 doesn't throw but returns the result code using
+    ///                 the parameter \a ec.
+    ///
+    /// \note           Publishing is not idempotent: publishing the same
+    ///                 event twice creates two distinct records with
+    ///                 different timestamps.
+    HPX_CXX_EXPORT HPX_EXPORT void publish_event(hpx::launch::sync_policy,
+        hpx::id_type const& locality, hpx::id_type const& target,
+        hpx::supervision::event ev, hpx::error_code& ec = hpx::throws);
+
+    /// \brief Publish a lifecycle event for a target actor on the local
+    ///        locality.
+    ///
+    /// This overload publishes \a ev directly through the local
+    /// supervision manager without going through AGAS or a remote parcel.
+    /// It is intended to be called from within an actor or action running
+    /// on the same locality as \a target.
+    ///
+    /// \param target [in] The actor (or component) for which the event is
+    ///               published. Must be local to the calling locality.
+    /// \param ev     [in] The lifecycle event to publish for \a target.
+    /// \param ec     [in,out] this represents the error status on exit, if
+    ///               this is pre-initialized to \a hpx::throws the
+    ///               function will throw on error instead.
+    ///
+    /// \throws       hpx::exception if \a target does not represent a
+    ///               valid target, unless \a ec was not pre-initialized to
+    ///               \a hpx::throws.
+    ///
+    /// \note         Publishing is not idempotent: publishing the same
+    ///               event twice creates two distinct records with
+    ///               different timestamps.
+    /// \note         Local observers of \a target are notified
+    ///               synchronously as part of this call.
+    HPX_CXX_EXPORT HPX_EXPORT void publish_event(hpx::id_type const& target,
+        hpx::supervision::event ev, hpx::error_code& ec = throws);
+
+    /// \brief Snapshot of the most recently observed lifecycle event for a
+    ///        supervised actor.
+    ///
+    /// A `lifecycle_state` value is returned by \ref hpx::supervision::query_state
+    /// and represents the last event recorded in the runtime's event log for the
+    /// queried actor.
+    ///
+    /// \par Semantics:
+    /// - Reflects the last event observed locally, i.e. the most recent value in
+    ///   the runtime's event log for \ref actor.
+    /// - If \ref actor is remote, the query is forwarded to the actor's home
+    ///   locality and completes with a latency of roughly one parcel round-trip.
+    /// - If the query originates from a remote caller, \ref ec may carry a
+    ///   staleness error code indicating that the returned state could be stale
+    ///   because the corresponding notification parcel has not yet been
+    ///   delivered to the caller's locality.
+    /// - \ref event_sequence_number allows callers to detect gaps, e.g. when an
+    ///   observer callback was skipped due to a network failure.
+    ///
+    /// \see hpx::supervision::event
+    /// \see hpx::supervision::query_state
+    /// \see hpx::supervision::lifecycle_event_notification
+    struct lifecycle_state
+    {
+        /// The global id of the actor this state describes.
+        hpx::id_type actor;
+
+        /// The most recently observed lifecycle event for \ref actor. Defaults
+        /// to \c hpx::supervision::event::unknown if no event has been recorded
+        /// yet.
+        event last_event = supervision::event::unknown;
+
+        /// The time at which \ref last_event was recorded, as observed by the
+        /// runtime managing \ref actor's registration.
+        std::chrono::steady_clock::time_point timestamp;
+
+        /// Monotonically increasing sequence number associated with
+        /// \ref last_event. Enables callers to detect gaps caused by dropped or
+        /// undelivered notifications.
+        std::uint64_t event_sequence_number = 0;
+
+        /// Error code describing the outcome of the query, or a staleness
+        /// indicator when the query was served from a remote/observer-side
+        /// cache. A successful query yields \c hpx::make_success_code().
+        hpx::error_code ec = hpx::make_success_code();
+    };
+
+    /// \cond NOINTERNAL
+    HPX_CXX_EXPORT HPX_EXPORT void serialize(
+        hpx::serialization::output_archive& ar, lifecycle_state const&,
+        unsigned int);
+    HPX_CXX_EXPORT HPX_EXPORT void serialize(
+        hpx::serialization::input_archive& ar, lifecycle_state&, unsigned int);
+    /// \endcond
+
+    /// \brief Query the last known lifecycle state of a target actor on a
+    ///        possibly remote locality.
+    ///
+    /// The function \a query_state() asynchronously retrieves the most
+    /// recently published lifecycle event for \a target, as observed by
+    /// the supervision manager running on \a locality.
+    ///
+    /// \param locality [in] The locality on which the supervision manager
+    ///                 responsible for \a target is running.
+    /// \param target   [in] The actor (or component) whose state is
+    ///                 queried.
+    ///
+    /// \returns        A future holding the last event recorded for
+    ///                 \a target (i.e., the most recent value in the
+    ///                 runtime's event log), together with its timestamp
+    ///                 and sequence number.
+    ///
+    /// \throws         hpx::exception if \a locality does not represent a
+    ///                 locality, or if \a target does not represent a
+    ///                 valid target. The returned future becomes
+    ///                 exceptional if the operation fails.
+    ///
+    /// \note           If \a target is not local to \a locality, the query
+    ///                 is forwarded to the actor's home locality, adding
+    ///                 about one parcel round-trip of latency.
+    /// \note           The returned \a lifecycle_state::ec may carry a
+    ///                 staleness error code, indicating that the returned
+    ///                 state may be stale if a preceding observer parcel
+    ///                 has not yet been delivered.
+    /// \note           The \a lifecycle_state::event_sequence_number
+    ///                 allows clients to detect gaps, e.g. if an observer
+    ///                 callback was skipped due to a network failure.
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future<lifecycle_state> query_state(
+        hpx::id_type const& locality, hpx::id_type const& target);
+
+    /// \brief Query the last known lifecycle state of a target actor on a
+    ///        possibly remote locality, blocking until the result is available.
+    ///
+    /// This is the synchronous equivalent of
+    /// \a query_state(hpx::id_type const&, hpx::id_type const&).
+    ///
+    /// \param locality [in] The locality on which the supervision manager
+    ///                 responsible for \a target is running.
+    /// \param target   [in] The actor (or component) whose state is
+    ///                 queried.
+    /// \param ec       [in,out] this represents the error status on exit,
+    ///                 if this is pre-initialized to \a hpx::throws the
+    ///                 function will throw on error instead.
+    ///
+    /// \returns        The last event recorded for \a target, together
+    ///                 with its timestamp and sequence number.
+    ///
+    /// \throws         hpx::exception if \a locality does not represent a
+    ///                 locality, or if \a target does not represent a
+    ///                 valid target, unless \a ec was not pre-initialized to
+    ///                 \a hpx::throws.
+    ///
+    /// \note           The returned \a lifecycle_state::ec may carry a
+    ///                 staleness error code, indicating that the returned
+    ///                 state may be stale if a preceding observer parcel
+    ///                 has not yet been delivered.
+    HPX_CXX_EXPORT HPX_EXPORT lifecycle_state query_state(
+        hpx::launch::sync_policy, hpx::id_type const& locality,
+        hpx::id_type const& target, hpx::error_code& ec = hpx::throws);
+
+    /// \brief Query the last known lifecycle state of a target actor on
+    ///        the local locality.
+    ///
+    /// \param target [in] The actor (or component) whose state is
+    ///               queried. Must be local to the calling locality.
+    /// \param ec     [in,out] this represents the error status on exit, if
+    ///               this is pre-initialized to \a hpx::throws the
+    ///               function will throw on error instead.
+    ///
+    /// \returns      The last event recorded locally for \a target,
+    ///               together with its timestamp and sequence number.
+    ///
+    /// \throws       hpx::exception if \a target does not represent a
+    ///               valid target, unless \a ec was not pre-initialized to
+    ///               \a hpx::throws.
+    HPX_CXX_EXPORT HPX_EXPORT lifecycle_state query_state(
+        hpx::id_type const& target, hpx::error_code& ec = hpx::throws);
+
+    /// \brief Payload delivered to a registered lifecycle observer callback
+    ///        whenever a supervised actor publishes a lifecycle event.
+    ///
+    /// A `lifecycle_event_notification` is constructed by the supervision
+    /// manager each time \ref hpx::supervision::publish_event is invoked for
+    /// a target actor that has one or more registered observers (see
+    /// \ref hpx::supervision::register_observer). It is delivered synchronously
+    /// to local observers within the publishing call, and asynchronously via a
+    /// dedicated parcel to remote observers.
+    ///
+    /// \note Instances are serializable so that they may be transmitted to
+    ///       remote observers across localities.
+    ///
+    /// \see hpx::supervision::event
+    /// \see hpx::supervision::lifecycle_callback
+    /// \see hpx::supervision::register_observer
+    /// \see hpx::supervision::publish_event
+    struct lifecycle_event_notification
+    {
+        /// The global id of the actor that published the event.
+        hpx::id_type actor;
+
+        /// The lifecycle event that was published. Defaults to
+        /// \c hpx::supervision::event::unknown if no event has been recorded.
+        supervision::event event = supervision::event::unknown;
+
+        /// The time at which the event was published, as observed by the
+        /// runtime managing \ref actor's registration.
+        std::chrono::steady_clock::time_point event_time;
+
+        /// Monotonically increasing sequence number assigned to this event.
+        /// Allows observers to detect gaps caused by dropped or undelivered
+        /// notifications (e.g., due to network failure).
+        std::uint64_t event_sequence_number = 0;
+
+        /// Error code describing the outcome of delivering this notification.
+        /// A successful delivery yields \c hpx::make_success_code(); a non-success
+        /// code may indicate staleness or a delivery failure that the observer
+        /// callback should account for.
+        hpx::error_code ec = hpx::make_success_code();
+    };
+
+    /// \cond NOINTERNAL
+    HPX_CXX_EXPORT HPX_EXPORT void serialize(
+        hpx::serialization::output_archive& ar,
+        lifecycle_event_notification const&, unsigned int);
+    HPX_CXX_EXPORT HPX_EXPORT void serialize(
+        hpx::serialization::input_archive& ar, lifecycle_event_notification&,
+        unsigned int);
+    /// \endcond
+
+    /// \brief Callback type used to observe lifecycle events for a supervised
+    ///        actor.
+    ///
+    /// The callback is invoked with the \ref lifecycle_event_notification
+    /// describing the event that occurred, and a \c hpx::error_code that
+    /// reports the outcome of delivering the notification (e.g. staleness or
+    /// delivery failures for remote observers).
+    ///
+    /// \note The callback must not throw. Any exception thrown from the
+    ///       callback is logged and does not affect observer registration.
+    /// \note The callback must not block indefinitely; local observers are
+    ///       invoked synchronously from within the call that publishes the
+    ///       event.
+    using lifecycle_callback = std::function<void(
+        lifecycle_event_notification const&, hpx::error_code&)>;
+
+    /// \brief Register a callback to observe lifecycle events published by
+    ///        a target actor running on a possibly remote locality.
+    ///
+    /// \param locality [in] The locality on which the callback should be
+    ///                 registered.
+    /// \param target   [in] The actor (or component) to observe.
+    /// \param callback [in] The callback invoked whenever \a target
+    ///                 publishes a lifecycle event.
+    ///
+    /// \returns        A future holding the global id of the observer
+    ///                 handle. This handle must be passed to
+    ///                 \a unregister_observer() in order to stop receiving
+    ///                 notifications.
+    ///
+    /// \throws         hpx::exception if \a locality does not represent a
+    ///                 locality, or if \a target does not represent a
+    ///                 valid target. The returned future becomes
+    ///                 exceptional if the operation fails.
+    ///
+    /// \note           If \a locality is the locality \a target is running
+    ///                 on, the callback is invoked synchronously from
+    ///                 within the publish call (best effort; the callback
+    ///                 must not block indefinitely).
+    /// \note           If \a locality differs from the locality \a target
+    ///                 is running on, the callback is invoked
+    ///                 asynchronously via a dedicated parcel, with retry
+    ///                 semantics (e.g., 3 attempts over 500 ms before
+    ///                 logging failure).
+    /// \note           The callback must not throw; exceptions thrown from
+    ///                 it are logged and do not affect the observer
+    ///                 registration.
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future<hpx::id_type> register_observer(
+        hpx::id_type const& locality, hpx::id_type const& target,
+        lifecycle_callback const& callback);
+
+    /// \brief Register a callback to observe lifecycle events published by
+    ///        a target actor running on a possibly remote locality, blocking
+    ///        until the registration has completed.
+    ///
+    /// This is the synchronous equivalent of
+    /// \a register_observer(hpx::id_type const&, hpx::id_type const&,
+    /// lifecycle_callback const&).
+    ///
+    /// \param locality [in] The locality on which the callback should be
+    ///                 registered.
+    /// \param target   [in] The actor (or component) to observe.
+    /// \param callback [in] The callback invoked whenever \a target
+    ///                 publishes a lifecycle event.
+    /// \param ec       [in,out] this represents the error status on exit,
+    ///                 if this is pre-initialized to \a hpx::throws the
+    ///                 function will throw on error instead.
+    ///
+    /// \returns        The global id of the observer handle. This handle
+    ///                 must be passed to \a unregister_observer() in order
+    ///                 to stop receiving notifications.
+    ///
+    /// \throws         hpx::exception if \a locality does not represent a
+    ///                 locality, or if \a target does not represent a
+    ///                 valid target, unless \a ec was not pre-initialized to
+    ///                 \a hpx::throws.
+    HPX_CXX_EXPORT HPX_EXPORT hpx::id_type register_observer(
+        hpx::launch::sync_policy, hpx::id_type const& locality,
+        hpx::id_type const& target, lifecycle_callback const& callback,
+        hpx::error_code& ec = hpx::throws);
+
+    /// \brief Register a callback to observe lifecycle events published by
+    ///        a target actor on the local locality.
+    ///
+    /// \param target   [in] The actor (or component) to observe. Must be
+    ///                 local to the calling locality.
+    /// \param callback [in] The callback invoked whenever \a target
+    ///                 publishes a lifecycle event.
+    /// \param ec       [in,out] this represents the error status on exit,
+    ///                 if this is pre-initialized to \a hpx::throws the
+    ///                 function will throw on error instead.
+    ///
+    /// \returns        The global id of the observer handle. This handle
+    ///                 must be passed to \a unregister_observer() in order
+    ///                 to stop receiving notifications.
+    ///
+    /// \throws         hpx::exception if \a target does not represent a
+    ///                 valid target, unless \a ec was initialized to
+    ///                 \a hpx::throws.
+    ///
+    /// \note           The callback is invoked synchronously from within
+    ///                 the publish call (best effort; the callback must
+    ///                 not block indefinitely) and must not throw;
+    ///                 exceptions thrown from it are logged and do not
+    ///                 affect the observer registration.
+    HPX_CXX_EXPORT HPX_EXPORT hpx::id_type register_observer(
+        hpx::id_type const& target, lifecycle_callback const& callback,
+        hpx::error_code& ec = hpx::throws);
+
+    /// \brief Unregister a previously registered observer on a possibly
+    ///        remote locality.
+    ///
+    /// \param locality        [in] The locality on which the observer was
+    ///                        registered.
+    /// \param observer_handle [in] The handle returned by a prior call to
+    ///                        \a register_observer().
+    ///
+    /// \returns               A future that becomes ready once the
+    ///                        observer has been unregistered.
+    ///
+    /// \throws                hpx::exception if \a locality does not
+    ///                        represent a locality, or if
+    ///                        \a observer_handle does not represent a
+    ///                        valid observer handle. The returned future
+    ///                        becomes exceptional if the operation
+    ///                        fails.
+    ///
+    /// \note                  Once the returned future has become ready,
+    ///                        no orphaned callbacks fire after
+    ///                        unregistration completes.
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future<void> unregister_observer(
+        hpx::id_type const& locality, hpx::id_type const& observer_handle);
+
+    /// \brief Unregister a previously registered observer on a possibly
+    ///        remote locality, blocking until the operation has completed.
+    ///
+    /// This is the synchronous equivalent of
+    /// \a unregister_observer(hpx::id_type const&, hpx::id_type const&).
+    ///
+    /// \param locality        [in] The locality on which the observer was
+    ///                        registered.
+    /// \param observer_handle [in] The handle returned by a prior call to
+    ///                        \a register_observer().
+    /// \param ec              [in,out] this represents the error status on
+    ///                        exit, if this pre-initialized to
+    ///                        \a hpx::throws the function will throw on
+    ///                        error instead.
+    ///
+    /// \throws                hpx::exception if \a locality does not
+    ///                        represent a locality, or if
+    ///                        \a observer_handle does not represent a
+    ///                        valid observer handle, unless \a ec was
+    ///                        initialized not to \a hpx::throws.
+    ///
+    /// \note                  No orphaned callbacks fire after
+    ///                        unregistration completes.
+    HPX_CXX_EXPORT HPX_EXPORT void unregister_observer(hpx::launch::sync_policy,
+        hpx::id_type const& locality, hpx::id_type const& observer_handle,
+        hpx::error_code& ec = hpx::throws);
+
+    /// \brief Unregister a previously registered observer on the local
+    ///        locality.
+    ///
+    /// \param observer_handle [in] The handle returned by a prior call to
+    ///                        \a register_observer(). Must be local to the
+    ///                        calling locality.
+    /// \param ec              [in,out] this represents the error status on
+    ///                        exit, if this is pre-initialized to
+    ///                        \a hpx::throws the function will throw on
+    ///                        error instead.
+    ///
+    /// \throws                hpx::exception if \a observer_handle does
+    ///                        not represent a valid observer handle,
+    ///                        unless \a ec was not pre-initialized to
+    ///                        \a hpx::throws.
+    ///
+    /// \note                  No orphaned callbacks fire after
+    ///                        unregistration completes.
+    HPX_CXX_EXPORT HPX_EXPORT void unregister_observer(
+        hpx::id_type const& observer_handle, hpx::error_code& ec = hpx::throws);
+}    // namespace hpx::supervision

--- a/libs/full/supervision/include/hpx/supervision/supervision_fwd.hpp
+++ b/libs/full/supervision/include/hpx/supervision/supervision_fwd.hpp
@@ -47,6 +47,7 @@ namespace hpx::supervision {
     HPX_CXX_EXPORT HPX_EXPORT void serialize(
         hpx::serialization::input_archive& ar, lifecycle_state&, unsigned int);
 
+    HPX_CXX_EXPORT enum class publish_result : std::uint8_t;
     HPX_CXX_EXPORT struct lifecycle_event_notification;
 
     HPX_CXX_EXPORT HPX_EXPORT void serialize(
@@ -56,7 +57,7 @@ namespace hpx::supervision {
         hpx::serialization::input_archive& ar, lifecycle_event_notification&,
         unsigned int);
 
-    HPX_CXX_EXPORT using lifecycle_callback = std::function<void(
-        lifecycle_event_notification const&, hpx::error_code&)>;
+    HPX_CXX_EXPORT using lifecycle_callback =
+        std::function<bool(lifecycle_event_notification const&)>;
 
 }    // namespace hpx::supervision

--- a/libs/full/supervision/include/hpx/supervision/supervision_manager.hpp
+++ b/libs/full/supervision/include/hpx/supervision/supervision_manager.hpp
@@ -24,7 +24,7 @@ namespace hpx::supervision {
         explicit supervision_manager(util::runtime_configuration const& ini);
 
         // supervision API
-        void publish_event(hpx::id_type const& target, event ev,
+        publish_result publish_event(hpx::id_type const& target, event ev,
             hpx::error_code& ec = throws) const;
 
         lifecycle_state query_state(

--- a/libs/full/supervision/include/hpx/supervision/supervision_manager.hpp
+++ b/libs/full/supervision/include/hpx/supervision/supervision_manager.hpp
@@ -14,6 +14,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 
 namespace hpx::supervision {
 
@@ -25,13 +26,15 @@ namespace hpx::supervision {
 
         // supervision API
         publish_result publish_event(hpx::id_type const& target, event ev,
-            hpx::error_code& ec = throws) const;
+            std::uint64_t epoch = 0, hpx::error_code& ec = throws) const;
 
         lifecycle_state query_state(
             hpx::id_type const& target, hpx::error_code& ec = throws) const;
 
         hpx::id_type register_observer(hpx::id_type const& target,
-            hpx::id_type const& agent, hpx::error_code& ec = throws) const;
+            hpx::id_type const& agent,
+            std::optional<std::uint64_t> epoch_filter = std::nullopt,
+            hpx::error_code& ec = throws) const;
 
         void unregister_observer(hpx::id_type const& observer_handle,
             hpx::error_code& ec = throws) const;

--- a/libs/full/supervision/include/hpx/supervision/supervision_manager.hpp
+++ b/libs/full/supervision/include/hpx/supervision/supervision_manager.hpp
@@ -1,0 +1,57 @@
+//  Copyright (c) 2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/modules/runtime_configuration.hpp>
+
+#include <hpx/supervision/server/supervision_manager.hpp>
+#include <hpx/supervision/supervision_fwd.hpp>
+
+#include <cstdint>
+#include <memory>
+
+namespace hpx::supervision {
+
+    ////////////////////////////////////////////////////////////////////////////
+    class supervision_manager
+    {
+    public:
+        explicit supervision_manager(util::runtime_configuration const& ini);
+
+        // supervision API
+        void publish_event(hpx::id_type const& target, event ev,
+            hpx::error_code& ec = throws) const;
+
+        lifecycle_state query_state(
+            hpx::id_type const& target, hpx::error_code& ec = throws) const;
+
+        hpx::id_type register_observer(hpx::id_type const& target,
+            hpx::id_type const& agent, hpx::error_code& ec = throws) const;
+
+        void unregister_observer(hpx::id_type const& observer_handle,
+            hpx::error_code& ec = throws) const;
+
+        // Helper functions
+        void register_server_instance(error_code& ec = throws) const;
+        void unregister_server_instance(error_code& ec = throws) const;
+
+        static naming::gid_type get_service_instance(
+            naming::gid_type const& dest, error_code& ec = throws);
+        static naming::gid_type get_service_instance(
+            std::uint32_t service_locality_id);
+
+        static naming::gid_type get_service_instance(hpx::id_type const& dest)
+        {
+            return get_service_instance(dest.get_gid());
+        }
+
+    private:
+        std::unique_ptr<server::supervision_manager> server_{};
+    };
+
+}    // namespace hpx::supervision

--- a/libs/full/supervision/src/server/agent_server.cpp
+++ b/libs/full/supervision/src/server/agent_server.cpp
@@ -11,11 +11,14 @@
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/components.hpp>
 #include <hpx/modules/components_base.hpp>
+#include <hpx/modules/functional.hpp>
 #include <hpx/modules/logging.hpp>
 #include <hpx/modules/runtime_components.hpp>
 
 #include <hpx/supervision/server/agent.hpp>
 #include <hpx/supervision/supervision_api.hpp>
+
+#include <cstddef>
 
 using agent_component = hpx::supervision::server::agent_component;
 using agent_component_type = hpx::components::component<agent_component>;
@@ -36,32 +39,35 @@ namespace hpx::supervision::server {
         return hpx::local_new<agent_component>(hpx::launch::sync, HPX_MOVE(f));
     }
 
-    void agent_component::invoke_if_active(
+    bool agent_component::invoke_if_active(
         lifecycle_event_notification const& notify)
     {
         {
             std::lock_guard<hpx::spinlock> l(mtx_);
             if (!active_)
             {
-                return;
+                return false;
             }
             ++in_flight_;
         }
 
+        bool result = true;
         try
         {
             if (f_)
             {
-                f_(notify, hpx::throws);
+                result = f_(notify);
             }
         }
         catch (...)
         {
             finish_delivery();
-            throw;
+            std::rethrow_exception(std::current_exception());
         }
 
         finish_delivery();
+
+        return result;
     }
 
     void agent_component::finish_delivery()
@@ -79,7 +85,8 @@ namespace hpx::supervision::server {
     {
         std::unique_lock<hpx::spinlock> l(mtx_);
         active_ = false;
-        while (in_flight_ != 0)
+
+        while (in_flight_ > 0)
         {
             cv_.wait(l);
         }

--- a/libs/full/supervision/src/server/agent_server.cpp
+++ b/libs/full/supervision/src/server/agent_server.cpp
@@ -1,0 +1,41 @@
+//  Copyright (c) 2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#include <hpx/modules/actions.hpp>
+#include <hpx/modules/actions_base.hpp>
+#include <hpx/modules/async_distributed.hpp>
+#include <hpx/modules/components.hpp>
+#include <hpx/modules/components_base.hpp>
+#include <hpx/modules/logging.hpp>
+#include <hpx/modules/runtime_components.hpp>
+
+#include <hpx/supervision/server/agent.hpp>
+#include <hpx/supervision/supervision_fwd.hpp>
+
+using agent_component = hpx::supervision::server::agent_component;
+using agent_component_type = hpx::components::component<agent_component>;
+HPX_REGISTER_COMPONENT(agent_component_type, agent_component);
+
+using invoke_action = agent_component::invoke_action;
+HPX_REGISTER_ACTION(invoke_action);
+
+namespace hpx::supervision::server {
+
+    hpx::id_type create_agent(lifecycle_callback f)
+    {
+        return hpx::local_new<agent_component>(hpx::launch::sync, HPX_MOVE(f));
+    }
+
+    void agent_component::invoke(
+        lifecycle_event_notification const& notify) const
+    {
+        if (f_)
+        {
+            f_(notify, hpx::throws);
+        }
+    }
+}    // namespace hpx::supervision::server

--- a/libs/full/supervision/src/server/agent_server.cpp
+++ b/libs/full/supervision/src/server/agent_server.cpp
@@ -5,6 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/config.hpp>
+#include <hpx/assert.hpp>
 #include <hpx/modules/actions.hpp>
 #include <hpx/modules/actions_base.hpp>
 #include <hpx/modules/async_distributed.hpp>
@@ -14,14 +15,19 @@
 #include <hpx/modules/runtime_components.hpp>
 
 #include <hpx/supervision/server/agent.hpp>
-#include <hpx/supervision/supervision_fwd.hpp>
+#include <hpx/supervision/supervision_api.hpp>
 
 using agent_component = hpx::supervision::server::agent_component;
 using agent_component_type = hpx::components::component<agent_component>;
 HPX_REGISTER_COMPONENT(agent_component_type, agent_component);
 
-using invoke_action = agent_component::invoke_action;
-HPX_REGISTER_ACTION(invoke_action);
+using invoke_if_active_action = agent_component::invoke_if_active_action;
+HPX_REGISTER_ACTION_ID(invoke_if_active_action, invoke_if_active_action,
+    hpx::actions::supervision_invoke_if_active_action_id);
+
+using deactivate_and_wait_action = agent_component::deactivate_and_wait_action;
+HPX_REGISTER_ACTION_ID(deactivate_and_wait_action, deactivate_and_wait_action,
+    hpx::actions::supervision_deactivate_and_wait_action_id);
 
 namespace hpx::supervision::server {
 
@@ -30,12 +36,52 @@ namespace hpx::supervision::server {
         return hpx::local_new<agent_component>(hpx::launch::sync, HPX_MOVE(f));
     }
 
-    void agent_component::invoke(
-        lifecycle_event_notification const& notify) const
+    void agent_component::invoke_if_active(
+        lifecycle_event_notification const& notify)
     {
-        if (f_)
         {
-            f_(notify, hpx::throws);
+            std::lock_guard<hpx::spinlock> l(mtx_);
+            if (!active_)
+            {
+                return;
+            }
+            ++in_flight_;
+        }
+
+        try
+        {
+            if (f_)
+            {
+                f_(notify, hpx::throws);
+            }
+        }
+        catch (...)
+        {
+            finish_delivery();
+            throw;
+        }
+
+        finish_delivery();
+    }
+
+    void agent_component::finish_delivery()
+    {
+        std::unique_lock<hpx::spinlock> l(mtx_);
+        HPX_ASSERT(in_flight_ != 0);
+
+        if (--in_flight_ == 0)
+        {
+            cv_.notify_all(HPX_MOVE(l));
+        }
+    }
+
+    void agent_component::deactivate_and_wait()
+    {
+        std::unique_lock<hpx::spinlock> l(mtx_);
+        active_ = false;
+        while (in_flight_ != 0)
+        {
+            cv_.wait(l);
         }
     }
 }    // namespace hpx::supervision::server

--- a/libs/full/supervision/src/server/supervision_manager_server.cpp
+++ b/libs/full/supervision/src/server/supervision_manager_server.cpp
@@ -15,6 +15,7 @@
 
 #include <hpx/supervision/server/agent.hpp>
 #include <hpx/supervision/server/supervision_manager.hpp>
+#include <hpx/supervision/supervision_api.hpp>
 
 #include <algorithm>
 #include <chrono>
@@ -22,10 +23,33 @@
 #include <exception>
 #include <map>
 #include <mutex>
+#include <optional>
 #include <utility>
 #include <vector>
 
 namespace hpx::supervision::server {
+
+    namespace {
+
+        // Testing infrastructure support
+        hpx::spinlock register_observer_hook_mtx;
+        std::function<void()> register_observer_snapshot_hook;
+
+        std::function<void()> get_register_observer_snapshot_hook()
+        {
+            std::lock_guard<hpx::spinlock> l(register_observer_hook_mtx);
+            return register_observer_snapshot_hook;
+        }
+    }    // namespace
+
+    namespace detail {
+
+        void set_register_observer_snapshot_hook(std::function<void()> hook)
+        {
+            std::lock_guard<hpx::spinlock> l(register_observer_hook_mtx);
+            register_observer_snapshot_hook = HPX_MOVE(hook);
+        }
+    }    // namespace detail
 
     void supervision_manager::finalize() const
     {
@@ -54,6 +78,7 @@ namespace hpx::supervision::server {
     void supervision_manager::publish_event(
         hpx::id_type const& target, event const ev)
     {
+        lifecycle_event_notification notification;
         {
             std::unique_lock<hpx::spinlock> l(mtx_);
 
@@ -66,12 +91,12 @@ namespace hpx::supervision::server {
             {
                 state.event_sequence_number =
                     it->second.event_sequence_number + 1;
-                it->second = HPX_MOVE(state);
+                it->second = state;
             }
             else
             {
                 auto const [_, inserted] =
-                    states_.insert(std::make_pair(target, HPX_MOVE(state)));
+                    states_.insert(std::make_pair(target, state));
                 if (!inserted)
                 {
                     l.unlock();
@@ -81,17 +106,19 @@ namespace hpx::supervision::server {
                         "failed to insert event");
                 }
             }
+
+            notification = {.actor = target,
+                .event = state.last_event,
+                .event_time = state.timestamp,
+                .event_sequence_number = state.event_sequence_number,
+                .ec = state.ec};
         }
 
         // now fire event for all observers of this target
-        auto f = fire_events(target);
+        auto f = fire_events(target, notification);
         try
         {
             f.get();
-        }
-        catch (std::exception_ptr const& ep)
-        {
-            record_error(target, hpx::make_error_code(ep));
         }
         catch (...)
         {
@@ -101,43 +128,40 @@ namespace hpx::supervision::server {
     }
 
     hpx::future<void> supervision_manager::fire_events(
-        hpx::id_type const& target)
+        hpx::id_type const& target,
+        lifecycle_event_notification const& notification)
     {
-        std::map<hpx::id_type, std::vector<hpx::id_type>> observers;
+        std::vector<hpx::id_type> observers;
         {
             std::unique_lock<hpx::spinlock> l(mtx_);
-            observers = observers_;
+            if (auto const it = observers_.find(target); it != observers_.end())
+            {
+                observers = it->second;
+            }
         }
 
         hpx::future<void> f;
-        if (auto const it = observers.find(target); it != observers.end())
+        for (hpx::id_type const& agent : observers)
         {
-            for (hpx::id_type const& agent : it->second)
+            if (f.valid())
             {
-                if (f.valid())
-                {
-                    f = f.then([&, this, target, agent](
-                                   hpx::future<void>&& prev_f) {
-                        try
-                        {
-                            prev_f.get();
-                        }
-                        catch (std::exception_ptr const& ep)
-                        {
-                            record_error(target, hpx::make_error_code(ep));
-                        }
-                        catch (...)
-                        {
-                            record_error(target,
-                                hpx::make_error_code(std::current_exception()));
-                        }
-                        return fire_event(target, agent);
-                    });
-                }
-                else
-                {
-                    f = fire_event(target, agent);
-                }
+                f = f.then([&, this, target, agent, notification](
+                               hpx::future<void>&& prev_f) {
+                    try
+                    {
+                        prev_f.get();
+                    }
+                    catch (...)
+                    {
+                        record_error(target,
+                            hpx::make_error_code(std::current_exception()));
+                    }
+                    return fire_event(target, agent, notification);
+                });
+            }
+            else
+            {
+                f = fire_event(target, agent, notification);
             }
         }
 
@@ -149,18 +173,11 @@ namespace hpx::supervision::server {
     }
 
     hpx::future<void> supervision_manager::fire_event(
-        hpx::id_type const& target, hpx::id_type const& agent) const
+        hpx::id_type const& target, hpx::id_type const& agent,
+        lifecycle_event_notification notification) const
     {
-        lifecycle_state state;
-
         {
             std::unique_lock<hpx::spinlock> l(mtx_);
-
-            auto const it = states_.find(target);
-            if (it == states_.end())
-            {
-                return hpx::make_ready_future();
-            }
 
             // check again if the agent is still registered as an observer for
             // the given target
@@ -174,24 +191,17 @@ namespace hpx::supervision::server {
             {
                 return hpx::make_ready_future();
             }
-
-            // use latest registered state for the target
-            state = it->second;
         }
 
-        lifecycle_event_notification notification = {.actor = target,
-            .event = state.last_event,
-            .event_time = state.timestamp,
-            .event_sequence_number = state.event_sequence_number,
-            .ec = state.ec};
-
-        return hpx::async(
-            agent_component::invoke_action(), agent, HPX_MOVE(notification));
+        using action_type = typename agent_component::invoke_if_active_action;
+        return hpx::async(action_type(), agent, HPX_MOVE(notification));
     }
 
     hpx::id_type supervision_manager::register_observer(
         hpx::id_type const& target, hpx::id_type const& agent)
     {
+        std::optional<lifecycle_event_notification> initial_notification;
+
         {
             std::unique_lock<hpx::spinlock> l(mtx_);
 
@@ -246,25 +256,42 @@ namespace hpx::supervision::server {
                 std::ranges::find(it2->second, target) == it2->second.end());
 
             it2->second.push_back(target);
+
+            // An existing target gets an initial notification. Keep a value
+            // snapshot: do not let a subsequent publish replace its contents.
+            if (auto const it3 = states_.find(target); it3 != states_.end())
+            {
+                lifecycle_state const& state = it3->second;
+                initial_notification =
+                    lifecycle_event_notification{.actor = target,
+                        .event = state.last_event,
+                        .event_time = state.timestamp,
+                        .event_sequence_number = state.event_sequence_number,
+                        .ec = state.ec};
+            }
+        }
+
+        // Testing infrastructure support
+        if (auto const hook = get_register_observer_snapshot_hook())
+        {
+            hook();
         }
 
         // now fire event for new observer; dispatched asynchronously, see
         // fire_event
-        auto f = fire_event(target, agent);
-        try
+        if (initial_notification)
         {
-            f.get();
+            auto f = fire_event(target, agent, HPX_MOVE(*initial_notification));
+            try
+            {
+                f.get();
+            }
+            catch (...)
+            {
+                record_error(
+                    target, hpx::make_error_code(std::current_exception()));
+            }
         }
-        catch (std::exception_ptr const& ep)
-        {
-            record_error(target, hpx::make_error_code(ep));
-        }
-        catch (...)
-        {
-            record_error(
-                target, hpx::make_error_code(std::current_exception()));
-        }
-
         return agent;
     }
 
@@ -301,6 +328,15 @@ namespace hpx::supervision::server {
             }
             agents_.erase(it);
         }
+
+        l.unlock();
+
+        // A delivery action that was already queued may still reach the agent.
+        // deactivate_and_wait fences such actions and drains any callback that
+        // had already begun before this call returns.
+        using action_type =
+            typename agent_component::deactivate_and_wait_action;
+        hpx::async(action_type(), observer_handle).get();
     }
 
     lifecycle_state supervision_manager::query_state(hpx::id_type const& target)

--- a/libs/full/supervision/src/server/supervision_manager_server.cpp
+++ b/libs/full/supervision/src/server/supervision_manager_server.cpp
@@ -1,0 +1,352 @@
+//  Copyright (c) 2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#include <hpx/assert.hpp>
+#include <hpx/modules/async_distributed.hpp>
+#include <hpx/modules/components_base.hpp>
+#include <hpx/modules/errors.hpp>
+#include <hpx/modules/futures.hpp>
+#include <hpx/modules/naming_base.hpp>
+#include <hpx/modules/type_support.hpp>
+
+#include <hpx/supervision/server/agent.hpp>
+#include <hpx/supervision/server/supervision_manager.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <exception>
+#include <map>
+#include <mutex>
+#include <utility>
+#include <vector>
+
+namespace hpx::supervision::server {
+
+    void supervision_manager::finalize() const
+    {
+        if (!instance_name_.empty())
+        {
+            error_code ec(throwmode::lightweight);
+            agas::unregister_name(launch::sync, instance_name_, ec);
+        }
+    }
+
+    void supervision_manager::record_error(
+        hpx::id_type const& target, hpx::error_code const& ec)
+    {
+        std::unique_lock<hpx::spinlock> l(mtx_);
+
+        if (auto const it = states_.find(target); it != states_.end())
+        {
+            it->second.last_event = supervision::event::failed;
+            it->second.timestamp = std::chrono::steady_clock::now();
+            it->second.event_sequence_number =
+                it->second.event_sequence_number + 1;
+            it->second.ec = ec;
+        }
+    }
+
+    void supervision_manager::publish_event(
+        hpx::id_type const& target, event const ev)
+    {
+        {
+            std::unique_lock<hpx::spinlock> l(mtx_);
+
+            lifecycle_state state = {.actor = target,
+                .last_event = ev,
+                .timestamp = std::chrono::steady_clock::now(),
+                .event_sequence_number = 1};
+
+            if (auto const it = states_.find(target); it != states_.end())
+            {
+                state.event_sequence_number =
+                    it->second.event_sequence_number + 1;
+                it->second = HPX_MOVE(state);
+            }
+            else
+            {
+                auto const [_, inserted] =
+                    states_.insert(std::make_pair(target, HPX_MOVE(state)));
+                if (!inserted)
+                {
+                    l.unlock();
+
+                    HPX_THROW_EXCEPTION(hpx::error::no_success,
+                        "supervision_manager::publish_event",
+                        "failed to insert event");
+                }
+            }
+        }
+
+        // now fire event for all observers of this target
+        auto f = fire_events(target);
+        try
+        {
+            f.get();
+        }
+        catch (std::exception_ptr const& ep)
+        {
+            record_error(target, hpx::make_error_code(ep));
+        }
+        catch (...)
+        {
+            record_error(
+                target, hpx::make_error_code(std::current_exception()));
+        }
+    }
+
+    hpx::future<void> supervision_manager::fire_events(
+        hpx::id_type const& target)
+    {
+        std::map<hpx::id_type, std::vector<hpx::id_type>> observers;
+        {
+            std::unique_lock<hpx::spinlock> l(mtx_);
+            observers = observers_;
+        }
+
+        hpx::future<void> f;
+        if (auto const it = observers.find(target); it != observers.end())
+        {
+            for (hpx::id_type const& agent : it->second)
+            {
+                if (f.valid())
+                {
+                    f = f.then([&, this, target, agent](
+                                   hpx::future<void>&& prev_f) {
+                        try
+                        {
+                            prev_f.get();
+                        }
+                        catch (std::exception_ptr const& ep)
+                        {
+                            record_error(target, hpx::make_error_code(ep));
+                        }
+                        catch (...)
+                        {
+                            record_error(target,
+                                hpx::make_error_code(std::current_exception()));
+                        }
+                        return fire_event(target, agent);
+                    });
+                }
+                else
+                {
+                    f = fire_event(target, agent);
+                }
+            }
+        }
+
+        if (!f.valid())
+        {
+            f = hpx::make_ready_future();
+        }
+        return f;
+    }
+
+    hpx::future<void> supervision_manager::fire_event(
+        hpx::id_type const& target, hpx::id_type const& agent) const
+    {
+        lifecycle_state state;
+
+        {
+            std::unique_lock<hpx::spinlock> l(mtx_);
+
+            auto const it = states_.find(target);
+            if (it == states_.end())
+            {
+                return hpx::make_ready_future();
+            }
+
+            // check again if the agent is still registered as an observer for
+            // the given target
+            auto const it2 = observers_.find(target);
+            if (it2 == observers_.end())
+            {
+                return hpx::make_ready_future();
+            }
+
+            if (std::ranges::find(it2->second, agent) == it2->second.end())
+            {
+                return hpx::make_ready_future();
+            }
+
+            // use latest registered state for the target
+            state = it->second;
+        }
+
+        lifecycle_event_notification notification = {.actor = target,
+            .event = state.last_event,
+            .event_time = state.timestamp,
+            .event_sequence_number = state.event_sequence_number,
+            .ec = state.ec};
+
+        return hpx::async(
+            agent_component::invoke_action(), agent, HPX_MOVE(notification));
+    }
+
+    hpx::id_type supervision_manager::register_observer(
+        hpx::id_type const& target, hpx::id_type const& agent)
+    {
+        {
+            std::unique_lock<hpx::spinlock> l(mtx_);
+
+            // insert observer into table of registered observers
+            auto it = observers_.find(target);
+            if (it == observers_.end())
+            {
+                auto [it2, inserted] = observers_.insert(
+                    std::make_pair(target, std::vector<hpx::id_type>()));
+                if (!inserted)
+                {
+                    l.unlock();
+
+                    HPX_THROW_EXCEPTION(hpx::error::no_success,
+                        "supervision_manager::register_observer",
+                        "failed to register observer");
+                }
+                it = it2;
+            }
+            else if (std::ranges::find(it->second, agent) != it->second.end())
+            {
+                l.unlock();
+
+                HPX_THROW_EXCEPTION(hpx::error::no_success,
+                    "supervision_manager::register_observer",
+                    "observer already registered for target");
+            }
+
+            it->second.push_back(agent);
+
+            // insert into inverse lookup table as well
+            auto it2 = agents_.find(agent);
+            if (it2 == agents_.end())
+            {
+                auto const [it3, inserted] = agents_.insert(
+                    std::make_pair(agent, std::vector<hpx::id_type>()));
+                if (!inserted)
+                {
+                    l.unlock();
+
+                    HPX_THROW_EXCEPTION(hpx::error::no_success,
+                        "supervision_manager::register_observer",
+                        "failed to register observer");
+                }
+                it2 = it3;
+            }
+
+            // Sanity check: the observers_/agents_ invariant should already
+            // guarantee this can't happen given the check above; catches future
+            // code paths that mutate one map without the other.
+            HPX_ASSERT(
+                std::ranges::find(it2->second, target) == it2->second.end());
+
+            it2->second.push_back(target);
+        }
+
+        // now fire event for new observer; dispatched asynchronously, see
+        // fire_event
+        auto f = fire_event(target, agent);
+        try
+        {
+            f.get();
+        }
+        catch (std::exception_ptr const& ep)
+        {
+            record_error(target, hpx::make_error_code(ep));
+        }
+        catch (...)
+        {
+            record_error(
+                target, hpx::make_error_code(std::current_exception()));
+        }
+
+        return agent;
+    }
+
+    void supervision_manager::unregister_observer(
+        hpx::id_type const& observer_handle)
+    {
+        // remove observer from all targets
+        std::unique_lock<hpx::spinlock> l(mtx_);
+
+        // locate targets the given observer was registered to
+        if (auto const it = agents_.find(observer_handle); it != agents_.end())
+        {
+            // remove observer from all targets
+            for (hpx::id_type const& target : it->second)
+            {
+                if (auto it2 = observers_.find(target); it2 != observers_.end())
+                {
+                    // it3 refers to observer in list
+
+                    // delete observer from list
+                    if (auto const it3 =
+                            std::ranges::find(it2->second, observer_handle);
+                        it3 != it2->second.end())
+                    {
+                        it2->second.erase(it3);
+                    }
+
+                    // delete list of observers from given target
+                    if (it2->second.empty())
+                    {
+                        observers_.erase(it2);
+                    }
+                }
+            }
+            agents_.erase(it);
+        }
+    }
+
+    lifecycle_state supervision_manager::query_state(hpx::id_type const& target)
+    {
+        std::scoped_lock<hpx::spinlock> l(mtx_);
+        if (auto const it = states_.find(target); it != states_.end())
+        {
+            return it->second;
+        }
+        return {};
+    }
+
+    void supervision_manager::register_server_instance(
+        char const* service_name, std::uint32_t locality_id, error_code& ec)
+    {
+        // set locality_id for this component
+        if (locality_id == naming::invalid_locality_id)
+            locality_id = 0;    // if not given, we're on the root
+
+        this->base_type::set_locality_id(locality_id);
+
+        // now register this supervision instance with AGAS
+        instance_name_ = supervision::service_name;
+        instance_name_ += service_name;
+        instance_name_ += supervision::server::supervision_manager_name;
+
+        auto const gid = get_unmanaged_id().get_gid();
+        //naming::gid_type const manager_gid(
+        //    gid.get_msb(), reinterpret_cast<std::uint64_t>(this));
+        naming::address const manager_address(agas::get_locality(),
+            components::get_component_type<
+                supervision::server::supervision_manager>(),
+            this);
+        agas::bind_gid_local(gid, manager_address, ec);
+        if (ec)
+            return;
+
+        // register a gid (not the id) to avoid AGAS holding a reference to this
+        // component
+        agas::register_name(launch::sync, instance_name_, gid, ec);
+    }
+
+    void supervision_manager::unregister_server_instance(error_code& ec) const
+    {
+        agas::unregister_name(launch::sync, instance_name_, ec);
+        this->base_type::finalize();
+    }
+
+}    // namespace hpx::supervision::server

--- a/libs/full/supervision/src/server/supervision_manager_server.cpp
+++ b/libs/full/supervision/src/server/supervision_manager_server.cpp
@@ -60,6 +60,14 @@ namespace hpx::supervision::server {
         }
     }
 
+    // event::completed and event::failed are terminal: once recorded,
+    // a target's state is latched and further publications for that
+    // target are no-ops (see supervision_manager::publish_event).
+    constexpr bool is_terminal(event const ev) noexcept
+    {
+        return ev == event::completed || ev == event::failed;
+    }
+
     void supervision_manager::record_error(
         hpx::id_type const& target, hpx::error_code const& ec)
     {
@@ -75,19 +83,41 @@ namespace hpx::supervision::server {
         }
     }
 
-    void supervision_manager::publish_event(
+    publish_result supervision_manager::publish_event(
         hpx::id_type const& target, event const ev)
     {
         lifecycle_event_notification notification;
         {
             std::unique_lock<hpx::spinlock> l(mtx_);
 
+            auto const it = states_.find(target);
+            event const prev_event =
+                it != states_.end() ? it->second.last_event : event::unknown;
+
+            // A terminal event (completed/failed) was reached, absorb any
+            // further event without mutating state or notifying observers again.
+            if (is_terminal(prev_event) && is_terminal(ev))
+            {
+                // exactly-once completion: the target already reached
+                // a terminal event, ignore this (duplicate) publication
+                return publish_result::already_terminal;
+            }
+
+            if (!is_valid_transition(prev_event, ev))
+            {
+                l.unlock();
+
+                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                    "supervision_manager::publish_event",
+                    "invalid lifecycle event transition");
+            }
+
             lifecycle_state state = {.actor = target,
                 .last_event = ev,
                 .timestamp = std::chrono::steady_clock::now(),
                 .event_sequence_number = 1};
 
-            if (auto const it = states_.find(target); it != states_.end())
+            if (it != states_.end())
             {
                 state.event_sequence_number =
                     it->second.event_sequence_number + 1;
@@ -125,6 +155,8 @@ namespace hpx::supervision::server {
             record_error(
                 target, hpx::make_error_code(std::current_exception()));
         }
+
+        return publish_result::applied;
     }
 
     hpx::future<void> supervision_manager::fire_events(
@@ -193,7 +225,7 @@ namespace hpx::supervision::server {
             }
         }
 
-        using action_type = typename agent_component::invoke_if_active_action;
+        using action_type = agent_component::invoke_if_active_action;
         return hpx::async(action_type(), agent, HPX_MOVE(notification));
     }
 
@@ -334,8 +366,7 @@ namespace hpx::supervision::server {
         // A delivery action that was already queued may still reach the agent.
         // deactivate_and_wait fences such actions and drains any callback that
         // had already begun before this call returns.
-        using action_type =
-            typename agent_component::deactivate_and_wait_action;
+        using action_type = agent_component::deactivate_and_wait_action;
         hpx::async(action_type(), observer_handle).get();
     }
 
@@ -346,7 +377,14 @@ namespace hpx::supervision::server {
         {
             return it->second;
         }
-        return {};
+
+        // No event has ever been recorded for this target: the returned
+        // (default) state may be stale, e.g. because the corresponding
+        // publication has not yet been observed on this locality.
+        return {.actor = target,
+            .ec = hpx::error_code(hpx::error::stale_state,
+                "no locally recorded lifecycle state is available for the "
+                "requested target, the returned state may be stale")};
     }
 
     void supervision_manager::register_server_instance(

--- a/libs/full/supervision/src/server/supervision_manager_server.cpp
+++ b/libs/full/supervision/src/server/supervision_manager_server.cpp
@@ -60,20 +60,18 @@ namespace hpx::supervision::server {
         }
     }
 
-    // event::completed and event::failed are terminal: once recorded,
-    // a target's state is latched and further publications for that
-    // target are no-ops (see supervision_manager::publish_event).
-    constexpr bool is_terminal(event const ev) noexcept
-    {
-        return ev == event::completed || ev == event::failed;
-    }
-
-    void supervision_manager::record_error(
-        hpx::id_type const& target, hpx::error_code const& ec)
+    void supervision_manager::record_error(hpx::id_type const& target,
+        std::uint64_t const expected_sequence_number, hpx::error_code const& ec)
     {
         std::unique_lock<hpx::spinlock> l(mtx_);
 
-        if (auto const it = states_.find(target); it != states_.end())
+        // Only apply the failure if the state that was being delivered when the
+        // failure occurred is still the current state for this target.
+        // Otherwise, a newer publish_event may have already superseded it, and
+        // recording the (now stale) failure would incorrectly stomp that newer
+        // state.
+        if (auto const it = states_.find(target); it != states_.end() &&
+            it->second.event_sequence_number == expected_sequence_number)
         {
             it->second.last_event = supervision::event::failed;
             it->second.timestamp = std::chrono::steady_clock::now();
@@ -84,64 +82,109 @@ namespace hpx::supervision::server {
     }
 
     publish_result supervision_manager::publish_event(
-        hpx::id_type const& target, event const ev)
+        hpx::id_type const& target, event const ev, std::uint64_t epoch)
     {
         lifecycle_event_notification notification;
         {
             std::unique_lock<hpx::spinlock> l(mtx_);
 
+            auto const epoch_it = current_epoch_.find(target);
+            std::uint64_t const current_ep =
+                epoch_it != current_epoch_.end() ? epoch_it->second : 0;
+
+            if (epoch < current_ep)
+            {
+                // stale/out-of-order publication for an epoch that has
+                // already been superseded: reject without mutating state or
+                // notifying observers
+                return publish_result::stale_epoch;
+            }
+
             auto const it = states_.find(target);
-            event const prev_event =
-                it != states_.end() ? it->second.last_event : event::unknown;
 
-            // A terminal event (completed/failed) was reached, absorb any
-            // further event without mutating state or notifying observers again.
-            if (is_terminal(prev_event) && is_terminal(ev))
+            if (epoch > current_ep)
             {
-                // exactly-once completion: the target already reached
-                // a terminal event, ignore this (duplicate) publication
-                return publish_result::already_terminal;
-            }
+                // Entering a new epoch resets the target's sequence number
+                // and unconditionally records the event: a higher epoch
+                // starts a fresh lifecycle for the target, regardless of
+                // what was last recorded for the previous epoch.
+                current_epoch_[target] = epoch;
 
-            if (!is_valid_transition(prev_event, ev))
-            {
-                l.unlock();
+                lifecycle_state const state = {.actor = target,
+                    .last_event = ev,
+                    .timestamp = std::chrono::steady_clock::now(),
+                    .event_sequence_number = 1,
+                    .epoch = epoch};
+                states_[target] = state;
 
-                HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
-                    "supervision_manager::publish_event",
-                    "invalid lifecycle event transition");
-            }
-
-            lifecycle_state state = {.actor = target,
-                .last_event = ev,
-                .timestamp = std::chrono::steady_clock::now(),
-                .event_sequence_number = 1};
-
-            if (it != states_.end())
-            {
-                state.event_sequence_number =
-                    it->second.event_sequence_number + 1;
-                it->second = state;
+                notification = {.actor = target,
+                    .event = state.last_event,
+                    .event_time = state.timestamp,
+                    .event_sequence_number = state.event_sequence_number,
+                    .epoch = state.epoch,
+                    .ec = state.ec};
             }
             else
             {
-                auto const [_, inserted] =
-                    states_.insert(std::make_pair(target, state));
-                if (!inserted)
+                // epoch == current_ep: apply within the target's current epoch,
+                // subject to the terminal-state latch and lifecycle transition
+                // validation.
+                event const prev_event = it != states_.end() ?
+                    it->second.last_event :
+                    event::unknown;
+
+                // A terminal event (completed/failed) was reached, absorb any
+                // further event without mutating state or notifying observers
+                // again.
+                if (is_terminal(prev_event) && is_terminal(ev))
+                {
+                    // exactly-once completion: the target already reached a
+                    // terminal event, ignore this (duplicate) publication
+                    return publish_result::already_terminal;
+                }
+
+                if (!is_valid_transition(prev_event, ev))
                 {
                     l.unlock();
 
-                    HPX_THROW_EXCEPTION(hpx::error::no_success,
+                    HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
                         "supervision_manager::publish_event",
-                        "failed to insert event");
+                        "invalid lifecycle event transition");
                 }
-            }
 
-            notification = {.actor = target,
-                .event = state.last_event,
-                .event_time = state.timestamp,
-                .event_sequence_number = state.event_sequence_number,
-                .ec = state.ec};
+                lifecycle_state state = {.actor = target,
+                    .last_event = ev,
+                    .timestamp = std::chrono::steady_clock::now(),
+                    .event_sequence_number = 1,
+                    .epoch = epoch};
+
+                if (it != states_.end())
+                {
+                    state.event_sequence_number =
+                        it->second.event_sequence_number + 1;
+                    it->second = state;
+                }
+                else
+                {
+                    auto const [_, inserted] =
+                        states_.insert(std::make_pair(target, state));
+                    if (!inserted)
+                    {
+                        l.unlock();
+
+                        HPX_THROW_EXCEPTION(hpx::error::no_success,
+                            "supervision_manager::publish_event",
+                            "failed to insert event");
+                    }
+                }
+
+                notification = {.actor = target,
+                    .event = state.last_event,
+                    .event_time = state.timestamp,
+                    .event_sequence_number = state.event_sequence_number,
+                    .epoch = state.epoch,
+                    .ec = state.ec};
+            }
         }
 
         // now fire event for all observers of this target
@@ -152,8 +195,8 @@ namespace hpx::supervision::server {
         }
         catch (...)
         {
-            record_error(
-                target, hpx::make_error_code(std::current_exception()));
+            record_error(target, notification.event_sequence_number,
+                hpx::make_error_code(std::current_exception()));
         }
 
         return publish_result::applied;
@@ -163,7 +206,7 @@ namespace hpx::supervision::server {
         hpx::id_type const& target,
         lifecycle_event_notification const& notification)
     {
-        std::vector<hpx::id_type> observers;
+        std::vector<observer_entry> observers;
         {
             std::unique_lock<hpx::spinlock> l(mtx_);
             if (auto const it = observers_.find(target); it != observers_.end())
@@ -173,11 +216,21 @@ namespace hpx::supervision::server {
         }
 
         hpx::future<void> f;
-        for (hpx::id_type const& agent : observers)
+        for (auto const& observer : observers)
         {
+            // An observer scoped to a specific epoch does not get notified of
+            // events published under any other epoch.
+            if (auto epoch_filter = observer.epoch_filter;
+                epoch_filter.has_value() && *epoch_filter != notification.epoch)
+            {
+                continue;
+            }
+
+            auto agent = observer.agent;
+
             if (f.valid())
             {
-                f = f.then([&, this, target, agent, notification](
+                f = f.then([this, target, agent, notification](
                                hpx::future<void>&& prev_f) {
                     try
                     {
@@ -185,7 +238,7 @@ namespace hpx::supervision::server {
                     }
                     catch (...)
                     {
-                        record_error(target,
+                        record_error(target, notification.event_sequence_number,
                             hpx::make_error_code(std::current_exception()));
                     }
                     return fire_event(target, agent, notification);
@@ -206,7 +259,7 @@ namespace hpx::supervision::server {
 
     hpx::future<void> supervision_manager::fire_event(
         hpx::id_type const& target, hpx::id_type const& agent,
-        lifecycle_event_notification notification) const
+        lifecycle_event_notification notification)
     {
         {
             std::unique_lock<hpx::spinlock> l(mtx_);
@@ -216,21 +269,56 @@ namespace hpx::supervision::server {
             auto const it2 = observers_.find(target);
             if (it2 == observers_.end())
             {
-                return hpx::make_ready_future();
+                return hpx::make_ready_future(true);
             }
 
-            if (std::ranges::find(it2->second, agent) == it2->second.end())
+            if (std::ranges::find(it2->second, agent, &observer_entry::agent) ==
+                it2->second.end())
             {
-                return hpx::make_ready_future();
+                return hpx::make_ready_future(true);
             }
         }
 
+        // prevent the agent callback from being run inline as it may block
         using action_type = agent_component::invoke_if_active_action;
-        return hpx::async(action_type(), agent, HPX_MOVE(notification));
+        auto fut = hpx::async(
+            hpx::launch::task, action_type(), agent, HPX_MOVE(notification));
+
+        return fut.then([this, target, agent](hpx::future<bool>&& f) mutable {
+            bool keep_registered = true;
+            std::exception_ptr ep;
+            try
+            {
+                keep_registered = f.get();
+            }
+            catch (...)
+            {
+                ep = std::current_exception();
+            }
+
+            if (!keep_registered)
+            {
+                // remove observer from the given target
+                std::unique_lock<hpx::spinlock> l(mtx_);
+
+                unregister_observer_target(target, agent);
+                if (auto const it = agents_.find(agent); it != agents_.end())
+                {
+                    agents_.erase(it);
+                }
+            }
+
+            // rethrow exception, if any
+            if (ep)
+            {
+                std::rethrow_exception(ep);
+            }
+        });
     }
 
     hpx::id_type supervision_manager::register_observer(
-        hpx::id_type const& target, hpx::id_type const& agent)
+        hpx::id_type const& target, hpx::id_type const& agent,
+        std::optional<std::uint64_t> epoch_filter)
     {
         std::optional<lifecycle_event_notification> initial_notification;
 
@@ -242,7 +330,7 @@ namespace hpx::supervision::server {
             if (it == observers_.end())
             {
                 auto [it2, inserted] = observers_.insert(
-                    std::make_pair(target, std::vector<hpx::id_type>()));
+                    std::make_pair(target, std::vector<observer_entry>()));
                 if (!inserted)
                 {
                     l.unlock();
@@ -253,7 +341,8 @@ namespace hpx::supervision::server {
                 }
                 it = it2;
             }
-            else if (std::ranges::find(it->second, agent) != it->second.end())
+            else if (std::ranges::find(it->second, agent,
+                         &observer_entry::agent) != it->second.end())
             {
                 l.unlock();
 
@@ -262,7 +351,7 @@ namespace hpx::supervision::server {
                     "observer already registered for target");
             }
 
-            it->second.push_back(agent);
+            it->second.push_back(observer_entry{agent, epoch_filter});
 
             // insert into inverse lookup table as well
             auto it2 = agents_.find(agent);
@@ -291,15 +380,23 @@ namespace hpx::supervision::server {
 
             // An existing target gets an initial notification. Keep a value
             // snapshot: do not let a subsequent publish replace its contents.
+            // A freshly-registered observer scoped to a specific epoch
+            // (epoch_filter engaged) does not receive this synchronous
+            // snapshot if it belongs to a different epoch, for consistency
+            // with the filtering applied in fire_events.
             if (auto const it3 = states_.find(target); it3 != states_.end())
             {
-                lifecycle_state const& state = it3->second;
-                initial_notification =
-                    lifecycle_event_notification{.actor = target,
+                if (lifecycle_state const& state = it3->second;
+                    !epoch_filter.has_value() || *epoch_filter == state.epoch)
+                {
+                    initial_notification = lifecycle_event_notification{
+                        .actor = target,
                         .event = state.last_event,
                         .event_time = state.timestamp,
                         .event_sequence_number = state.event_sequence_number,
+                        .epoch = state.epoch,
                         .ec = state.ec};
+                }
             }
         }
 
@@ -313,6 +410,12 @@ namespace hpx::supervision::server {
         // fire_event
         if (initial_notification)
         {
+            // Capture the sequence number before the notification is moved out
+            // below, so record_error() can still compare it against the
+            // (possibly since-updated) state for target.
+            auto const initial_sequence =
+                initial_notification->event_sequence_number;
+
             auto f = fire_event(target, agent, HPX_MOVE(*initial_notification));
             try
             {
@@ -320,71 +423,84 @@ namespace hpx::supervision::server {
             }
             catch (...)
             {
-                record_error(
-                    target, hpx::make_error_code(std::current_exception()));
+                record_error(target, initial_sequence,
+                    hpx::make_error_code(std::current_exception()));
             }
         }
         return agent;
     }
 
+    void supervision_manager::unregister_observer_target(
+        hpx::id_type const& target, hpx::id_type const& observer_handle)
+    {
+        if (auto const it = observers_.find(target); it != observers_.end())
+        {
+            // it2 refers to observer in observer target list
+
+            // delete observer from list
+            if (auto const it2 = std::ranges::find(
+                    it->second, observer_handle, &observer_entry::agent);
+                it2 != it->second.end())
+            {
+                it->second.erase(it2);
+            }
+
+            // delete list of targets from given observer
+            if (it->second.empty())
+            {
+                observers_.erase(it);
+            }
+        }
+    }
+
     void supervision_manager::unregister_observer(
         hpx::id_type const& observer_handle)
     {
-        // remove observer from all targets
-        std::unique_lock<hpx::spinlock> l(mtx_);
-
-        // locate targets the given observer was registered to
-        if (auto const it = agents_.find(observer_handle); it != agents_.end())
         {
             // remove observer from all targets
-            for (hpx::id_type const& target : it->second)
+            std::unique_lock<hpx::spinlock> l(mtx_);
+
+            // locate targets the given observer was registered to
+            if (auto const it = agents_.find(observer_handle);
+                it != agents_.end())
             {
-                if (auto it2 = observers_.find(target); it2 != observers_.end())
+                // remove observer from all targets
+                for (hpx::id_type const& target : it->second)
                 {
-                    // it3 refers to observer in list
-
-                    // delete observer from list
-                    if (auto const it3 =
-                            std::ranges::find(it2->second, observer_handle);
-                        it3 != it2->second.end())
-                    {
-                        it2->second.erase(it3);
-                    }
-
-                    // delete list of observers from given target
-                    if (it2->second.empty())
-                    {
-                        observers_.erase(it2);
-                    }
+                    unregister_observer_target(target, observer_handle);
                 }
+                agents_.erase(it);
             }
-            agents_.erase(it);
         }
-
-        l.unlock();
 
         // A delivery action that was already queued may still reach the agent.
         // deactivate_and_wait fences such actions and drains any callback that
         // had already begun before this call returns.
+
+        // prevent the agent callback from being run inline as it may block
         using action_type = agent_component::deactivate_and_wait_action;
-        hpx::async(action_type(), observer_handle).get();
+        hpx::async(hpx::launch::task, action_type(), observer_handle).get();
     }
 
     lifecycle_state supervision_manager::query_state(hpx::id_type const& target)
     {
-        std::scoped_lock<hpx::spinlock> l(mtx_);
-        if (auto const it = states_.find(target); it != states_.end())
         {
-            return it->second;
+            std::scoped_lock<hpx::spinlock> l(mtx_);
+            if (auto const it = states_.find(target); it != states_.end())
+            {
+                return it->second;
+            }
         }
 
         // No event has ever been recorded for this target: the returned
         // (default) state may be stale, e.g. because the corresponding
         // publication has not yet been observed on this locality.
         return {.actor = target,
+            .timestamp = std::chrono::steady_clock::now(),
             .ec = hpx::error_code(hpx::error::stale_state,
                 "no locally recorded lifecycle state is available for the "
-                "requested target, the returned state may be stale")};
+                "requested target, the returned state may be stale",
+                hpx::throwmode::lightweight)};
     }
 
     void supervision_manager::register_server_instance(
@@ -402,8 +518,6 @@ namespace hpx::supervision::server {
         instance_name_ += supervision::server::supervision_manager_name;
 
         auto const gid = get_unmanaged_id().get_gid();
-        //naming::gid_type const manager_gid(
-        //    gid.get_msb(), reinterpret_cast<std::uint64_t>(this));
         naming::address const manager_address(agas::get_locality(),
             components::get_component_type<
                 supervision::server::supervision_manager>(),
@@ -422,5 +536,4 @@ namespace hpx::supervision::server {
         agas::unregister_name(launch::sync, instance_name_, ec);
         this->base_type::finalize();
     }
-
 }    // namespace hpx::supervision::server

--- a/libs/full/supervision/src/supervision.cpp
+++ b/libs/full/supervision/src/supervision.cpp
@@ -20,7 +20,9 @@
 
 using hpx::supervision::server::supervision_manager;
 
+#include <cstdint>
 #include <exception>
+#include <optional>
 
 HPX_DEFINE_COMPONENT_NAME(supervision_manager, hpx_supervision_manager)
 HPX_DEFINE_GET_COMPONENT_TYPE_STATIC(supervision_manager,
@@ -83,7 +85,8 @@ namespace hpx::supervision {
     ///////////////////////////////////////////////////////////////////////////
     // Publish a lifecycle event from within an actor or action
     hpx::future<publish_result> publish_event(hpx::id_type const& locality,
-        hpx::id_type const& target, hpx::supervision::event const ev)
+        hpx::id_type const& target, hpx::supervision::event const ev,
+        std::uint64_t epoch)
     {
         if (!hpx::naming::is_locality(locality))
         {
@@ -105,8 +108,8 @@ namespace hpx::supervision {
         {
             return hpx::detail::try_catch_exception_ptr(
                 [&]() {
-                    auto result =
-                        get_supervision_manager().publish_event(target, ev);
+                    auto result = get_supervision_manager().publish_event(
+                        target, ev, epoch);
                     return hpx::make_ready_future(result);
                 },
                 [&](std::exception_ptr const& ep) {
@@ -118,19 +121,37 @@ namespace hpx::supervision {
             hpx::id_type(supervision_manager::get_service_instance(locality),
                 hpx::id_type::management_type::unmanaged);
         using action_type = server::supervision_manager::publish_event_action;
-        return hpx::async(action_type(), dest, target, ev);
+        return hpx::async(action_type(), dest, target, ev, epoch);
     }
 
     publish_result publish_event(hpx::launch::sync_policy,
         hpx::id_type const& locality, hpx::id_type const& target,
-        hpx::supervision::event const ev, hpx::error_code& ec)
+        hpx::supervision::event const ev, std::uint64_t const epoch,
+        hpx::error_code& ec)
     {
-        return publish_event(locality, target, ev).get(ec);
+        if (!hpx::naming::is_locality(locality))
+        {
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "hpx::supervision::publish_event",
+                "The id passed as the first argument is not representing "
+                "a locality");
+            return publish_result::already_terminal;
+        }
+        if (!target)
+        {
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "hpx::supervision::publish_event",
+                "The id passed as the second argument is not representing "
+                "a valid target");
+            return publish_result::already_terminal;
+        }
+        return publish_event(locality, target, ev, epoch).get(ec);
     }
 
     // purely local request
     publish_result publish_event(hpx::id_type const& target,
-        hpx::supervision::event const ev, hpx::error_code& ec)
+        hpx::supervision::event const ev, std::uint64_t const epoch,
+        hpx::error_code& ec)
     {
         if (!target)
         {
@@ -140,7 +161,7 @@ namespace hpx::supervision {
                 "a valid target");
             return publish_result::already_terminal;
         }
-        return get_supervision_manager().publish_event(target, ev, ec);
+        return get_supervision_manager().publish_event(target, ev, epoch, ec);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -149,14 +170,14 @@ namespace hpx::supervision {
         lifecycle_state const& state, unsigned int)
     {
         ar << state.actor << state.last_event << state.timestamp
-           << state.event_sequence_number << state.ec;
+           << state.event_sequence_number << state.epoch << state.ec;
     }
 
     void serialize(hpx::serialization::input_archive& ar,
         lifecycle_state& state, unsigned int)
     {
         ar >> state.actor >> state.last_event >> state.timestamp >>
-            state.event_sequence_number >> state.ec;
+            state.event_sequence_number >> state.epoch >> state.ec;
     }
 
     hpx::future<lifecycle_state> query_state(
@@ -201,6 +222,22 @@ namespace hpx::supervision {
         hpx::id_type const& locality, hpx::id_type const& target,
         hpx::error_code& ec)
     {
+        if (!hpx::naming::is_locality(locality))
+        {
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "hpx::supervision::query_state",
+                "The id passed as the first argument is not representing "
+                "a locality");
+            return {};
+        }
+        if (!target)
+        {
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "hpx::supervision::query_state",
+                "The id passed as the second argument is not representing "
+                "a valid target");
+            return {};
+        }
         return query_state(locality, target).get(ec);
     }
 
@@ -223,7 +260,7 @@ namespace hpx::supervision {
     {
         ar << notification.actor << notification.event
            << notification.event_time << notification.event_sequence_number
-           << notification.ec;
+           << notification.epoch << notification.ec;
     }
 
     void serialize(hpx::serialization::input_archive& ar,
@@ -231,12 +268,13 @@ namespace hpx::supervision {
     {
         ar >> notification.actor >> notification.event >>
             notification.event_time >> notification.event_sequence_number >>
-            notification.ec;
+            notification.epoch >> notification.ec;
     }
 
     // Register a callback to observe lifecycle events from a target actor
     hpx::future<hpx::id_type> register_observer(hpx::id_type const& locality,
-        hpx::id_type const& target, lifecycle_callback const& callback)
+        hpx::id_type const& target, lifecycle_callback const& callback,
+        std::optional<std::uint64_t> epoch_filter)
     {
         if (!hpx::naming::is_locality(locality))
         {
@@ -261,7 +299,7 @@ namespace hpx::supervision {
             return hpx::detail::try_catch_exception_ptr(
                 [&]() {
                     auto result = get_supervision_manager().register_observer(
-                        target, agent);
+                        target, agent, HPX_MOVE(epoch_filter));
                     return hpx::make_ready_future(result);
                 },
                 [&](std::exception_ptr const& ep) {
@@ -274,18 +312,39 @@ namespace hpx::supervision {
                 hpx::id_type::management_type::unmanaged);
         using action_type =
             server::supervision_manager::register_observer_action;
-        return hpx::async(action_type(), dest, target, agent);
+        return hpx::async(
+            action_type(), dest, target, agent, HPX_MOVE(epoch_filter));
     }
 
     hpx::id_type register_observer(hpx::launch::sync_policy,
         hpx::id_type const& locality, hpx::id_type const& target,
-        lifecycle_callback const& callback, hpx::error_code& ec)
+        lifecycle_callback const& callback,
+        std::optional<std::uint64_t> epoch_filter, hpx::error_code& ec)
     {
-        return register_observer(locality, target, callback).get(ec);
+        if (!hpx::naming::is_locality(locality))
+        {
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "hpx::supervision::register_observer",
+                "The id passed as the first argument is not representing "
+                "a locality");
+            return hpx::invalid_id;
+        }
+        if (!target)
+        {
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "hpx::supervision::register_observer",
+                "The id passed as the second argument is not representing "
+                "a valid target");
+            return hpx::invalid_id;
+        }
+        return register_observer(
+            locality, target, callback, HPX_MOVE(epoch_filter))
+            .get(ec);
     }
 
     hpx::id_type register_observer(hpx::id_type const& target,
-        lifecycle_callback const& callback, hpx::error_code& ec)
+        lifecycle_callback const& callback,
+        std::optional<std::uint64_t> epoch_filter, hpx::error_code& ec)
     {
         if (!target)
         {
@@ -297,7 +356,7 @@ namespace hpx::supervision {
         }
         auto agent = server::create_agent(callback);
         return get_supervision_manager().register_observer(
-            target, HPX_MOVE(agent), ec);
+            target, HPX_MOVE(agent), HPX_MOVE(epoch_filter), ec);
     }
 
     // Register a callback
@@ -345,6 +404,22 @@ namespace hpx::supervision {
         hpx::id_type const& locality, hpx::id_type const& observer_handle,
         hpx::error_code& ec)
     {
+        if (!hpx::naming::is_locality(locality))
+        {
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "hpx::supervision::unregister_observer",
+                "The id passed as the first argument is not representing "
+                "a locality");
+            return;
+        }
+        if (!observer_handle)
+        {
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "hpx::supervision::unregister_observer",
+                "The id passed as the second argument is not representing "
+                "a valid observer handle");
+            return;
+        }
         unregister_observer(locality, observer_handle).get(ec);
     }
 

--- a/libs/full/supervision/src/supervision.cpp
+++ b/libs/full/supervision/src/supervision.cpp
@@ -13,6 +13,7 @@
 
 #include <hpx/supervision/server/agent.hpp>
 #include <hpx/supervision/server/supervision_manager.hpp>
+#include <hpx/supervision/supervision_api.hpp>
 #include <hpx/supervision/supervision_manager.hpp>
 
 #include <hpx/config/warnings_prefix.hpp>
@@ -80,8 +81,9 @@ namespace hpx::supervision {
         auto dest =
             hpx::id_type(supervision_manager::get_service_instance(locality),
                 hpx::id_type::management_type::unmanaged);
-        return hpx::async(server::supervision_manager::publish_event_action(),
-            dest, target, ev);
+        using action_type =
+            typename server::supervision_manager::publish_event_action;
+        return hpx::async(action_type(), dest, target, ev);
     }
 
     void publish_event(hpx::launch::sync_policy, hpx::id_type const& locality,
@@ -156,8 +158,9 @@ namespace hpx::supervision {
         auto dest =
             hpx::id_type(supervision_manager::get_service_instance(locality),
                 hpx::id_type::management_type::unmanaged);
-        return hpx::async(
-            server::supervision_manager::query_state_action(), dest, target);
+        using action_type =
+            typename server::supervision_manager::query_state_action;
+        return hpx::async(action_type(), dest, target);
     }
 
     lifecycle_state query_state(hpx::launch::sync_policy,
@@ -235,9 +238,9 @@ namespace hpx::supervision {
         auto dest =
             hpx::id_type(supervision_manager::get_service_instance(locality),
                 hpx::id_type::management_type::unmanaged);
-        return hpx::async(
-            server::supervision_manager::register_observer_action(), dest,
-            target, agent);
+        using action_type =
+            typename server::supervision_manager::register_observer_action;
+        return hpx::async(action_type(), dest, target, agent);
     }
 
     hpx::id_type register_observer(hpx::launch::sync_policy,
@@ -299,9 +302,9 @@ namespace hpx::supervision {
         auto dest =
             hpx::id_type(supervision_manager::get_service_instance(locality),
                 hpx::id_type::management_type::unmanaged);
-        return hpx::async(
-            server::supervision_manager::unregister_observer_action(), dest,
-            observer_handle);
+        using action_type =
+            typename server::supervision_manager::unregister_observer_action;
+        return hpx::async(action_type(), dest, observer_handle);
     }
 
     void unregister_observer(hpx::launch::sync_policy,

--- a/libs/full/supervision/src/supervision.cpp
+++ b/libs/full/supervision/src/supervision.cpp
@@ -46,8 +46,43 @@ HPX_REGISTER_ACTION_ID(
 namespace hpx::supervision {
 
     ///////////////////////////////////////////////////////////////////////////
+    bool is_valid_transition(event const from, event const to) noexcept
+    {
+        switch (from)
+        {
+        case event::unknown:
+            // the first event recorded for a target must be `started`
+            return to == event::started;
+
+        case event::started:
+            return to == event::started || to == event::running ||
+                to == event::failed || to == event::losing_locality;
+
+        case event::running:
+            return to == event::running || to == event::suspending ||
+                to == event::completed || to == event::failed ||
+                to == event::losing_locality;
+
+        case event::suspending:
+            return to == event::suspending || to == event::running ||
+                to == event::completed || to == event::failed ||
+                to == event::losing_locality;
+
+        case event::losing_locality:
+            // a locality that is going away can only end in failure
+            return to == event::failed;
+
+        case event::completed:
+        case event::failed:
+            // terminal states, no outgoing transitions
+            return false;
+        }
+        return false;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
     // Publish a lifecycle event from within an actor or action
-    hpx::future<void> publish_event(hpx::id_type const& locality,
+    hpx::future<publish_result> publish_event(hpx::id_type const& locality,
         hpx::id_type const& target, hpx::supervision::event const ev)
     {
         if (!hpx::naming::is_locality(locality))
@@ -70,31 +105,31 @@ namespace hpx::supervision {
         {
             return hpx::detail::try_catch_exception_ptr(
                 [&]() {
-                    get_supervision_manager().publish_event(target, ev);
-                    return hpx::make_ready_future();
+                    auto result =
+                        get_supervision_manager().publish_event(target, ev);
+                    return hpx::make_ready_future(result);
                 },
                 [&](std::exception_ptr const& ep) {
-                    return hpx::make_exceptional_future<void>(ep);
+                    return hpx::make_exceptional_future<publish_result>(ep);
                 });
         }
 
         auto dest =
             hpx::id_type(supervision_manager::get_service_instance(locality),
                 hpx::id_type::management_type::unmanaged);
-        using action_type =
-            typename server::supervision_manager::publish_event_action;
+        using action_type = server::supervision_manager::publish_event_action;
         return hpx::async(action_type(), dest, target, ev);
     }
 
-    void publish_event(hpx::launch::sync_policy, hpx::id_type const& locality,
-        hpx::id_type const& target, hpx::supervision::event const ev,
-        hpx::error_code& ec)
+    publish_result publish_event(hpx::launch::sync_policy,
+        hpx::id_type const& locality, hpx::id_type const& target,
+        hpx::supervision::event const ev, hpx::error_code& ec)
     {
         return publish_event(locality, target, ev).get(ec);
     }
 
     // purely local request
-    void publish_event(hpx::id_type const& target,
+    publish_result publish_event(hpx::id_type const& target,
         hpx::supervision::event const ev, hpx::error_code& ec)
     {
         if (!target)
@@ -103,9 +138,9 @@ namespace hpx::supervision {
                 "hpx::supervision::publish_event",
                 "The id passed as the first argument is not representing "
                 "a valid target");
-            return;
+            return publish_result::already_terminal;
         }
-        get_supervision_manager().publish_event(target, ev, ec);
+        return get_supervision_manager().publish_event(target, ev, ec);
     }
 
     ///////////////////////////////////////////////////////////////////////////
@@ -158,8 +193,7 @@ namespace hpx::supervision {
         auto dest =
             hpx::id_type(supervision_manager::get_service_instance(locality),
                 hpx::id_type::management_type::unmanaged);
-        using action_type =
-            typename server::supervision_manager::query_state_action;
+        using action_type = server::supervision_manager::query_state_action;
         return hpx::async(action_type(), dest, target);
     }
 
@@ -239,7 +273,7 @@ namespace hpx::supervision {
             hpx::id_type(supervision_manager::get_service_instance(locality),
                 hpx::id_type::management_type::unmanaged);
         using action_type =
-            typename server::supervision_manager::register_observer_action;
+            server::supervision_manager::register_observer_action;
         return hpx::async(action_type(), dest, target, agent);
     }
 
@@ -303,7 +337,7 @@ namespace hpx::supervision {
             hpx::id_type(supervision_manager::get_service_instance(locality),
                 hpx::id_type::management_type::unmanaged);
         using action_type =
-            typename server::supervision_manager::unregister_observer_action;
+            server::supervision_manager::unregister_observer_action;
         return hpx::async(action_type(), dest, observer_handle);
     }
 

--- a/libs/full/supervision/src/supervision.cpp
+++ b/libs/full/supervision/src/supervision.cpp
@@ -1,0 +1,330 @@
+//  Copyright (c) 2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#include <hpx/modules/actions.hpp>
+#include <hpx/modules/actions_base.hpp>
+#include <hpx/modules/async_distributed.hpp>
+#include <hpx/modules/errors.hpp>
+#include <hpx/modules/serialization.hpp>
+
+#include <hpx/supervision/server/agent.hpp>
+#include <hpx/supervision/server/supervision_manager.hpp>
+#include <hpx/supervision/supervision_manager.hpp>
+
+#include <hpx/config/warnings_prefix.hpp>
+
+using hpx::supervision::server::supervision_manager;
+
+#include <exception>
+
+HPX_DEFINE_COMPONENT_NAME(supervision_manager, hpx_supervision_manager)
+HPX_DEFINE_GET_COMPONENT_TYPE_STATIC(supervision_manager,
+    to_int(components::component_enum_type::supervision_manager))
+
+HPX_REGISTER_ACTION_ID(
+    hpx::supervision::server::supervision_manager::publish_event_action,
+    supervision_manager_publish_event_action,
+    hpx::actions::supervision_manager_publish_event_action_id)
+HPX_REGISTER_ACTION_ID(
+    hpx::supervision::server::supervision_manager::register_observer_action,
+    supervision_manager_register_observer_action,
+    hpx::actions::supervision_manager_register_observer_action_id)
+HPX_REGISTER_ACTION_ID(
+    hpx::supervision::server::supervision_manager::unregister_observer_action,
+    supervision_manager_unregister_observer_action,
+    hpx::actions::supervision_manager_unregister_observer_action_id)
+HPX_REGISTER_ACTION_ID(
+    hpx::supervision::server::supervision_manager::query_state_action,
+    supervision_manager_query_state_action,
+    hpx::actions::supervision_manager_query_state_action_id)
+
+namespace hpx::supervision {
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Publish a lifecycle event from within an actor or action
+    hpx::future<void> publish_event(hpx::id_type const& locality,
+        hpx::id_type const& target, hpx::supervision::event const ev)
+    {
+        if (!hpx::naming::is_locality(locality))
+        {
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "hpx::supervision::publish_event",
+                "The id passed as the first argument is not representing "
+                "a locality");
+        }
+        if (!target)
+        {
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "hpx::supervision::publish_event",
+                "The id passed as the second argument is not representing "
+                "a valid target");
+        }
+
+        // handle local requests locally
+        if (locality.get_gid() == agas::get_locality())
+        {
+            return hpx::detail::try_catch_exception_ptr(
+                [&]() {
+                    get_supervision_manager().publish_event(target, ev);
+                    return hpx::make_ready_future();
+                },
+                [&](std::exception_ptr const& ep) {
+                    return hpx::make_exceptional_future<void>(ep);
+                });
+        }
+
+        auto dest =
+            hpx::id_type(supervision_manager::get_service_instance(locality),
+                hpx::id_type::management_type::unmanaged);
+        return hpx::async(server::supervision_manager::publish_event_action(),
+            dest, target, ev);
+    }
+
+    void publish_event(hpx::launch::sync_policy, hpx::id_type const& locality,
+        hpx::id_type const& target, hpx::supervision::event const ev,
+        hpx::error_code& ec)
+    {
+        return publish_event(locality, target, ev).get(ec);
+    }
+
+    // purely local request
+    void publish_event(hpx::id_type const& target,
+        hpx::supervision::event const ev, hpx::error_code& ec)
+    {
+        if (!target)
+        {
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "hpx::supervision::publish_event",
+                "The id passed as the first argument is not representing "
+                "a valid target");
+            return;
+        }
+        get_supervision_manager().publish_event(target, ev, ec);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Completion Query
+    void serialize(hpx::serialization::output_archive& ar,
+        lifecycle_state const& state, unsigned int)
+    {
+        ar << state.actor << state.last_event << state.timestamp
+           << state.event_sequence_number << state.ec;
+    }
+
+    void serialize(hpx::serialization::input_archive& ar,
+        lifecycle_state& state, unsigned int)
+    {
+        ar >> state.actor >> state.last_event >> state.timestamp >>
+            state.event_sequence_number >> state.ec;
+    }
+
+    hpx::future<lifecycle_state> query_state(
+        hpx::id_type const& locality, hpx::id_type const& target)
+    {
+        if (!hpx::naming::is_locality(locality))
+        {
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "hpx::supervision::query_state",
+                "The id passed as the first argument is not representing "
+                "a locality");
+        }
+        if (!target)
+        {
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "hpx::supervision::query_state",
+                "The id passed as the second argument is not representing "
+                "a valid target");
+        }
+
+        // handle local requests locally
+        if (locality.get_gid() == agas::get_locality())
+        {
+            return hpx::detail::try_catch_exception_ptr(
+                [&]() {
+                    auto result = get_supervision_manager().query_state(target);
+                    return hpx::make_ready_future(HPX_MOVE(result));
+                },
+                [&](std::exception_ptr const& ep) {
+                    return hpx::make_exceptional_future<lifecycle_state>(ep);
+                });
+        }
+
+        auto dest =
+            hpx::id_type(supervision_manager::get_service_instance(locality),
+                hpx::id_type::management_type::unmanaged);
+        return hpx::async(
+            server::supervision_manager::query_state_action(), dest, target);
+    }
+
+    lifecycle_state query_state(hpx::launch::sync_policy,
+        hpx::id_type const& locality, hpx::id_type const& target,
+        hpx::error_code& ec)
+    {
+        return query_state(locality, target).get(ec);
+    }
+
+    lifecycle_state query_state(hpx::id_type const& target, hpx::error_code& ec)
+    {
+        if (!target)
+        {
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "hpx::supervision::query_state",
+                "The id passed as the first argument is not representing "
+                "a valid target");
+            return {};
+        }
+        return get_supervision_manager().query_state(target, ec);
+    }
+
+    /////////////////////////////////////////////////////////////////////////////
+    void serialize(hpx::serialization::output_archive& ar,
+        lifecycle_event_notification const& notification, unsigned int)
+    {
+        ar << notification.actor << notification.event
+           << notification.event_time << notification.event_sequence_number
+           << notification.ec;
+    }
+
+    void serialize(hpx::serialization::input_archive& ar,
+        lifecycle_event_notification& notification, unsigned int)
+    {
+        ar >> notification.actor >> notification.event >>
+            notification.event_time >> notification.event_sequence_number >>
+            notification.ec;
+    }
+
+    // Register a callback to observe lifecycle events from a target actor
+    hpx::future<hpx::id_type> register_observer(hpx::id_type const& locality,
+        hpx::id_type const& target, lifecycle_callback const& callback)
+    {
+        if (!hpx::naming::is_locality(locality))
+        {
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "hpx::supervision::register_observer",
+                "The id passed as the first argument is not representing "
+                "a locality");
+        }
+        if (!target)
+        {
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "hpx::supervision::register_observer",
+                "The id passed as the second argument is not representing "
+                "a valid target");
+        }
+
+        auto agent = server::create_agent(callback);
+
+        // handle local requests locally
+        if (locality.get_gid() == agas::get_locality())
+        {
+            return hpx::detail::try_catch_exception_ptr(
+                [&]() {
+                    auto result = get_supervision_manager().register_observer(
+                        target, agent);
+                    return hpx::make_ready_future(result);
+                },
+                [&](std::exception_ptr const& ep) {
+                    return hpx::make_exceptional_future<hpx::id_type>(ep);
+                });
+        }
+
+        auto dest =
+            hpx::id_type(supervision_manager::get_service_instance(locality),
+                hpx::id_type::management_type::unmanaged);
+        return hpx::async(
+            server::supervision_manager::register_observer_action(), dest,
+            target, agent);
+    }
+
+    hpx::id_type register_observer(hpx::launch::sync_policy,
+        hpx::id_type const& locality, hpx::id_type const& target,
+        lifecycle_callback const& callback, hpx::error_code& ec)
+    {
+        return register_observer(locality, target, callback).get(ec);
+    }
+
+    hpx::id_type register_observer(hpx::id_type const& target,
+        lifecycle_callback const& callback, hpx::error_code& ec)
+    {
+        if (!target)
+        {
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "hpx::supervision::register_observer",
+                "The id passed as the first argument is not representing "
+                "a valid target");
+            return hpx::invalid_id;
+        }
+        auto agent = server::create_agent(callback);
+        return get_supervision_manager().register_observer(
+            target, HPX_MOVE(agent), ec);
+    }
+
+    // Register a callback
+    hpx::future<void> unregister_observer(
+        hpx::id_type const& locality, hpx::id_type const& observer_handle)
+    {
+        if (!hpx::naming::is_locality(locality))
+        {
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "hpx::supervision::unregister_observer",
+                "The id passed as the first argument is not representing "
+                "a locality");
+        }
+        if (!observer_handle)
+        {
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "hpx::supervision::unregister_observer",
+                "The id passed as the second argument is not representing "
+                "a valid observer handle");
+        }
+
+        // handle local requests locally
+        if (locality.get_gid() == agas::get_locality())
+        {
+            return hpx::detail::try_catch_exception_ptr(
+                [&]() {
+                    get_supervision_manager().unregister_observer(
+                        observer_handle);
+                    return hpx::make_ready_future();
+                },
+                [&](std::exception_ptr const& ep) {
+                    return hpx::make_exceptional_future<void>(ep);
+                });
+        }
+
+        auto dest =
+            hpx::id_type(supervision_manager::get_service_instance(locality),
+                hpx::id_type::management_type::unmanaged);
+        return hpx::async(
+            server::supervision_manager::unregister_observer_action(), dest,
+            observer_handle);
+    }
+
+    void unregister_observer(hpx::launch::sync_policy,
+        hpx::id_type const& locality, hpx::id_type const& observer_handle,
+        hpx::error_code& ec)
+    {
+        unregister_observer(locality, observer_handle).get(ec);
+    }
+
+    // Local callback unregistration
+    void unregister_observer(
+        hpx::id_type const& observer_handle, hpx::error_code& ec)
+    {
+        if (!observer_handle)
+        {
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "hpx::supervision::unregister_observer",
+                "The id passed as the first argument is not representing "
+                "a valid observer handle");
+            return;
+        }
+        get_supervision_manager().unregister_observer(observer_handle, ec);
+    }
+}    // namespace hpx::supervision
+
+#include <hpx/config/warnings_suffix.hpp>

--- a/libs/full/supervision/src/supervision_manager.cpp
+++ b/libs/full/supervision/src/supervision_manager.cpp
@@ -1,0 +1,150 @@
+//  Copyright (c) 2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+
+#include <hpx/modules/errors.hpp>
+#include <hpx/modules/naming_base.hpp>
+#include <hpx/modules/runtime_configuration.hpp>
+
+#include <hpx/supervision/supervision_manager.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+namespace hpx::supervision {
+
+    supervision_manager::supervision_manager(util::runtime_configuration const&)
+      : server_(std::make_unique<server::supervision_manager>())
+    {
+    }
+
+    void supervision_manager::register_server_instance(error_code& ec) const
+    {
+        if (!server_)
+        {
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                "hpx::supervision::supervision_manager::register_server_"
+                "instance",
+                "server is not registered");
+            return;
+        }
+
+        // register root server
+        auto const locality_id = agas::get_locality_id();
+        std::string const str("locality#" + std::to_string(locality_id) + "/");
+        server_->register_server_instance(str.c_str(), locality_id, ec);
+    }
+
+    void supervision_manager::unregister_server_instance(error_code& ec) const
+    {
+        if (!server_)
+        {
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                "hpx::supervision::supervision_manager::unregister_server_"
+                "instance",
+                "server is not registered");
+            return;
+        }
+
+        server_->unregister_server_instance(ec);
+    }
+
+    void supervision_manager::publish_event(
+        hpx::id_type const& target, event const ev, hpx::error_code& ec) const
+    {
+        if (!server_)
+        {
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                "hpx::supervision::supervision_manager::publish_event",
+                "server is not registered");
+            return;
+        }
+
+        server_->publish_event(target, ev);
+        if (&ec != &throws)
+            ec = make_success_code();
+    }
+
+    lifecycle_state supervision_manager::query_state(
+        hpx::id_type const& target, hpx::error_code& ec) const
+    {
+        if (!server_)
+        {
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                "hpx::supervision::supervision_manager::query_state",
+                "server is not registered");
+            return {};
+        }
+
+        auto result = server_->query_state(target);
+        if (&ec != &throws)
+            ec = make_success_code();
+        return result;
+    }
+
+    hpx::id_type supervision_manager::register_observer(
+        hpx::id_type const& target, hpx::id_type const& agent,
+        hpx::error_code& ec) const
+    {
+        if (!server_)
+        {
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                "hpx::supervision::supervision_manager::register_observer",
+                "server is not registered");
+            return {};
+        }
+
+        auto result = server_->register_observer(target, agent);
+        if (&ec != &throws)
+            ec = make_success_code();
+        return result;
+    }
+
+    void supervision_manager::unregister_observer(
+        hpx::id_type const& observer_handle, hpx::error_code& ec) const
+    {
+        if (!server_)
+        {
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                "hpx::supervision::supervision_manager::unregister_observer",
+                "server is not registered");
+            return;
+        }
+
+        server_->unregister_observer(observer_handle);
+        if (&ec != &throws)
+            ec = make_success_code();
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    naming::gid_type supervision_manager::get_service_instance(
+        std::uint32_t const service_locality_id)
+    {
+        naming::gid_type const service(supervision::supervision_manager_msb,
+            supervision::supervision_manager_lsb);
+        return naming::replace_locality_id(service, service_locality_id);
+    }
+
+    naming::gid_type supervision_manager::get_service_instance(
+        naming::gid_type const& dest, error_code& ec)
+    {
+        std::uint32_t const service_locality_id =
+            naming::get_locality_id_from_gid(dest);
+        if (service_locality_id == naming::invalid_locality_id)
+        {
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "supervision_manager::get_service_instance",
+                "can't retrieve a valid locality id from global address "
+                "({1}): ",
+                dest);
+            return naming::gid_type();
+        }
+        return get_service_instance(service_locality_id);
+    }
+
+}    // namespace hpx::supervision

--- a/libs/full/supervision/src/supervision_manager.cpp
+++ b/libs/full/supervision/src/supervision_manager.cpp
@@ -55,7 +55,7 @@ namespace hpx::supervision {
         server_->unregister_server_instance(ec);
     }
 
-    void supervision_manager::publish_event(
+    publish_result supervision_manager::publish_event(
         hpx::id_type const& target, event const ev, hpx::error_code& ec) const
     {
         if (!server_)
@@ -63,12 +63,13 @@ namespace hpx::supervision {
             HPX_THROWS_IF(ec, hpx::error::invalid_status,
                 "hpx::supervision::supervision_manager::publish_event",
                 "server is not registered");
-            return;
+            return publish_result::already_terminal;
         }
 
-        server_->publish_event(target, ev);
+        auto const result = server_->publish_event(target, ev);
         if (&ec != &throws)
             ec = make_success_code();
+        return result;
     }
 
     lifecycle_state supervision_manager::query_state(

--- a/libs/full/supervision/src/supervision_manager.cpp
+++ b/libs/full/supervision/src/supervision_manager.cpp
@@ -15,6 +15,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 
 namespace hpx::supervision {
@@ -56,7 +57,8 @@ namespace hpx::supervision {
     }
 
     publish_result supervision_manager::publish_event(
-        hpx::id_type const& target, event const ev, hpx::error_code& ec) const
+        hpx::id_type const& target, event const ev, std::uint64_t const epoch,
+        hpx::error_code& ec) const
     {
         if (!server_)
         {
@@ -66,7 +68,7 @@ namespace hpx::supervision {
             return publish_result::already_terminal;
         }
 
-        auto const result = server_->publish_event(target, ev);
+        auto const result = server_->publish_event(target, ev, epoch);
         if (&ec != &throws)
             ec = make_success_code();
         return result;
@@ -91,7 +93,7 @@ namespace hpx::supervision {
 
     hpx::id_type supervision_manager::register_observer(
         hpx::id_type const& target, hpx::id_type const& agent,
-        hpx::error_code& ec) const
+        std::optional<std::uint64_t> epoch_filter, hpx::error_code& ec) const
     {
         if (!server_)
         {
@@ -101,7 +103,8 @@ namespace hpx::supervision {
             return {};
         }
 
-        auto result = server_->register_observer(target, agent);
+        auto result =
+            server_->register_observer(target, agent, HPX_MOVE(epoch_filter));
         if (&ec != &throws)
             ec = make_success_code();
         return result;

--- a/libs/full/supervision/src/supervision_manager.cpp
+++ b/libs/full/supervision/src/supervision_manager.cpp
@@ -10,6 +10,7 @@
 #include <hpx/modules/naming_base.hpp>
 #include <hpx/modules/runtime_configuration.hpp>
 
+#include <hpx/supervision/supervision_api.hpp>
 #include <hpx/supervision/supervision_manager.hpp>
 
 #include <cstdint>
@@ -125,8 +126,9 @@ namespace hpx::supervision {
     naming::gid_type supervision_manager::get_service_instance(
         std::uint32_t const service_locality_id)
     {
-        naming::gid_type const service(supervision::supervision_manager_msb,
-            supervision::supervision_manager_lsb);
+        naming::gid_type const service(
+            supervision::detail::supervision_manager_msb,
+            supervision::detail::supervision_manager_lsb);
         return naming::replace_locality_id(service, service_locality_id);
     }
 

--- a/libs/full/supervision/tests/CMakeLists.txt
+++ b/libs/full/supervision/tests/CMakeLists.txt
@@ -1,0 +1,42 @@
+# Copyright (c) 2020-2023 The STE||AR-Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+include(HPX_Message)
+
+if(HPX_WITH_TESTS)
+  if(HPX_WITH_TESTS_UNIT)
+    add_hpx_pseudo_target(tests.unit.modules.supervision)
+    add_hpx_pseudo_dependencies(
+      tests.unit.modules tests.unit.modules.supervision
+    )
+    add_subdirectory(unit)
+  endif()
+
+  if(HPX_WITH_TESTS_REGRESSIONS)
+    add_hpx_pseudo_target(tests.regressions.modules.supervision)
+    add_hpx_pseudo_dependencies(
+      tests.regressions.modules tests.regressions.modules.supervision
+    )
+    add_subdirectory(regressions)
+  endif()
+
+  if(HPX_WITH_TESTS_BENCHMARKS)
+    add_hpx_pseudo_target(tests.performance.modules.supervision)
+    add_hpx_pseudo_dependencies(
+      tests.performance.modules tests.performance.modules.supervision
+    )
+    add_subdirectory(performance)
+  endif()
+
+  if(HPX_WITH_TESTS_HEADERS)
+    add_hpx_header_tests(
+      modules.supervision
+      HEADERS ${supervision_headers}
+      HEADER_ROOT ${PROJECT_SOURCE_DIR}/include
+      DEPENDENCIES hpx_supervision
+    )
+  endif()
+endif()

--- a/libs/full/supervision/tests/performance/CMakeLists.txt
+++ b/libs/full/supervision/tests/performance/CMakeLists.txt
@@ -1,0 +1,5 @@
+# Copyright (c) 2020-2023 The STE||AR-Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/libs/full/supervision/tests/regressions/CMakeLists.txt
+++ b/libs/full/supervision/tests/regressions/CMakeLists.txt
@@ -1,0 +1,5 @@
+# Copyright (c) 2020-2023 The STE||AR-Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)

--- a/libs/full/supervision/tests/unit/CMakeLists.txt
+++ b/libs/full/supervision/tests/unit/CMakeLists.txt
@@ -6,7 +6,7 @@
 
 set(tests supervision_api)
 
-set(supervision_api_PARAMETERS LOCALITIES 2)
+set(supervision_api_PARAMETERS LOCALITIES 2 THREADS_PER_LOCALITY 4)
 
 foreach(test ${tests})
   set(sources ${test}.cpp)

--- a/libs/full/supervision/tests/unit/CMakeLists.txt
+++ b/libs/full/supervision/tests/unit/CMakeLists.txt
@@ -1,0 +1,37 @@
+# Copyright (c) 2026 The STE||AR-Group
+#
+# SPDX-License-Identifier: BSL-1.0
+# Distributed under the Boost Software License, Version 1.0. (See accompanying
+# file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+set(tests supervision_api)
+
+set(supervision_api_PARAMETERS LOCALITIES 2)
+
+foreach(test ${tests})
+  set(sources ${test}.cpp)
+
+  source_group("Source Files" FILES ${sources})
+
+  # add example executable
+  add_hpx_executable(
+    ${test}_test INTERNAL_FLAGS
+    SOURCES ${sources}
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Unit/Modules/Full/Supervision"
+  )
+
+  add_hpx_unit_test("modules.supervision" ${test} ${${test}_PARAMETERS})
+
+endforeach()
+
+# MSVC V1951 and V1952 expose ICE compiling this in C++20 module mode
+if(HPX_WITH_CXX_MODULES
+   AND (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+   AND (NOT (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 1952))
+)
+  target_compile_definitions(
+    supervision_api_test PRIVATE HPX_HAVE_FORCE_NO_CXX_MODULES
+  )
+endif()

--- a/libs/full/supervision/tests/unit/supervision_api.cpp
+++ b/libs/full/supervision/tests/unit/supervision_api.cpp
@@ -16,6 +16,7 @@
 #include <atomic>
 #include <iostream>
 #include <mutex>
+#include <optional>
 #include <vector>
 
 // ============================================================================
@@ -96,13 +97,24 @@ struct test_context
     }
 };
 
-// Reach `completed` via a legal path: started -> running -> completed.
-void reach_completed(hpx::id_type const& locality, hpx::id_type const& target)
+// Reach `running` via a legal path: started -> running.
+void reach_running(hpx::id_type const& locality, hpx::id_type const& target)
 {
     hpx::supervision::publish_event(
         hpx::launch::sync, locality, target, hpx::supervision::event::started);
     hpx::supervision::publish_event(
         hpx::launch::sync, locality, target, hpx::supervision::event::running);
+}
+
+// Same as reach_running(), but publishing both events under the given epoch
+// rather than the default (0) epoch.
+void reach_running_at_epoch(hpx::id_type const& locality,
+    hpx::id_type const& target, std::uint64_t const epoch)
+{
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+        hpx::supervision::event::started, epoch);
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+        hpx::supervision::event::running, epoch);
 }
 
 // Global test context
@@ -116,7 +128,7 @@ void test_publish_completion()
     hpx::id_type const locality = hpx::find_here();
     hpx::id_type const target = make_test_target();
 
-    reach_completed(locality, target);
+    reach_running(locality, target);
 
     hpx::supervision::publish_event(hpx::launch::sync, locality, target,
         hpx::supervision::event::completed);
@@ -143,7 +155,7 @@ void test_publish_completion_async(hpx::id_type const& locality)
 {
     hpx::id_type const target = make_test_target();
 
-    reach_completed(locality, target);
+    reach_running(locality, target);
 
     auto const future = hpx::supervision::publish_event(
         locality, target, hpx::supervision::event::completed);
@@ -180,10 +192,10 @@ void test_register_observer_local_completion(hpx::id_type const& locality)
 
     auto const observer_handle = hpx::supervision::register_observer(
         hpx::launch::sync, locality, target,
-        [](hpx::supervision::lifecycle_event_notification const& notification,
-            hpx::error_code&) {
+        [](hpx::supervision::lifecycle_event_notification const& notification) {
             g_test_context.record_event(
                 notification.actor, notification.event, notification.ec);
+            return true;
         });
 
     HPX_TEST_NEQ(observer_handle, hpx::invalid_id);
@@ -191,7 +203,7 @@ void test_register_observer_local_completion(hpx::id_type const& locality)
     // Reach `completed` via a legal path; do this before resetting the test
     // context so these preliminary events don't count towards the
     // callback_count assertion below.
-    reach_completed(locality, target);
+    reach_running(locality, target);
 
     g_test_context.reset();
 
@@ -220,16 +232,16 @@ void test_register_observer_multiple_events(hpx::id_type const& locality)
 
     auto const observer_handle = hpx::supervision::register_observer(
         hpx::launch::sync, locality, target,
-        [](hpx::supervision::lifecycle_event_notification const& notification,
-            hpx::error_code&) {
+        [](hpx::supervision::lifecycle_event_notification const& notification) {
             g_test_context.record_event(
                 notification.actor, notification.event, notification.ec);
+            return true;
         });
 
     g_test_context.reset();
 
     // Publish multiple events
-    reach_completed(locality, target);
+    reach_running(locality, target);
 
     hpx::supervision::publish_event(hpx::launch::sync, locality, target,
         hpx::supervision::event::completed);
@@ -258,16 +270,16 @@ void test_register_observer(hpx::id_type const& locality)
     hpx::id_type const target = make_test_target();
 
     auto observer_future = hpx::supervision::register_observer(locality, target,
-        [](hpx::supervision::lifecycle_event_notification const& notification,
-            hpx::error_code&) {
+        [](hpx::supervision::lifecycle_event_notification const& notification) {
             g_test_context.record_event(
                 notification.actor, notification.event, notification.ec);
+            return true;
         });
 
     auto const observer_handle = observer_future.get();
     HPX_TEST_NEQ(observer_handle, hpx::invalid_id);
 
-    reach_completed(locality, target);
+    reach_running(locality, target);
 
     g_test_context.reset();
 
@@ -298,21 +310,22 @@ void test_register_observer_receives_existing_state(
     hpx::spinlock mtx;
     std::vector<hpx::supervision::lifecycle_event_notification> received;
 
-    auto const observer_handle = hpx::supervision::register_observer(
-        hpx::launch::sync, locality, target,
-        [&](hpx::supervision::lifecycle_event_notification const& notification,
-            hpx::error_code&) {
-            std::scoped_lock<hpx::spinlock> l(mtx);
-            received.push_back(notification);
-        });
+    auto const observer_handle =
+        hpx::supervision::register_observer(hpx::launch::sync, locality, target,
+            [&](hpx::supervision::lifecycle_event_notification const&
+                    notification) {
+                std::scoped_lock<hpx::spinlock> l(mtx);
+                received.push_back(notification);
+                return true;
+            });
 
     // register_observer synchronously waits for its initial delivery.
     {
         std::scoped_lock<hpx::spinlock> l(mtx);
         HPX_TEST_EQ(received.size(), static_cast<std::size_t>(1));
 
-        auto const& [actor, event, event_time, event_sequence_number, ec] =
-            received.front();
+        auto const& [actor, event, event_time, event_sequence_number, epoch,
+            ec] = received.front();
         HPX_TEST_EQ(actor, target);
         HPX_TEST(event == hpx::supervision::event::started);
         HPX_TEST_EQ(event_sequence_number, expected.event_sequence_number);
@@ -352,10 +365,10 @@ void test_register_observer_keeps_initial_state_snapshot()
 
     auto registration = hpx::async([&] {
         return hpx::supervision::register_observer(target,
-            [&](hpx::supervision::lifecycle_event_notification const& n,
-                hpx::error_code&) {
+            [&](hpx::supervision::lifecycle_event_notification const& n) {
                 std::scoped_lock<hpx::spinlock> l(received_mtx);
                 received.push_back(n);
+                return true;
             });
     });
 
@@ -410,10 +423,10 @@ void test_observe_failure_detection(hpx::id_type const& locality)
 
     auto const observer_handle = hpx::supervision::register_observer(
         hpx::launch::sync, locality, target,
-        [](hpx::supervision::lifecycle_event_notification const& notification,
-            hpx::error_code&) {
+        [](hpx::supervision::lifecycle_event_notification const& notification) {
             g_test_context.record_event(
                 notification.actor, notification.event, notification.ec);
+            return true;
         });
 
     // `failed` is reachable directly from `started`.
@@ -473,23 +486,25 @@ void test_sequence_numbers_no_gaps(hpx::id_type const& locality)
         hpx::launch::sync, locality, target, hpx::supervision::event::started);
 
     std::vector<uint64_t> sequence_numbers;
-    auto const observer_handle = hpx::supervision::register_observer(
-        hpx::launch::sync, locality, target,
-        [&sequence_numbers, locality](
-            hpx::supervision::lifecycle_event_notification const& notification,
-            hpx::error_code&) {
-            // query state during callback
-            auto const state = hpx::supervision::query_state(
-                hpx::launch::sync, locality, notification.actor);
-            sequence_numbers.push_back(state.event_sequence_number);
+    auto const observer_handle =
+        hpx::supervision::register_observer(hpx::launch::sync, locality, target,
+            [&sequence_numbers, locality](
+                hpx::supervision::lifecycle_event_notification const&
+                    notification) {
+                // query state during callback
+                auto const state = hpx::supervision::query_state(
+                    hpx::launch::sync, locality, notification.actor);
+                sequence_numbers.push_back(state.event_sequence_number);
 
-            // sequence numbers must match
-            HPX_TEST(notification.event_sequence_number ==
-                state.event_sequence_number);
+                // sequence numbers must match
+                HPX_TEST(notification.event_sequence_number ==
+                    state.event_sequence_number);
 
-            g_test_context.record_event(
-                notification.actor, notification.event, notification.ec);
-        });
+                g_test_context.record_event(
+                    notification.actor, notification.event, notification.ec);
+
+                return true;
+            });
 
     g_test_context.reset();
 
@@ -516,15 +531,13 @@ void test_detect_connector_terminal(hpx::id_type const& locality)
 {
     hpx::id_type const target = make_test_target();
 
-    reach_completed(locality, target);
+    reach_running(locality, target);
 
     auto const observer_handle = hpx::supervision::register_observer(
         hpx::launch::sync, locality, target,
-        [](hpx::supervision::lifecycle_event_notification const& notification,
-            hpx::error_code& ec) {
-            g_test_context.record_event(
-                notification.actor, notification.event, notification.ec);
-            HPX_THROWS_IF(ec, hpx::error::no_success,
+        [](hpx::supervision::lifecycle_event_notification const& n) -> bool {
+            g_test_context.record_event(n.actor, n.event, n.ec);
+            HPX_THROW_EXCEPTION(hpx::error::no_success,
                 "test_detect_connector_terminal", "testing error reporting");
         });
 
@@ -554,25 +567,28 @@ void test_error_does_not_stop_callbacks(hpx::id_type const& locality)
 
     auto const observer_handle = hpx::supervision::register_observer(
         hpx::launch::sync, locality, target,
-        [](hpx::supervision::lifecycle_event_notification const& notification,
-            hpx::error_code& ec) {
-            g_test_context.record_event(
-                notification.actor, notification.event, notification.ec);
-            HPX_THROWS_IF(ec, hpx::error::no_success,
+        [](hpx::supervision::lifecycle_event_notification const& n) -> bool {
+            g_test_context.record_event(n.actor, n.event, n.ec);
+            HPX_THROW_EXCEPTION(hpx::error::no_success,
                 "test_detect_connector_terminal", "testing error reporting");
         });
 
     auto const observer_handle2 = hpx::supervision::register_observer(
         hpx::launch::sync, locality, target,
-        [](hpx::supervision::lifecycle_event_notification const& notification,
-            hpx::error_code&) {
+        [](hpx::supervision::lifecycle_event_notification const& notification) {
             g_test_context.record_event(
                 notification.actor, notification.event, notification.ec);
+            return true;
         });
 
-    // Attempt to reach `completed` via a legal path before resetting counters.
-    // However, `started` raises an exception in one of the observers, causing
-    // the state to shift to `failure`.
+    // Reset before publishing so that wait_for_callback() and
+    // get_callback_count() below only account for callbacks triggered by
+    // this test, not any residual state left behind by earlier tests
+    // sharing the global g_test_context.
+    g_test_context.reset();
+
+    // `started` raises an exception in one of the observers, causing the
+    // state to shift to `failure`.
     hpx::supervision::publish_event(
         hpx::launch::sync, locality, target, hpx::supervision::event::started);
 
@@ -624,13 +640,13 @@ void test_duplicate_completion_is_latched(hpx::id_type const& locality)
 
     auto const observer_handle = hpx::supervision::register_observer(
         hpx::launch::sync, locality, target,
-        [](hpx::supervision::lifecycle_event_notification const& notification,
-            hpx::error_code&) {
+        [](hpx::supervision::lifecycle_event_notification const& notification) {
             g_test_context.record_event(
                 notification.actor, notification.event, notification.ec);
+            return true;
         });
 
-    reach_completed(locality, target);
+    reach_running(locality, target);
 
     g_test_context.reset();
 
@@ -673,6 +689,384 @@ void test_duplicate_completion_is_latched(hpx::id_type const& locality)
 }
 
 // ============================================================================
+// Test Cases: Epoch-Scoped Idempotent Publishing
+// ============================================================================
+
+// Double-publishing `completed` at the same epoch must behave exactly like the
+// (epoch-less) duplicate-completion latch: the sequence number does not
+// advance, observers are notified exactly once, and the repeated call reports
+// `already_terminal`.
+void test_epoch_duplicate_completion_is_latched(hpx::id_type const& locality)
+{
+    hpx::id_type const target = make_test_target();
+    std::uint64_t const epoch = 1;
+
+    auto const observer_handle = hpx::supervision::register_observer(
+        hpx::launch::sync, locality, target,
+        [](hpx::supervision::lifecycle_event_notification const& notification) {
+            g_test_context.record_event(
+                notification.actor, notification.event, notification.ec);
+            return true;
+        });
+
+    reach_running_at_epoch(locality, target, epoch);
+
+    g_test_context.reset();
+
+    auto const first_result = hpx::supervision::publish_event(hpx::launch::sync,
+        locality, target, hpx::supervision::event::completed, epoch);
+    HPX_TEST(first_result == hpx::supervision::publish_result::applied);
+
+    auto const state_after_first =
+        hpx::supervision::query_state(hpx::launch::sync, locality, target);
+    HPX_TEST(
+        state_after_first.last_event == hpx::supervision::event::completed);
+    HPX_TEST_EQ(state_after_first.epoch, epoch);
+
+    // Duplicate completion at the same epoch is a latched no-op.
+    auto const second_result =
+        hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+            hpx::supervision::event::completed, epoch);
+    HPX_TEST(
+        second_result == hpx::supervision::publish_result::already_terminal);
+
+    auto const state_after_second =
+        hpx::supervision::query_state(hpx::launch::sync, locality, target);
+    HPX_TEST_EQ(state_after_second.event_sequence_number,
+        state_after_first.event_sequence_number);
+
+    hpx::this_thread::sleep_for(std::chrono::milliseconds(20));
+
+    // Observers must be notified exactly once for the completion.
+    HPX_TEST_EQ(g_test_context.get_callback_count(), 1);
+    HPX_TEST(
+        g_test_context.get_events()[0] == hpx::supervision::event::completed);
+
+    hpx::supervision::unregister_observer(
+        hpx::launch::sync, locality, observer_handle);
+}
+
+// Publishing under a higher epoch than the target's current epoch resets the
+// sequence number and is accepted, regardless of the previous epoch's recorded
+// (possibly terminal) state.
+void test_epoch_increase_resets_sequence_number(hpx::id_type const& locality)
+{
+    hpx::id_type const target = make_test_target();
+
+    reach_running_at_epoch(locality, target, 1);
+
+    auto const state_epoch1 =
+        hpx::supervision::query_state(hpx::launch::sync, locality, target);
+    HPX_TEST_EQ(state_epoch1.epoch, static_cast<std::uint64_t>(1));
+    HPX_TEST_NEQ(state_epoch1.event_sequence_number, 0u);
+
+    // A higher epoch is accepted and resets the sequence number, even though
+    // `started` would otherwise be an illegal transition from `running`.
+    hpx::error_code ec;
+    auto const result = hpx::supervision::publish_event(hpx::launch::sync,
+        locality, target, hpx::supervision::event::started, 2, ec);
+    HPX_TEST(!ec);
+    HPX_TEST(result == hpx::supervision::publish_result::applied);
+
+    auto const state_epoch2 =
+        hpx::supervision::query_state(hpx::launch::sync, locality, target);
+    HPX_TEST_EQ(state_epoch2.epoch, static_cast<std::uint64_t>(2));
+    HPX_TEST_EQ(
+        state_epoch2.event_sequence_number, static_cast<std::uint64_t>(1));
+    HPX_TEST(state_epoch2.last_event == hpx::supervision::event::started);
+}
+
+// A publication for an epoch lower than the target's current epoch must be
+// rejected as stale: no state mutation, no observer notifications.
+void test_stale_epoch_publish_is_noop(hpx::id_type const& locality)
+{
+    hpx::id_type const target = make_test_target();
+
+    auto const observer_handle = hpx::supervision::register_observer(
+        hpx::launch::sync, locality, target,
+        [](hpx::supervision::lifecycle_event_notification const& notification) {
+            g_test_context.record_event(
+                notification.actor, notification.event, notification.ec);
+            return true;
+        });
+
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+        hpx::supervision::event::started, 5);
+
+    auto const state_before =
+        hpx::supervision::query_state(hpx::launch::sync, locality, target);
+
+    g_test_context.reset();
+
+    auto const result = hpx::supervision::publish_event(hpx::launch::sync,
+        locality, target, hpx::supervision::event::running, 3);
+    HPX_TEST(result == hpx::supervision::publish_result::stale_epoch);
+
+    auto const state_after =
+        hpx::supervision::query_state(hpx::launch::sync, locality, target);
+    HPX_TEST(state_after.last_event == state_before.last_event);
+    HPX_TEST_EQ(
+        state_after.event_sequence_number, state_before.event_sequence_number);
+    HPX_TEST_EQ(state_after.epoch, state_before.epoch);
+
+    hpx::this_thread::sleep_for(std::chrono::milliseconds(20));
+    HPX_TEST_EQ(g_test_context.get_callback_count(), 0);
+
+    hpx::supervision::unregister_observer(
+        hpx::launch::sync, locality, observer_handle);
+}
+
+// Concurrent publications spanning several epochs must deterministically settle
+// on the highest epoch published, no matter the interleaving: any publication
+// for the highest epoch always wins over lower (now stale) epochs, whichever
+// order they are processed in.
+void test_concurrent_publishes_settle_on_higher_epoch(
+    hpx::id_type const& locality)
+{
+    hpx::id_type const target = make_test_target();
+
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+        hpx::supervision::event::started, 1);
+
+    constexpr std::uint64_t highest_epoch = 6;
+    std::vector<hpx::future<void>> publications;
+    for (std::uint64_t epoch = 2; epoch <= highest_epoch; ++epoch)
+    {
+        publications.push_back(hpx::async([&locality, &target, epoch] {
+            hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+                hpx::supervision::event::started, epoch);
+        }));
+    }
+    hpx::wait_all(publications);
+
+    auto const state =
+        hpx::supervision::query_state(hpx::launch::sync, locality, target);
+    HPX_TEST_EQ(state.epoch, highest_epoch);
+    HPX_TEST_EQ(state.event_sequence_number, static_cast<std::uint64_t>(1));
+}
+
+// ============================================================================
+// Test Cases: Observer Epoch Filtering
+// ============================================================================
+
+// An observer registered with an epoch filter must be notified for events
+// published under the matching epoch.
+void test_epoch_filter_basic_match(hpx::id_type const& locality)
+{
+    hpx::id_type const target = make_test_target();
+    constexpr std::uint64_t epoch = 4;
+
+    auto const observer_handle = hpx::supervision::register_observer(
+        hpx::launch::sync, locality, target,
+        [](hpx::supervision::lifecycle_event_notification const& notification) {
+            g_test_context.record_event(
+                notification.actor, notification.event, notification.ec);
+            return true;
+        },
+        epoch);
+
+    g_test_context.reset();
+
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+        hpx::supervision::event::started, epoch);
+
+    bool const received =
+        g_test_context.wait_for_callback(std::chrono::milliseconds(10));
+    HPX_TEST_MSG(received, "Callback not received within 10ms");
+    HPX_TEST_EQ(g_test_context.get_callback_count(), 1);
+    HPX_TEST(
+        g_test_context.get_events()[0] == hpx::supervision::event::started);
+
+    hpx::supervision::unregister_observer(
+        hpx::launch::sync, locality, observer_handle);
+}
+
+// An observer filtered to a specific epoch must not be notified for events
+// published under a different epoch.
+void test_epoch_filter_mismatch_ignored(hpx::id_type const& locality)
+{
+    hpx::id_type const target = make_test_target();
+    constexpr std::uint64_t filter_epoch = 4;
+    constexpr std::uint64_t other_epoch = 5;
+
+    auto const observer_handle = hpx::supervision::register_observer(
+        hpx::launch::sync, locality, target,
+        [](hpx::supervision::lifecycle_event_notification const& notification) {
+            g_test_context.record_event(
+                notification.actor, notification.event, notification.ec);
+            return true;
+        },
+        filter_epoch);
+
+    g_test_context.reset();
+
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+        hpx::supervision::event::started, other_epoch);
+
+    hpx::this_thread::sleep_for(std::chrono::milliseconds(20));
+    HPX_TEST_EQ(g_test_context.get_callback_count(), 0);
+
+    hpx::supervision::unregister_observer(
+        hpx::launch::sync, locality, observer_handle);
+}
+
+// An observer registered without an epoch filter (the default) continues to
+// receive notifications for every epoch (regression guard for existing,
+// unfiltered behavior).
+void test_epoch_filter_default_receives_all_epochs(hpx::id_type const& locality)
+{
+    hpx::id_type const target = make_test_target();
+
+    auto const observer_handle = hpx::supervision::register_observer(
+        hpx::launch::sync, locality, target,
+        [](hpx::supervision::lifecycle_event_notification const& notification) {
+            g_test_context.record_event(
+                notification.actor, notification.event, notification.ec);
+            return true;
+        });
+
+    g_test_context.reset();
+
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+        hpx::supervision::event::started, 7);
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+        hpx::supervision::event::started, 9);
+
+    hpx::this_thread::sleep_for(std::chrono::milliseconds(20));
+    HPX_TEST_EQ(g_test_context.get_callback_count(), 2);
+
+    hpx::supervision::unregister_observer(
+        hpx::launch::sync, locality, observer_handle);
+}
+
+// When a target has both a filtered and an unfiltered observer, an event
+// published under an epoch that does not match the filter must only reach the
+// unfiltered observer.
+void test_epoch_filter_mixed_observers(hpx::id_type const& locality)
+{
+    hpx::id_type const target = make_test_target();
+    constexpr std::uint64_t filter_epoch = 2;
+    constexpr std::uint64_t publish_epoch = 3;
+
+    test_context filtered_ctx, unfiltered_ctx;
+
+    auto const filtered_handle = hpx::supervision::register_observer(
+        hpx::launch::sync, locality, target,
+        [&filtered_ctx](hpx::supervision::lifecycle_event_notification const&
+                notification) {
+            filtered_ctx.record_event(
+                notification.actor, notification.event, notification.ec);
+            return true;
+        },
+        filter_epoch);
+
+    auto const unfiltered_handle = hpx::supervision::register_observer(
+        hpx::launch::sync, locality, target,
+        [&unfiltered_ctx](hpx::supervision::lifecycle_event_notification const&
+                notification) {
+            unfiltered_ctx.record_event(
+                notification.actor, notification.event, notification.ec);
+            return true;
+        });
+
+    filtered_ctx.reset();
+    unfiltered_ctx.reset();
+
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+        hpx::supervision::event::started, publish_epoch);
+
+    hpx::this_thread::sleep_for(std::chrono::milliseconds(20));
+
+    HPX_TEST_EQ(filtered_ctx.get_callback_count(), 0);
+    HPX_TEST_EQ(unfiltered_ctx.get_callback_count(), 1);
+
+    hpx::supervision::unregister_observer(
+        hpx::launch::sync, locality, filtered_handle);
+    hpx::supervision::unregister_observer(
+        hpx::launch::sync, locality, unfiltered_handle);
+}
+
+// Registering with an epoch filter while the target's currently recorded state
+// belongs to a different epoch must not synchronously deliver that
+// (non-matching) snapshot to the new observer. A later publication under the
+// matching epoch must still reach it. This is the spec for the otherwise
+// ambiguous "initial snapshot vs. filter" interaction: epoch_filter applies
+// uniformly to every notification an observer can receive, including the
+// initial state snapshot delivered at registration time.
+void test_epoch_filter_initial_snapshot_respects_filter(
+    hpx::id_type const& locality)
+{
+    hpx::id_type const target = make_test_target();
+    constexpr std::uint64_t state_epoch = 1;
+    constexpr std::uint64_t filter_epoch = 2;
+
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+        hpx::supervision::event::started, state_epoch);
+
+    hpx::spinlock mtx;
+    std::vector<hpx::supervision::lifecycle_event_notification> received;
+
+    auto const observer_handle = hpx::supervision::register_observer(
+        hpx::launch::sync, locality, target,
+        [&](hpx::supervision::lifecycle_event_notification const&
+                notification) {
+            std::scoped_lock<hpx::spinlock> l(mtx);
+            received.push_back(notification);
+            return true;
+        },
+        filter_epoch);
+
+    {
+        std::scoped_lock<hpx::spinlock> l(mtx);
+        HPX_TEST(received.empty());
+    }
+
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+        hpx::supervision::event::started, filter_epoch);
+
+    hpx::this_thread::sleep_for(std::chrono::milliseconds(20));
+
+    {
+        std::scoped_lock<hpx::spinlock> l(mtx);
+        HPX_TEST_EQ(received.size(), static_cast<std::size_t>(1));
+        HPX_TEST_EQ(received.front().epoch, filter_epoch);
+    }
+
+    hpx::supervision::unregister_observer(
+        hpx::launch::sync, locality, observer_handle);
+}
+
+// Unregistering a filtered observer must remove its filter entry as well: a
+// matching-epoch event published afterward must not invoke the callback (guards
+// the unregister_observer lookup against the new epoch-filter storage).
+void test_epoch_filter_unregister_removes_filter_entry(
+    hpx::id_type const& locality)
+{
+    hpx::id_type const target = make_test_target();
+    constexpr std::uint64_t epoch = 3;
+
+    auto const observer_handle = hpx::supervision::register_observer(
+        hpx::launch::sync, locality, target,
+        [](hpx::supervision::lifecycle_event_notification const& notification) {
+            g_test_context.record_event(
+                notification.actor, notification.event, notification.ec);
+            return true;
+        },
+        epoch);
+
+    g_test_context.reset();
+
+    hpx::supervision::unregister_observer(
+        hpx::launch::sync, locality, observer_handle);
+
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+        hpx::supervision::event::started, epoch);
+
+    hpx::this_thread::sleep_for(std::chrono::milliseconds(20));
+    HPX_TEST_EQ(g_test_context.get_callback_count(), 0);
+}
+
+// ============================================================================
 // Test Cases: Unregister Observer
 // ============================================================================
 void test_unregister_waits_for_in_flight_callback(hpx::id_type const& locality)
@@ -686,8 +1080,7 @@ void test_unregister_waits_for_in_flight_callback(hpx::id_type const& locality)
 
     auto const observer_handle =
         hpx::supervision::register_observer(hpx::launch::sync, locality, target,
-            [&](hpx::supervision::lifecycle_event_notification const&,
-                hpx::error_code&) {
+            [&](hpx::supervision::lifecycle_event_notification const&) {
                 ++callback_count;
                 if (block_callbacks.load())
                 {
@@ -697,6 +1090,7 @@ void test_unregister_waits_for_in_flight_callback(hpx::id_type const& locality)
                         hpx::this_thread::yield();
                     }
                 }
+                return true;
             });
 
     // Registration may synchronously deliver the state left by an earlier test.
@@ -739,10 +1133,10 @@ void test_unregister_observer_stops_callbacks(hpx::id_type const& locality)
 
     auto const observer_handle = hpx::supervision::register_observer(
         hpx::launch::sync, locality, target,
-        [](hpx::supervision::lifecycle_event_notification const& notification,
-            hpx::error_code&) {
+        [](hpx::supervision::lifecycle_event_notification const& notification) {
             g_test_context.record_event(
                 notification.actor, notification.event, notification.ec);
+            return true;
         });
 
     g_test_context.reset();
@@ -774,43 +1168,84 @@ void test_unregister_observer_stops_callbacks(hpx::id_type const& locality)
     HPX_TEST_EQ(count_after, 0);
 }
 
+// Regression test: unregister_observer() forced by returning false from
+// the callback. Unregistering must not deadlock.
+void test_unregister_observer_from_within_callback(hpx::id_type const& locality)
+{
+    hpx::id_type const target = make_test_target();
+
+    std::atomic<int> invocation_count{0};
+
+    hpx::id_type observer_handle =
+        hpx::supervision::register_observer(hpx::launch::sync, locality, target,
+            [&](hpx::supervision::lifecycle_event_notification const&) {
+                invocation_count.fetch_add(1);
+                return false;    // unregister this observer
+            });
+
+    // Triggers the callback above, which unregisters itself before returning.
+    // If deactivate_and_wait() incorrectly waited on this in-flight invocation,
+    // this call would hang forever.
+    hpx::supervision::publish_event(
+        hpx::launch::sync, locality, target, hpx::supervision::event::started);
+
+    HPX_TEST_EQ(invocation_count.load(), 1);
+
+    // The observer must really be gone: later publications must not invoke
+    // the callback again.
+    hpx::supervision::publish_event(
+        hpx::launch::sync, locality, target, hpx::supervision::event::running);
+    HPX_TEST_EQ(invocation_count.load(), 1);
+}
+
 void test_multiple_observers_same_target(hpx::id_type const& locality)
 {
     hpx::id_type const target = make_test_target();
 
     test_context ctx1, ctx2;
 
-    auto const observer_handle1 = hpx::supervision::register_observer(
-        hpx::launch::sync, locality, target,
-        [&ctx1](
-            hpx::supervision::lifecycle_event_notification const& notification,
-            hpx::error_code&) {
-            ctx1.record_event(
-                notification.actor, notification.event, notification.ec);
-        });
+    auto const observer_handle1 =
+        hpx::supervision::register_observer(hpx::launch::sync, locality, target,
+            [&ctx1](hpx::supervision::lifecycle_event_notification const&
+                    notification) {
+                ctx1.record_event(
+                    notification.actor, notification.event, notification.ec);
+                return true;
+            });
 
-    auto const observer_handle2 = hpx::supervision::register_observer(
-        hpx::launch::sync, locality, target,
-        [&ctx2](
-            hpx::supervision::lifecycle_event_notification const& notification,
-            hpx::error_code&) {
-            ctx2.record_event(
-                notification.actor, notification.event, notification.ec);
-        });
+    auto const observer_handle2 =
+        hpx::supervision::register_observer(hpx::launch::sync, locality, target,
+            [&ctx2](hpx::supervision::lifecycle_event_notification const&
+                    notification) {
+                ctx2.record_event(
+                    notification.actor, notification.event, notification.ec);
+                return true;
+            });
 
     ctx1.reset();
     ctx2.reset();
 
-    reach_completed(locality, target);
+    reach_running(locality, target);
 
     hpx::supervision::publish_event(hpx::launch::sync, locality, target,
         hpx::supervision::event::completed);
 
     // Both observers should receive callback
+    auto const wait_for_count = [](test_context const& ctx, int const expected,
+                                    std::chrono::milliseconds const timeout) {
+        auto const deadline = std::chrono::steady_clock::now() + timeout;
+        while (ctx.get_callback_count() < expected &&
+            std::chrono::steady_clock::now() < deadline)
+        {
+            hpx::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        return ctx.get_callback_count() >= expected;
+    };
+
     bool const received1 =
-        ctx1.wait_for_callback(std::chrono::milliseconds(10));
+        wait_for_count(ctx1, 3, std::chrono::milliseconds(100));
     bool const received2 =
-        ctx2.wait_for_callback(std::chrono::milliseconds(10));
+        wait_for_count(ctx2, 3, std::chrono::milliseconds(100));
     HPX_TEST(received1);
     HPX_TEST(received2);
 
@@ -840,8 +1275,7 @@ void test_publish_delivers_its_own_event_snapshot(hpx::id_type const& locality)
     // reaches the recorder below.
     auto const blocker =
         hpx::supervision::register_observer(hpx::launch::sync, locality, target,
-            [&](hpx::supervision::lifecycle_event_notification const&,
-                hpx::error_code&) {
+            [&](hpx::supervision::lifecycle_event_notification const&) {
                 if (block_first_delivery.load() &&
                     blocker_invocations.fetch_add(1) == 0)
                 {
@@ -851,18 +1285,20 @@ void test_publish_delivers_its_own_event_snapshot(hpx::id_type const& locality)
                         hpx::this_thread::yield();
                     }
                 }
+                return true;
             });
 
     hpx::spinlock received_mtx;
     std::vector<hpx::supervision::lifecycle_event_notification> received;
 
-    auto const recorder = hpx::supervision::register_observer(hpx::launch::sync,
-        locality, target,
-        [&](hpx::supervision::lifecycle_event_notification const& notification,
-            hpx::error_code&) {
-            std::scoped_lock<hpx::spinlock> l(received_mtx);
-            received.push_back(notification);
-        });
+    auto const recorder =
+        hpx::supervision::register_observer(hpx::launch::sync, locality, target,
+            [&](hpx::supervision::lifecycle_event_notification const&
+                    notification) {
+                std::scoped_lock<hpx::spinlock> l(received_mtx);
+                received.push_back(notification);
+                return true;
+            });
 
     // Both registrations may have synchronously delivered the state retained
     // from earlier tests. Start the controlled race from a clean baseline.
@@ -943,7 +1379,7 @@ void test_publish_no_observers(hpx::id_type const& locality)
 {
     hpx::id_type const target = make_test_target();
 
-    reach_completed(locality, target);
+    reach_running(locality, target);
 
     // Publishing with no observers should not fail
     hpx::supervision::publish_event(hpx::launch::sync, locality, target,
@@ -961,10 +1397,10 @@ void test_rapid_event_sequence(hpx::id_type const& locality)
 
     auto const observer_handle = hpx::supervision::register_observer(
         hpx::launch::sync, locality, target,
-        [](hpx::supervision::lifecycle_event_notification const& notification,
-            hpx::error_code&) {
+        [](hpx::supervision::lifecycle_event_notification const& notification) {
             g_test_context.record_event(
                 notification.actor, notification.event, notification.ec);
+            return true;
         });
 
     g_test_context.reset();
@@ -1064,18 +1500,19 @@ void test_query_state_concurrent_access(hpx::id_type const& locality)
         hpx::launch::sync, locality, target, hpx::supervision::event::started);
 
     std::atomic<bool> stop{false};
-    auto writer = hpx::async([&] {
+    auto writer = hpx::async(hpx::launch::task, [&] {
         while (!stop.load(std::memory_order_relaxed))
         {
             hpx::supervision::publish_event(hpx::launch::sync, locality, target,
                 hpx::supervision::event::running);
+            hpx::this_thread::yield();
         }
     });
 
     std::vector<hpx::future<void>> readers;
     for (int i = 0; i != 4; ++i)
     {
-        readers.push_back(hpx::async([&] {
+        readers.push_back(hpx::async(hpx::launch::task, [&] {
             for (int j = 0; j != 200; ++j)
             {
                 auto const state = hpx::supervision::query_state(
@@ -1109,7 +1546,7 @@ void test_illegal_transition_out_of_completed(hpx::id_type const& locality)
     // `completed` is terminal; no further transitions are legal.
     hpx::error_code ec;
     hpx::supervision::publish_event(hpx::launch::sync, locality, target,
-        hpx::supervision::event::running, ec);
+        hpx::supervision::event::running, 0, ec);
     HPX_TEST(ec);
     HPX_TEST(ec.value() == hpx::error::bad_parameter);
 
@@ -1123,11 +1560,11 @@ void test_illegal_transition_unknown_to_completed(hpx::id_type const& locality)
 {
     hpx::id_type const target = make_test_target();
 
-    // The very first event recorded for a target must be `started`;
-    // jumping straight to `completed` is illegal.
+    // The very first event recorded for a target must be `started`; jumping
+    // straight to `completed` is illegal.
     hpx::error_code ec;
     hpx::supervision::publish_event(hpx::launch::sync, locality, target,
-        hpx::supervision::event::completed, ec);
+        hpx::supervision::event::completed, 0, ec);
     HPX_TEST(ec);
     HPX_TEST(ec.value() == hpx::error::bad_parameter);
 
@@ -1153,7 +1590,7 @@ void test_illegal_transitions_out_of_failed(hpx::id_type const& locality)
     {
         hpx::error_code ec;
         hpx::supervision::publish_event(
-            hpx::launch::sync, locality, target, ev, ec);
+            hpx::launch::sync, locality, target, ev, 0, ec);
         HPX_TEST(ec);
         HPX_TEST(ec.value() == hpx::error::bad_parameter);
     }
@@ -1178,12 +1615,12 @@ void test_legal_transitions_suspending_running_resume(
     // Resume: suspending -> running is legal.
     hpx::error_code ec;
     hpx::supervision::publish_event(hpx::launch::sync, locality, target,
-        hpx::supervision::event::running, ec);
+        hpx::supervision::event::running, 0, ec);
     HPX_TEST(!ec);
 
     // running -> suspending is legal as well.
     hpx::supervision::publish_event(hpx::launch::sync, locality, target,
-        hpx::supervision::event::suspending, ec);
+        hpx::supervision::event::suspending, 0, ec);
     HPX_TEST(!ec);
 
     auto const state =
@@ -1194,8 +1631,8 @@ void test_legal_transitions_suspending_running_resume(
 void test_legal_transition_losing_locality_to_failed(
     hpx::id_type const& locality)
 {
-    // losing_locality is reachable from started, running, and suspending,
-    // and may only transition to failed.
+    // losing_locality is reachable from started, running, and suspending, and
+    // may only transition to failed.
     std::vector<hpx::supervision::event> const precursors = {
         hpx::supervision::event::started, hpx::supervision::event::running,
         hpx::supervision::event::suspending};
@@ -1219,11 +1656,11 @@ void test_legal_transition_losing_locality_to_failed(
 
         hpx::error_code ec;
         hpx::supervision::publish_event(hpx::launch::sync, locality, target,
-            hpx::supervision::event::losing_locality, ec);
+            hpx::supervision::event::losing_locality, 0, ec);
         HPX_TEST(!ec);
 
         hpx::supervision::publish_event(hpx::launch::sync, locality, target,
-            hpx::supervision::event::failed, ec);
+            hpx::supervision::event::failed, 0, ec);
         HPX_TEST(!ec);
 
         auto const state =
@@ -1240,22 +1677,37 @@ void test_observer_latency_local()
     hpx::id_type const target = make_test_target();
 
     std::atomic<std::chrono::high_resolution_clock::time_point> callback_time;
+    std::atomic<bool> delivered{false};
 
-    auto const observer_handle = hpx::supervision::register_observer(target,
-        [&](hpx::supervision::lifecycle_event_notification const&,
-            hpx::error_code&) {
+    auto const observer_handle = hpx::supervision::register_observer(
+        target, [&](hpx::supervision::lifecycle_event_notification const&) {
             callback_time.store(std::chrono::high_resolution_clock::now());
+            delivered.store(true);
+            return true;
         });
 
     hpx::supervision::publish_event(target, hpx::supervision::event::started);
+
+    // Registration/the started event above may already have delivered a
+    // callback; ignore that delivery and only measure the one triggered by
+    // the timed publish operation below.
+    delivered.store(false);
 
     auto const publish_time = std::chrono::high_resolution_clock::now();
 
     hpx::supervision::publish_event(target, hpx::supervision::event::running);
 
-    // Latency should be < 1ms for local observation
+    auto const deadline =
+        std::chrono::steady_clock::now() + std::chrono::milliseconds(1000);
+    while (!delivered.load() && std::chrono::steady_clock::now() < deadline)
+    {
+        hpx::this_thread::yield();
+    }
+    HPX_TEST(delivered.load());
+
+    // Latency should be < 10ms for local observation
     auto const duration = callback_time.load() - publish_time;
-    HPX_TEST(duration < std::chrono::milliseconds(1));
+    HPX_TEST(duration < std::chrono::milliseconds(10));
 
     hpx::supervision::unregister_observer(observer_handle);
 }
@@ -1266,8 +1718,10 @@ void test_publication_throughput()
 
     std::atomic<int> event_count{0};
     auto const observer_handle = hpx::supervision::register_observer(target,
-        [&event_count](hpx::supervision::lifecycle_event_notification const&,
-            hpx::error_code&) { event_count.fetch_add(1); });
+        [&event_count](hpx::supervision::lifecycle_event_notification const&) {
+            event_count.fetch_add(1);
+            return true;
+        });
 
     hpx::supervision::publish_event(target, hpx::supervision::event::started);
 
@@ -1282,12 +1736,20 @@ void test_publication_throughput()
             target, hpx::supervision::event::running);
     }
 
-    // 100 events should complete in < 10ms
+    auto const deadline =
+        std::chrono::steady_clock::now() + std::chrono::milliseconds(1000);
+    while (
+        event_count.load() < 100 && std::chrono::steady_clock::now() < deadline)
+    {
+        hpx::this_thread::yield();
+    }
+
+    // 100 events should complete in < 100ms
     auto const end = std::chrono::high_resolution_clock::now();
     auto const duration = end - start;
 
     HPX_TEST_EQ(event_count.load(), 100);
-    HPX_TEST(duration < std::chrono::milliseconds(10));
+    HPX_TEST(duration < std::chrono::milliseconds(100));
 
     hpx::supervision::unregister_observer(observer_handle);
 }
@@ -1337,6 +1799,7 @@ int hpx_main()
 
         HPX_TEST_RUN(test_unregister_waits_for_in_flight_callback, locality);
         HPX_TEST_RUN(test_unregister_observer_stops_callbacks, locality);
+        HPX_TEST_RUN(test_unregister_observer_from_within_callback, locality);
         HPX_TEST_RUN(test_multiple_observers_same_target, locality);
         HPX_TEST_RUN(test_publish_delivers_its_own_event_snapshot, locality);
 
@@ -1345,6 +1808,21 @@ int hpx_main()
         HPX_TEST_RUN(test_rapid_event_sequence, locality);
 
         HPX_TEST_RUN(test_query_after_publication, locality);
+
+        HPX_TEST_RUN(test_epoch_duplicate_completion_is_latched, locality);
+        HPX_TEST_RUN(test_epoch_increase_resets_sequence_number, locality);
+        HPX_TEST_RUN(test_stale_epoch_publish_is_noop, locality);
+        HPX_TEST_RUN(
+            test_concurrent_publishes_settle_on_higher_epoch, locality);
+
+        HPX_TEST_RUN(test_epoch_filter_basic_match, locality);
+        HPX_TEST_RUN(test_epoch_filter_mismatch_ignored, locality);
+        HPX_TEST_RUN(test_epoch_filter_default_receives_all_epochs, locality);
+        HPX_TEST_RUN(test_epoch_filter_mixed_observers, locality);
+        HPX_TEST_RUN(
+            test_epoch_filter_initial_snapshot_respects_filter, locality);
+        HPX_TEST_RUN(
+            test_epoch_filter_unregister_removes_filter_entry, locality);
 
         HPX_TEST_RUN(test_query_state_miss_returns_stale_state, locality);
         HPX_TEST_RUN(test_query_state_hit_returns_success, locality);

--- a/libs/full/supervision/tests/unit/supervision_api.cpp
+++ b/libs/full/supervision/tests/unit/supervision_api.cpp
@@ -1,0 +1,894 @@
+//  Copyright (c) 2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/modules/preprocessor.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/supervision.hpp>
+
+#include <atomic>
+#include <condition_variable>
+#include <iostream>
+#include <mutex>
+#include <vector>
+
+// ============================================================================
+// Test Infrastructure
+// ============================================================================
+
+struct test_context
+{
+    hpx::mutex mtx;
+    hpx::condition_variable cv;
+    std::vector<hpx::supervision::event> observed_events;
+    std::vector<hpx::error_code> observed_errors;
+    std::atomic<int> callback_count{0};
+    std::atomic<bool> callback_received{false};
+
+    void reset()
+    {
+        std::scoped_lock<hpx::mutex> lock(mtx);
+        observed_events.clear();
+        observed_errors.clear();
+        callback_count.store(0);
+        callback_received.store(false);
+    }
+
+    void record_event(hpx::id_type const&, hpx::supervision::event const event,
+        hpx::error_code const& ec)
+    {
+        {
+            std::scoped_lock<hpx::mutex> lock(mtx);
+            observed_events.push_back(event);
+            observed_errors.push_back(ec);
+        }
+        callback_count.fetch_add(1);
+        callback_received.store(true);
+        cv.notify_all();
+    }
+
+    bool wait_for_callback(std::chrono::milliseconds const timeout)
+    {
+        std::unique_lock<hpx::mutex> lock(mtx);
+        return cv.wait_for(
+            lock, timeout, [this] { return callback_received.load(); });
+    }
+
+    int get_callback_count() const
+    {
+        return callback_count.load();
+    }
+
+    std::vector<hpx::supervision::event> const& get_events() const
+    {
+        return observed_events;
+    }
+
+    std::vector<hpx::error_code> const& get_errors() const
+    {
+        return observed_errors;
+    }
+};
+
+// Global test context
+test_context g_test_context;
+
+// ============================================================================
+// Test Actions
+// ============================================================================
+
+//void publish_completed_action()
+//{
+//    hpx::supervision::publish_event(hpx::launch::sync, hpx::find_here(),
+//        hpx::supervision::event::completed);
+//}
+//HPX_PLAIN_ACTION(publish_completed_action);
+//
+//void publish_failed_action()
+//{
+//    hpx::supervision::publish_event(
+//        hpx::launch::sync, hpx::find_here(), hpx::supervision::event::failed);
+//}
+//HPX_PLAIN_ACTION(publish_failed_action);
+//
+//void publish_async_completed_action()
+//{
+//    hpx::supervision::publish_event(
+//        hpx::find_here(), hpx::supervision::event::completed)
+//        .wait();
+//}
+//HPX_PLAIN_ACTION(publish_async_completed_action);
+//
+//void publish_started_action()
+//{
+//    hpx::supervision::publish_event(
+//        hpx::launch::sync, hpx::find_here(), hpx::supervision::event::started);
+//}
+//HPX_PLAIN_ACTION(publish_started_action);
+//
+//void publish_running_action()
+//{
+//    hpx::supervision::publish_event(
+//        hpx::launch::sync, hpx::find_here(), hpx::supervision::event::running);
+//}
+//HPX_PLAIN_ACTION(publish_running_action);
+
+// ============================================================================
+// Test Cases: 2B.1 - Connector Publishes Explicit Completion
+// ============================================================================
+void test_publish_completion_local(hpx::id_type const& locality)
+{
+    hpx::id_type const target = hpx::find_here();
+
+    // Publish a completed event
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+        hpx::supervision::event::completed);
+
+    // Query the state immediately (remote API)
+    auto state =
+        hpx::supervision::query_state(hpx::launch::sync, locality, target);
+
+    HPX_TEST_EQ(state.actor, target);
+    HPX_TEST(state.last_event == hpx::supervision::event::completed);
+    HPX_TEST(state.timestamp != std::chrono::steady_clock::time_point{});
+    HPX_TEST_NEQ(state.event_sequence_number, 0u);
+
+    // Query the state immediately (locally)
+    state = hpx::supervision::query_state(target);
+
+    HPX_TEST_EQ(state.actor, target);
+    HPX_TEST(state.last_event == hpx::supervision::event::completed);
+    HPX_TEST(state.timestamp != std::chrono::steady_clock::time_point{});
+    HPX_TEST_NEQ(state.event_sequence_number, 0u);
+}
+
+void test_publish_completion_async(hpx::id_type const& locality)
+{
+    hpx::id_type const target = hpx::find_here();
+
+    // Publish asynchronously
+    auto const future = hpx::supervision::publish_event(
+        locality, target, hpx::supervision::event::completed);
+    future.wait();
+
+    // Verify the state was recorded (remote API)
+    auto const state =
+        hpx::supervision::query_state(hpx::launch::sync, locality, target);
+    HPX_TEST(state.last_event == hpx::supervision::event::completed);
+}
+
+void test_publish_failed_state(hpx::id_type const& locality)
+{
+    hpx::id_type const target = hpx::find_here();
+
+    hpx::supervision::publish_event(
+        hpx::launch::sync, locality, target, hpx::supervision::event::failed);
+
+    auto const state =
+        hpx::supervision::query_state(hpx::launch::sync, locality, target);
+    HPX_TEST(state.last_event == hpx::supervision::event::failed);
+}
+
+// ============================================================================
+// Test Cases: 2B.2 - Root Observes Completion Without Polling
+// ============================================================================
+void test_register_observer_local_completion(hpx::id_type const& locality)
+{
+    hpx::id_type const target = hpx::find_here();
+
+    auto const observer_handle = hpx::supervision::register_observer(
+        hpx::launch::sync, locality, target,
+        [](hpx::supervision::lifecycle_event_notification const& notification,
+            hpx::error_code&) {
+            g_test_context.record_event(
+                notification.actor, notification.event, notification.ec);
+        });
+
+    HPX_TEST_NEQ(observer_handle, hpx::invalid_id);
+
+    g_test_context.reset();
+
+    // Publish completion event
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+        hpx::supervision::event::completed);
+
+    // Callback should fire within 10ms
+    bool const received =
+        g_test_context.wait_for_callback(std::chrono::milliseconds(10));
+
+    HPX_TEST_MSG(received, "Callback not received within 10ms");
+    HPX_TEST_EQ(g_test_context.get_callback_count(), 1);
+    HPX_TEST(
+        g_test_context.get_events()[0] == hpx::supervision::event::completed);
+    HPX_TEST(g_test_context.get_errors()[0] == hpx::make_success_code());
+
+    // Cleanup
+    hpx::supervision::unregister_observer(
+        hpx::launch::sync, locality, observer_handle);
+}
+
+void test_register_observer_multiple_events(hpx::id_type const& locality)
+{
+    hpx::id_type const target = hpx::find_here();
+
+    auto const observer_handle = hpx::supervision::register_observer(
+        hpx::launch::sync, locality, target,
+        [](hpx::supervision::lifecycle_event_notification const& notification,
+            hpx::error_code&) {
+            g_test_context.record_event(
+                notification.actor, notification.event, notification.ec);
+        });
+
+    g_test_context.reset();
+
+    // Publish multiple events
+    hpx::supervision::publish_event(
+        hpx::launch::sync, locality, target, hpx::supervision::event::started);
+    hpx::supervision::publish_event(
+        hpx::launch::sync, locality, target, hpx::supervision::event::running);
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+        hpx::supervision::event::completed);
+
+    // Wait for all callbacks
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+    HPX_TEST_EQ(g_test_context.get_callback_count(), 3);
+
+    auto const& events = g_test_context.get_events();
+    HPX_TEST(events[0] == hpx::supervision::event::started);
+    HPX_TEST(events[1] == hpx::supervision::event::running);
+    HPX_TEST(events[2] == hpx::supervision::event::completed);
+
+    auto const& errors = g_test_context.get_errors();
+    HPX_TEST(errors[0] == hpx::make_success_code());
+    HPX_TEST(errors[1] == hpx::make_success_code());
+    HPX_TEST(errors[2] == hpx::make_success_code());
+
+    hpx::supervision::unregister_observer(
+        hpx::launch::sync, locality, observer_handle);
+}
+
+void test_register_observer(hpx::id_type const& locality)
+{
+    hpx::id_type const target = hpx::find_here();
+
+    auto observer_future = hpx::supervision::register_observer(locality, target,
+        [](hpx::supervision::lifecycle_event_notification const& notification,
+            hpx::error_code&) {
+            g_test_context.record_event(
+                notification.actor, notification.event, notification.ec);
+        });
+
+    auto const observer_handle = observer_future.get();
+    HPX_TEST_NEQ(observer_handle, hpx::invalid_id);
+
+    g_test_context.reset();
+
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+        hpx::supervision::event::completed);
+
+    bool const received =
+        g_test_context.wait_for_callback(std::chrono::milliseconds(10));
+    HPX_TEST(received);
+
+    HPX_TEST_EQ(g_test_context.get_callback_count(), 1);
+
+    hpx::supervision::unregister_observer(
+        hpx::launch::sync, locality, observer_handle);
+}
+
+// ============================================================================
+// Test Cases: 2B.3 - Root Observes Failure Without External Witness
+// ============================================================================
+void test_observe_failure_detection(hpx::id_type const& locality)
+{
+    hpx::id_type const target = hpx::find_here();
+
+    auto const observer_handle = hpx::supervision::register_observer(
+        hpx::launch::sync, locality, target,
+        [](hpx::supervision::lifecycle_event_notification const& notification,
+            hpx::error_code&) {
+            g_test_context.record_event(
+                notification.actor, notification.event, notification.ec);
+        });
+
+    g_test_context.reset();
+
+    // Publish a failure event
+    hpx::supervision::publish_event(
+        hpx::launch::sync, locality, target, hpx::supervision::event::failed);
+
+    bool const received =
+        g_test_context.wait_for_callback(std::chrono::milliseconds(10));
+    HPX_TEST(received);
+
+    HPX_TEST_EQ(g_test_context.get_callback_count(), 1);
+    HPX_TEST(g_test_context.get_events()[0] == hpx::supervision::event::failed);
+    HPX_TEST(g_test_context.get_errors()[0] == hpx::make_success_code());
+
+    hpx::supervision::unregister_observer(
+        hpx::launch::sync, locality, observer_handle);
+}
+
+// ============================================================================
+// Test Cases: 2B.4 - Sequence Numbers & Lost Connector Detection
+// ============================================================================
+void test_sequence_numbers_monotonic(hpx::id_type const& locality)
+{
+    hpx::id_type const target = hpx::find_here();
+
+    auto const state1 =
+        hpx::supervision::query_state(hpx::launch::sync, locality, target);
+    hpx::supervision::publish_event(
+        hpx::launch::sync, locality, target, hpx::supervision::event::started);
+
+    auto const state2 =
+        hpx::supervision::query_state(hpx::launch::sync, locality, target);
+    hpx::supervision::publish_event(
+        hpx::launch::sync, locality, target, hpx::supervision::event::running);
+
+    auto const state3 =
+        hpx::supervision::query_state(hpx::launch::sync, locality, target);
+
+    HPX_TEST_LT(state1.event_sequence_number, state2.event_sequence_number);
+    HPX_TEST_LT(state2.event_sequence_number, state3.event_sequence_number);
+}
+
+void test_sequence_numbers_no_gaps(hpx::id_type const& locality)
+{
+    hpx::id_type const target = hpx::find_here();
+
+    std::vector<uint64_t> sequence_numbers;
+    auto const observer_handle = hpx::supervision::register_observer(
+        hpx::launch::sync, locality, target,
+        [&sequence_numbers, target](
+            hpx::supervision::lifecycle_event_notification const& notification,
+            hpx::error_code&) {
+            // query state during callback
+            auto const state = hpx::supervision::query_state(
+                hpx::launch::sync, target, notification.actor);
+            sequence_numbers.push_back(state.event_sequence_number);
+
+            // sequence numbers must match
+            HPX_TEST(notification.event_sequence_number ==
+                state.event_sequence_number);
+
+            g_test_context.record_event(
+                notification.actor, notification.event, notification.ec);
+        });
+
+    g_test_context.reset();
+
+    // Publish 5 events
+    for (int i = 0; i < 5; ++i)
+    {
+        hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+            hpx::supervision::event::running);
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    // Verify sequence numbers are consecutive or increasing
+    for (size_t i = 1; i < sequence_numbers.size(); ++i)
+    {
+        HPX_TEST_LTE(sequence_numbers[i - 1], sequence_numbers[i]);
+    }
+
+    hpx::supervision::unregister_observer(
+        hpx::launch::sync, locality, observer_handle);
+}
+
+void test_detect_connector_terminal(hpx::id_type const& locality)
+{
+    hpx::id_type const target = hpx::find_here();
+
+    auto const observer_handle = hpx::supervision::register_observer(
+        hpx::launch::sync, locality, target,
+        [](hpx::supervision::lifecycle_event_notification const& notification,
+            hpx::error_code& ec) {
+            g_test_context.record_event(
+                notification.actor, notification.event, notification.ec);
+            HPX_THROWS_IF(ec, hpx::error::no_success,
+                "test_detect_connector_terminal", "testing error reporting");
+        });
+
+    g_test_context.reset();
+
+    // Simulate connector reaching terminal state
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+        hpx::supervision::event::completed);
+
+    bool const received =
+        g_test_context.wait_for_callback(std::chrono::milliseconds(10));
+    HPX_TEST(received);
+
+    // Query to confirm failed state
+    auto const state =
+        hpx::supervision::query_state(hpx::launch::sync, locality, target);
+    HPX_TEST(state.last_event == hpx::supervision::event::failed);
+
+    // Verify error was reported back correctly
+    HPX_TEST(state.ec.value() == hpx::error::no_success);
+
+    hpx::supervision::unregister_observer(
+        hpx::launch::sync, locality, observer_handle);
+}
+
+void test_error_does_not_stop_callbacks(hpx::id_type const& locality)
+{
+    hpx::id_type const target = hpx::find_here();
+
+    auto const observer_handle = hpx::supervision::register_observer(
+        hpx::launch::sync, locality, target,
+        [](hpx::supervision::lifecycle_event_notification const& notification,
+            hpx::error_code& ec) {
+            g_test_context.record_event(
+                notification.actor, notification.event, notification.ec);
+            HPX_THROWS_IF(ec, hpx::error::no_success,
+                "test_detect_connector_terminal", "testing error reporting");
+        });
+
+    auto const observer_handle2 = hpx::supervision::register_observer(
+        hpx::launch::sync, locality, target,
+        [](hpx::supervision::lifecycle_event_notification const& notification,
+            hpx::error_code& ec) {
+            g_test_context.record_event(
+                notification.actor, notification.event, notification.ec);
+        });
+
+    g_test_context.reset();
+
+    // Simulate connector reaching terminal state
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+        hpx::supervision::event::completed);
+
+    bool const received =
+        g_test_context.wait_for_callback(std::chrono::milliseconds(10));
+    HPX_TEST(received);
+
+    HPX_TEST_EQ(g_test_context.get_callback_count(), 2);
+
+    auto const& events = g_test_context.get_events();
+    HPX_TEST(events[0] == hpx::supervision::event::completed);
+    HPX_TEST(events[1] == hpx::supervision::event::failed);
+
+    auto const& errors = g_test_context.get_errors();
+    HPX_TEST(errors[0] == hpx::make_success_code());
+    HPX_TEST(errors[1].value() == hpx::error::no_success);
+
+    // Query to confirm failed state
+    auto const state =
+        hpx::supervision::query_state(hpx::launch::sync, locality, target);
+    HPX_TEST(state.last_event == hpx::supervision::event::failed);
+
+    // Verify error was reported back correctly
+    HPX_TEST(state.ec.value() == hpx::error::no_success);
+
+    hpx::supervision::unregister_observer(
+        hpx::launch::sync, locality, observer_handle2);
+    hpx::supervision::unregister_observer(
+        hpx::launch::sync, locality, observer_handle);
+}
+
+// ============================================================================
+// Test Cases: Unregister Observer
+// ============================================================================
+void test_unregister_observer_stops_callbacks(hpx::id_type const& locality)
+{
+    hpx::id_type const target = hpx::find_here();
+
+    auto const observer_handle = hpx::supervision::register_observer(
+        hpx::launch::sync, locality, target,
+        [](hpx::supervision::lifecycle_event_notification const& notification,
+            hpx::error_code& ec) {
+            g_test_context.record_event(
+                notification.actor, notification.event, notification.ec);
+        });
+
+    g_test_context.reset();
+
+    // Publish first event
+    hpx::supervision::publish_event(
+        hpx::launch::sync, locality, target, hpx::supervision::event::started);
+
+    bool const received =
+        g_test_context.wait_for_callback(std::chrono::milliseconds(10));
+    HPX_TEST(received);
+    int const count_before = g_test_context.get_callback_count();
+    HPX_TEST_EQ(count_before, 1);
+
+    // Unregister the observer
+    hpx::supervision::unregister_observer(
+        hpx::launch::sync, locality, observer_handle);
+
+    g_test_context.reset();
+
+    // Publish second event
+    hpx::supervision::publish_event(
+        hpx::launch::sync, locality, target, hpx::supervision::event::running);
+
+    // Wait but should NOT receive callback
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+    int const count_after = g_test_context.get_callback_count();
+    HPX_TEST_EQ(count_after, 0);
+}
+
+void test_multiple_observers_same_target(hpx::id_type const& locality)
+{
+    hpx::id_type const target = hpx::find_here();
+
+    test_context ctx1, ctx2;
+
+    auto const observer_handle1 = hpx::supervision::register_observer(
+        hpx::launch::sync, locality, target,
+        [&ctx1](
+            hpx::supervision::lifecycle_event_notification const& notification,
+            hpx::error_code& ec) {
+            ctx1.record_event(
+                notification.actor, notification.event, notification.ec);
+        });
+
+    auto const observer_handle2 = hpx::supervision::register_observer(
+        hpx::launch::sync, locality, target,
+        [&ctx2](
+            hpx::supervision::lifecycle_event_notification const& notification,
+            hpx::error_code& ec) {
+            ctx2.record_event(
+                notification.actor, notification.event, notification.ec);
+        });
+
+    ctx1.reset();
+    ctx2.reset();
+
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+        hpx::supervision::event::completed);
+
+    // Both observers should receive callback
+    bool const received1 =
+        ctx1.wait_for_callback(std::chrono::milliseconds(10));
+    bool const received2 =
+        ctx2.wait_for_callback(std::chrono::milliseconds(10));
+    HPX_TEST(received1);
+    HPX_TEST(received2);
+
+    HPX_TEST_EQ(ctx1.get_callback_count(), 1);
+    HPX_TEST_EQ(ctx2.get_callback_count(), 1);
+
+    hpx::supervision::unregister_observer(
+        hpx::launch::sync, locality, observer_handle1);
+    hpx::supervision::unregister_observer(
+        hpx::launch::sync, locality, observer_handle2);
+}
+
+// ============================================================================
+// Test Cases: Error Handling & Edge Cases
+// ============================================================================
+void test_query_nonexistent_actor()
+{
+    hpx::id_type const invalid_actor = hpx::invalid_id;
+
+    hpx::error_code ec;
+    auto state = hpx::supervision::query_state(invalid_actor, ec);
+    HPX_TEST(ec);    // Should have error
+}
+
+void test_publish_no_observers(hpx::id_type const& locality)
+{
+    hpx::id_type const target = hpx::find_here();
+
+    // Publishing with no observers should not fail
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+        hpx::supervision::event::completed);
+
+    // Query should still work
+    auto const state =
+        hpx::supervision::query_state(hpx::launch::sync, locality, target);
+    HPX_TEST(state.last_event == hpx::supervision::event::completed);
+}
+
+void test_rapid_event_sequence(hpx::id_type const& locality)
+{
+    hpx::id_type const target = hpx::find_here();
+
+    auto const observer_handle = hpx::supervision::register_observer(
+        hpx::launch::sync, locality, target,
+        [](hpx::supervision::lifecycle_event_notification const& notification,
+            hpx::error_code& ec) {
+            g_test_context.record_event(
+                notification.actor, notification.event, notification.ec);
+        });
+
+    g_test_context.reset();
+
+    // Publish events rapidly
+    std::vector<hpx::supervision::event> const events = {
+        hpx::supervision::event::started, hpx::supervision::event::running,
+        hpx::supervision::event::suspending, hpx::supervision::event::completed,
+        hpx::supervision::event::failed};
+
+    for (auto const event : events)
+    {
+        hpx::supervision::publish_event(
+            hpx::launch::sync, locality, target, event);
+    }
+
+    hpx::this_thread::sleep_for(std::chrono::milliseconds(20));
+
+    // All events should be recorded
+    HPX_TEST_EQ(g_test_context.get_callback_count(), 5);
+
+    auto const observed = g_test_context.get_events();
+    for (size_t i = 0; i < observed.size(); ++i)
+    {
+        HPX_TEST(observed[i] == events[i]);
+    }
+
+    hpx::supervision::unregister_observer(
+        hpx::launch::sync, locality, observer_handle);
+}
+
+void test_query_after_publication(hpx::id_type const& locality)
+{
+    hpx::id_type const target = hpx::find_here();
+
+    hpx::supervision::publish_event(
+        hpx::launch::sync, locality, target, hpx::supervision::event::started);
+
+    auto const state =
+        hpx::supervision::query_state(hpx::launch::sync, locality, target);
+
+    HPX_TEST(state.last_event == hpx::supervision::event::started);
+    HPX_TEST(std::chrono::steady_clock::now() > state.timestamp);
+}
+
+// ============================================================================
+// Performance Tests
+// ============================================================================
+void test_observer_latency_local()
+{
+    hpx::id_type const target = hpx::find_here();
+
+    std::atomic<std::chrono::high_resolution_clock::time_point> callback_time;
+
+    auto const observer_handle = hpx::supervision::register_observer(target,
+        [&](hpx::supervision::lifecycle_event_notification const&,
+            hpx::error_code&) {
+            callback_time.store(std::chrono::high_resolution_clock::now());
+        });
+
+    auto const publish_time = std::chrono::high_resolution_clock::now();
+
+    hpx::supervision::publish_event(target, hpx::supervision::event::completed);
+
+    // Latency should be < 1ms for local observation
+    auto const duration = callback_time.load() - publish_time;
+    HPX_TEST(duration < std::chrono::milliseconds(1));
+
+    hpx::supervision::unregister_observer(observer_handle);
+}
+
+void test_publication_throughput()
+{
+    hpx::id_type const target = hpx::find_here();
+
+    std::atomic<int> event_count{0};
+    auto const observer_handle = hpx::supervision::register_observer(target,
+        [&event_count](hpx::supervision::lifecycle_event_notification const&,
+            hpx::error_code&) { event_count.fetch_add(1); });
+
+    event_count.store(0);
+
+    auto const start = std::chrono::high_resolution_clock::now();
+
+    // Publish 100 events
+    for (int i = 0; i < 100; ++i)
+    {
+        hpx::supervision::publish_event(
+            target, hpx::supervision::event::running);
+    }
+
+    // 100 events should complete in < 10ms
+    auto const end = std::chrono::high_resolution_clock::now();
+    auto const duration = end - start;
+
+    HPX_TEST_EQ(event_count.load(), 100);
+    HPX_TEST(duration < std::chrono::milliseconds(10));
+
+    hpx::supervision::unregister_observer(observer_handle);
+}
+
+#if 0
+// ============================================================================
+// Test Cases: Observer Staleness Detection
+// ============================================================================
+void test_observer_staleness_detection()
+{
+    std::vector<hpx::id_type> const localities = hpx::find_all_localities();
+
+    if (localities.size() < 2)
+    {
+        HPX_TEST_MSG(false, "Test requires at least 2 localities");
+        return;
+    }
+
+    hpx::id_type remote_locality = localities[1];
+
+    // Register observer from non-owner locality
+    std::atomic<bool> observer_registered{false};
+    auto const observer_handle =
+        hpx::supervision::register_observer(hpx::launch::sync, remote_locality,
+            [&observer_registered](hpx::id_type actor,
+                hpx::supervision::event event, hpx::error_code& ec) {
+                if (!ec)
+                {
+                    observer_registered.store(true);
+                }
+            });
+
+    // Query state - may indicate staleness if observer hasn't synced
+    auto const state =
+        hpx::supervision::query_state(hpx::launch::sync, remote_locality);
+
+    // If observer_staleness is set, it indicates the remote observer
+    // may not have latest state
+    if (state.observer_staleness)
+    {
+        HPX_TEST_MSG(
+            true, "Observer staleness detected and reported correctly");
+    }
+
+    hpx::supervision::unregister_observer(hpx::launch::sync, observer_handle);
+}
+
+// ============================================================================
+// Test Cases: Bulk Observation (Locality-Level)
+// ============================================================================
+void test_bulk_observe_locality_completions()
+{
+    hpx::id_type const locality = hpx::find_here();
+
+    std::atomic<int> summary_count{0};
+    std::atomic<uint64_t> last_version{0};
+
+    auto const observer_handle =
+        hpx::supervision::observe_locality_completions(locality,
+            [&summary_count, &last_version](
+                hpx::supervision::locality_completion_summary const& summary,
+                hpx::error_code& ec) {
+                if (!ec)
+                {
+                    summary_count.fetch_add(1);
+                    last_version.store(summary.summary_version);
+                }
+            });
+
+    HPX_TEST_NEQ(observer_handle, hpx::invalid_id);
+
+    // Publish multiple events
+    hpx::supervision::publish_event(
+        hpx::launch::sync, locality, hpx::supervision::event::started);
+    hpx::supervision::publish_event(
+        hpx::launch::sync, locality, hpx::supervision::event::running);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    // Should receive updates for each event
+    HPX_TEST_GT(summary_count.load(), 0);
+    HPX_TEST_GT(last_version.load(), 0u);
+
+    hpx::supervision::unregister_observer(hpx::launch::sync, observer_handle);
+}
+
+void test_bulk_observe_version_increments()
+{
+    hpx::id_type const locality = hpx::find_here();
+
+    std::vector<uint64_t> versions;
+
+    auto const observer_handle =
+        hpx::supervision::observe_locality_completions(locality,
+            [&versions](
+                hpx::supervision::locality_completion_summary const& summary,
+                hpx::error_code& ec) {
+                if (!ec)
+                {
+                    versions.push_back(summary.summary_version);
+                }
+            });
+
+    // Publish multiple events
+    for (int i = 0; i < 3; ++i)
+    {
+        hpx::supervision::publish_event(
+            hpx::launch::sync, locality, hpx::supervision::event::running);
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    // Versions should increment
+    for (size_t i = 1; i < versions.size(); ++i)
+    {
+        HPX_TEST_GT(versions[i], versions[i - 1]);
+    }
+
+    hpx::supervision::unregister_observer(hpx::launch::sync, observer_handle);
+}
+#endif
+
+// ============================================================================
+// Main Test Entry Point
+// ============================================================================
+
+template <typename... Args>
+void print(Args... args)
+{
+    (..., (std::cout << args));
+}
+
+template <typename T, typename... Args>
+void print(T first, Args&&... rest)
+{
+    std::cout << first;
+    print(std::forward<Args>(rest)...);
+}
+
+#define HPX_TEST_RUN(func, ...)                                                \
+    std::cout << HPX_PP_STRINGIZE(func) << "(";                                \
+    print(__VA_ARGS__);                                                        \
+    std::cout << ")\n";                                                        \
+    func(__VA_ARGS__)
+
+int hpx_main()
+{
+    // 2B.1 Tests
+    for (auto const& locality : hpx::find_all_localities())
+    {
+        HPX_TEST_RUN(test_publish_completion_local, locality);
+        HPX_TEST_RUN(test_publish_completion_async, locality);
+        HPX_TEST_RUN(test_publish_failed_state, locality);
+
+        HPX_TEST_RUN(test_register_observer_local_completion, locality);
+        HPX_TEST_RUN(test_register_observer_multiple_events, locality);
+        HPX_TEST_RUN(test_register_observer, locality);
+
+        HPX_TEST_RUN(test_observe_failure_detection, locality);
+
+        HPX_TEST_RUN(test_sequence_numbers_monotonic, locality);
+        HPX_TEST_RUN(test_sequence_numbers_no_gaps, locality);
+        HPX_TEST_RUN(test_detect_connector_terminal, locality);
+        HPX_TEST_RUN(test_error_does_not_stop_callbacks, locality);
+
+        HPX_TEST_RUN(test_unregister_observer_stops_callbacks, locality);
+        HPX_TEST_RUN(test_multiple_observers_same_target, locality);
+
+        HPX_TEST_RUN(test_publish_no_observers, locality);
+
+        HPX_TEST_RUN(test_rapid_event_sequence, locality);
+
+        HPX_TEST_RUN(test_query_after_publication, locality);
+    }
+
+    HPX_TEST_RUN(test_query_nonexistent_actor);
+    HPX_TEST_RUN(test_observer_latency_local);
+    HPX_TEST_RUN(test_publication_throughput);
+
+#if 0
+    HPX_TEST_RUN(test_observer_staleness_detection);
+
+    HPX_TEST_RUN(test_bulk_observe_locality_completions);
+    HPX_TEST_RUN(test_bulk_observe_version_increments);
+#endif
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    HPX_TEST_EQ(hpx::init(argc, argv), 0);
+    return hpx::util::report_errors();
+}

--- a/libs/full/supervision/tests/unit/supervision_api.cpp
+++ b/libs/full/supervision/tests/unit/supervision_api.cpp
@@ -5,6 +5,9 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #include <hpx/hpx.hpp>
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+
 #include <hpx/hpx_init.hpp>
 #include <hpx/modules/preprocessor.hpp>
 #include <hpx/modules/testing.hpp>
@@ -14,6 +17,26 @@
 #include <iostream>
 #include <mutex>
 #include <vector>
+
+// ============================================================================
+// Test Helpers
+// ============================================================================
+
+// publish_event() now validates lifecycle event transitions and rejects
+// invalid ones (see hpx::supervision::is_valid_transition()). Each test
+// therefore needs its own private target: reusing hpx::find_here() as a
+// shared key across independent tests would let one test's published
+// history make a later test's (otherwise legal) first event look like an
+// illegal transition. make_test_target() hands out a fresh id that is only
+// ever used as a lookup key by the supervision manager, so it does not need
+// to name a real, live component.
+hpx::id_type make_test_target()
+{
+    static std::atomic<std::uint64_t> counter{1};
+    hpx::naming::gid_type const gid(
+        0x1ull, counter.fetch_add(1, std::memory_order_relaxed));
+    return hpx::id_type(gid, hpx::id_type::management_type::unmanaged);
+}
 
 // ============================================================================
 // Test Infrastructure
@@ -73,17 +96,28 @@ struct test_context
     }
 };
 
+// Reach `completed` via a legal path: started -> running -> completed.
+void reach_completed(hpx::id_type const& locality, hpx::id_type const& target)
+{
+    hpx::supervision::publish_event(
+        hpx::launch::sync, locality, target, hpx::supervision::event::started);
+    hpx::supervision::publish_event(
+        hpx::launch::sync, locality, target, hpx::supervision::event::running);
+}
+
 // Global test context
 test_context g_test_context;
 
 // ============================================================================
 // Test Cases: 2B.1 - Connector Publishes Explicit Completion
 // ============================================================================
-void test_publish_completion_local(hpx::id_type const& locality)
+void test_publish_completion()
 {
-    hpx::id_type const target = hpx::find_here();
+    hpx::id_type const locality = hpx::find_here();
+    hpx::id_type const target = make_test_target();
 
-    // Publish a completed event
+    reach_completed(locality, target);
+
     hpx::supervision::publish_event(hpx::launch::sync, locality, target,
         hpx::supervision::event::completed);
 
@@ -107,9 +141,10 @@ void test_publish_completion_local(hpx::id_type const& locality)
 
 void test_publish_completion_async(hpx::id_type const& locality)
 {
-    hpx::id_type const target = hpx::find_here();
+    hpx::id_type const target = make_test_target();
 
-    // Publish asynchronously
+    reach_completed(locality, target);
+
     auto const future = hpx::supervision::publish_event(
         locality, target, hpx::supervision::event::completed);
     future.wait();
@@ -122,7 +157,11 @@ void test_publish_completion_async(hpx::id_type const& locality)
 
 void test_publish_failed_state(hpx::id_type const& locality)
 {
-    hpx::id_type const target = hpx::find_here();
+    hpx::id_type const target = make_test_target();
+
+    // `failed` is reachable from `started` directly.
+    hpx::supervision::publish_event(
+        hpx::launch::sync, locality, target, hpx::supervision::event::started);
 
     hpx::supervision::publish_event(
         hpx::launch::sync, locality, target, hpx::supervision::event::failed);
@@ -137,7 +176,7 @@ void test_publish_failed_state(hpx::id_type const& locality)
 // ============================================================================
 void test_register_observer_local_completion(hpx::id_type const& locality)
 {
-    hpx::id_type const target = hpx::find_here();
+    hpx::id_type const target = make_test_target();
 
     auto const observer_handle = hpx::supervision::register_observer(
         hpx::launch::sync, locality, target,
@@ -148,6 +187,11 @@ void test_register_observer_local_completion(hpx::id_type const& locality)
         });
 
     HPX_TEST_NEQ(observer_handle, hpx::invalid_id);
+
+    // Reach `completed` via a legal path; do this before resetting the test
+    // context so these preliminary events don't count towards the
+    // callback_count assertion below.
+    reach_completed(locality, target);
 
     g_test_context.reset();
 
@@ -172,7 +216,7 @@ void test_register_observer_local_completion(hpx::id_type const& locality)
 
 void test_register_observer_multiple_events(hpx::id_type const& locality)
 {
-    hpx::id_type const target = hpx::find_here();
+    hpx::id_type const target = make_test_target();
 
     auto const observer_handle = hpx::supervision::register_observer(
         hpx::launch::sync, locality, target,
@@ -185,15 +229,13 @@ void test_register_observer_multiple_events(hpx::id_type const& locality)
     g_test_context.reset();
 
     // Publish multiple events
-    hpx::supervision::publish_event(
-        hpx::launch::sync, locality, target, hpx::supervision::event::started);
-    hpx::supervision::publish_event(
-        hpx::launch::sync, locality, target, hpx::supervision::event::running);
+    reach_completed(locality, target);
+
     hpx::supervision::publish_event(hpx::launch::sync, locality, target,
         hpx::supervision::event::completed);
 
     // Wait for all callbacks
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    hpx::this_thread::sleep_for(std::chrono::milliseconds(10));
 
     HPX_TEST_EQ(g_test_context.get_callback_count(), 3);
 
@@ -213,7 +255,7 @@ void test_register_observer_multiple_events(hpx::id_type const& locality)
 
 void test_register_observer(hpx::id_type const& locality)
 {
-    hpx::id_type const target = hpx::find_here();
+    hpx::id_type const target = make_test_target();
 
     auto observer_future = hpx::supervision::register_observer(locality, target,
         [](hpx::supervision::lifecycle_event_notification const& notification,
@@ -224,6 +266,8 @@ void test_register_observer(hpx::id_type const& locality)
 
     auto const observer_handle = observer_future.get();
     HPX_TEST_NEQ(observer_handle, hpx::invalid_id);
+
+    reach_completed(locality, target);
 
     g_test_context.reset();
 
@@ -243,7 +287,7 @@ void test_register_observer(hpx::id_type const& locality)
 void test_register_observer_receives_existing_state(
     hpx::id_type const& locality)
 {
-    hpx::id_type const target = hpx::find_here();
+    hpx::id_type const target = make_test_target();
 
     // Establish state before any observer exists.
     hpx::supervision::publish_event(
@@ -267,13 +311,13 @@ void test_register_observer_receives_existing_state(
         std::scoped_lock<hpx::spinlock> l(mtx);
         HPX_TEST_EQ(received.size(), static_cast<std::size_t>(1));
 
-        auto const& notification = received.front();
-        HPX_TEST_EQ(notification.actor, target);
-        HPX_TEST(notification.event == hpx::supervision::event::started);
-        HPX_TEST_EQ(
-            notification.event_sequence_number, expected.event_sequence_number);
-        HPX_TEST(notification.event_time == expected.timestamp);
-        HPX_TEST(notification.ec == expected.ec);
+        auto const& [actor, event, event_time, event_sequence_number, ec] =
+            received.front();
+        HPX_TEST_EQ(actor, target);
+        HPX_TEST(event == hpx::supervision::event::started);
+        HPX_TEST_EQ(event_sequence_number, expected.event_sequence_number);
+        HPX_TEST(event_time == expected.timestamp);
+        HPX_TEST(ec == expected.ec);
     }
 
     hpx::supervision::unregister_observer(
@@ -282,7 +326,7 @@ void test_register_observer_receives_existing_state(
 
 void test_register_observer_keeps_initial_state_snapshot()
 {
-    hpx::id_type const target = hpx::find_here();
+    hpx::id_type const target = make_test_target();
 
     hpx::supervision::publish_event(target, hpx::supervision::event::started);
 
@@ -362,7 +406,7 @@ void test_register_observer_keeps_initial_state_snapshot()
 // ============================================================================
 void test_observe_failure_detection(hpx::id_type const& locality)
 {
-    hpx::id_type const target = hpx::find_here();
+    hpx::id_type const target = make_test_target();
 
     auto const observer_handle = hpx::supervision::register_observer(
         hpx::launch::sync, locality, target,
@@ -371,6 +415,10 @@ void test_observe_failure_detection(hpx::id_type const& locality)
             g_test_context.record_event(
                 notification.actor, notification.event, notification.ec);
         });
+
+    // `failed` is reachable directly from `started`.
+    hpx::supervision::publish_event(
+        hpx::launch::sync, locality, target, hpx::supervision::event::started);
 
     g_test_context.reset();
 
@@ -395,7 +443,7 @@ void test_observe_failure_detection(hpx::id_type const& locality)
 // ============================================================================
 void test_sequence_numbers_monotonic(hpx::id_type const& locality)
 {
-    hpx::id_type const target = hpx::find_here();
+    hpx::id_type const target = make_test_target();
 
     auto const state1 =
         hpx::supervision::query_state(hpx::launch::sync, locality, target);
@@ -416,17 +464,23 @@ void test_sequence_numbers_monotonic(hpx::id_type const& locality)
 
 void test_sequence_numbers_no_gaps(hpx::id_type const& locality)
 {
-    hpx::id_type const target = hpx::find_here();
+    hpx::id_type const target = make_test_target();
+
+    // Establish the required first event before running the repeated
+    // `running` publications below (running -> running is a legal self
+    // transition, used here purely to exercise sequence numbers).
+    hpx::supervision::publish_event(
+        hpx::launch::sync, locality, target, hpx::supervision::event::started);
 
     std::vector<uint64_t> sequence_numbers;
     auto const observer_handle = hpx::supervision::register_observer(
         hpx::launch::sync, locality, target,
-        [&sequence_numbers, target](
+        [&sequence_numbers, locality](
             hpx::supervision::lifecycle_event_notification const& notification,
             hpx::error_code&) {
             // query state during callback
             auto const state = hpx::supervision::query_state(
-                hpx::launch::sync, target, notification.actor);
+                hpx::launch::sync, locality, notification.actor);
             sequence_numbers.push_back(state.event_sequence_number);
 
             // sequence numbers must match
@@ -446,7 +500,7 @@ void test_sequence_numbers_no_gaps(hpx::id_type const& locality)
             hpx::supervision::event::running);
     }
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    hpx::this_thread::sleep_for(std::chrono::milliseconds(50));
 
     // Verify sequence numbers are consecutive or increasing
     for (size_t i = 1; i < sequence_numbers.size(); ++i)
@@ -460,7 +514,9 @@ void test_sequence_numbers_no_gaps(hpx::id_type const& locality)
 
 void test_detect_connector_terminal(hpx::id_type const& locality)
 {
-    hpx::id_type const target = hpx::find_here();
+    hpx::id_type const target = make_test_target();
+
+    reach_completed(locality, target);
 
     auto const observer_handle = hpx::supervision::register_observer(
         hpx::launch::sync, locality, target,
@@ -478,9 +534,7 @@ void test_detect_connector_terminal(hpx::id_type const& locality)
     hpx::supervision::publish_event(hpx::launch::sync, locality, target,
         hpx::supervision::event::completed);
 
-    bool const received =
-        g_test_context.wait_for_callback(std::chrono::milliseconds(10));
-    HPX_TEST(received);
+    hpx::this_thread::sleep_for(std::chrono::milliseconds(20));
 
     // Query to confirm failed state
     auto const state =
@@ -496,7 +550,7 @@ void test_detect_connector_terminal(hpx::id_type const& locality)
 
 void test_error_does_not_stop_callbacks(hpx::id_type const& locality)
 {
-    hpx::id_type const target = hpx::find_here();
+    hpx::id_type const target = make_test_target();
 
     auto const observer_handle = hpx::supervision::register_observer(
         hpx::launch::sync, locality, target,
@@ -516,11 +570,11 @@ void test_error_does_not_stop_callbacks(hpx::id_type const& locality)
                 notification.actor, notification.event, notification.ec);
         });
 
-    g_test_context.reset();
-
-    // Simulate connector reaching terminal state
-    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
-        hpx::supervision::event::completed);
+    // Attempt to reach `completed` via a legal path before resetting counters.
+    // However, `started` raises an exception in one of the observers, causing
+    // the state to shift to `failure`.
+    hpx::supervision::publish_event(
+        hpx::launch::sync, locality, target, hpx::supervision::event::started);
 
     bool const received =
         g_test_context.wait_for_callback(std::chrono::milliseconds(10));
@@ -529,12 +583,23 @@ void test_error_does_not_stop_callbacks(hpx::id_type const& locality)
     HPX_TEST_EQ(g_test_context.get_callback_count(), 2);
 
     auto const& events = g_test_context.get_events();
-    HPX_TEST(events[0] == hpx::supervision::event::completed);
-    HPX_TEST(events[1] == hpx::supervision::event::completed);
+    HPX_TEST(events[0] == hpx::supervision::event::started);
+    HPX_TEST(events[1] == hpx::supervision::event::started);
 
     auto const& errors = g_test_context.get_errors();
     HPX_TEST(errors[0] == hpx::make_success_code());
     HPX_TEST(errors[1] == hpx::make_success_code());
+
+    g_test_context.reset();
+
+    // publish another event, will fail and not invoke callbacks
+    auto const result = hpx::supervision::publish_event(hpx::launch::sync,
+        locality, target, hpx::supervision::event::completed);
+    HPX_TEST(result == hpx::supervision::publish_result::already_terminal);
+
+    hpx::this_thread::sleep_for(std::chrono::milliseconds(20));
+
+    HPX_TEST_EQ(g_test_context.get_callback_count(), 0);
 
     // Query to confirm failed state
     auto const state =
@@ -551,11 +616,68 @@ void test_error_does_not_stop_callbacks(hpx::id_type const& locality)
 }
 
 // ============================================================================
+// Test Cases: Exactly-Once Completion Semantics
+// ============================================================================
+void test_duplicate_completion_is_latched(hpx::id_type const& locality)
+{
+    hpx::id_type const target = make_test_target();
+
+    auto const observer_handle = hpx::supervision::register_observer(
+        hpx::launch::sync, locality, target,
+        [](hpx::supervision::lifecycle_event_notification const& notification,
+            hpx::error_code&) {
+            g_test_context.record_event(
+                notification.actor, notification.event, notification.ec);
+        });
+
+    reach_completed(locality, target);
+
+    g_test_context.reset();
+
+    // First completion publication wins.
+    auto const first_result = hpx::supervision::publish_event(hpx::launch::sync,
+        locality, target, hpx::supervision::event::completed);
+    HPX_TEST(first_result == hpx::supervision::publish_result::applied);
+
+    auto const state_after_first =
+        hpx::supervision::query_state(hpx::launch::sync, locality, target);
+    HPX_TEST(
+        state_after_first.last_event == hpx::supervision::event::completed);
+
+    // A duplicate completion publication is a latched no-op.
+    auto const second_result =
+        hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+            hpx::supervision::event::completed);
+    HPX_TEST(
+        second_result == hpx::supervision::publish_result::already_terminal);
+
+    auto const state_after_second =
+        hpx::supervision::query_state(hpx::launch::sync, locality, target);
+
+    // query_state must still reflect the original record, unchanged.
+    HPX_TEST(
+        state_after_second.last_event == hpx::supervision::event::completed);
+    HPX_TEST_EQ(state_after_second.event_sequence_number,
+        state_after_first.event_sequence_number);
+    HPX_TEST(state_after_second.timestamp == state_after_first.timestamp);
+
+    hpx::this_thread::sleep_for(std::chrono::milliseconds(20));
+
+    // Observers must be notified exactly once, not twice.
+    HPX_TEST_EQ(g_test_context.get_callback_count(), 1);
+    HPX_TEST(
+        g_test_context.get_events()[0] == hpx::supervision::event::completed);
+
+    hpx::supervision::unregister_observer(
+        hpx::launch::sync, locality, observer_handle);
+}
+
+// ============================================================================
 // Test Cases: Unregister Observer
 // ============================================================================
 void test_unregister_waits_for_in_flight_callback(hpx::id_type const& locality)
 {
-    hpx::id_type const target = hpx::find_here();
+    hpx::id_type const target = make_test_target();
 
     std::atomic<bool> callback_entered{false};
     std::atomic<bool> release_callback{false};
@@ -613,7 +735,7 @@ void test_unregister_waits_for_in_flight_callback(hpx::id_type const& locality)
 
 void test_unregister_observer_stops_callbacks(hpx::id_type const& locality)
 {
-    hpx::id_type const target = hpx::find_here();
+    hpx::id_type const target = make_test_target();
 
     auto const observer_handle = hpx::supervision::register_observer(
         hpx::launch::sync, locality, target,
@@ -646,7 +768,7 @@ void test_unregister_observer_stops_callbacks(hpx::id_type const& locality)
         hpx::launch::sync, locality, target, hpx::supervision::event::running);
 
     // Wait but should NOT receive callback
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    hpx::this_thread::sleep_for(std::chrono::milliseconds(10));
 
     int const count_after = g_test_context.get_callback_count();
     HPX_TEST_EQ(count_after, 0);
@@ -654,7 +776,7 @@ void test_unregister_observer_stops_callbacks(hpx::id_type const& locality)
 
 void test_multiple_observers_same_target(hpx::id_type const& locality)
 {
-    hpx::id_type const target = hpx::find_here();
+    hpx::id_type const target = make_test_target();
 
     test_context ctx1, ctx2;
 
@@ -679,6 +801,8 @@ void test_multiple_observers_same_target(hpx::id_type const& locality)
     ctx1.reset();
     ctx2.reset();
 
+    reach_completed(locality, target);
+
     hpx::supervision::publish_event(hpx::launch::sync, locality, target,
         hpx::supervision::event::completed);
 
@@ -690,8 +814,8 @@ void test_multiple_observers_same_target(hpx::id_type const& locality)
     HPX_TEST(received1);
     HPX_TEST(received2);
 
-    HPX_TEST_EQ(ctx1.get_callback_count(), 1);
-    HPX_TEST_EQ(ctx2.get_callback_count(), 1);
+    HPX_TEST_EQ(ctx1.get_callback_count(), 3);
+    HPX_TEST_EQ(ctx2.get_callback_count(), 3);
 
     hpx::supervision::unregister_observer(
         hpx::launch::sync, locality, observer_handle1);
@@ -702,10 +826,9 @@ void test_multiple_observers_same_target(hpx::id_type const& locality)
 // ============================================================================
 // Test Cases: Event Snapshot Delivery
 // ============================================================================
-
 void test_publish_delivers_its_own_event_snapshot(hpx::id_type const& locality)
 {
-    hpx::id_type const target = hpx::find_here();
+    hpx::id_type const target = make_test_target();
 
     std::atomic<bool> first_callback_entered{false};
     std::atomic<bool> release_first_callback{false};
@@ -818,7 +941,9 @@ void test_query_nonexistent_actor()
 
 void test_publish_no_observers(hpx::id_type const& locality)
 {
-    hpx::id_type const target = hpx::find_here();
+    hpx::id_type const target = make_test_target();
+
+    reach_completed(locality, target);
 
     // Publishing with no observers should not fail
     hpx::supervision::publish_event(hpx::launch::sync, locality, target,
@@ -832,7 +957,7 @@ void test_publish_no_observers(hpx::id_type const& locality)
 
 void test_rapid_event_sequence(hpx::id_type const& locality)
 {
-    hpx::id_type const target = hpx::find_here();
+    hpx::id_type const target = make_test_target();
 
     auto const observer_handle = hpx::supervision::register_observer(
         hpx::launch::sync, locality, target,
@@ -844,22 +969,31 @@ void test_rapid_event_sequence(hpx::id_type const& locality)
 
     g_test_context.reset();
 
-    // Publish events rapidly
+    // Publish events rapidly; this is a legal walk of the lifecycle diagram
+    // that also exercises the suspending <-> running resume edge.
     std::vector<hpx::supervision::event> const events = {
         hpx::supervision::event::started, hpx::supervision::event::running,
-        hpx::supervision::event::suspending, hpx::supervision::event::completed,
-        hpx::supervision::event::failed};
+        hpx::supervision::event::suspending, hpx::supervision::event::running,
+        hpx::supervision::event::completed};
 
     for (auto const event : events)
     {
-        hpx::supervision::publish_event(
+        auto const result = hpx::supervision::publish_event(
             hpx::launch::sync, locality, target, event);
+        HPX_TEST(result == hpx::supervision::publish_result::applied);
     }
+
+    // Once completed, the target's terminal state is latched: a further
+    // terminal publication is a no-op and delivers no notification.
+    auto const result = hpx::supervision::publish_event(
+        hpx::launch::sync, locality, target, hpx::supervision::event::failed);
+    HPX_TEST(result == hpx::supervision::publish_result::already_terminal);
 
     hpx::this_thread::sleep_for(std::chrono::milliseconds(20));
 
-    // All events should be recorded
-    HPX_TEST_EQ(g_test_context.get_callback_count(), 5);
+    // Only the non-latched events should be recorded
+    HPX_TEST_EQ(
+        g_test_context.get_callback_count(), static_cast<int>(events.size()));
 
     auto const observed = g_test_context.get_events();
     for (size_t i = 0; i < observed.size(); ++i)
@@ -873,7 +1007,7 @@ void test_rapid_event_sequence(hpx::id_type const& locality)
 
 void test_query_after_publication(hpx::id_type const& locality)
 {
-    hpx::id_type const target = hpx::find_here();
+    hpx::id_type const target = make_test_target();
 
     hpx::supervision::publish_event(
         hpx::launch::sync, locality, target, hpx::supervision::event::started);
@@ -885,12 +1019,225 @@ void test_query_after_publication(hpx::id_type const& locality)
     HPX_TEST(std::chrono::steady_clock::now() > state.timestamp);
 }
 
+// Miss case: querying a target for which no event has ever been recorded
+// must report a staleness error code through lifecycle_state::ec, without
+// the query call itself throwing or reporting failure through its own `ec`
+// out-parameter.
+void test_query_state_miss_returns_stale_state(hpx::id_type const& locality)
+{
+    hpx::id_type const target = make_test_target();
+
+    hpx::error_code ec;
+    auto const state =
+        hpx::supervision::query_state(hpx::launch::sync, locality, target, ec);
+    HPX_TEST(!ec);
+    HPX_TEST(state.last_event == hpx::supervision::event::unknown);
+    HPX_TEST(state.ec);
+    HPX_TEST(state.ec.value() == hpx::error::stale_state);
+}
+
+// Hit case (regression guard): once a target has a recorded event, querying
+// it must still report success through lifecycle_state::ec.
+void test_query_state_hit_returns_success(hpx::id_type const& locality)
+{
+    hpx::id_type const target = make_test_target();
+
+    hpx::supervision::publish_event(
+        hpx::launch::sync, locality, target, hpx::supervision::event::started);
+
+    hpx::error_code ec;
+    auto const state =
+        hpx::supervision::query_state(hpx::launch::sync, locality, target, ec);
+    HPX_TEST(!ec);
+    HPX_TEST(state.last_event == hpx::supervision::event::started);
+    HPX_TEST(!state.ec);
+    HPX_TEST(state.ec.value() == hpx::error::success);
+}
+
+// Sanity check: query_state() must remain safe to call concurrently with
+// publish_event() mutating the same target's recorded state.
+void test_query_state_concurrent_access(hpx::id_type const& locality)
+{
+    hpx::id_type const target = make_test_target();
+
+    hpx::supervision::publish_event(
+        hpx::launch::sync, locality, target, hpx::supervision::event::started);
+
+    std::atomic<bool> stop{false};
+    auto writer = hpx::async([&] {
+        while (!stop.load(std::memory_order_relaxed))
+        {
+            hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+                hpx::supervision::event::running);
+        }
+    });
+
+    std::vector<hpx::future<void>> readers;
+    for (int i = 0; i != 4; ++i)
+    {
+        readers.push_back(hpx::async([&] {
+            for (int j = 0; j != 200; ++j)
+            {
+                auto const state = hpx::supervision::query_state(
+                    hpx::launch::sync, locality, target);
+                HPX_TEST(state.last_event == hpx::supervision::event::started ||
+                    state.last_event == hpx::supervision::event::running);
+            }
+        }));
+    }
+
+    hpx::wait_all(readers);
+
+    stop.store(true, std::memory_order_relaxed);
+    writer.get();
+}
+
+// ============================================================================
+// Test Cases: Lifecycle Event Transition Validation
+// ============================================================================
+void test_illegal_transition_out_of_completed(hpx::id_type const& locality)
+{
+    hpx::id_type const target = make_test_target();
+
+    hpx::supervision::publish_event(
+        hpx::launch::sync, locality, target, hpx::supervision::event::started);
+    hpx::supervision::publish_event(
+        hpx::launch::sync, locality, target, hpx::supervision::event::running);
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+        hpx::supervision::event::completed);
+
+    // `completed` is terminal; no further transitions are legal.
+    hpx::error_code ec;
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+        hpx::supervision::event::running, ec);
+    HPX_TEST(ec);
+    HPX_TEST(ec.value() == hpx::error::bad_parameter);
+
+    // The rejected transition must not have modified the recorded state.
+    auto const state =
+        hpx::supervision::query_state(hpx::launch::sync, locality, target);
+    HPX_TEST(state.last_event == hpx::supervision::event::completed);
+}
+
+void test_illegal_transition_unknown_to_completed(hpx::id_type const& locality)
+{
+    hpx::id_type const target = make_test_target();
+
+    // The very first event recorded for a target must be `started`;
+    // jumping straight to `completed` is illegal.
+    hpx::error_code ec;
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+        hpx::supervision::event::completed, ec);
+    HPX_TEST(ec);
+    HPX_TEST(ec.value() == hpx::error::bad_parameter);
+
+    auto const state =
+        hpx::supervision::query_state(hpx::launch::sync, locality, target);
+    HPX_TEST(state.last_event == hpx::supervision::event::unknown);
+}
+
+void test_illegal_transitions_out_of_failed(hpx::id_type const& locality)
+{
+    hpx::id_type const target = make_test_target();
+
+    hpx::supervision::publish_event(
+        hpx::launch::sync, locality, target, hpx::supervision::event::started);
+    hpx::supervision::publish_event(
+        hpx::launch::sync, locality, target, hpx::supervision::event::failed);
+
+    // `failed` is terminal; every possible outgoing event is illegal.
+    for (auto const ev :
+        {hpx::supervision::event::started, hpx::supervision::event::running,
+            hpx::supervision::event::suspending,
+            hpx::supervision::event::losing_locality})
+    {
+        hpx::error_code ec;
+        hpx::supervision::publish_event(
+            hpx::launch::sync, locality, target, ev, ec);
+        HPX_TEST(ec);
+        HPX_TEST(ec.value() == hpx::error::bad_parameter);
+    }
+
+    auto const state =
+        hpx::supervision::query_state(hpx::launch::sync, locality, target);
+    HPX_TEST(state.last_event == hpx::supervision::event::failed);
+}
+
+void test_legal_transitions_suspending_running_resume(
+    hpx::id_type const& locality)
+{
+    hpx::id_type const target = make_test_target();
+
+    hpx::supervision::publish_event(
+        hpx::launch::sync, locality, target, hpx::supervision::event::started);
+    hpx::supervision::publish_event(
+        hpx::launch::sync, locality, target, hpx::supervision::event::running);
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+        hpx::supervision::event::suspending);
+
+    // Resume: suspending -> running is legal.
+    hpx::error_code ec;
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+        hpx::supervision::event::running, ec);
+    HPX_TEST(!ec);
+
+    // running -> suspending is legal as well.
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+        hpx::supervision::event::suspending, ec);
+    HPX_TEST(!ec);
+
+    auto const state =
+        hpx::supervision::query_state(hpx::launch::sync, locality, target);
+    HPX_TEST(state.last_event == hpx::supervision::event::suspending);
+}
+
+void test_legal_transition_losing_locality_to_failed(
+    hpx::id_type const& locality)
+{
+    // losing_locality is reachable from started, running, and suspending,
+    // and may only transition to failed.
+    std::vector<hpx::supervision::event> const precursors = {
+        hpx::supervision::event::started, hpx::supervision::event::running,
+        hpx::supervision::event::suspending};
+
+    for (auto const precursor : precursors)
+    {
+        hpx::id_type const target = make_test_target();
+
+        hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+            hpx::supervision::event::started);
+        if (precursor != hpx::supervision::event::started)
+        {
+            hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+                hpx::supervision::event::running);
+        }
+        if (precursor == hpx::supervision::event::suspending)
+        {
+            hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+                hpx::supervision::event::suspending);
+        }
+
+        hpx::error_code ec;
+        hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+            hpx::supervision::event::losing_locality, ec);
+        HPX_TEST(!ec);
+
+        hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+            hpx::supervision::event::failed, ec);
+        HPX_TEST(!ec);
+
+        auto const state =
+            hpx::supervision::query_state(hpx::launch::sync, locality, target);
+        HPX_TEST(state.last_event == hpx::supervision::event::failed);
+    }
+}
+
 // ============================================================================
 // Performance Tests
 // ============================================================================
 void test_observer_latency_local()
 {
-    hpx::id_type const target = hpx::find_here();
+    hpx::id_type const target = make_test_target();
 
     std::atomic<std::chrono::high_resolution_clock::time_point> callback_time;
 
@@ -900,9 +1247,11 @@ void test_observer_latency_local()
             callback_time.store(std::chrono::high_resolution_clock::now());
         });
 
+    hpx::supervision::publish_event(target, hpx::supervision::event::started);
+
     auto const publish_time = std::chrono::high_resolution_clock::now();
 
-    hpx::supervision::publish_event(target, hpx::supervision::event::completed);
+    hpx::supervision::publish_event(target, hpx::supervision::event::running);
 
     // Latency should be < 1ms for local observation
     auto const duration = callback_time.load() - publish_time;
@@ -913,12 +1262,14 @@ void test_observer_latency_local()
 
 void test_publication_throughput()
 {
-    hpx::id_type const target = hpx::find_here();
+    hpx::id_type const target = make_test_target();
 
     std::atomic<int> event_count{0};
     auto const observer_handle = hpx::supervision::register_observer(target,
         [&event_count](hpx::supervision::lifecycle_event_notification const&,
             hpx::error_code&) { event_count.fetch_add(1); });
+
+    hpx::supervision::publish_event(target, hpx::supervision::event::started);
 
     event_count.store(0);
 
@@ -966,10 +1317,8 @@ void print(T first, Args&&... rest)
 
 int hpx_main()
 {
-    // 2B.1 Tests
     for (auto const& locality : hpx::find_all_localities())
     {
-        HPX_TEST_RUN(test_publish_completion_local, locality);
         HPX_TEST_RUN(test_publish_completion_async, locality);
         HPX_TEST_RUN(test_publish_failed_state, locality);
 
@@ -984,6 +1333,7 @@ int hpx_main()
         HPX_TEST_RUN(test_sequence_numbers_no_gaps, locality);
         HPX_TEST_RUN(test_detect_connector_terminal, locality);
         HPX_TEST_RUN(test_error_does_not_stop_callbacks, locality);
+        HPX_TEST_RUN(test_duplicate_completion_is_latched, locality);
 
         HPX_TEST_RUN(test_unregister_waits_for_in_flight_callback, locality);
         HPX_TEST_RUN(test_unregister_observer_stops_callbacks, locality);
@@ -995,8 +1345,20 @@ int hpx_main()
         HPX_TEST_RUN(test_rapid_event_sequence, locality);
 
         HPX_TEST_RUN(test_query_after_publication, locality);
+
+        HPX_TEST_RUN(test_query_state_miss_returns_stale_state, locality);
+        HPX_TEST_RUN(test_query_state_hit_returns_success, locality);
+        HPX_TEST_RUN(test_query_state_concurrent_access, locality);
+
+        HPX_TEST_RUN(test_illegal_transition_out_of_completed, locality);
+        HPX_TEST_RUN(test_illegal_transition_unknown_to_completed, locality);
+        HPX_TEST_RUN(test_illegal_transitions_out_of_failed, locality);
+        HPX_TEST_RUN(
+            test_legal_transitions_suspending_running_resume, locality);
+        HPX_TEST_RUN(test_legal_transition_losing_locality_to_failed, locality);
     }
 
+    HPX_TEST_RUN(test_publish_completion);
     HPX_TEST_RUN(test_register_observer_keeps_initial_state_snapshot);
     HPX_TEST_RUN(test_query_nonexistent_actor);
     HPX_TEST_RUN(test_observer_latency_local);
@@ -1010,3 +1372,12 @@ int main(int argc, char* argv[])
     HPX_TEST_EQ(hpx::init(argc, argv), 0);
     return hpx::util::report_errors();
 }
+
+#else
+
+int main(int, char*[])
+{
+    return 0;
+}
+
+#endif

--- a/libs/full/supervision/tests/unit/supervision_api.cpp
+++ b/libs/full/supervision/tests/unit/supervision_api.cpp
@@ -11,7 +11,6 @@
 #include <hpx/supervision.hpp>
 
 #include <atomic>
-#include <condition_variable>
 #include <iostream>
 #include <mutex>
 #include <vector>
@@ -76,46 +75,6 @@ struct test_context
 
 // Global test context
 test_context g_test_context;
-
-// ============================================================================
-// Test Actions
-// ============================================================================
-
-//void publish_completed_action()
-//{
-//    hpx::supervision::publish_event(hpx::launch::sync, hpx::find_here(),
-//        hpx::supervision::event::completed);
-//}
-//HPX_PLAIN_ACTION(publish_completed_action);
-//
-//void publish_failed_action()
-//{
-//    hpx::supervision::publish_event(
-//        hpx::launch::sync, hpx::find_here(), hpx::supervision::event::failed);
-//}
-//HPX_PLAIN_ACTION(publish_failed_action);
-//
-//void publish_async_completed_action()
-//{
-//    hpx::supervision::publish_event(
-//        hpx::find_here(), hpx::supervision::event::completed)
-//        .wait();
-//}
-//HPX_PLAIN_ACTION(publish_async_completed_action);
-//
-//void publish_started_action()
-//{
-//    hpx::supervision::publish_event(
-//        hpx::launch::sync, hpx::find_here(), hpx::supervision::event::started);
-//}
-//HPX_PLAIN_ACTION(publish_started_action);
-//
-//void publish_running_action()
-//{
-//    hpx::supervision::publish_event(
-//        hpx::launch::sync, hpx::find_here(), hpx::supervision::event::running);
-//}
-//HPX_PLAIN_ACTION(publish_running_action);
 
 // ============================================================================
 // Test Cases: 2B.1 - Connector Publishes Explicit Completion
@@ -281,6 +240,123 @@ void test_register_observer(hpx::id_type const& locality)
         hpx::launch::sync, locality, observer_handle);
 }
 
+void test_register_observer_receives_existing_state(
+    hpx::id_type const& locality)
+{
+    hpx::id_type const target = hpx::find_here();
+
+    // Establish state before any observer exists.
+    hpx::supervision::publish_event(
+        hpx::launch::sync, locality, target, hpx::supervision::event::started);
+    auto const expected =
+        hpx::supervision::query_state(hpx::launch::sync, locality, target);
+
+    hpx::spinlock mtx;
+    std::vector<hpx::supervision::lifecycle_event_notification> received;
+
+    auto const observer_handle = hpx::supervision::register_observer(
+        hpx::launch::sync, locality, target,
+        [&](hpx::supervision::lifecycle_event_notification const& notification,
+            hpx::error_code&) {
+            std::scoped_lock<hpx::spinlock> l(mtx);
+            received.push_back(notification);
+        });
+
+    // register_observer synchronously waits for its initial delivery.
+    {
+        std::scoped_lock<hpx::spinlock> l(mtx);
+        HPX_TEST_EQ(received.size(), static_cast<std::size_t>(1));
+
+        auto const& notification = received.front();
+        HPX_TEST_EQ(notification.actor, target);
+        HPX_TEST(notification.event == hpx::supervision::event::started);
+        HPX_TEST_EQ(
+            notification.event_sequence_number, expected.event_sequence_number);
+        HPX_TEST(notification.event_time == expected.timestamp);
+        HPX_TEST(notification.ec == expected.ec);
+    }
+
+    hpx::supervision::unregister_observer(
+        hpx::launch::sync, locality, observer_handle);
+}
+
+void test_register_observer_keeps_initial_state_snapshot()
+{
+    hpx::id_type const target = hpx::find_here();
+
+    hpx::supervision::publish_event(target, hpx::supervision::event::started);
+
+    auto const initial_state = hpx::supervision::query_state(target);
+
+    std::atomic<bool> snapshot_taken{false};
+    std::atomic<bool> continue_registration{false};
+    hpx::spinlock received_mtx;
+    std::vector<hpx::supervision::lifecycle_event_notification> received;
+
+    hpx::supervision::server::detail::set_register_observer_snapshot_hook([&] {
+        snapshot_taken.store(true);
+        while (!continue_registration.load())
+        {
+            hpx::this_thread::yield();
+        }
+    });
+
+    auto clear_hook = hpx::experimental::scope_exit([] {
+        hpx::supervision::server::detail::set_register_observer_snapshot_hook(
+            {});
+    });
+
+    auto registration = hpx::async([&] {
+        return hpx::supervision::register_observer(target,
+            [&](hpx::supervision::lifecycle_event_notification const& n,
+                hpx::error_code&) {
+                std::scoped_lock<hpx::spinlock> l(received_mtx);
+                received.push_back(n);
+            });
+    });
+
+    while (!snapshot_taken.load())
+    {
+        hpx::this_thread::yield();
+    }
+
+    // This replaces the manager's current state while registration is paused.
+    hpx::supervision::publish_event(target, hpx::supervision::event::running);
+
+    continue_registration.store(true);
+    auto const observer_handle = registration.get();
+
+    {
+        std::scoped_lock<hpx::spinlock> l(received_mtx);
+        HPX_TEST_EQ(received.size(), static_cast<std::size_t>(2));
+
+        bool saw_initial_snapshot = false;
+        bool saw_running_publication = false;
+
+        for (auto const& notification : received)
+        {
+            if (notification.event == hpx::supervision::event::started &&
+                notification.event_sequence_number ==
+                    initial_state.event_sequence_number)
+            {
+                saw_initial_snapshot = true;
+            }
+
+            if (notification.event == hpx::supervision::event::running &&
+                notification.event_sequence_number ==
+                    initial_state.event_sequence_number + 1)
+            {
+                saw_running_publication = true;
+            }
+        }
+
+        HPX_TEST(saw_initial_snapshot);
+        HPX_TEST(saw_running_publication);
+    }
+
+    hpx::supervision::unregister_observer(observer_handle);
+}
+
 // ============================================================================
 // Test Cases: 2B.3 - Root Observes Failure Without External Witness
 // ============================================================================
@@ -435,7 +511,7 @@ void test_error_does_not_stop_callbacks(hpx::id_type const& locality)
     auto const observer_handle2 = hpx::supervision::register_observer(
         hpx::launch::sync, locality, target,
         [](hpx::supervision::lifecycle_event_notification const& notification,
-            hpx::error_code& ec) {
+            hpx::error_code&) {
             g_test_context.record_event(
                 notification.actor, notification.event, notification.ec);
         });
@@ -454,11 +530,11 @@ void test_error_does_not_stop_callbacks(hpx::id_type const& locality)
 
     auto const& events = g_test_context.get_events();
     HPX_TEST(events[0] == hpx::supervision::event::completed);
-    HPX_TEST(events[1] == hpx::supervision::event::failed);
+    HPX_TEST(events[1] == hpx::supervision::event::completed);
 
     auto const& errors = g_test_context.get_errors();
     HPX_TEST(errors[0] == hpx::make_success_code());
-    HPX_TEST(errors[1].value() == hpx::error::no_success);
+    HPX_TEST(errors[1] == hpx::make_success_code());
 
     // Query to confirm failed state
     auto const state =
@@ -477,6 +553,64 @@ void test_error_does_not_stop_callbacks(hpx::id_type const& locality)
 // ============================================================================
 // Test Cases: Unregister Observer
 // ============================================================================
+void test_unregister_waits_for_in_flight_callback(hpx::id_type const& locality)
+{
+    hpx::id_type const target = hpx::find_here();
+
+    std::atomic<bool> callback_entered{false};
+    std::atomic<bool> release_callback{false};
+    std::atomic<int> callback_count{0};
+    std::atomic<bool> block_callbacks{false};
+
+    auto const observer_handle =
+        hpx::supervision::register_observer(hpx::launch::sync, locality, target,
+            [&](hpx::supervision::lifecycle_event_notification const&,
+                hpx::error_code&) {
+                ++callback_count;
+                if (block_callbacks.load())
+                {
+                    callback_entered.store(true);
+                    while (!release_callback.load())
+                    {
+                        hpx::this_thread::yield();
+                    }
+                }
+            });
+
+    // Registration may synchronously deliver the state left by an earlier test.
+    // Do not let that initial delivery participate in this test.
+    callback_count.store(0);
+    callback_entered.store(false);
+    block_callbacks.store(true);
+
+    auto publication = hpx::async([&] {
+        hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+            hpx::supervision::event::started);
+    });
+
+    while (!callback_entered.load())
+    {
+        hpx::this_thread::yield();
+    }
+
+    auto unregistration = hpx::async([&] {
+        hpx::supervision::unregister_observer(
+            hpx::launch::sync, locality, observer_handle);
+    });
+
+    // unregister must wait until the callback already in progress completes.
+    HPX_TEST(!unregistration.is_ready());
+
+    release_callback.store(true);
+    unregistration.get();
+    publication.get();
+
+    // After unregister returns, no later publication may invoke the callback.
+    hpx::supervision::publish_event(
+        hpx::launch::sync, locality, target, hpx::supervision::event::running);
+    HPX_TEST_EQ(callback_count.load(), 1);
+}
+
 void test_unregister_observer_stops_callbacks(hpx::id_type const& locality)
 {
     hpx::id_type const target = hpx::find_here();
@@ -484,7 +618,7 @@ void test_unregister_observer_stops_callbacks(hpx::id_type const& locality)
     auto const observer_handle = hpx::supervision::register_observer(
         hpx::launch::sync, locality, target,
         [](hpx::supervision::lifecycle_event_notification const& notification,
-            hpx::error_code& ec) {
+            hpx::error_code&) {
             g_test_context.record_event(
                 notification.actor, notification.event, notification.ec);
         });
@@ -528,7 +662,7 @@ void test_multiple_observers_same_target(hpx::id_type const& locality)
         hpx::launch::sync, locality, target,
         [&ctx1](
             hpx::supervision::lifecycle_event_notification const& notification,
-            hpx::error_code& ec) {
+            hpx::error_code&) {
             ctx1.record_event(
                 notification.actor, notification.event, notification.ec);
         });
@@ -537,7 +671,7 @@ void test_multiple_observers_same_target(hpx::id_type const& locality)
         hpx::launch::sync, locality, target,
         [&ctx2](
             hpx::supervision::lifecycle_event_notification const& notification,
-            hpx::error_code& ec) {
+            hpx::error_code&) {
             ctx2.record_event(
                 notification.actor, notification.event, notification.ec);
         });
@@ -563,6 +697,111 @@ void test_multiple_observers_same_target(hpx::id_type const& locality)
         hpx::launch::sync, locality, observer_handle1);
     hpx::supervision::unregister_observer(
         hpx::launch::sync, locality, observer_handle2);
+}
+
+// ============================================================================
+// Test Cases: Event Snapshot Delivery
+// ============================================================================
+
+void test_publish_delivers_its_own_event_snapshot(hpx::id_type const& locality)
+{
+    hpx::id_type const target = hpx::find_here();
+
+    std::atomic<bool> first_callback_entered{false};
+    std::atomic<bool> release_first_callback{false};
+    std::atomic<int> blocker_invocations{0};
+    std::atomic<bool> block_first_delivery{false};
+
+    // The first observer blocks only the first publication. This lets the
+    // second publication update states_[target] before the first publication
+    // reaches the recorder below.
+    auto const blocker =
+        hpx::supervision::register_observer(hpx::launch::sync, locality, target,
+            [&](hpx::supervision::lifecycle_event_notification const&,
+                hpx::error_code&) {
+                if (block_first_delivery.load() &&
+                    blocker_invocations.fetch_add(1) == 0)
+                {
+                    first_callback_entered.store(true);
+                    while (!release_first_callback.load())
+                    {
+                        hpx::this_thread::yield();
+                    }
+                }
+            });
+
+    hpx::spinlock received_mtx;
+    std::vector<hpx::supervision::lifecycle_event_notification> received;
+
+    auto const recorder = hpx::supervision::register_observer(hpx::launch::sync,
+        locality, target,
+        [&](hpx::supervision::lifecycle_event_notification const& notification,
+            hpx::error_code&) {
+            std::scoped_lock<hpx::spinlock> l(received_mtx);
+            received.push_back(notification);
+        });
+
+    // Both registrations may have synchronously delivered the state retained
+    // from earlier tests. Start the controlled race from a clean baseline.
+    {
+        std::scoped_lock<hpx::spinlock> l(received_mtx);
+        received.clear();
+    }
+
+    blocker_invocations.store(0);
+    first_callback_entered.store(false);
+    block_first_delivery.store(true);
+
+    auto first_publication = hpx::async([&] {
+        hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+            hpx::supervision::event::started);
+    });
+
+    while (!first_callback_entered.load())
+    {
+        hpx::this_thread::yield();
+    }
+
+    // This updates the manager state while the first delivery is paused.
+    hpx::supervision::publish_event(
+        hpx::launch::sync, locality, target, hpx::supervision::event::running);
+
+    release_first_callback.store(true);
+    first_publication.get();
+
+    {
+        std::scoped_lock<hpx::spinlock> l(received_mtx);
+        HPX_TEST_EQ(received.size(), static_cast<std::size_t>(2));
+
+        // Delivery order is intentionally not asserted. What matters is that
+        // both distinct publications retain their own event snapshots.
+        bool saw_started = false;
+        bool saw_running = false;
+        std::uint64_t started_sequence = 0;
+        std::uint64_t running_sequence = 0;
+
+        for (auto const& notification : received)
+        {
+            if (notification.event == hpx::supervision::event::started)
+            {
+                saw_started = true;
+                started_sequence = notification.event_sequence_number;
+            }
+            else if (notification.event == hpx::supervision::event::running)
+            {
+                saw_running = true;
+                running_sequence = notification.event_sequence_number;
+            }
+        }
+
+        HPX_TEST(saw_started);
+        HPX_TEST(saw_running);
+        HPX_TEST_LT(started_sequence, running_sequence);
+    }
+
+    hpx::supervision::unregister_observer(
+        hpx::launch::sync, locality, recorder);
+    hpx::supervision::unregister_observer(hpx::launch::sync, locality, blocker);
 }
 
 // ============================================================================
@@ -598,7 +837,7 @@ void test_rapid_event_sequence(hpx::id_type const& locality)
     auto const observer_handle = hpx::supervision::register_observer(
         hpx::launch::sync, locality, target,
         [](hpx::supervision::lifecycle_event_notification const& notification,
-            hpx::error_code& ec) {
+            hpx::error_code&) {
             g_test_context.record_event(
                 notification.actor, notification.event, notification.ec);
         });
@@ -702,124 +941,6 @@ void test_publication_throughput()
     hpx::supervision::unregister_observer(observer_handle);
 }
 
-#if 0
-// ============================================================================
-// Test Cases: Observer Staleness Detection
-// ============================================================================
-void test_observer_staleness_detection()
-{
-    std::vector<hpx::id_type> const localities = hpx::find_all_localities();
-
-    if (localities.size() < 2)
-    {
-        HPX_TEST_MSG(false, "Test requires at least 2 localities");
-        return;
-    }
-
-    hpx::id_type remote_locality = localities[1];
-
-    // Register observer from non-owner locality
-    std::atomic<bool> observer_registered{false};
-    auto const observer_handle =
-        hpx::supervision::register_observer(hpx::launch::sync, remote_locality,
-            [&observer_registered](hpx::id_type actor,
-                hpx::supervision::event event, hpx::error_code& ec) {
-                if (!ec)
-                {
-                    observer_registered.store(true);
-                }
-            });
-
-    // Query state - may indicate staleness if observer hasn't synced
-    auto const state =
-        hpx::supervision::query_state(hpx::launch::sync, remote_locality);
-
-    // If observer_staleness is set, it indicates the remote observer
-    // may not have latest state
-    if (state.observer_staleness)
-    {
-        HPX_TEST_MSG(
-            true, "Observer staleness detected and reported correctly");
-    }
-
-    hpx::supervision::unregister_observer(hpx::launch::sync, observer_handle);
-}
-
-// ============================================================================
-// Test Cases: Bulk Observation (Locality-Level)
-// ============================================================================
-void test_bulk_observe_locality_completions()
-{
-    hpx::id_type const locality = hpx::find_here();
-
-    std::atomic<int> summary_count{0};
-    std::atomic<uint64_t> last_version{0};
-
-    auto const observer_handle =
-        hpx::supervision::observe_locality_completions(locality,
-            [&summary_count, &last_version](
-                hpx::supervision::locality_completion_summary const& summary,
-                hpx::error_code& ec) {
-                if (!ec)
-                {
-                    summary_count.fetch_add(1);
-                    last_version.store(summary.summary_version);
-                }
-            });
-
-    HPX_TEST_NEQ(observer_handle, hpx::invalid_id);
-
-    // Publish multiple events
-    hpx::supervision::publish_event(
-        hpx::launch::sync, locality, hpx::supervision::event::started);
-    hpx::supervision::publish_event(
-        hpx::launch::sync, locality, hpx::supervision::event::running);
-
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
-
-    // Should receive updates for each event
-    HPX_TEST_GT(summary_count.load(), 0);
-    HPX_TEST_GT(last_version.load(), 0u);
-
-    hpx::supervision::unregister_observer(hpx::launch::sync, observer_handle);
-}
-
-void test_bulk_observe_version_increments()
-{
-    hpx::id_type const locality = hpx::find_here();
-
-    std::vector<uint64_t> versions;
-
-    auto const observer_handle =
-        hpx::supervision::observe_locality_completions(locality,
-            [&versions](
-                hpx::supervision::locality_completion_summary const& summary,
-                hpx::error_code& ec) {
-                if (!ec)
-                {
-                    versions.push_back(summary.summary_version);
-                }
-            });
-
-    // Publish multiple events
-    for (int i = 0; i < 3; ++i)
-    {
-        hpx::supervision::publish_event(
-            hpx::launch::sync, locality, hpx::supervision::event::running);
-    }
-
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
-
-    // Versions should increment
-    for (size_t i = 1; i < versions.size(); ++i)
-    {
-        HPX_TEST_GT(versions[i], versions[i - 1]);
-    }
-
-    hpx::supervision::unregister_observer(hpx::launch::sync, observer_handle);
-}
-#endif
-
 // ============================================================================
 // Main Test Entry Point
 // ============================================================================
@@ -855,6 +976,7 @@ int hpx_main()
         HPX_TEST_RUN(test_register_observer_local_completion, locality);
         HPX_TEST_RUN(test_register_observer_multiple_events, locality);
         HPX_TEST_RUN(test_register_observer, locality);
+        HPX_TEST_RUN(test_register_observer_receives_existing_state, locality);
 
         HPX_TEST_RUN(test_observe_failure_detection, locality);
 
@@ -863,8 +985,10 @@ int hpx_main()
         HPX_TEST_RUN(test_detect_connector_terminal, locality);
         HPX_TEST_RUN(test_error_does_not_stop_callbacks, locality);
 
+        HPX_TEST_RUN(test_unregister_waits_for_in_flight_callback, locality);
         HPX_TEST_RUN(test_unregister_observer_stops_callbacks, locality);
         HPX_TEST_RUN(test_multiple_observers_same_target, locality);
+        HPX_TEST_RUN(test_publish_delivers_its_own_event_snapshot, locality);
 
         HPX_TEST_RUN(test_publish_no_observers, locality);
 
@@ -873,16 +997,10 @@ int hpx_main()
         HPX_TEST_RUN(test_query_after_publication, locality);
     }
 
+    HPX_TEST_RUN(test_register_observer_keeps_initial_state_snapshot);
     HPX_TEST_RUN(test_query_nonexistent_actor);
     HPX_TEST_RUN(test_observer_latency_local);
     HPX_TEST_RUN(test_publication_throughput);
-
-#if 0
-    HPX_TEST_RUN(test_observer_staleness_detection);
-
-    HPX_TEST_RUN(test_bulk_observe_locality_completions);
-    HPX_TEST_RUN(test_bulk_observe_version_increments);
-#endif
 
     return hpx::finalize();
 }


### PR DESCRIPTION
This PR adds a full HPX Supervision module — infrastructure for tracking actor/component lifecycle state and notifying interested observers, both locally and across localities. Key functionality added:

#### Core supervision contracts (libs/full/supervision/...supervision_api.hpp, supervision_fwd.hpp) 

- New `hpx::supervision::event` enum: `unknown`, `started`, `running`, `suspending`, `completed`, `failed`, `losing_locality`, with `completed`/`failed` marked as terminal (`is_terminal()`).
- `publish_result` enum (`applied`, `already_terminal`, `stale_epoch`) describing the outcome of publishing a lifecycle event.
- Public API functions: `publish_event`, `query_state`, `register_observer`, `unregister_observer` - each with async, sync (hpx::launch::sync_policy), and local-vs-remote overloads.
- Epoch-based ordering semantics: publications carry an epoch/sequence number; stale epochs are rejected, higher epochs reset state, and terminal events are latched (first terminal event wins, later ones are no-ops).

#### Server-side implementation (agent_server.cpp, supervision_manager_server.cpp)

- An "agent" server component that stores per-target lifecycle state and delivers events to registered observer callbacks.
- A supervision manager server component handling observer registration/unregistration, event recording, error tracking, and remote delivery via AGAS/parcels.
- Component action wiring for these operations so they're callable across localities.

#### Public API dispatch layer (supervision.cpp, supervision_manager.cpp)

- Routes public API calls to either a fast local path or a remote action invocation depending on target locality.
- A supervision_manager wrapper class delegating to the server implementation.

#### Error handling integration (errors/..., serialization/error_code.hpp)

- New/extended error categories and throw-mode handling to support supervision-specific errors.
- Serialization support added for `hpx::error_code`, so error codes can be transmitted between localities (needed for reporting failures over the network).
- New component type and preassigned action IDs registered for supervision components.

#### Runtime integration (runtime_distributed.cpp, pre_main.cpp, addressing_service.cpp, runtime_support_server.cpp)

- The HPX runtime now owns and manages a supervision manager instance: it's created/registered during startup (pre_main) and cleaned up during shutdown.
- AGAS and runtime-support integration so supervision state ties into locality/component lifecycle management.

#### Build, docs, and tests

- New CMake module wiring (libs/full/supervision/CMakeLists.txt and subdirectories) integrating the module into the build, plus an entry in modules.rst.
- Documentation (docs/index.rst) describing the supervision API and concepts.
- Unit tests (supervision_api.cpp) exercising publish/query/register/unregister flows, epoch semantics, and terminal-state latching.
- Unit tests for the new error_code serialization (serialization_error_code.cpp).

Summary: The PR delivers an end-to-end supervision subsystem - a lifecycle-event pub/sub mechanism with observer registration, epoch-ordered/terminal-latched delivery semantics, local and distributed dispatch, runtime lifecycle ownership, error-code network serialization, and accompanying build/doc/test coverage.

- attempt to address #7390
- flyby: fixing problem in hpx::error_code constructor

@taless474 This is a first sketch for the basic functionalities you described in slice 2B.