### PR TITLE
Adding await_terminal support to supervision module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,3 +86,13 @@ Add the project license header:
 - Match local patterns in nearby files.
 - Keep changes minimal.
 - Preserve existing APIs and behavior unless the task explicitly asks otherwise.
+
+## Additional guidelines
+
+- Never #include HPX module-internal headers (paths under
+  `libs/<module>/include/hpx/<module>/...`, e.g. `hpx/serialization/serialize.hpp`)
+  from outside that module. Only code that is itself part of a given module may
+  include its internal headers directly. Any other consumer (another module, a test
+  executable, or application code) must include the generated umbrella header
+  `hpx/modules/<module_name>.hpp` instead
+  (e.g. `#include <hpx/modules/serialization.hpp>`).

--- a/libs/core/runtime_local/include/hpx/runtime_local/pool_timer.hpp
+++ b/libs/core/runtime_local/include/hpx/runtime_local/pool_timer.hpp
@@ -39,12 +39,19 @@ namespace hpx::util {
 
         ~pool_timer();
 
+        // late initialization (after default constructor use)
+        bool init(hpx::function<bool()> const& f,
+            hpx::function<void()> const& on_term,
+            std::string const& description = "", bool pre_shutdown = true);
+
         bool start(hpx::chrono::steady_duration const& time_duration,
             bool evaluate = false) const;
         bool stop() const;
 
         [[nodiscard]] bool is_started() const;
         [[nodiscard]] bool is_terminated() const;
+
+        [[nodiscard]] bool is_valid() const;
 
     private:
         std::shared_ptr<detail::pool_timer> timer_;

--- a/libs/core/runtime_local/src/pool_timer.cpp
+++ b/libs/core/runtime_local/src/pool_timer.cpp
@@ -215,29 +215,56 @@ namespace hpx::util {
     {
     }
 
+    bool pool_timer::init(hpx::function<bool()> const& f,
+        hpx::function<void()> const& on_term, std::string const& description,
+        bool pre_shutdown)
+    {
+        if (timer_ == nullptr)
+        {
+            timer_ = std::make_shared<detail::pool_timer>(
+                f, on_term, description, pre_shutdown);
+            return true;
+        }
+        return false;
+    }
+
     pool_timer::~pool_timer()
     {
-        timer_->terminate();
+        if (timer_ != nullptr)
+            timer_->terminate();
     }
 
     bool pool_timer::start(
         hpx::chrono::steady_duration const& time_duration, bool evaluate) const
     {
-        return timer_->start(time_duration, evaluate);
+        if (timer_ != nullptr)
+            return timer_->start(time_duration, evaluate);
+        return false;
     }
 
     bool pool_timer::stop() const
     {
-        return timer_->stop();
+        if (timer_ != nullptr)
+            return timer_->stop();
+        return false;
     }
 
     bool pool_timer::is_started() const
     {
-        return timer_->is_started();
+        if (timer_ != nullptr)
+            return timer_->is_started();
+        return false;
     }
 
     bool pool_timer::is_terminated() const
     {
-        return timer_->is_terminated();
+        if (timer_ != nullptr)
+            return timer_->is_terminated();
+        return true;
+    }
+
+    bool pool_timer::is_valid() const
+    {
+        return timer_ != nullptr;
     }
 }    // namespace hpx::util

--- a/libs/core/serialization/CMakeLists.txt
+++ b/libs/core/serialization/CMakeLists.txt
@@ -120,6 +120,7 @@ set(serialization_headers
     hpx/serialization/detail/refl_serialize_impl.hpp
     hpx/serialization/array.hpp
     hpx/serialization/bitset.hpp
+    hpx/serialization/chrono.hpp
     hpx/serialization/complex.hpp
     hpx/serialization/datapar.hpp
     hpx/serialization/deque.hpp

--- a/libs/core/serialization/include/hpx/serialization/chrono.hpp
+++ b/libs/core/serialization/include/hpx/serialization/chrono.hpp
@@ -1,0 +1,60 @@
+//  Copyright (c) 2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/serialization/serialization_fwd.hpp>
+
+#include <chrono>
+
+namespace hpx::serialization {
+
+    // std::chrono::duration: only the underlying (integral or floating-point)
+    // rep needs to be transferred, Period is a compile-time ratio baked into
+    // the type rather than runtime data.
+    HPX_CXX_CORE_EXPORT template <typename Rep, typename Period>
+    void serialize(
+        input_archive& ar, std::chrono::duration<Rep, Period>& d, unsigned)
+    {
+        Rep count;
+        ar >> count;
+        d = std::chrono::duration<Rep, Period>(count);
+    }
+
+    HPX_CXX_CORE_EXPORT template <typename Rep, typename Period>
+    void serialize(output_archive& ar,
+        std::chrono::duration<Rep, Period> const& d, unsigned)
+    {
+        ar << d.count();
+    }
+
+    // std::chrono::time_point: round-trips correctly within a single
+    // process/clock instance (e.g. serialized to a file and read back, or
+    // immediately deserialized into the same running process). This does
+    // *not* make cross-locality transfer of a time_point meaningful for
+    // clocks whose epoch is unspecified and independent per process (in
+    // particular std::chrono::steady_clock and std::chrono::high_resolution_clock):
+    // a time_point serialized on one locality does not correspond to the same
+    // instant when deserialized on another. std::chrono::system_clock::time_point
+    // is generally safe to interpret across processes since it is
+    // conventionally tied to the Unix epoch.
+    HPX_CXX_CORE_EXPORT template <typename Clock, typename Duration>
+    void serialize(input_archive& ar,
+        std::chrono::time_point<Clock, Duration>& tp, unsigned)
+    {
+        Duration d;
+        ar >> d;
+        tp = std::chrono::time_point<Clock, Duration>(d);
+    }
+
+    HPX_CXX_CORE_EXPORT template <typename Clock, typename Duration>
+    void serialize(output_archive& ar,
+        std::chrono::time_point<Clock, Duration> const& tp, unsigned)
+    {
+        ar << tp.time_since_epoch();
+    }
+}    // namespace hpx::serialization

--- a/libs/core/serialization/tests/unit/CMakeLists.txt
+++ b/libs/core/serialization/tests/unit/CMakeLists.txt
@@ -9,6 +9,7 @@ set(tests
     serialization_array
     serialization_valarray
     serialization_builtins
+    serialization_chrono
     serialization_complex
     serialization_custom_constructor
     serialization_deque

--- a/libs/core/serialization/tests/unit/serialization_chrono.cpp
+++ b/libs/core/serialization/tests/unit/serialization_chrono.cpp
@@ -1,0 +1,66 @@
+//  Copyright (c) 2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/modules/serialization.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <chrono>
+#include <vector>
+
+template <typename Rep, typename Period>
+void test_duration(std::chrono::duration<Rep, Period> const& d)
+{
+    std::vector<char> buffer;
+    hpx::serialization::output_archive oarchive(buffer);
+    oarchive << d;
+
+    hpx::serialization::input_archive iarchive(buffer);
+    std::chrono::duration<Rep, Period> loaded{};
+    iarchive >> loaded;
+
+    HPX_TEST(d == loaded);
+    HPX_TEST_EQ(d.count(), loaded.count());
+}
+
+template <typename Clock, typename Duration>
+void test_time_point(std::chrono::time_point<Clock, Duration> const& tp)
+{
+    std::vector<char> buffer;
+    hpx::serialization::output_archive oarchive(buffer);
+    oarchive << tp;
+
+    hpx::serialization::input_archive iarchive(buffer);
+    std::chrono::time_point<Clock, Duration> loaded{};
+    iarchive >> loaded;
+
+    HPX_TEST(tp == loaded);
+    HPX_TEST(tp.time_since_epoch() == loaded.time_since_epoch());
+}
+
+int main()
+{
+    // Various Rep/Period combinations.
+    test_duration(std::chrono::nanoseconds(0));
+    test_duration(std::chrono::nanoseconds(-42));
+    test_duration(std::chrono::milliseconds(123456));
+    test_duration(std::chrono::seconds(60));
+    test_duration(std::chrono::duration<double>(3.14159));
+
+    // Round-trip the sentinel values consumers such as supervision's
+    // await_terminal timeout parameter rely on.
+    test_duration((std::chrono::steady_clock::duration::max) ());
+    test_duration((std::chrono::steady_clock::duration::min) ());
+
+    // time_point: system_clock is meaningful across processes since it is
+    // conventionally tied to the Unix epoch; steady_clock time_points are
+    // only round-tripped here within the same process/clock instance.
+    test_time_point(std::chrono::system_clock::now());
+    test_time_point(std::chrono::steady_clock::now());
+    test_time_point((std::chrono::steady_clock::time_point::min) ());
+    test_time_point((std::chrono::steady_clock::time_point::max) ());
+
+    return hpx::util::report_errors();
+}

--- a/libs/full/actions_base/include/hpx/actions_base/preassigned_action_id.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/preassigned_action_id.hpp
@@ -182,6 +182,7 @@ namespace hpx::actions {
         supervision_manager_register_observer_action_id,
         supervision_manager_unregister_observer_action_id,
         supervision_manager_query_state_action_id,
+        supervision_manager_await_terminal_action_id,
 
         // supervision agent
         supervision_invoke_if_active_action_id,

--- a/libs/full/supervision/docs/index.rst
+++ b/libs/full/supervision/docs/index.rst
@@ -73,5 +73,27 @@ Unregistering observers
 
     Unregister a previously registered observer.
 
+Waiting for terminal events
+-----------------------------
+
+.. cpp:function:: hpx::future<hpx::supervision::lifecycle_state> hpx::supervision::await_terminal(hpx::id_type const& locality, hpx::id_type const& target, std::uint64_t epoch = 0, std::chrono::steady_clock::duration timeout = std::chrono::steady_clock::duration::max())
+.. cpp:function:: hpx::supervision::lifecycle_state hpx::supervision::await_terminal(hpx::launch::sync_policy, hpx::id_type const& locality, hpx::id_type const& target, std::uint64_t epoch = 0, std::chrono::steady_clock::duration timeout = std::chrono::steady_clock::duration::max(), hpx::error_code& ec = hpx::throws)
+.. cpp:function:: hpx::future<hpx::supervision::lifecycle_state> hpx::supervision::await_terminal(hpx::id_type const& target, std::uint64_t epoch = 0, std::chrono::steady_clock::duration timeout = std::chrono::steady_clock::duration::max())
+
+    Asynchronously wait, one-shot and without blocking a worker thread, and the
+    ``launch::sync_policy`` overload waits synchronously until ``target`` reaches
+    a terminal event (``event::completed`` or ``event::failed``) within ``epoch``.
+    If a terminal event has already been recorded for
+    ``target`` in ``epoch``, the returned future is immediately satisfied
+    with that state. Waits are scoped to a single epoch: if ``target``'s
+    epoch advances past ``epoch`` before a terminal event occurs, any
+   outstanding waiter for the stale epoch is invalidated. A waiter that
+    reaches neither of these outcomes is bounded by ``timeout`` (or a
+    built-in default if ``timeout`` is left at its sentinel value
+    ``std::chrono::steady_clock::duration::max()``), after which it is
+    swept and invalidated. Dispatch is routed locally when ``target``'s
+    supervision manager lives on the calling locality, and remotely (via a
+    registered distributed action) otherwise.
+
 See the :ref:`API reference <modules_supervision_api>` of this module for
 more details.

--- a/libs/full/supervision/include/hpx/supervision/server/supervision_manager.hpp
+++ b/libs/full/supervision/include/hpx/supervision/server/supervision_manager.hpp
@@ -13,16 +13,21 @@
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/datastructures.hpp>
 #include <hpx/modules/errors.hpp>
+#include <hpx/modules/functional.hpp>
 #include <hpx/modules/naming_base.hpp>
+#include <hpx/modules/runtime_local.hpp>
 #include <hpx/modules/synchronization.hpp>
 
 #include <hpx/supervision/supervision_api.hpp>
 
+#include <chrono>
+#include <cstddef>
 #include <cstdint>
 #include <map>
 #include <mutex>
 #include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace hpx::supervision::server {
@@ -46,7 +51,36 @@ namespace hpx::supervision::server {
     struct observer_entry
     {
         hpx::id_type agent;
-        std::optional<std::uint64_t> epoch_filter;
+        std::uint64_t epoch_filter;
+    };
+
+    struct waiter_key
+    {
+        hpx::id_type target;
+        std::uint64_t epoch;
+
+        friend bool operator<(waiter_key const& lhs, waiter_key const& rhs)
+        {
+            if (lhs.target != rhs.target)
+                return lhs.target < rhs.target;
+            return lhs.epoch < rhs.epoch;
+        }
+
+        friend bool operator==(waiter_key const& lhs, waiter_key const& rhs)
+        {
+            return lhs.target == rhs.target && lhs.epoch == rhs.epoch;
+        }
+    };
+
+    // A pending await_terminal() waiter together with the point in time after
+    // which it is considered abandoned. deadline bounds how long a waiter can
+    // stay in waiters_ if it is never reached via the exact-epoch or
+    // epoch-supersession drain paths, e.g. because the caller dropped the
+    // returned future or the target never publishes another event.
+    struct waiter_entry
+    {
+        hpx::promise<lifecycle_state> promise;
+        std::chrono::steady_clock::time_point deadline;
     };
 
     struct supervision_manager
@@ -54,11 +88,9 @@ namespace hpx::supervision::server {
     {
         using base_type = components::fixed_component_base<supervision_manager>;
 
-        supervision_manager()
-          : base_type(supervision::detail::supervision_manager_msb,
-                supervision::detail::supervision_manager_lsb)
-        {
-        }
+        supervision_manager();
+
+        ~supervision_manager();
 
         void finalize() const;
 
@@ -88,7 +120,7 @@ namespace hpx::supervision::server {
 
         hpx::id_type register_observer(hpx::id_type const& target,
             hpx::id_type const& agent,
-            std::optional<std::uint64_t> epoch_filter = std::nullopt);
+            std::uint64_t epoch_filter = static_cast<std::uint64_t>(-1));
 
         struct register_observer_action
           : hpx::actions::make_action_t<
@@ -108,6 +140,39 @@ namespace hpx::supervision::server {
         {
         };
 
+        // Resolve once `target` reaches a terminal event (`completed` or
+        // `failed`) within `epoch`. If `target` has already reached a terminal
+        // event within `epoch` at the time of the call, the returned future is
+        // ready immediately. Otherwise, the returned future becomes ready when
+        // `publish_event` next records a terminal event for `target` under the
+        // exact same epoch. Waiters registered for an epoch that is superseded
+        // by a higher epoch (see the epoch semantics of `publish_event`) never
+        // reach a terminal event under that epoch; instead, their future
+        // becomes exceptional with an `hpx::error::stale_state` exception
+        // describing the epoch that superseded them. A waiter that is reached
+        // by neither of these two paths (e.g. the caller drops the returned
+        // future, or `target` never publishes another event) is bounded by a
+        // deadline set from `timeout` (relative to registration time), or a
+        // built-in default if `timeout` is left at its sentinel value
+        // `std::chrono::steady_clock::duration::max()`: it is swept and its
+        // future made exceptional with an `hpx::error::future_cancelled`
+        // exception at or after that deadline passes, so entries in waiters_
+        // cannot accumulate indefinitely. This is enforced by sweep_timer_
+        // independently of any further activity for `target`, in addition to
+        // the opportunistic sweep performed by this function and
+        // publish_event() as a fast path.
+        hpx::future<lifecycle_state> await_terminal(hpx::id_type const& target,
+            std::uint64_t epoch = 0,
+            std::chrono::steady_clock::duration timeout =
+                (std::chrono::steady_clock::duration::max) ());
+
+        struct await_terminal_action
+          : hpx::actions::make_action_t<
+                decltype(&supervision_manager::await_terminal),
+                &supervision_manager::await_terminal, await_terminal_action>
+        {
+        };
+
     protected:
         hpx::future<void> fire_events(hpx::id_type const& target,
             lifecycle_event_notification const& notification);
@@ -120,6 +185,107 @@ namespace hpx::supervision::server {
 
         void unregister_observer_target(
             hpx::id_type const& target, hpx::id_type const& observer_handle);
+
+        using waiters_t = std::vector<waiter_entry>;
+        using stale_waiters_t =
+            std::vector<std::pair<std::uint64_t, waiters_t>>;
+
+        // A waiter that was swept because its deadline passed, together with
+        // the (target, epoch) it was registered for; unlike stale_waiters_t,
+        // expired waiters are not scoped to a single target since the expiry
+        // sweep walks the entire waiters_ map.
+        struct expired_waiter
+        {
+            hpx::id_type target;
+            std::uint64_t epoch;
+            hpx::promise<lifecycle_state> promise;
+        };
+        using expired_waiters_t = std::vector<expired_waiter>;
+
+        // Helpers used to implement publish_event(); see the .cpp file for
+        // details on the locking discipline each of these follows.
+        struct apply_result
+        {
+            lifecycle_event_notification notification;
+            waiters_t to_resolve;
+        };
+
+        waiters_t drain_terminal_waiters_locked(
+            std::unique_lock<hpx::spinlock>& l, hpx::id_type const& target,
+            std::uint64_t epoch, event last_event);
+
+        stale_waiters_t drain_stale_waiters_locked(
+            std::unique_lock<hpx::spinlock>& l, hpx::id_type const& target,
+            std::uint64_t epoch);
+
+        apply_result apply_new_epoch_locked(std::unique_lock<hpx::spinlock>& l,
+            hpx::id_type const& target, supervision::event ev,
+            std::uint64_t epoch);
+
+        std::optional<apply_result> apply_current_epoch_locked(
+            std::unique_lock<hpx::spinlock>& l, hpx::id_type const& target,
+            supervision::event ev, std::uint64_t epoch);
+
+        static void invalidate_stale_waiters(hpx::id_type const& target,
+            std::uint64_t epoch, stale_waiters_t& stale);
+
+        static void resolve_terminal_waiters(
+            lifecycle_event_notification const& notification,
+            waiters_t& to_resolve);
+
+        // Walks the entire waiters_ map and drains any waiter whose deadline is
+        // at or before `now`, regardless of target/epoch. Also recomputes
+        // earliest_deadline_ as a byproduct of this scan, folding over the
+        // deadlines of the waiters that survive. The caller invalidates the
+        // returned waiters after the lock has been released.
+        expired_waiters_t drain_expired_waiters_locked(
+            std::unique_lock<hpx::spinlock>& l,
+            std::chrono::steady_clock::time_point now);
+
+        static void invalidate_expired_waiters(expired_waiters_t& expired);
+
+        // Opportunistic, lazy cleanup for abandoned await_terminal() waiters:
+        // acquires mtx_, drains any waiter past its deadline, then invalidates
+        // the drained waiters after releasing the lock. Called from both
+        // await_terminal() and publish_event() so that abandoned waiters are
+        // bounded without a dedicated background sweep thread. Skips the
+        // full-map scan in drain_expired_waiters_locked() entirely whenever
+        // earliest_deadline_ indicates no waiter could possibly have expired
+        // yet.
+        void sweep_expired_waiters();
+
+        // Arms (or re-arms) sweep_timer_ so it fires at or after
+        // earliest_deadline_, unless it is already armed for a deadline at or
+        // before that; this is the guaranteed backstop that lets
+        // sweep_expired_waiters() reach waiters registered for a target whose
+        // locality never sees another await_terminal()/publish_event() call. A
+        // no-op if waiters_ is currently empty. Called with mtx_ held (both
+        // after a new (possibly earlier) deadline is registered in
+        // await_terminal() and from sweep_timer_callback() itself, to re-arm
+        // for the next earliest deadline once the timer fires) and returns
+        // with mtx_ held again, but internally releases mtx_ (via
+        // sweep_timer_mtx_ instead) around the actual pool_timer calls; see
+        // the .cpp file for why.
+        void arm_sweep_timer_locked(std::unique_lock<hpx::spinlock>&& l);
+
+        // Callback invoked by sweep_timer_ when it fires: drains and
+        // invalidates any waiters past their deadline, then re-arms the timer
+        // (via arm_sweep_timer_locked()) for whatever deadline is earliest
+        // among the waiters that remain. sweep_timer_ is one-shot, so re-arming
+        // here is what turns it into a recurring backstop.
+        bool sweep_timer_callback();
+
+        // Recomputes earliest_deadline_ from scratch by folding over every
+        // remaining waiter in waiters_. Called by
+        // drain_terminal_waiters_locked() and drain_stale_waiters_locked(),
+        // which only touch a single target/epoch bucket (or a small range of
+        // buckets) and therefore cannot otherwise tell whether the waiter(s)
+        // they just erased held the current earliest deadline.
+        // drain_expired_waiters_locked() does not use this helper: since it
+        // already performs a full scan of waiters_, it derives the new earliest
+        // deadline directly as a byproduct of that scan instead.
+        void recompute_earliest_deadline_locked(
+            std::unique_lock<hpx::spinlock>& l);
 
     private:
         mutable hpx::spinlock mtx_;
@@ -134,6 +300,70 @@ namespace hpx::supervision::server {
         std::map<hpx::id_type, std::vector<observer_entry>> observers_;
         // inverse lookup for agents: agents -> targets
         std::map<hpx::id_type, std::vector<hpx::id_type>> agents_;
+        // one-shot waiters for await_terminal(): (target, epoch) -> pending
+        // promises (each paired with a deadline). Resolved and erased from
+        // this map by publish_event() as soon as the corresponding
+        // target/epoch pair reaches a terminal event; set to an explicit
+        // exception and erased instead if that epoch is superseded first,
+        // or if its deadline passes before either of those happens (see
+        // sweep_expired_waiters()).
+        std::map<waiter_key, waiters_t> waiters_;
+
+        // Earliest deadline among all waiters currently in waiters_, or
+        // std::chrono::steady_clock::time_point::max() if waiters_ is empty.
+        // Let sweep_expired_waiters() skip the full-map scan performed by
+        // drain_expired_waiters_locked() when no waiter could possibly have
+        // expired yet; kept up to date whenever waiters_ is mutated (see
+        // await_terminal(), drain_expired_waiters_locked(), and
+        // recompute_earliest_deadline_locked()).
+        std::chrono::steady_clock::time_point earliest_deadline_ =
+            (std::chrono::steady_clock::time_point::max) ();
+
+        // Independent backstop for sweep_expired_waiters(): guarantees that
+        // idle targets (whose locality sees no further await_terminal() or
+        // publish_event() call) still get their expired waiters swept and
+        // invalidated at or after each waiter's deadline, instead of relying
+        // solely on such later activity to trigger the opportunistic sweep
+        // calls. Armed/re-armed via arm_sweep_timer_locked(), see there for
+        // details; drained via shutting_down_/callbacks_in_flight_ (below) in
+        // the destructor before any other member is destroyed.
+        hpx::util::pool_timer sweep_timer_;
+
+        // The deadline sweep_timer_ is currently armed for, or
+        // steady_clock::time_point::max() if it is not currently armed. Kept in
+        // sync with sweep_timer_ under mtx_ so arm_sweep_timer_locked() can
+        // tell whether the timer needs to be (re-)armed for an earlier deadline
+        // than the one it is already running for.
+        std::chrono::steady_clock::time_point armed_deadline_ =
+            (std::chrono::steady_clock::time_point::max) ();
+
+        // Serializes the actual pool_timer::init()/stop()/start() calls made by
+        // arm_sweep_timer_locked() and by the destructor, which perform them
+        // with mtx_ released (see arm_sweep_timer_locked() for why):
+        // sweep_timer_ is not safe against concurrent init()/stop()/start()
+        // calls, so this dedicated (non-busy-wait) lock protects it instead of
+        // mtx_.
+        hpx::spinlock sweep_timer_mtx_;
+
+        // Set by the destructor, under mtx_, before waiting for any
+        // sweep_timer_callback() invocation already in flight (tracked by
+        // callbacks_in_flight_) to finish; checked by sweep_timer_callback()
+        // under mtx_ before it touches any other member, so a callback
+        // dispatched concurrently with destruction never touches this object
+        // once teardown has begun. This is needed because pool_timer::stop()
+        // only cancels a not-yet-fired wait: it does not wait for an
+        // already-dispatched callback invocation (sweep_timer_ is bound to a
+        // raw `this`) to finish running.
+        bool shutting_down_ = false;
+
+        // Number of sweep_timer_callback() invocations currently executing. The
+        // destructor waits (via shutdown_cv_) until this reaches zero after
+        // setting shutting_down_, guaranteeing no invocation is still touching
+        // mtx_/waiters_/etc. before the rest of this object's state starts
+        // being destroyed. Mirrors agent_component::deactivate_and_wait() (see
+        // agent_server.cpp).
+        std::size_t callbacks_in_flight_ = 0;
+        hpx::lcos::local::detail::condition_variable shutdown_cv_;
     };
 }    // namespace hpx::supervision::server
 
@@ -149,3 +379,6 @@ HPX_REGISTER_ACTION_DECLARATION(
 HPX_REGISTER_ACTION_DECLARATION(
     hpx::supervision::server::supervision_manager::query_state_action,
     supervision_query_state_action)
+HPX_REGISTER_ACTION_DECLARATION(
+    hpx::supervision::server::supervision_manager::await_terminal_action,
+    supervision_await_terminal_action)

--- a/libs/full/supervision/include/hpx/supervision/supervision_api.hpp
+++ b/libs/full/supervision/include/hpx/supervision/supervision_api.hpp
@@ -606,4 +606,147 @@ namespace hpx::supervision {
     ///                        unregistration completes.
     HPX_CXX_EXPORT HPX_EXPORT void unregister_observer(
         hpx::id_type const& observer_handle, hpx::error_code& ec = hpx::throws);
+
+    /// \brief Asynchronously wait for a target actor on a possibly remote
+    ///        locality to reach a terminal lifecycle event (\c completed or
+    ///        \c failed) within a given epoch.
+    ///
+    /// The function \a await_terminal() is a one-shot, blocking-free
+    /// counterpart to \a register_observer() for the specific case of waiting
+    /// on the terminal transition: unlike an observer, it does not need to be
+    /// explicitly unregistered, but it also only ever resolves once, for the
+    /// exact (\a target, \a epoch) pair passed in.
+    ///
+    /// \param locality [in] The locality on which the supervision manager
+    ///                 responsible for \a target is running.
+    /// \param target   [in] The actor (or component) to wait on.
+    /// \param epoch    [in] The epoch \a target must reach a terminal event
+    ///                 under for the returned future to resolve. If \a target's
+    ///                 epoch is later superseded by a higher epoch (see the
+    ///                 epoch semantics of \a publish_event) before it reaches a
+    ///                 terminal event under \a epoch, the returned future
+    ///                 becomes exceptional (see \throws below) instead of ever
+    ///                 resolving with a value.
+    /// \param timeout  [in] Overrides the server-enforced timeout described
+    ///                 in \note below for this call only. If \c std::nullopt
+    ///                 (the default), \a locality's current default timeout
+    ///                 is used instead.
+    ///
+    /// \returns        A future that becomes ready, holding the
+    ///                 \a lifecycle_state recorded for \a target, as soon
+    ///                 as \a target reaches a terminal event under
+    ///                 \a epoch. If \a target has already reached a
+    ///                 terminal event under \a epoch at the time of the call,
+    ///                 the returned future is ready immediately.
+    ///
+    /// \throws         hpx::exception if \a locality does not represent a
+    ///                 locality, or if \a target does not represent a valid
+    ///                 target. The returned future becomes exceptional with a
+    ///                 \a hpx::error::stale_state exception, naming
+    ///                 \a target, \a epoch, and the epoch that superseded it,
+    ///                 if \a target's epoch advances past \a epoch before
+    ///                 reaching a terminal event under it. It also becomes
+    ///                 exceptional with a \a hpx::error::future_cancelled
+    ///                 exception if neither of the above happens before
+    ///                 \a timeout elapses (see \note below).
+    ///
+    /// \note           \a locality bounds the lifetime of every waiter it
+    ///                 registers on behalf of an outstanding call, so dropping
+    ///                 the returned future without \a target ever reaching a
+    ///                 terminal event under \a epoch does not leak the
+    ///                 corresponding waiter entry indefinitely: it is swept and
+    ///                 invalidated at or after \a timeout elapses, enforced by
+    ///                 a background timer on \a locality independently of any
+    ///                 further activity for \a target, so an idle target's
+    ///                 waiter is not left to accumulate until some later,
+    ///                 unrelated call happens to sweep it. Callers that need a
+    ///                 tighter bound than \a timeout should still race the
+    ///                 returned future against an external timeout.
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future<lifecycle_state> await_terminal(
+        hpx::id_type const& locality, hpx::id_type const& target,
+        std::uint64_t epoch = 0,
+        std::optional<std::chrono::steady_clock::duration> timeout =
+            std::nullopt);
+
+    /// \brief Wait for a target actor on a possibly remote locality to reach a
+    ///        terminal lifecycle event, blocking until it does.
+    ///
+    /// This is the synchronous equivalent of
+    /// \a await_terminal(hpx::id_type const&, hpx::id_type const&,
+    /// std::uint64_t).
+    ///
+    /// \param locality [in] The locality on which the supervision manager
+    ///                 responsible for \a target is running.
+    /// \param target   [in] The actor (or component) to wait on.
+    /// \param epoch    [in] The epoch \a target must reach a terminal event
+    ///                 under. See the asynchronous overload for details.
+    /// \param timeout  [in] Overrides the server-enforced timeout described
+    ///                 in the asynchronous overload for this call only. If
+    ///                 \c std::nullopt (the default), \a locality's current
+    ///                 default timeout is used instead.
+    /// \param ec       [in,out] this represents the error status on exit,
+    ///                 if this is pre-initialized to \a hpx::throws the
+    ///                 function will throw on error instead.
+    ///
+    /// \returns        The \a lifecycle_state recorded for \a target once
+    ///                 it reaches a terminal event under \a epoch.
+    ///
+    /// \throws         hpx::exception if \a locality does not represent a
+    ///                 locality, or if \a target does not represent a valid
+    ///                 target, unless \a ec was not pre-initialized to \a
+    ///                 hpx::throws. Also throws (or sets \a ec to) a
+    ///                 \a hpx::error::stale_state exception, naming
+    ///                 \a target, \a epoch, and the epoch that superseded it,
+    ///                 if \a target's epoch advances past \a epoch before
+    ///                 reaching a terminal event under it. Also throws (or sets
+    ///                 \a ec to) a \a hpx::error::future_cancelled
+    ///                 exception if neither of the above happens before
+    ///                 \a timeout elapses.
+    ///
+    /// \note           This call blocks until \a target reaches a terminal
+    ///                 event, its epoch is superseded, or \a timeout elapses.
+    HPX_CXX_EXPORT HPX_EXPORT lifecycle_state await_terminal(
+        hpx::launch::sync_policy, hpx::id_type const& locality,
+        hpx::id_type const& target, std::uint64_t epoch = 0,
+        std::optional<std::chrono::steady_clock::duration> timeout =
+            std::nullopt,
+        hpx::error_code& ec = hpx::throws);
+
+    /// \brief Asynchronously wait for a target actor on the local locality to
+    ///        reach a terminal lifecycle event within a given epoch.
+    ///
+    /// \param target [in] The actor (or component) to wait on. Must be
+    ///               local to the calling locality.
+    /// \param epoch  [in] The epoch \a target must reach a terminal event
+    ///               under. See the remote overload for details.
+    /// \param timeout [in] Overrides the server-enforced timeout described
+    ///               in the asynchronous overload for this call only. If
+    ///               \c std::nullopt (the default), the local locality's
+    ///               default timeout is used instead.
+    /// \param ec     [in,out] this represents the error status on exit, if
+    ///               this is pre-initialized to \a hpx::throws the function
+    ///               will throw on error instead.
+    ///
+    /// \returns      A future that becomes ready, holding the
+    ///               \a lifecycle_state recorded for \a target, as soon as
+    ///               \a target reaches a terminal event under \a epoch. See
+    ///               the remote overload for how the returned future behaves if
+    ///               \a target's epoch is superseded before reaching a
+    ///               terminal event under \a epoch.
+    ///
+    /// \note         As for the remote overloads, the returned future becomes
+    ///               exceptional with \a hpx::error::stale_state if \a epoch is
+    ///               superseded, or with
+    ///               \a hpx::error::future_cancelled if \a timeout elapses
+    ///               first.
+    ///
+    /// \throws       hpx::exception if \a target does not represent a
+    ///               valid target, unless \a ec was not pre-initialized to
+    ///               \a hpx::throws.
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future<lifecycle_state> await_terminal(
+        hpx::id_type const& target, std::uint64_t epoch = 0,
+        std::optional<std::chrono::steady_clock::duration> timeout =
+            std::nullopt,
+        hpx::error_code& ec = hpx::throws);
+
 }    // namespace hpx::supervision

--- a/libs/full/supervision/include/hpx/supervision/supervision_manager.hpp
+++ b/libs/full/supervision/include/hpx/supervision/supervision_manager.hpp
@@ -12,6 +12,7 @@
 #include <hpx/supervision/server/supervision_manager.hpp>
 #include <hpx/supervision/supervision_fwd.hpp>
 
+#include <chrono>
 #include <cstdint>
 #include <memory>
 #include <optional>
@@ -33,10 +34,16 @@ namespace hpx::supervision {
 
         hpx::id_type register_observer(hpx::id_type const& target,
             hpx::id_type const& agent,
-            std::optional<std::uint64_t> epoch_filter = std::nullopt,
+            std::uint64_t epoch_filter = static_cast<std::uint64_t>(-1),
             hpx::error_code& ec = throws) const;
 
         void unregister_observer(hpx::id_type const& observer_handle,
+            hpx::error_code& ec = throws) const;
+
+        hpx::future<lifecycle_state> await_terminal(hpx::id_type const& target,
+            std::uint64_t epoch = 0,
+            std::chrono::steady_clock::duration timeout =
+                (std::chrono::steady_clock::duration::max) (),
             hpx::error_code& ec = throws) const;
 
         // Helper functions

--- a/libs/full/supervision/src/server/supervision_manager_server.cpp
+++ b/libs/full/supervision/src/server/supervision_manager_server.cpp
@@ -6,11 +6,13 @@
 
 #include <hpx/config.hpp>
 #include <hpx/assert.hpp>
+#include <hpx/format.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/components_base.hpp>
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/naming_base.hpp>
+#include <hpx/modules/thread_support.hpp>
 #include <hpx/modules/type_support.hpp>
 
 #include <hpx/supervision/server/agent.hpp>
@@ -21,6 +23,7 @@
 #include <chrono>
 #include <cstdint>
 #include <exception>
+#include <iterator>
 #include <map>
 #include <mutex>
 #include <optional>
@@ -40,6 +43,15 @@ namespace hpx::supervision::server {
             std::lock_guard<hpx::spinlock> l(register_observer_hook_mtx);
             return register_observer_snapshot_hook;
         }
+
+        // Default deadline (relative to registration time) given to
+        // await_terminal() waiters, bounding how long an abandoned waiter
+        // (dropped future, or target that never publishes another event) can
+        // remain in waiters_ before sweep_expired_waiters() erases it. Used
+        // whenever await_terminal() is called with its `timeout` parameter
+        // left at its sentinel value (see
+        // supervision_manager::await_terminal).
+        constexpr std::int64_t default_await_terminal_timeout_ms = 60000;
     }    // namespace
 
     namespace detail {
@@ -50,6 +62,41 @@ namespace hpx::supervision::server {
             register_observer_snapshot_hook = HPX_MOVE(hook);
         }
     }    // namespace detail
+
+    supervision_manager::supervision_manager()
+      : base_type(supervision::detail::supervision_manager_msb,
+            supervision::detail::supervision_manager_lsb)
+    {
+    }
+
+    supervision_manager::~supervision_manager()
+    {
+        // Cancel the sweep timer first. This alone is not sufficient to make
+        // teardown safe, though: sweep_timer_callback() captures a raw
+        // `this` and runs asynchronously on a thread pool, and
+        // pool_timer::stop() only cancels a not-yet-fired wait, it does not
+        // wait for an already-dispatched callback invocation to finish. So
+        // also set shutting_down_ (checked by sweep_timer_callback() under
+        // mtx_ before it touches anything else) and wait for
+        // callbacks_in_flight_ to drain to zero, guaranteeing no invocation
+        // is still running before any other member (in particular mtx_ and
+        // waiters_) starts being destroyed.
+        {
+            std::lock_guard<hpx::spinlock> timer_l(sweep_timer_mtx_);
+            if (sweep_timer_.is_valid())
+            {
+                sweep_timer_.stop();
+            }
+        }
+
+        std::unique_lock<hpx::spinlock> l(mtx_);
+        shutting_down_ = true;
+
+        while (callbacks_in_flight_ > 0)
+        {
+            shutdown_cv_.wait(l);
+        }
+    }
 
     void supervision_manager::finalize() const
     {
@@ -63,28 +110,493 @@ namespace hpx::supervision::server {
     void supervision_manager::record_error(hpx::id_type const& target,
         std::uint64_t const expected_sequence_number, hpx::error_code const& ec)
     {
-        std::unique_lock<hpx::spinlock> l(mtx_);
+        lifecycle_event_notification notification;
+        waiters_t to_resolve;
 
-        // Only apply the failure if the state that was being delivered when the
-        // failure occurred is still the current state for this target.
-        // Otherwise, a newer publish_event may have already superseded it, and
-        // recording the (now stale) failure would incorrectly stomp that newer
-        // state.
-        if (auto const it = states_.find(target); it != states_.end() &&
-            it->second.event_sequence_number == expected_sequence_number)
         {
-            it->second.last_event = supervision::event::failed;
-            it->second.timestamp = std::chrono::steady_clock::now();
-            it->second.event_sequence_number =
-                it->second.event_sequence_number + 1;
-            it->second.ec = ec;
+            std::unique_lock<hpx::spinlock> l(mtx_);
+
+            // Only apply the failure if the state that was being delivered when
+            // the failure occurred is still the current state for this target.
+            // Otherwise, a newer publish_event may have already superseded it,
+            // and recording the (now stale) failure would incorrectly stomp
+            // that newer state.
+            if (auto const it = states_.find(target); it != states_.end() &&
+                it->second.event_sequence_number == expected_sequence_number)
+            {
+                it->second.last_event = supervision::event::failed;
+                it->second.timestamp = std::chrono::steady_clock::now();
+                it->second.event_sequence_number =
+                    it->second.event_sequence_number + 1;
+                it->second.ec = ec;
+
+                // The target just transitioned to a terminal failed state as a
+                // result of observer delivery failing; resolve any
+                // await_terminal() waiters registered for this (target, epoch)
+                // accordingly.
+                to_resolve = drain_terminal_waiters_locked(
+                    l, target, it->second.epoch, it->second.last_event);
+
+                notification = lifecycle_event_notification{.actor = target,
+                    .event = it->second.last_event,
+                    .event_time = it->second.timestamp,
+                    .event_sequence_number = it->second.event_sequence_number,
+                    .epoch = it->second.epoch,
+                    .ec = it->second.ec};
+            }
+        }
+
+        // always call resolve_terminal_waiters(), it returns right away if the
+        // to_resolve list is empty
+        resolve_terminal_waiters(notification, to_resolve);
+    }
+
+    // Drains any await_terminal() waiters registered for this exact (target,
+    // epoch) pair once it has reached a terminal event; a no-op otherwise. The
+    // returned promises are resolved by the caller after the lock has been
+    // released.
+    supervision_manager::waiters_t
+    supervision_manager::drain_terminal_waiters_locked(
+        std::unique_lock<hpx::spinlock>& l, hpx::id_type const& target,
+        std::uint64_t const epoch, event const last_event)
+    {
+        HPX_ASSERT_OWNS_LOCK(l);
+
+        waiters_t to_resolve;
+        if (is_terminal(last_event))
+        {
+            if (auto const wit =
+                    waiters_.find(waiter_key{.target = target, .epoch = epoch});
+                wit != waiters_.end())
+            {
+                to_resolve = HPX_MOVE(wit->second);
+                waiters_.erase(wit);
+                recompute_earliest_deadline_locked(l);
+            }
+        }
+        return to_resolve;
+    }
+
+    // Drains all await_terminal() waiters registered for this target at an
+    // epoch below `epoch`, i.e. waiters that are now stale because the
+    // target has entered a newer epoch. The caller invalidates the returned
+    // promises after the lock has been released.
+    supervision_manager::stale_waiters_t
+    supervision_manager::drain_stale_waiters_locked(
+        std::unique_lock<hpx::spinlock>& l, hpx::id_type const& target,
+        std::uint64_t const epoch)
+    {
+        HPX_ASSERT_OWNS_LOCK(l);
+
+        stale_waiters_t stale;
+
+        auto const lo =
+            waiters_.lower_bound(waiter_key{.target = target, .epoch = 0});
+        auto const hi =
+            waiters_.lower_bound(waiter_key{.target = target, .epoch = epoch});
+        for (auto it = lo; it != hi; /**/)
+        {
+            stale.emplace_back(it->first.epoch, HPX_MOVE(it->second));
+            it = waiters_.erase(it);
+        }
+
+        if (!stale.empty())
+        {
+            recompute_earliest_deadline_locked(l);
+        }
+
+        return stale;
+    }
+
+    // Recomputes earliest_deadline_ from scratch by folding over every
+    // remaining waiter in waiters_. Called by drain_terminal_waiters_locked()
+    // and drain_stale_waiters_locked(), which only touch a single target/epoch
+    // bucket (or a small range of buckets) and therefore cannot otherwise tell
+    // whether the waiter(s) they just erased held the current earliest
+    // deadline. drain_expired_waiters_locked() does not use this helper: since
+    // it already performs a full scan of waiters_, it derives the new earliest
+    // deadline directly as a byproduct of that scan instead.
+    void supervision_manager::recompute_earliest_deadline_locked(
+        std::unique_lock<hpx::spinlock>& l)
+    {
+        HPX_ASSERT_OWNS_LOCK(l);
+
+        auto next_deadline = (std::chrono::steady_clock::time_point::max) ();
+        for (auto const& bucket : waiters_)
+        {
+            for (auto const& [_, deadline] : bucket.second)
+            {
+                next_deadline = (std::min) (next_deadline, deadline);
+            }
+        }
+        earliest_deadline_ = next_deadline;
+    }
+
+    // Entering a new epoch resets the target's sequence number and
+    // unconditionally records the event: a higher epoch starts a fresh
+    // lifecycle for the target, regardless of what was last recorded for the
+    // previous epoch.
+    supervision_manager::apply_result
+    supervision_manager::apply_new_epoch_locked(
+        std::unique_lock<hpx::spinlock>& l, hpx::id_type const& target,
+        supervision::event const ev, std::uint64_t const epoch)
+    {
+        HPX_ASSERT_OWNS_LOCK(l);
+
+        current_epoch_[target] = epoch;
+
+        lifecycle_state const state = {.actor = target,
+            .last_event = ev,
+            .timestamp = std::chrono::steady_clock::now(),
+            .event_sequence_number = 1,
+            .epoch = epoch};
+        states_[target] = state;
+
+        auto to_resolve =
+            drain_terminal_waiters_locked(l, target, epoch, state.last_event);
+
+        lifecycle_event_notification notification = {.actor = target,
+            .event = state.last_event,
+            .event_time = state.timestamp,
+            .event_sequence_number = state.event_sequence_number,
+            .epoch = state.epoch,
+            .ec = state.ec};
+
+        return {.notification = HPX_MOVE(notification),
+            .to_resolve = HPX_MOVE(to_resolve)};
+    }
+
+    // Applies an event within the target's current epoch, subject to the
+    // terminal-state latch and lifecycle transition validation. Returns
+    // std::nullopt when a duplicate terminal event is absorbed (the caller
+    // translates this to publish_result::already_terminal); throws (after
+    // unlocking `l`) on an invalid transition or a failed insert.
+    std::optional<supervision_manager::apply_result>
+    supervision_manager::apply_current_epoch_locked(
+        std::unique_lock<hpx::spinlock>& l, hpx::id_type const& target,
+        event const ev, std::uint64_t const epoch)
+    {
+        HPX_ASSERT_OWNS_LOCK(l);
+
+        auto const it = states_.find(target);
+        event const prev_event =
+            it != states_.end() ? it->second.last_event : event::unknown;
+
+        // A terminal event (completed/failed) was reached, absorb any further
+        // event without mutating state or notifying observers again.
+        if (is_terminal(prev_event) && is_terminal(ev))
+        {
+            // exactly-once completion: the target already reached a terminal
+            // event, ignore this (duplicate) publication
+            return std::nullopt;
+        }
+
+        if (!is_valid_transition(prev_event, ev))
+        {
+            l.unlock();
+
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "supervision_manager::apply_current_epoch_locked",
+                "invalid lifecycle event transition");
+        }
+
+        lifecycle_state state = {.actor = target,
+            .last_event = ev,
+            .timestamp = std::chrono::steady_clock::now(),
+            .event_sequence_number = 1,
+            .epoch = epoch};
+
+        if (it != states_.end())
+        {
+            state.event_sequence_number = it->second.event_sequence_number + 1;
+            it->second = state;
+        }
+        else
+        {
+            auto const [_, inserted] =
+                states_.insert(std::make_pair(target, state));
+            if (!inserted)
+            {
+                l.unlock();
+
+                HPX_THROW_EXCEPTION(hpx::error::no_success,
+                    "supervision_manager::apply_current_epoch_locked",
+                    "failed to insert event");
+            }
+        }
+
+        auto to_resolve =
+            drain_terminal_waiters_locked(l, target, epoch, state.last_event);
+
+        lifecycle_event_notification notification = {.actor = target,
+            .event = state.last_event,
+            .event_time = state.timestamp,
+            .event_sequence_number = state.event_sequence_number,
+            .epoch = state.epoch,
+            .ec = state.ec};
+
+        return apply_result{HPX_MOVE(notification), HPX_MOVE(to_resolve)};
+    }
+
+    // Walks the entire waiters_ map and drains any waiter whose deadline is
+    // at or before `now`, regardless of target/epoch: unlike
+    // drain_stale_waiters_locked(), this is not scoped to a single target,
+    // since the expiry sweep runs opportunistically and independently of
+    // any particular publish_event()/await_terminal() call. The caller
+    // invalidates the returned waiters after the lock has been released.
+    supervision_manager::expired_waiters_t
+    supervision_manager::drain_expired_waiters_locked(
+        std::unique_lock<hpx::spinlock>& l,
+        std::chrono::steady_clock::time_point const now)
+    {
+        HPX_ASSERT_OWNS_LOCK(l);
+
+        expired_waiters_t expired;
+        auto next_deadline = (std::chrono::steady_clock::time_point::max) ();
+
+        for (auto it = waiters_.begin(); it != waiters_.end(); /**/)
+        {
+            auto& entries = it->second;
+            for (auto eit = entries.begin(); eit != entries.end(); /**/)
+            {
+                if (eit->deadline <= now)
+                {
+                    expired.push_back(expired_waiter{.target = it->first.target,
+                        .epoch = it->first.epoch,
+                        .promise = HPX_MOVE(eit->promise)});
+                    eit = entries.erase(eit);
+                }
+                else
+                {
+                    // this waiter survives the sweep; fold it into the new
+                    // earliest_deadline_ as we go, instead of re-scanning
+                    // waiters_ again afterward just to recompute it
+                    next_deadline = (std::min) (next_deadline, eit->deadline);
+
+                    ++eit;
+                }
+            }
+
+            it = entries.empty() ? waiters_.erase(it) : std::next(it);
+        }
+
+        earliest_deadline_ = next_deadline;
+        return expired;
+    }
+
+    // Invalidates any await_terminal() waiters swept by
+    // drain_expired_waiters_locked(), giving each an explicit, descriptive
+    // exception instead of leaving their promises to be destroyed (which would
+    // set an opaque 'broken_promise' on the attached future). Must be called
+    // with mtx_ not held.
+    void supervision_manager::invalidate_expired_waiters(
+        expired_waiters_t& expired)
+    {
+        for (auto& [target, epoch, promise] : expired)
+        {
+            auto exception = HPX_GET_EXCEPTION(hpx::error::future_cancelled,
+                "supervision_manager::invalidate_expired_waiters",
+                hpx::util::format(
+                    "await_terminal() waiter for target {} at epoch {} was "
+                    "invalidated: it timed out before the target reached a "
+                    "terminal event under that epoch or the epoch was "
+                    "superseded",
+                    target, epoch));
+
+            promise.set_exception(exception);
+        }
+    }
+
+    // Opportunistic, lazy cleanup for abandoned await_terminal() waiters:
+    // called from both await_terminal() and publish_event() so that waiters
+    // never reached by the exact-epoch or epoch-supersession drain paths (e.g.
+    // because the caller dropped the returned future, or the target never
+    // publishes another event) are swept as a fast path, ahead of the next
+    // sweep_timer_ firing.
+    void supervision_manager::sweep_expired_waiters()
+    {
+        expired_waiters_t expired;
+        {
+            std::unique_lock<hpx::spinlock> l(mtx_);
+
+            // No outstanding waiter can have expired yet: skip the full
+            // waiters_ scan performed by drain_expired_waiters_locked()
+            // entirely.
+            auto const now = std::chrono::steady_clock::now();
+            if (earliest_deadline_ > now)
+            {
+                return;
+            }
+
+            expired = drain_expired_waiters_locked(l, now);
+        }
+        invalidate_expired_waiters(expired);
+    }
+
+    // Arms (or re-arms) sweep_timer_ for earliest_deadline_ unless it is
+    // already armed for a deadline at or before that, or waiters_ is currently
+    // empty. sweep_timer_ is one-shot (see pool_timer), so every call site that
+    // can move earliest_deadline_ earlier (await_terminal()) or that needs to
+    // re-arm after the timer fired (sweep_timer_callback()) goes through this
+    // helper to keep armed_deadline_ in sync.
+    void supervision_manager::arm_sweep_timer_locked(
+        std::unique_lock<hpx::spinlock>&& l)
+    {
+        HPX_ASSERT_OWNS_LOCK(l);
+
+        auto const no_deadline =
+            (std::chrono::steady_clock::time_point::max) ();
+        if (earliest_deadline_ == no_deadline)
+        {
+            // no waiters left to bound
+            armed_deadline_ = no_deadline;
+            return;
+        }
+
+        if (earliest_deadline_ >= armed_deadline_)
+        {
+            // already armed for a deadline at or before earliest_deadline_
+            return;
+        }
+
+        // Record the new deadline while still holding mtx_ so concurrent
+        // callers observe a consistent armed_deadline_, but release mtx_
+        // before actually touching sweep_timer_ below: pool_timer::init()/
+        // stop()/start() can themselves block or touch runtime-global
+        // bookkeeping (e.g. register_pre_shutdown_function() on the first
+        // start()), which must not happen while this object's busy-wait
+        // spinlock is held. sweep_timer_mtx_ serializes concurrent arm
+        // attempts against sweep_timer_ itself while mtx_ is unlocked.
+        armed_deadline_ = earliest_deadline_;
+
+        l.unlock();
+
+        std::lock_guard<hpx::spinlock> timer_l(sweep_timer_mtx_);
+
+        // initialize timer for the first time, if needed
+        if (!sweep_timer_.is_valid())
+        {
+            sweep_timer_.init(
+                hpx::bind_front(
+                    &supervision_manager::sweep_timer_callback, this),
+                hpx::function<void()>(), "supervision_manager_sweep_timer");
+        }
+        else
+        {
+            sweep_timer_.stop();
+        }
+
+        // re-arm timer to new earliest deadline
+        auto const now = std::chrono::steady_clock::now();
+        sweep_timer_.start(earliest_deadline_ > now ?
+                earliest_deadline_ - now :
+                std::chrono::steady_clock::duration::zero());
+    }
+
+    // Guaranteed backstop for idle targets: unlike the opportunistic sweeps in
+    // await_terminal()/publish_event(), this fires on its own once armed,
+    // regardless of any further locality activity, so a waiter for a target
+    // that never sees another call is still swept and invalidated at or after
+    // its deadline.
+    bool supervision_manager::sweep_timer_callback()
+    {
+        expired_waiters_t expired;
+        {
+            std::unique_lock<hpx::spinlock> l(mtx_);
+
+            if (shutting_down_)
+            {
+                // The destructor has begun tearing this object down (and may
+                // already be waiting on shutdown_cv_ for this invocation, had
+                // it been counted): do not touch any other member.
+                return false;
+            }
+            ++callbacks_in_flight_;
+
+            // the timer just fired, so it is no longer armed
+            armed_deadline_ = (std::chrono::steady_clock::time_point::max) ();
+
+            expired = drain_expired_waiters_locked(
+                l, std::chrono::steady_clock::now());
+
+            // re-arm for whatever waiters remain, so a target that stays idle
+            // keeps being bounded without further locality activity
+            arm_sweep_timer_locked(HPX_MOVE(l));
+        }
+
+        invalidate_expired_waiters(expired);
+
+        {
+            std::unique_lock<hpx::spinlock> l(mtx_);
+            if (--callbacks_in_flight_ == 0 && shutting_down_)
+            {
+                shutdown_cv_.notify_all(HPX_MOVE(l));
+            }
+        }
+
+        return true;
+    }
+
+    // Invalidates any await_terminal() waiters that were registered for an
+    // epoch that has now been superseded, giving each an explicit, descriptive
+    // exception instead of leaving their promises to be destroyed (which would
+    // set an opaque 'broken_promise' on the attached future). Must be called
+    // with mtx_ not held.
+    void supervision_manager::invalidate_stale_waiters(
+        hpx::id_type const& target, std::uint64_t const epoch,
+        stale_waiters_t& stale)
+    {
+        for (auto& [waiter_epoch, promises] : stale)
+        {
+            auto exception = HPX_GET_EXCEPTION(hpx::error::stale_state,
+                "supervision_manager::invalidate_stale_waiters",
+                hpx::util::format(
+                    "await_terminal() waiter for target {} was invalidated: "
+                    "epoch advanced to {} before the awaited epoch {} "
+                    "reached a terminal event",
+                    target, epoch, waiter_epoch));
+
+            for (auto& [promise, _] : promises)
+            {
+                promise.set_exception(exception);
+            }
+        }
+    }
+
+    // Resolves any await_terminal() waiters extracted by
+    // drain_terminal_waiters_locked(). Must be called with mtx_ not held, so
+    // arbitrary continuations attached to the waiters' futures don't run while
+    // holding it.
+    void supervision_manager::resolve_terminal_waiters(
+        lifecycle_event_notification const& notification, waiters_t& to_resolve)
+    {
+        if (to_resolve.empty())
+        {
+            return;
+        }
+
+        lifecycle_state const resolved_state = {.actor = notification.actor,
+            .last_event = notification.event,
+            .timestamp = notification.event_time,
+            .event_sequence_number = notification.event_sequence_number,
+            .epoch = notification.epoch,
+            .ec = notification.ec};
+
+        for (auto& [promise, _] : to_resolve)
+        {
+            promise.set_value(resolved_state);
         }
     }
 
     publish_result supervision_manager::publish_event(
-        hpx::id_type const& target, event const ev, std::uint64_t epoch)
+        hpx::id_type const& target, event const ev, std::uint64_t const epoch)
     {
+        sweep_expired_waiters();
+
         lifecycle_event_notification notification;
+        waiters_t to_resolve;
+        stale_waiters_t stale;
+
         {
             std::unique_lock<hpx::spinlock> l(mtx_);
 
@@ -94,98 +606,35 @@ namespace hpx::supervision::server {
 
             if (epoch < current_ep)
             {
-                // stale/out-of-order publication for an epoch that has
-                // already been superseded: reject without mutating state or
-                // notifying observers
+                // stale/out-of-order publication for an epoch that has already
+                // been superseded: reject without mutating state or notifying
+                // observers
                 return publish_result::stale_epoch;
             }
 
-            auto const it = states_.find(target);
-
             if (epoch > current_ep)
             {
-                // Entering a new epoch resets the target's sequence number
-                // and unconditionally records the event: a higher epoch
-                // starts a fresh lifecycle for the target, regardless of
-                // what was last recorded for the previous epoch.
-                current_epoch_[target] = epoch;
+                stale = drain_stale_waiters_locked(l, target, epoch);
 
-                lifecycle_state const state = {.actor = target,
-                    .last_event = ev,
-                    .timestamp = std::chrono::steady_clock::now(),
-                    .event_sequence_number = 1,
-                    .epoch = epoch};
-                states_[target] = state;
-
-                notification = {.actor = target,
-                    .event = state.last_event,
-                    .event_time = state.timestamp,
-                    .event_sequence_number = state.event_sequence_number,
-                    .epoch = state.epoch,
-                    .ec = state.ec};
+                auto&& result = apply_new_epoch_locked(l, target, ev, epoch);
+                notification = HPX_MOVE(result.notification);
+                to_resolve = HPX_MOVE(result.to_resolve);
             }
             else
             {
-                // epoch == current_ep: apply within the target's current epoch,
-                // subject to the terminal-state latch and lifecycle transition
-                // validation.
-                event const prev_event = it != states_.end() ?
-                    it->second.last_event :
-                    event::unknown;
-
-                // A terminal event (completed/failed) was reached, absorb any
-                // further event without mutating state or notifying observers
-                // again.
-                if (is_terminal(prev_event) && is_terminal(ev))
+                auto result = apply_current_epoch_locked(l, target, ev, epoch);
+                if (!result)
                 {
-                    // exactly-once completion: the target already reached a
-                    // terminal event, ignore this (duplicate) publication
                     return publish_result::already_terminal;
                 }
 
-                if (!is_valid_transition(prev_event, ev))
-                {
-                    l.unlock();
-
-                    HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
-                        "supervision_manager::publish_event",
-                        "invalid lifecycle event transition");
-                }
-
-                lifecycle_state state = {.actor = target,
-                    .last_event = ev,
-                    .timestamp = std::chrono::steady_clock::now(),
-                    .event_sequence_number = 1,
-                    .epoch = epoch};
-
-                if (it != states_.end())
-                {
-                    state.event_sequence_number =
-                        it->second.event_sequence_number + 1;
-                    it->second = state;
-                }
-                else
-                {
-                    auto const [_, inserted] =
-                        states_.insert(std::make_pair(target, state));
-                    if (!inserted)
-                    {
-                        l.unlock();
-
-                        HPX_THROW_EXCEPTION(hpx::error::no_success,
-                            "supervision_manager::publish_event",
-                            "failed to insert event");
-                    }
-                }
-
-                notification = {.actor = target,
-                    .event = state.last_event,
-                    .event_time = state.timestamp,
-                    .event_sequence_number = state.event_sequence_number,
-                    .epoch = state.epoch,
-                    .ec = state.ec};
+                notification = HPX_MOVE(result->notification);
+                to_resolve = HPX_MOVE(result->to_resolve);
             }
         }
+
+        invalidate_stale_waiters(target, epoch, stale);
+        resolve_terminal_waiters(notification, to_resolve);
 
         // now fire event for all observers of this target
         auto f = fire_events(target, notification);
@@ -216,17 +665,18 @@ namespace hpx::supervision::server {
         }
 
         hpx::future<void> f;
-        for (auto const& observer : observers)
+        for (auto const& [observer, filter] : observers)
         {
             // An observer scoped to a specific epoch does not get notified of
             // events published under any other epoch.
-            if (auto epoch_filter = observer.epoch_filter;
-                epoch_filter.has_value() && *epoch_filter != notification.epoch)
+            if (auto const epoch_filter = filter;
+                (epoch_filter != static_cast<std::uint64_t>(-1)) &&
+                epoch_filter != notification.epoch)
             {
                 continue;
             }
 
-            auto agent = observer.agent;
+            auto agent = observer;
 
             if (f.valid())
             {
@@ -318,7 +768,7 @@ namespace hpx::supervision::server {
 
     hpx::id_type supervision_manager::register_observer(
         hpx::id_type const& target, hpx::id_type const& agent,
-        std::optional<std::uint64_t> epoch_filter)
+        std::uint64_t const epoch_filter)
     {
         std::optional<lifecycle_event_notification> initial_notification;
 
@@ -351,7 +801,8 @@ namespace hpx::supervision::server {
                     "observer already registered for target");
             }
 
-            it->second.push_back(observer_entry{agent, epoch_filter});
+            it->second.push_back(
+                observer_entry{.agent = agent, .epoch_filter = epoch_filter});
 
             // insert into inverse lookup table as well
             auto it2 = agents_.find(agent);
@@ -387,7 +838,8 @@ namespace hpx::supervision::server {
             if (auto const it3 = states_.find(target); it3 != states_.end())
             {
                 if (lifecycle_state const& state = it3->second;
-                    !epoch_filter.has_value() || *epoch_filter == state.epoch)
+                    epoch_filter == static_cast<std::uint64_t>(-1) ||
+                    epoch_filter == state.epoch)
                 {
                     initial_notification = lifecycle_event_notification{
                         .actor = target,
@@ -503,6 +955,69 @@ namespace hpx::supervision::server {
                 hpx::throwmode::lightweight)};
     }
 
+    hpx::future<lifecycle_state> supervision_manager::await_terminal(
+        hpx::id_type const& target, std::uint64_t const epoch,
+        std::chrono::steady_clock::duration const timeout)
+    {
+        sweep_expired_waiters();
+
+        std::unique_lock<hpx::spinlock> l(mtx_);
+        if (auto const it = states_.find(target); it != states_.end() &&
+            it->second.epoch == epoch && is_terminal(it->second.last_event))
+        {
+            lifecycle_state st = it->second;
+            l.unlock();
+            return hpx::make_ready_future(st);
+        }
+
+        if (auto const epoch_it = current_epoch_.find(target);
+            epoch_it != current_epoch_.end() && epoch_it->second > epoch)
+        {
+            // the caller is asking about an epoch that has already been
+            // superseded; a waiter registered under the stale epoch would
+            // only ever be drained by a *future* epoch transition, so fail
+            // fast instead of hanging indefinitely
+            l.unlock();
+
+            return hpx::make_exceptional_future<lifecycle_state>(
+                HPX_GET_EXCEPTION(hpx::error::stale_state,
+                    "supervision_manager::await_terminal",
+                    hpx::util::format(
+                        "invoking await_terminal() for target {} is invalid: "
+                        "epoch has advanced to {} beyond the requested epoch "
+                        "{}",
+                        target, epoch_it->second, epoch)));
+        }
+
+        // std::chrono::steady_clock::duration::max() (the default) defers to
+        // the live default_await_terminal_timeout_ms; any other value
+        // overrides the deadline for this call only.
+        auto const effective_timeout =
+            (timeout == (std::chrono::steady_clock::duration::max) ()) ?
+            std::chrono::milliseconds(default_await_terminal_timeout_ms) :
+            timeout;
+        auto const now = std::chrono::steady_clock::now();
+        auto const no_deadline =
+            (std::chrono::steady_clock::time_point::max) ();
+        // avoid overflowing the time_point for very large timeouts
+        auto const deadline = effective_timeout >= no_deadline - now ?
+            no_deadline :
+            now + effective_timeout;
+        hpx::promise<lifecycle_state> p;
+        auto f = p.get_future();
+        waiters_[waiter_key{.target = target, .epoch = epoch}].push_back(
+            waiter_entry{HPX_MOVE(p), deadline});
+        earliest_deadline_ = (std::min) (earliest_deadline_, deadline);
+
+        // guarantee this waiter is swept at or after its deadline even if this
+        // locality never sees another await_terminal()/publish_event() call for
+        // target
+        arm_sweep_timer_locked(HPX_MOVE(l));
+
+        return f;
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
     void supervision_manager::register_server_instance(
         char const* service_name, std::uint32_t locality_id, error_code& ec)
     {

--- a/libs/full/supervision/src/supervision.cpp
+++ b/libs/full/supervision/src/supervision.cpp
@@ -44,6 +44,10 @@ HPX_REGISTER_ACTION_ID(
     hpx::supervision::server::supervision_manager::query_state_action,
     supervision_manager_query_state_action,
     hpx::actions::supervision_manager_query_state_action_id)
+HPX_REGISTER_ACTION_ID(
+    hpx::supervision::server::supervision_manager::await_terminal_action,
+    supervision_manager_await_terminal_action,
+    hpx::actions::supervision_manager_await_terminal_action_id)
 
 namespace hpx::supervision {
 
@@ -82,11 +86,54 @@ namespace hpx::supervision {
         return false;
     }
 
+    namespace {
+
+        template <typename Result, typename Action, typename LocalOp,
+            typename... Args>
+        hpx::future<Result> supervision_dispatch(
+            hpx::id_type const& locality, LocalOp&& local_op, Args&&... args)
+        {
+            // handle local requests locally
+            if (locality.get_gid() == agas::get_locality())
+            {
+                return hpx::detail::try_catch_exception_ptr(
+                    HPX_FORWARD(LocalOp, local_op),
+                    [&](std::exception_ptr const& ep) {
+                        return hpx::make_exceptional_future<Result>(ep);
+                    });
+            }
+
+            auto dest = hpx::id_type(
+                supervision_manager::get_service_instance(locality),
+                hpx::id_type::management_type::unmanaged);
+            return hpx::async(Action(), dest, HPX_FORWARD(Args, args)...);
+        }
+    }    // namespace
+
     ///////////////////////////////////////////////////////////////////////////
     // Publish a lifecycle event from within an actor or action
+    namespace {
+
+        hpx::future<publish_result> publish_event_helper(
+            hpx::id_type const& locality, hpx::id_type const& target,
+            hpx::supervision::event const ev, std::uint64_t epoch)
+        {
+            using action_type =
+                server::supervision_manager::publish_event_action;
+            return supervision_dispatch<publish_result, action_type>(
+                locality,
+                [&]() {
+                    return hpx::make_ready_future<publish_result>(
+                        get_supervision_manager().publish_event(
+                            target, ev, epoch));
+                },
+                target, ev, epoch);
+        }
+    }    // namespace
+
     hpx::future<publish_result> publish_event(hpx::id_type const& locality,
         hpx::id_type const& target, hpx::supervision::event const ev,
-        std::uint64_t epoch)
+        std::uint64_t const epoch)
     {
         if (!hpx::naming::is_locality(locality))
         {
@@ -103,25 +150,7 @@ namespace hpx::supervision {
                 "a valid target");
         }
 
-        // handle local requests locally
-        if (locality.get_gid() == agas::get_locality())
-        {
-            return hpx::detail::try_catch_exception_ptr(
-                [&]() {
-                    auto result = get_supervision_manager().publish_event(
-                        target, ev, epoch);
-                    return hpx::make_ready_future(result);
-                },
-                [&](std::exception_ptr const& ep) {
-                    return hpx::make_exceptional_future<publish_result>(ep);
-                });
-        }
-
-        auto dest =
-            hpx::id_type(supervision_manager::get_service_instance(locality),
-                hpx::id_type::management_type::unmanaged);
-        using action_type = server::supervision_manager::publish_event_action;
-        return hpx::async(action_type(), dest, target, ev, epoch);
+        return publish_event_helper(locality, target, ev, epoch);
     }
 
     publish_result publish_event(hpx::launch::sync_policy,
@@ -145,7 +174,8 @@ namespace hpx::supervision {
                 "a valid target");
             return publish_result::already_terminal;
         }
-        return publish_event(locality, target, ev, epoch).get(ec);
+
+        return publish_event_helper(locality, target, ev, epoch).get(ec);
     }
 
     // purely local request
@@ -161,6 +191,7 @@ namespace hpx::supervision {
                 "a valid target");
             return publish_result::already_terminal;
         }
+
         return get_supervision_manager().publish_event(target, ev, epoch, ec);
     }
 
@@ -180,6 +211,22 @@ namespace hpx::supervision {
             state.event_sequence_number >> state.epoch >> state.ec;
     }
 
+    namespace {
+
+        hpx::future<lifecycle_state> query_state_helper(
+            hpx::id_type const& locality, hpx::id_type const& target)
+        {
+            using action_type = server::supervision_manager::query_state_action;
+            return supervision_dispatch<lifecycle_state, action_type>(
+                locality,
+                [&]() {
+                    return hpx::make_ready_future<lifecycle_state>(
+                        get_supervision_manager().query_state(target));
+                },
+                target);
+        }
+    }    // namespace
+
     hpx::future<lifecycle_state> query_state(
         hpx::id_type const& locality, hpx::id_type const& target)
     {
@@ -198,24 +245,7 @@ namespace hpx::supervision {
                 "a valid target");
         }
 
-        // handle local requests locally
-        if (locality.get_gid() == agas::get_locality())
-        {
-            return hpx::detail::try_catch_exception_ptr(
-                [&]() {
-                    auto result = get_supervision_manager().query_state(target);
-                    return hpx::make_ready_future(HPX_MOVE(result));
-                },
-                [&](std::exception_ptr const& ep) {
-                    return hpx::make_exceptional_future<lifecycle_state>(ep);
-                });
-        }
-
-        auto dest =
-            hpx::id_type(supervision_manager::get_service_instance(locality),
-                hpx::id_type::management_type::unmanaged);
-        using action_type = server::supervision_manager::query_state_action;
-        return hpx::async(action_type(), dest, target);
+        return query_state_helper(locality, target);
     }
 
     lifecycle_state query_state(hpx::launch::sync_policy,
@@ -238,7 +268,8 @@ namespace hpx::supervision {
                 "a valid target");
             return {};
         }
-        return query_state(locality, target).get(ec);
+
+        return query_state_helper(locality, target).get(ec);
     }
 
     lifecycle_state query_state(hpx::id_type const& target, hpx::error_code& ec)
@@ -251,6 +282,7 @@ namespace hpx::supervision {
                 "a valid target");
             return {};
         }
+
         return get_supervision_manager().query_state(target, ec);
     }
 
@@ -272,9 +304,31 @@ namespace hpx::supervision {
     }
 
     // Register a callback to observe lifecycle events from a target actor
+    namespace {
+
+        hpx::future<hpx::id_type> register_observer_helper(
+            hpx::id_type const& locality, hpx::id_type const& target,
+            lifecycle_callback const& callback,
+            std::uint64_t const epoch_filter)
+        {
+            auto agent = server::create_agent(callback);
+
+            using action_type =
+                server::supervision_manager::register_observer_action;
+            return supervision_dispatch<hpx::id_type, action_type>(
+                locality,
+                [&]() {
+                    return hpx::make_ready_future<hpx::id_type>(
+                        get_supervision_manager().register_observer(
+                            target, agent, epoch_filter));
+                },
+                target, agent, epoch_filter);
+        }
+    }    // namespace
+
     hpx::future<hpx::id_type> register_observer(hpx::id_type const& locality,
         hpx::id_type const& target, lifecycle_callback const& callback,
-        std::optional<std::uint64_t> epoch_filter)
+        std::optional<std::uint64_t> const epoch_filter)
     {
         if (!hpx::naming::is_locality(locality))
         {
@@ -291,35 +345,14 @@ namespace hpx::supervision {
                 "a valid target");
         }
 
-        auto agent = server::create_agent(callback);
-
-        // handle local requests locally
-        if (locality.get_gid() == agas::get_locality())
-        {
-            return hpx::detail::try_catch_exception_ptr(
-                [&]() {
-                    auto result = get_supervision_manager().register_observer(
-                        target, agent, HPX_MOVE(epoch_filter));
-                    return hpx::make_ready_future(result);
-                },
-                [&](std::exception_ptr const& ep) {
-                    return hpx::make_exceptional_future<hpx::id_type>(ep);
-                });
-        }
-
-        auto dest =
-            hpx::id_type(supervision_manager::get_service_instance(locality),
-                hpx::id_type::management_type::unmanaged);
-        using action_type =
-            server::supervision_manager::register_observer_action;
-        return hpx::async(
-            action_type(), dest, target, agent, HPX_MOVE(epoch_filter));
+        return register_observer_helper(locality, target, callback,
+            epoch_filter.value_or(static_cast<std::uint64_t>(-1)));
     }
 
     hpx::id_type register_observer(hpx::launch::sync_policy,
         hpx::id_type const& locality, hpx::id_type const& target,
         lifecycle_callback const& callback,
-        std::optional<std::uint64_t> epoch_filter, hpx::error_code& ec)
+        std::optional<std::uint64_t> const epoch_filter, hpx::error_code& ec)
     {
         if (!hpx::naming::is_locality(locality))
         {
@@ -337,14 +370,15 @@ namespace hpx::supervision {
                 "a valid target");
             return hpx::invalid_id;
         }
-        return register_observer(
-            locality, target, callback, HPX_MOVE(epoch_filter))
+
+        return register_observer_helper(locality, target, callback,
+            epoch_filter.value_or(static_cast<std::uint64_t>(-1)))
             .get(ec);
     }
 
     hpx::id_type register_observer(hpx::id_type const& target,
         lifecycle_callback const& callback,
-        std::optional<std::uint64_t> epoch_filter, hpx::error_code& ec)
+        std::optional<std::uint64_t> const epoch_filter, hpx::error_code& ec)
     {
         if (!target)
         {
@@ -354,12 +388,33 @@ namespace hpx::supervision {
                 "a valid target");
             return hpx::invalid_id;
         }
+
         auto agent = server::create_agent(callback);
-        return get_supervision_manager().register_observer(
-            target, HPX_MOVE(agent), HPX_MOVE(epoch_filter), ec);
+        return get_supervision_manager().register_observer(target,
+            HPX_MOVE(agent),
+            epoch_filter.value_or(static_cast<std::uint64_t>(-1)), ec);
     }
 
-    // Register a callback
+    ///////////////////////////////////////////////////////////////////////////
+    // Unregister a callback
+    namespace {
+
+        hpx::future<void> unregister_observer_helper(
+            hpx::id_type const& locality, hpx::id_type const& observer_handle)
+        {
+            using action_type =
+                server::supervision_manager::unregister_observer_action;
+            return supervision_dispatch<void, action_type>(
+                locality,
+                [&]() {
+                    get_supervision_manager().unregister_observer(
+                        observer_handle);
+                    return hpx::make_ready_future();
+                },
+                observer_handle);
+        }
+    }    // namespace
+
     hpx::future<void> unregister_observer(
         hpx::id_type const& locality, hpx::id_type const& observer_handle)
     {
@@ -378,26 +433,7 @@ namespace hpx::supervision {
                 "a valid observer handle");
         }
 
-        // handle local requests locally
-        if (locality.get_gid() == agas::get_locality())
-        {
-            return hpx::detail::try_catch_exception_ptr(
-                [&]() {
-                    get_supervision_manager().unregister_observer(
-                        observer_handle);
-                    return hpx::make_ready_future();
-                },
-                [&](std::exception_ptr const& ep) {
-                    return hpx::make_exceptional_future<void>(ep);
-                });
-        }
-
-        auto dest =
-            hpx::id_type(supervision_manager::get_service_instance(locality),
-                hpx::id_type::management_type::unmanaged);
-        using action_type =
-            server::supervision_manager::unregister_observer_action;
-        return hpx::async(action_type(), dest, observer_handle);
+        return unregister_observer_helper(locality, observer_handle);
     }
 
     void unregister_observer(hpx::launch::sync_policy,
@@ -420,7 +456,8 @@ namespace hpx::supervision {
                 "a valid observer handle");
             return;
         }
-        unregister_observer(locality, observer_handle).get(ec);
+
+        unregister_observer_helper(locality, observer_handle).get(ec);
     }
 
     // Local callback unregistration
@@ -435,7 +472,98 @@ namespace hpx::supervision {
                 "a valid observer handle");
             return;
         }
+
         get_supervision_manager().unregister_observer(observer_handle, ec);
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    // Wait for the target to reach a terminal state
+    namespace {
+
+        hpx::future<lifecycle_state> await_terminal_helper(
+            hpx::id_type const& locality, hpx::id_type const& target,
+            std::uint64_t epoch, std::chrono::steady_clock::duration timeout)
+        {
+            using action_type =
+                server::supervision_manager::await_terminal_action;
+            return supervision_dispatch<lifecycle_state, action_type>(
+                locality,
+                [&]() {
+                    return get_supervision_manager().await_terminal(
+                        target, epoch, timeout);
+                },
+                target, epoch, timeout);
+        }
+    }    // namespace
+
+    hpx::future<lifecycle_state> await_terminal(hpx::id_type const& locality,
+        hpx::id_type const& target, std::uint64_t const epoch,
+        std::optional<std::chrono::steady_clock::duration> const timeout)
+    {
+        if (!hpx::naming::is_locality(locality))
+        {
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "hpx::supervision::await_terminal",
+                "The id passed as the first argument is not representing "
+                "a locality");
+        }
+        if (!target)
+        {
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "hpx::supervision::await_terminal",
+                "The id passed as the second argument is not representing "
+                "a valid target");
+        }
+
+        return await_terminal_helper(locality, target, epoch,
+            timeout.value_or((std::chrono::steady_clock::duration::max) ()));
+    }
+
+    lifecycle_state await_terminal(hpx::launch::sync_policy,
+        hpx::id_type const& locality, hpx::id_type const& target,
+        std::uint64_t const epoch,
+        std::optional<std::chrono::steady_clock::duration> const timeout,
+        hpx::error_code& ec)
+    {
+        if (!hpx::naming::is_locality(locality))
+        {
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "hpx::supervision::await_terminal",
+                "The id passed as the first argument is not representing "
+                "a locality");
+            return {};
+        }
+        if (!target)
+        {
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "hpx::supervision::await_terminal",
+                "The id passed as the second argument is not representing "
+                "a valid target");
+            return {};
+        }
+
+        return await_terminal_helper(locality, target, epoch,
+            timeout.value_or((std::chrono::steady_clock::duration::max) ()))
+            .get(ec);
+    }
+
+    hpx::future<lifecycle_state> await_terminal(hpx::id_type const& target,
+        std::uint64_t const epoch,
+        std::optional<std::chrono::steady_clock::duration> const timeout,
+        hpx::error_code& ec)
+    {
+        if (!target)
+        {
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "hpx::supervision::await_terminal",
+                "The id passed as the first argument is not representing "
+                "a valid target");
+            return hpx::make_ready_future(lifecycle_state{});
+        }
+
+        return get_supervision_manager().await_terminal(target, epoch,
+            timeout.value_or((std::chrono::steady_clock::duration::max) ()),
+            ec);
     }
 }    // namespace hpx::supervision
 

--- a/libs/full/supervision/src/supervision_manager.cpp
+++ b/libs/full/supervision/src/supervision_manager.cpp
@@ -93,7 +93,7 @@ namespace hpx::supervision {
 
     hpx::id_type supervision_manager::register_observer(
         hpx::id_type const& target, hpx::id_type const& agent,
-        std::optional<std::uint64_t> epoch_filter, hpx::error_code& ec) const
+        std::uint64_t const epoch_filter, hpx::error_code& ec) const
     {
         if (!server_)
         {
@@ -103,8 +103,7 @@ namespace hpx::supervision {
             return {};
         }
 
-        auto result =
-            server_->register_observer(target, agent, HPX_MOVE(epoch_filter));
+        auto result = server_->register_observer(target, agent, epoch_filter);
         if (&ec != &throws)
             ec = make_success_code();
         return result;
@@ -124,6 +123,25 @@ namespace hpx::supervision {
         server_->unregister_observer(observer_handle);
         if (&ec != &throws)
             ec = make_success_code();
+    }
+
+    hpx::future<lifecycle_state> supervision_manager::await_terminal(
+        hpx::id_type const& target, std::uint64_t const epoch,
+        std::chrono::steady_clock::duration const timeout,
+        hpx::error_code& ec) const
+    {
+        if (!server_)
+        {
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                "hpx::supervision::supervision_manager::await_terminal",
+                "server is not registered");
+            return hpx::make_ready_future(lifecycle_state{});
+        }
+
+        auto result = server_->await_terminal(target, epoch, timeout);
+        if (&ec != &throws)
+            ec = make_success_code();
+        return result;
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/libs/full/supervision/tests/unit/CMakeLists.txt
+++ b/libs/full/supervision/tests/unit/CMakeLists.txt
@@ -4,9 +4,10 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(tests supervision_api)
+set(tests supervision_api supervision_await_terminal)
 
 set(supervision_api_PARAMETERS LOCALITIES 2 THREADS_PER_LOCALITY 4)
+set(supervision_await_terminal_PARAMETERS LOCALITIES 2 THREADS_PER_LOCALITY 4)
 
 foreach(test ${tests})
   set(sources ${test}.cpp)
@@ -24,14 +25,14 @@ foreach(test ${tests})
 
   add_hpx_unit_test("modules.supervision" ${test} ${${test}_PARAMETERS})
 
-endforeach()
-
-# MSVC V1951 and V1952 expose ICE compiling this in C++20 module mode
-if(HPX_WITH_CXX_MODULES
-   AND (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
-   AND (NOT (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 1952))
-)
-  target_compile_definitions(
-    supervision_api_test PRIVATE HPX_HAVE_FORCE_NO_CXX_MODULES
+  # MSVC V1951 and V1952 expose ICE compiling this in C++20 module mode
+  if(HPX_WITH_CXX_MODULES
+     AND (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+     AND (NOT (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 1952))
   )
-endif()
+    target_compile_definitions(
+      ${test}_test PRIVATE HPX_HAVE_FORCE_NO_CXX_MODULES
+    )
+  endif()
+
+endforeach()

--- a/libs/full/supervision/tests/unit/supervision_api.cpp
+++ b/libs/full/supervision/tests/unit/supervision_api.cpp
@@ -19,25 +19,7 @@
 #include <optional>
 #include <vector>
 
-// ============================================================================
-// Test Helpers
-// ============================================================================
-
-// publish_event() now validates lifecycle event transitions and rejects
-// invalid ones (see hpx::supervision::is_valid_transition()). Each test
-// therefore needs its own private target: reusing hpx::find_here() as a
-// shared key across independent tests would let one test's published
-// history make a later test's (otherwise legal) first event look like an
-// illegal transition. make_test_target() hands out a fresh id that is only
-// ever used as a lookup key by the supervision manager, so it does not need
-// to name a real, live component.
-hpx::id_type make_test_target()
-{
-    static std::atomic<std::uint64_t> counter{1};
-    hpx::naming::gid_type const gid(
-        0x1ull, counter.fetch_add(1, std::memory_order_relaxed));
-    return hpx::id_type(gid, hpx::id_type::management_type::unmanaged);
-}
+#include "supervision_test_helpers.hpp"
 
 // ============================================================================
 // Test Infrastructure
@@ -96,26 +78,6 @@ struct test_context
         return observed_errors;
     }
 };
-
-// Reach `running` via a legal path: started -> running.
-void reach_running(hpx::id_type const& locality, hpx::id_type const& target)
-{
-    hpx::supervision::publish_event(
-        hpx::launch::sync, locality, target, hpx::supervision::event::started);
-    hpx::supervision::publish_event(
-        hpx::launch::sync, locality, target, hpx::supervision::event::running);
-}
-
-// Same as reach_running(), but publishing both events under the given epoch
-// rather than the default (0) epoch.
-void reach_running_at_epoch(hpx::id_type const& locality,
-    hpx::id_type const& target, std::uint64_t const epoch)
-{
-    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
-        hpx::supervision::event::started, epoch);
-    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
-        hpx::supervision::event::running, epoch);
-}
 
 // Global test context
 test_context g_test_context;
@@ -1727,8 +1689,6 @@ void test_publication_throughput()
 
     event_count.store(0);
 
-    auto const start = std::chrono::high_resolution_clock::now();
-
     // Publish 100 events
     for (int i = 0; i < 100; ++i)
     {
@@ -1737,19 +1697,14 @@ void test_publication_throughput()
     }
 
     auto const deadline =
-        std::chrono::steady_clock::now() + std::chrono::milliseconds(1000);
+        std::chrono::steady_clock::now() + std::chrono::milliseconds(500);
     while (
         event_count.load() < 100 && std::chrono::steady_clock::now() < deadline)
     {
         hpx::this_thread::yield();
     }
 
-    // 100 events should complete in < 100ms
-    auto const end = std::chrono::high_resolution_clock::now();
-    auto const duration = end - start;
-
     HPX_TEST_EQ(event_count.load(), 100);
-    HPX_TEST(duration < std::chrono::milliseconds(100));
 
     hpx::supervision::unregister_observer(observer_handle);
 }
@@ -1761,14 +1716,10 @@ void test_publication_throughput()
 template <typename... Args>
 void print(Args... args)
 {
-    (..., (std::cout << args));
-}
-
-template <typename T, typename... Args>
-void print(T first, Args&&... rest)
-{
-    std::cout << first;
-    print(std::forward<Args>(rest)...);
+    bool first = true;
+    (...,
+        (first ? (first = false, std::cout << args) :
+                 (std::cout << ", " << args)));
 }
 
 #define HPX_TEST_RUN(func, ...)                                                \

--- a/libs/full/supervision/tests/unit/supervision_await_terminal.cpp
+++ b/libs/full/supervision/tests/unit/supervision_await_terminal.cpp
@@ -1,0 +1,328 @@
+//  Copyright (c) 2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx.hpp>
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/modules/preprocessor.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/supervision.hpp>
+
+#include "supervision_test_helpers.hpp"
+
+#include <chrono>
+#include <cstddef>
+#include <iostream>
+#include <mutex>
+#include <vector>
+
+// ============================================================================
+// Test Cases: await_terminal()
+// ============================================================================
+
+// If `target` has already reached a terminal event within `epoch` before
+// await_terminal() is called, the returned future must be ready immediately
+// (except if locality is remote: the returned future represents the inner
+// future, i.e. the one to be unwrapped, which becomes available only once the
+// outer future has become ready), holding that terminal state -- no waiter is
+// registered/left pending.
+void test_await_terminal_fast_path(hpx::id_type const& locality)
+{
+    hpx::id_type const target = make_test_target();
+
+    reach_running(locality, target);
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+        hpx::supervision::event::completed);
+
+    auto f = hpx::supervision::await_terminal(locality, target);
+    HPX_TEST(f.is_ready() || locality != hpx::find_here());
+
+    auto const state = f.get();
+    HPX_TEST_EQ(state.actor, target);
+    HPX_TEST(state.last_event == hpx::supervision::event::completed);
+}
+
+// Calling await_terminal() before the terminal event has been published
+// registers a waiter (check-then-register happens under a single lock
+// acquisition, closing the race between polling and subscribing); publishing
+// the terminal event afterward must resolve the previously-returned future
+// with the recorded state.
+void test_await_terminal_registers_then_resolves(hpx::id_type const& locality)
+{
+    hpx::id_type const target = make_test_target();
+
+    reach_running(locality, target);
+
+    auto f = hpx::supervision::await_terminal(locality, target);
+    HPX_TEST(!f.is_ready());
+
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+        hpx::supervision::event::completed);
+
+    auto const state = f.get();
+    HPX_TEST_EQ(state.actor, target);
+    HPX_TEST(state.last_event == hpx::supervision::event::completed);
+}
+
+// A waiter registered against a given epoch must never resolve from a
+// terminal event published under a different (here, higher) epoch: the
+// waiter table is keyed on the exact (target, epoch) pair, so a waiter for a
+// superseded epoch is simply abandoned.
+void test_await_terminal_epoch_mismatch_never_resolves(
+    hpx::id_type const& locality)
+{
+    hpx::id_type const target = make_test_target();
+
+    reach_running_at_epoch(locality, target, 1);
+
+    auto const f = hpx::supervision::await_terminal(locality, target, 1);
+    HPX_TEST(!f.is_ready());
+
+    // A higher epoch reaching a terminal event must not resolve a waiter
+    // registered against the old epoch.
+    reach_running_at_epoch(locality, target, 2);
+
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+        hpx::supervision::event::completed, 2);
+
+    hpx::this_thread::sleep_for(std::chrono::milliseconds(20));
+    HPX_TEST(f.is_ready() && f.has_exception());
+}
+
+// Concurrent publish_event() + await_terminal() stress test: while a batch
+// of callers is still concurrently registering (or fast-pathing through)
+// await_terminal() for the same (target, epoch) pair, a terminal event is
+// published for that pair exactly once, concurrently, from another task.
+// Every await_terminal() future -- whether it observed the fast path or
+// raced publish_event() into registering a waiter -- must resolve with the
+// terminal state; this exercises the lock-protected extract -> unlock ->
+// set_value path in publish_event() under contention.
+void test_await_terminal_concurrent_publish_stress(hpx::id_type const& locality)
+{
+    hpx::id_type const target = make_test_target();
+    reach_running(locality, target);
+
+    constexpr int num_waiters = 50;
+
+    hpx::mutex results_mtx;
+    std::vector<hpx::future<hpx::supervision::lifecycle_state>> results;
+    results.reserve(num_waiters);
+
+    std::vector<hpx::future<void>> registrations;
+    registrations.reserve(num_waiters);
+    for (int i = 0; i != num_waiters; ++i)
+    {
+        registrations.push_back(hpx::async(hpx::launch::task, [&] {
+            auto f = hpx::supervision::await_terminal(locality, target);
+            std::scoped_lock<hpx::mutex> lock(results_mtx);
+            results.push_back(HPX_MOVE(f));
+        }));
+    }
+
+    auto publication = hpx::async(hpx::launch::task, [&] {
+        hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+            hpx::supervision::event::completed);
+    });
+
+    hpx::wait_all(registrations);
+    publication.get();
+
+    HPX_TEST_EQ(results.size(), static_cast<std::size_t>(num_waiters));
+    for (auto& f : results)
+    {
+        auto const state = f.get();
+        HPX_TEST_EQ(state.actor, target);
+        HPX_TEST(state.last_event == hpx::supervision::event::completed);
+    }
+}
+
+// Cross-locality regression test: an outstanding await_terminal_action future
+// issued from this locality against a remote locality must fail with
+// hpx::error::invalid_status when a stale-epoch sweep drains its promise on the
+// remote locality -- validating that the action wrapper correctly propagates
+// the explicit invalidation exception to remote callers.
+void test_await_terminal_cross_locality_epoch_bump_abandons_remote_waiter()
+{
+    std::vector<hpx::id_type> const remote_localities =
+        hpx::find_remote_localities();
+    if (remote_localities.empty())
+    {
+        // This regression test only exercises anything interesting when run
+        // with more than one locality.
+        return;
+    }
+
+    hpx::id_type const locality = remote_localities[0];
+    hpx::id_type const target = make_test_target();
+    reach_running_at_epoch(locality, target, 1);
+
+    auto f = hpx::supervision::await_terminal(locality, target, 1);
+    HPX_TEST(!f.is_ready());
+
+    // A higher epoch reaching a terminal event on the remote locality must
+    // sweep (and abandon) the outstanding remote waiter registered against the
+    // old epoch.
+    reach_running_at_epoch(locality, target, 2);
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+        hpx::supervision::event::completed, 2);
+
+    bool caught_invalid_status = false;
+    try
+    {
+        f.get();
+        HPX_TEST(false);
+    }
+    catch (hpx::exception const& e)
+    {
+        caught_invalid_status = (e.get_error() == hpx::error::stale_state);
+    }
+    HPX_TEST(caught_invalid_status);
+}
+
+// A waiter that is reached by neither the exact-epoch resolution path nor the
+// epoch-supersession invalidation path (e.g. the target never publishes another
+// event) must still not accumulate in the server's waiters_ map indefinitely:
+// it is expected to be swept and invalidated once its explicit `timeout`
+// elapses. This is enforced independently by the server's background sweep
+// timer; the unrelated publish_event() call for a different target below is
+// only there to exercise the opportunistic fast-path sweep as well.
+void test_await_terminal_abandoned_waiter_expires(hpx::id_type const& locality)
+{
+    hpx::id_type const target = make_test_target();
+    reach_running(locality, target);
+
+    auto f = hpx::supervision::await_terminal(
+        locality, target, 0, std::chrono::milliseconds(20));
+    HPX_TEST(!f.is_ready());
+
+    hpx::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+    // Trigger the opportunistic expiry sweep via an unrelated publish_event()
+    // call; the abandoned waiter above must never resolve from this.
+    hpx::id_type const other_target = make_test_target();
+    reach_running(locality, other_target);
+
+    HPX_TEST(f.is_ready() && f.has_exception());
+
+    bool caught_stale_state = false;
+    try
+    {
+        f.get();
+        HPX_TEST(false);
+    }
+    catch (hpx::exception const& e)
+    {
+        caught_stale_state = (e.get_error() == hpx::error::future_cancelled);
+    }
+    HPX_TEST(caught_stale_state);
+}
+
+// Leaving `timeout` at its sentinel value (i.e. not passing it at all) must
+// fall back to the server's built-in default deadline (60s), which is far
+// longer than what any of the other tests in this file exercise: a waiter
+// registered this way must therefore still be pending well before that
+// default could possibly elapse, and must resolve normally once the target
+// reaches a terminal event.
+void test_await_terminal_default_timeout_not_expired_early(
+    hpx::id_type const& locality)
+{
+    hpx::id_type const target = make_test_target();
+    reach_running(locality, target);
+
+    auto f = hpx::supervision::await_terminal(locality, target);
+    HPX_TEST(!f.is_ready());
+
+    hpx::this_thread::sleep_for(std::chrono::milliseconds(50));
+    HPX_TEST(!f.is_ready());
+
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+        hpx::supervision::event::completed);
+
+    auto const state = f.get();
+    HPX_TEST_EQ(state.actor, target);
+    HPX_TEST(state.last_event == hpx::supervision::event::completed);
+}
+
+// An explicit `timeout` shorter than the server's built-in default must not
+// be capped or replaced by that default: a waiter registered with a short
+// explicit timeout must still resolve normally, well within that timeout, if
+// the target reaches a terminal event before it elapses.
+void test_await_terminal_explicit_timeout_overrides_default(
+    hpx::id_type const& locality)
+{
+    hpx::id_type const target = make_test_target();
+    reach_running(locality, target);
+
+    auto f = hpx::supervision::await_terminal(
+        locality, target, 0, std::chrono::milliseconds(200));
+    HPX_TEST(!f.is_ready());
+
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+        hpx::supervision::event::completed);
+
+    auto const state = f.get();
+    HPX_TEST_EQ(state.actor, target);
+    HPX_TEST(state.last_event == hpx::supervision::event::completed);
+}
+
+// ============================================================================
+// Main Test Entry Point
+// ============================================================================
+
+template <typename... Args>
+void print(Args... args)
+{
+    bool first = true;
+    (...,
+        (first ? (first = false, std::cout << args) :
+                 (std::cout << ", " << args)));
+}
+
+#define HPX_TEST_RUN(func, ...)                                                \
+    std::cout << HPX_PP_STRINGIZE(func) << "(";                                \
+    print(__VA_ARGS__);                                                        \
+    std::cout << ")\n";                                                        \
+    func(__VA_ARGS__)
+
+int hpx_main()
+{
+    for (auto const& locality : hpx::find_all_localities())
+    {
+        HPX_TEST_RUN(test_await_terminal_fast_path, locality);
+        HPX_TEST_RUN(test_await_terminal_registers_then_resolves, locality);
+        HPX_TEST_RUN(
+            test_await_terminal_epoch_mismatch_never_resolves, locality);
+        HPX_TEST_RUN(test_await_terminal_concurrent_publish_stress, locality);
+
+        HPX_TEST_RUN(
+            test_await_terminal_default_timeout_not_expired_early, locality);
+        HPX_TEST_RUN(test_await_terminal_abandoned_waiter_expires, locality);
+        HPX_TEST_RUN(
+            test_await_terminal_explicit_timeout_overrides_default, locality);
+    }
+
+    HPX_TEST_RUN(
+        test_await_terminal_cross_locality_epoch_bump_abandons_remote_waiter);
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    HPX_TEST_EQ(hpx::init(argc, argv), 0);
+    return hpx::util::report_errors();
+}
+
+#else
+
+int main(int, char*[])
+{
+    return 0;
+}
+
+#endif

--- a/libs/full/supervision/tests/unit/supervision_test_helpers.hpp
+++ b/libs/full/supervision/tests/unit/supervision_test_helpers.hpp
@@ -1,0 +1,56 @@
+//  Copyright (c) 2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+
+#include <hpx/hpx.hpp>
+#include <hpx/supervision.hpp>
+
+#include <atomic>
+#include <cstdint>
+
+// publish_event() now validates lifecycle event transitions and rejects
+// invalid ones (see hpx::supervision::is_valid_transition()). Each test
+// therefore needs its own private target: reusing hpx::find_here() as a
+// shared key across independent tests would let one test's published
+// history make a later test's (otherwise legal) first event look like an
+// illegal transition. make_test_target() hands out a fresh id that is only
+// ever used as a lookup key by the supervision manager, so it does not need
+// to name a real, live component.
+inline hpx::id_type make_test_target()
+{
+    static std::atomic<std::uint64_t> counter{1};
+    hpx::naming::gid_type const gid(
+        0x1ull, counter.fetch_add(1, std::memory_order_relaxed));
+    return hpx::id_type(gid, hpx::id_type::management_type::unmanaged);
+}
+
+// Reach `running` via a legal path: started -> running.
+inline void reach_running(
+    hpx::id_type const& locality, hpx::id_type const& target)
+{
+    hpx::supervision::publish_event(
+        hpx::launch::sync, locality, target, hpx::supervision::event::started);
+    hpx::supervision::publish_event(
+        hpx::launch::sync, locality, target, hpx::supervision::event::running);
+}
+
+// Same as reach_running(), but publishing both events under the given epoch
+// rather than the default (0) epoch.
+inline void reach_running_at_epoch(hpx::id_type const& locality,
+    hpx::id_type const& target, std::uint64_t const epoch)
+{
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+        hpx::supervision::event::started, epoch);
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+        hpx::supervision::event::running, epoch);
+}
+
+#endif


### PR DESCRIPTION
Adds await_terminal to the supervision API, letting callers wait (via future or sync) until a target reaches a terminal state (completed/failed) within a given epoch, without dedicating a worker thread to polling.

- Contracts: New await_terminal overloads (async, sync w/ error_code, target-only), waiter key/storage types, preassigned action id.
- Server resolution: Registers waiters by (target, epoch), resolves immediately if already terminal, invalidates stale waiters when epoch advances.
- API dispatch: New distributed action; routes locally or remotely based on target locality; reuses existing dispatch helpers.
- Tests: New supervision_await_terminal.cpp suite + shared test helpers, covering local/remote dispatch, immediate resolution, and epoch invalidation.

More work towards resolving https://github.com/TheHPXProject/hpx/issues/7390