### PR TITLE
 Make MPI parcelport teardown orderly: quiesce before MPI_Finalize

### DIFF
--- a/libs/core/mpi_base/src/mpi_environment.cpp
+++ b/libs/core/mpi_base/src/mpi_environment.cpp
@@ -321,19 +321,28 @@ namespace hpx::util {
             MPI_Finalized(&is_finalized);
             if (!is_finalized)
             {
-                // Synchronize entry into MPI_Finalize across all ranks. The
-                // runtime shuts down independently on every locality, so
-                // ranks reach this point at noticeably different times.
-                // Entering MPI_Finalize while peers are still communicating
-                // exposes teardown races in the underlying MPI
-                // implementation (observed with Open MPI's btl/uct: fatal
-                // UD endpoint timeouts while a rank that is already inside
-                // MPI_Finalize processes a peer's late connection request).
-                // A barrier immediately before MPI_Finalize lets every rank
-                // finish its outstanding traffic while all peers still
-                // progress normally. Any error is ignored: proceeding to
-                // MPI_Finalize is the best remaining option either way.
-                [[maybe_unused]] int const ret = MPI_Barrier(communicator_);
+                if (communicator_ != MPI_COMM_NULL)
+                {
+                    // Synchronize entry into MPI_Finalize across all ranks.
+                    // The runtime shuts down independently on every
+                    // locality, so ranks reach this point at noticeably
+                    // different times. Entering MPI_Finalize while peers
+                    // are still communicating exposes teardown races in
+                    // the underlying MPI implementation (observed with
+                    // Open MPI's btl/uct: fatal UD endpoint timeouts while
+                    // a rank that is already inside MPI_Finalize processes
+                    // a peer's late connection request). A barrier
+                    // immediately before MPI_Finalize lets every rank
+                    // finish its outstanding traffic while all peers still
+                    // progress normally. Any error is ignored: proceeding
+                    // to MPI_Finalize is the best remaining option either
+                    // way.
+                    [[maybe_unused]] int const ret = MPI_Barrier(communicator_);
+
+                    // Release the duplicated communicator before
+                    // MPI_Finalize reclaims the remaining MPI state.
+                    MPI_Comm_free(&communicator_);
+                }
 
                 MPI_Finalize();
             }

--- a/libs/core/mpi_base/src/mpi_environment.cpp
+++ b/libs/core/mpi_base/src/mpi_environment.cpp
@@ -321,6 +321,20 @@ namespace hpx::util {
             MPI_Finalized(&is_finalized);
             if (!is_finalized)
             {
+                // Synchronize entry into MPI_Finalize across all ranks. The
+                // runtime shuts down independently on every locality, so
+                // ranks reach this point at noticeably different times.
+                // Entering MPI_Finalize while peers are still communicating
+                // exposes teardown races in the underlying MPI
+                // implementation (observed with Open MPI's btl/uct: fatal
+                // UD endpoint timeouts while a rank that is already inside
+                // MPI_Finalize processes a peer's late connection request).
+                // A barrier immediately before MPI_Finalize lets every rank
+                // finish its outstanding traffic while all peers still
+                // progress normally. Any error is ignored: proceeding to
+                // MPI_Finalize is the best remaining option either way.
+                [[maybe_unused]] int const ret = MPI_Barrier(communicator_);
+
                 MPI_Finalize();
             }
         }

--- a/libs/full/parcelport_mpi/include/hpx/parcelport_mpi/receiver.hpp
+++ b/libs/full/parcelport_mpi/include/hpx/parcelport_mpi/receiver.hpp
@@ -47,6 +47,30 @@ namespace hpx::parcelset::policies::mpi {
             post_new_header(l);
         }
 
+        void stop() noexcept
+        {
+            // Cancel the permanently re-posted wildcard header receive.
+            // Leaving it pending would let MPI_Finalize run with an active
+            // request on the communicator, which the MPI standard does not
+            // allow and which leaves live receive state for the MPI library
+            // to trip over during teardown. Errors are ignored: this runs
+            // directly before MPI is finalized anyway.
+            int is_finalized = 0;
+            MPI_Finalized(&is_finalized);
+            if (is_finalized)
+            {
+                return;
+            }
+
+            util::mpi_environment::scoped_lock l;
+            if (hdr_posted_)
+            {
+                hdr_posted_ = false;
+                MPI_Cancel(&hdr_request_);
+                MPI_Wait(&hdr_request_, MPI_STATUS_IGNORE);
+            }
+        }
+
         bool background_work() noexcept
         {
             // We first try to accept a new connection
@@ -146,12 +170,14 @@ namespace hpx::parcelset::policies::mpi {
                 &hdr_request_);
             util::mpi_environment::check_mpi_error(
                 l, HPX_CURRENT_SOURCE_LOCATION(), ret);
+            hdr_posted_ = true;
         }
 
         Parcelport& pp_;
 
         hpx::spinlock headers_mtx_;
         MPI_Request hdr_request_;
+        bool hdr_posted_ = false;
         std::vector<char> header_buffer_;
 
         hpx::spinlock connections_mtx_;

--- a/libs/full/parcelport_mpi/include/hpx/parcelport_mpi/receiver.hpp
+++ b/libs/full/parcelport_mpi/include/hpx/parcelport_mpi/receiver.hpp
@@ -62,6 +62,15 @@ namespace hpx::parcelset::policies::mpi {
                 return;
             }
 
+            // Serialize against any late header polling. accept_locked()
+            // and its re-post of the header receive run under headers_mtx_,
+            // so holding it here gives stop() exclusive ownership of
+            // hdr_request_ and hdr_posted_ in all MPI threading modes (the
+            // mpi_environment lock alone is a no-op for multithreaded MPI).
+            // Lock order matches accept(): headers_mtx_ first, then the
+            // MPI serialization lock.
+            std::unique_lock const header_lock(headers_mtx_);
+
             util::mpi_environment::scoped_lock l;
             if (hdr_posted_)
             {

--- a/libs/full/parcelport_mpi/src/parcelport_mpi.cpp
+++ b/libs/full/parcelport_mpi/src/parcelport_mpi.cpp
@@ -175,6 +175,7 @@ namespace hpx::parcelset {
 
             ~parcelport() override
             {
+                receiver_.stop();
                 util::mpi_environment::finalize();
             }
 


### PR DESCRIPTION
## Proposed Changes

  - Synchronize entry into `MPI_Finalize` with a barrier in
    `mpi_environment::finalize()`: `do_stop()` already drains and barriers,
    but the destructor runs `MPI_Finalize` much later, so ranks entered
    Open MPI's teardown at noticeably different times.
  - Cancel the permanently re-posted wildcard header receive before
    finalizing - we used to enter `MPI_Finalize` with an active request,
    which the MPI standard does not allow.
  - Release the duplicated communicator before `MPI_Finalize`.

## Any background context you want to provide?

Addresses the intermittent shutdown segfaults of MPI-parcelport tests on
rostam (e.g. https://cdash.rostam.cct.lsu.edu/test/67322319,
https://cdash.rostam.cct.lsu.edu/test/67322335). Every stack dies inside
`ompi_mpi_finalize` -> `mca_btl_uct_process_connection_request` with a fatal
UCX UD endpoint timeout: a rank already inside `MPI_Finalize` is still
processing a peer's late connection request. These changes close that window:
complete or cancel everything outstanding, then enter `MPI_Finalize` together.

All 45 collectives tests pass over the MPI parcelport locally (Open MPI
5.0.9); the two tests that crash on rostam pass 10 consecutive runs each.
Caveat: local runs use the sm/tcp BTLs, not rostam's ib/uct path, so this
hardens teardown from the crash stacks rather than reproducing the crash.
Separately measured support: pinning `OMPI_MCA_btl=self,tcp` at 16 nodes
turned repeated finalize crashes into 200/200 clean runs, pointing at uct
teardown as the crash site.

## Checklist

Not all points below apply to all pull requests.

- [ ] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.