### PR TITLE
Let the OS pick the parcelport port in the departed locality test

### DIFF
--- a/libs/full/agas/tests/regressions/departed_locality_7384.cpp
+++ b/libs/full/agas/tests/regressions/departed_locality_7384.cpp
@@ -20,10 +20,12 @@
 #include <hpx/modules/testing.hpp>
 
 #include <hpx/agas/addressing_service.hpp>
+#include <hpx/asio/asio_util.hpp>
 
 #include <algorithm>
 #include <chrono>
 #include <cstddef>
+#include <cstdint>
 #include <iterator>
 #include <string>
 #include <system_error>
@@ -55,6 +57,51 @@ std::vector<std::string> get_environment()
 #error "Don't know, how to access the execution environment on this platform"
 #endif
     return env;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Return a TCP port on the given address that is unused right now.
+//
+// The launched locality needs a parcelport port of its own. Deriving that port
+// from a fixed constant collides with whatever else happens to hold it: a
+// concurrent test run, an unrelated HPX application, or a socket still
+// lingering in TIME_WAIT. Worse, the collision is never diagnosed: the launched
+// locality simply cannot bind, so this test hangs until it is killed rather
+// than failing. Let the operating system name a free port instead.
+//
+// The port is claimed the same way the TCP parcelport claims its own acceptor,
+// so whatever is returned here is a port the launched locality can bind in
+// turn.
+std::uint16_t get_unused_port(std::string const& address)
+{
+    ::asio::io_context io_service;
+
+    for (auto it = hpx::util::accept_begin(address, 0, io_service);
+        it != hpx::util::accept_end(); ++it)
+    {
+        std::error_code ec;
+        ::asio::ip::tcp::endpoint const ep = *it;
+        ::asio::ip::tcp::acceptor acceptor(io_service);
+
+        acceptor.open(ep.protocol(), ec);
+        if (ec)
+            continue;
+
+        acceptor.set_option(::asio::ip::tcp::acceptor::reuse_address(true), ec);
+        if (ec)
+            continue;
+
+        acceptor.bind(ep, ec);
+        if (ec)
+            continue;
+
+        // the acceptor is closed again on the way out, releasing the port for
+        // the launched locality to pick up
+        return acceptor.local_endpoint().port();
+    }
+
+    HPX_THROW_EXCEPTION(hpx::error::network_error, "get_unused_port",
+        "failed to find an unused port on {}", address);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -100,14 +147,11 @@ int hpx_main(hpx::program_options::variables_map& vm)
         hpx::get_config_entry(
             "hpx.agas.port", std::to_string(HPX_INITIAL_IP_PORT)));
 
-    // The launched executable will run on the same host as this test. Each
-    // launched HPX locality needs to be assigned a unique port (the
-    // launch_process test uses 42).
-    int const port = 43;
-
+    // the launched executable runs on the same host as this test, so give it a
+    // parcelport port that is known to be free at this moment
     env.push_back("HPX_PARCEL_SERVER_ADDRESS=" + address);
-    env.push_back("HPX_PARCEL_SERVER_PORT=" +
-        std::to_string(HPX_CONNECTING_IP_PORT - port));
+    env.push_back(
+        "HPX_PARCEL_SERVER_PORT=" + std::to_string(get_unused_port(address)));
 
     // instruct new locality to connect back on startup using the given name
     env.push_back("HPX_ON_STARTUP_WAIT_ON_LATCH=departed_locality_7384");

--- a/libs/full/agas/tests/regressions/departed_locality_7384.cpp
+++ b/libs/full/agas/tests/regressions/departed_locality_7384.cpp
@@ -70,8 +70,11 @@ std::vector<std::string> get_environment()
 // than failing. Let the operating system name a free port instead.
 //
 // The port is claimed the same way the TCP parcelport claims its own acceptor,
-// so whatever is returned here is a port the launched locality can bind in
-// turn.
+// so the probe rejects anything the launched locality could not bind either.
+// The probe cannot reserve it, though: the port is released before the child
+// starts, so a small window remains in which another process could take it.
+// Closing that window would require the parcelport to bind port 0 and report
+// the port it actually got, which it does not do.
 std::uint16_t get_unused_port(std::string const& address)
 {
     ::asio::io_context io_service;

--- a/libs/full/agas/tests/regressions/departed_locality_7384.cpp
+++ b/libs/full/agas/tests/regressions/departed_locality_7384.cpp
@@ -89,9 +89,13 @@ int hpx_main(hpx::program_options::variables_map& vm)
     // set up environment for the launched executable
     std::vector<std::string> env = get_environment();    // current environment
 
+    // the launched locality talks to this locality's AGAS server and runs its
+    // own parcelport on the same host
+    std::string const address =
+        hpx::get_config_entry("hpx.agas.address", HPX_INITIAL_IP_ADDRESS);
+
     // pass along the console parcelport address
-    env.push_back("HPX_AGAS_SERVER_ADDRESS=" +
-        hpx::get_config_entry("hpx.agas.address", HPX_INITIAL_IP_ADDRESS));
+    env.push_back("HPX_AGAS_SERVER_ADDRESS=" + address);
     env.push_back("HPX_AGAS_SERVER_PORT=" +
         hpx::get_config_entry(
             "hpx.agas.port", std::to_string(HPX_INITIAL_IP_PORT)));
@@ -101,8 +105,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
     // launch_process test uses 42).
     int const port = 43;
 
-    env.push_back("HPX_PARCEL_SERVER_ADDRESS=" +
-        hpx::get_config_entry("hpx.agas.address", HPX_INITIAL_IP_ADDRESS));
+    env.push_back("HPX_PARCEL_SERVER_ADDRESS=" + address);
     env.push_back("HPX_PARCEL_SERVER_PORT=" +
         std::to_string(HPX_CONNECTING_IP_PORT - port));
 

--- a/libs/full/agas/tests/regressions/departed_locality_7384.cpp
+++ b/libs/full/agas/tests/regressions/departed_locality_7384.cpp
@@ -82,25 +82,23 @@ std::uint16_t get_unused_port(std::string const& address)
     for (auto it = hpx::util::accept_begin(address, 0, io_service);
         it != hpx::util::accept_end(); ++it)
     {
-        std::error_code ec;
-        ::asio::ip::tcp::endpoint const ep = *it;
-        ::asio::ip::tcp::acceptor acceptor(io_service);
+        try
+        {
+            ::asio::ip::tcp::endpoint const ep = *it;
+            ::asio::ip::tcp::acceptor acceptor(io_service);
 
-        acceptor.open(ep.protocol(), ec);
-        if (ec)
+            acceptor.open(ep.protocol());
+            acceptor.set_option(::asio::ip::tcp::acceptor::reuse_address(true));
+            acceptor.bind(ep);
+
+            // the acceptor is closed again on the way out, releasing the port
+            // for the launched locality to pick up
+            return acceptor.local_endpoint().port();
+        }
+        catch (std::system_error const&)
+        {
             continue;
-
-        acceptor.set_option(::asio::ip::tcp::acceptor::reuse_address(true), ec);
-        if (ec)
-            continue;
-
-        acceptor.bind(ep, ec);
-        if (ec)
-            continue;
-
-        // the acceptor is closed again on the way out, releasing the port for
-        // the launched locality to pick up
-        return acceptor.local_endpoint().port();
+        }
     }
 
     HPX_THROW_EXCEPTION(hpx::error::network_error, "get_unused_port",


### PR DESCRIPTION
Follow-up hardening for the `#7384` regression test added in `5d526b0a87`.

The test derives the launched locality's parcelport port from a fixed constant (`HPX_CONNECTING_IP_PORT - 43`), so the child always binds `7866`. Anything else holding that port breaks the test, and it breaks badly: the collision is never diagnosed, so the child dies unable to bind, the parent waits on the startup latch forever, and the test hangs until ctest kills it at 1500s.

This is not a fix for an observed CI failure; the test is currently green. It is a latent collision, but a deterministic one. Holding `127.0.0.1:7866` and running the test, same build, only the commit differing:

| | port free | 7866 held |
|---|---|---|
| before | passes | hangs, killed at 60s |
| after | passes | passes, 0.92s |

`get_unused_port()` asks the OS for a free port instead: it binds through `hpx::util::accept_begin(address, 0, ...)` and reads back `local_endpoint().port()`. The open / `reuse_address` / bind sequence mirrors what the TCP parcelport does for its own acceptor, so the port returned is one the launched locality can bind in turn. A sub-millisecond window remains
between release and rebind, which is inherent to handing a port to another process, but it replaces a collision that is certain whenever the fixed port is busy. The first commit is a prerequisite: `hpx.agas.address` was looked up twice and the probe needs the same address, so it is hoisted into a local.

Testing: the test passes with and without 7866 held; the full `tests.regressions.modules.agas.*` suite plus `tests.unit.modules.runtime_components.launch_process` is 7/7; clang-format 20, codespell, non-ASCII and module CMakeLists/dependency checks are clean.

`launch_process.cpp:105` has the identical pattern one port over (42 -> 7867).
Left alone to keep this to one concern.