### PR TITLE
Tracing inline future continuations

### DIFF
--- a/libs/core/futures/src/future_data.cpp
+++ b/libs/core/futures/src/future_data.cpp
@@ -16,6 +16,7 @@
 #include <hpx/modules/functional.hpp>
 #include <hpx/modules/logging.hpp>
 #include <hpx/modules/memory.hpp>
+#include <hpx/modules/tracing.hpp>
 
 #include <cstddef>
 #include <exception>
@@ -251,6 +252,8 @@ namespace hpx::lcos::detail {
     template <typename Callback>
     void handle_on_completed_impl(Callback&& on_completed)
     {
+        HPX_TRACING_MARK_EVENT("future::handle_on_completed");
+
         // We need to run the completion on a new thread if we are on a non HPX
         // thread.
         bool const is_hpx_thread = nullptr != hpx::threads::get_self_ptr();


### PR DESCRIPTION


### Proposed Changes
- Added `HPX_TRACING_MARK_EVENT("future::handle_on_completed")` inside `handle_on_completed_impl` in `libs/core/futures/src/future_data.cpp`.
- Included `<hpx/modules/tracing.hpp>` in the futures module to route the annotation to the active profiling backend.

### Any background context you want to provide?
This is a direct follow-up to PR #7392 (Tracing data parallel workloads). 

While #7392 addressed the execution of data payloads, this PR eliminates another major blind spot in the profiler: inline future continuations. When a future is fulfilled, attached continuations (like `.then(...)`) often run "inline" on the fulfilling thread to avoid context switching overhead. Previously, these executions blended invisibly into whatever parent task happened to be running. 

By wrapping the user's callback invocation, we ensure that inline continuations are tracked as distinct, explicit profiling spans in Tracy. This is a critical prerequisite for tackling Causal Tracing (Wake Chains) in the next phase.

### Checklist
- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
