### PR TITLE
Implement check_admission in supervision module

### DIFF
--- a/libs/core/errors/include/hpx/errors/error.hpp
+++ b/libs/core/errors/include/hpx/errors/error.hpp
@@ -145,8 +145,14 @@ namespace hpx {
                              ///< preceding notification has not yet been
                              ///< delivered
 
+        target_fenced = 58,    ///< A dispatch was deliberately and correctly
+                               ///< refused because the target had already
+                               ///< latched a terminal lifecycle event; this
+                               ///< is a final rejection, not a staleness
+                               ///< signal, and should not be retried
+
         /// \cond NOINTERNAL
-        last_error = 58,
+        last_error = 59,
 
         system_error_flag = 0x4000L,
 

--- a/libs/core/errors/src/error_code.cpp
+++ b/libs/core/errors/src/error_code.cpp
@@ -76,6 +76,7 @@ namespace hpx {
         /* 55 */ "length_error",
         /* 56 */ "migration_needs_retry",
         /* 57 */ "stale_state",
+        /* 58 */ "target_fenced",
 
         /*    */ ""};
     /// \endcond

--- a/libs/core/runtime_local/src/pool_timer.cpp
+++ b/libs/core/runtime_local/src/pool_timer.cpp
@@ -260,7 +260,7 @@ namespace hpx::util {
     {
         if (timer_ != nullptr)
             return timer_->is_terminated();
-        return true;
+        return false;
     }
 
     bool pool_timer::is_valid() const

--- a/libs/core/serialization/tests/unit/serialization_error_code.cpp
+++ b/libs/core/serialization/tests/unit/serialization_error_code.cpp
@@ -47,6 +47,24 @@ void test_hpx_category_stale_state()
     HPX_TEST_EQ(ec.get_message(), ec2.get_message());
 }
 
+void test_hpx_category_target_fenced()
+{
+    hpx::error_code const ec(
+        hpx::error::target_fenced, "some message", hpx::throwmode::plain);
+
+    std::vector<char> buffer;
+    hpx::serialization::output_archive oarchive(buffer);
+    oarchive << ec;
+
+    hpx::serialization::input_archive iarchive(buffer);
+    hpx::error_code ec2;
+    iarchive >> ec2;
+
+    HPX_TEST_EQ(ec.value(), ec2.value());
+    HPX_TEST(ec.category() == ec2.category());
+    HPX_TEST_EQ(ec.get_message(), ec2.get_message());
+}
+
 void test_generic_category_large_value()
 {
     hpx::error_code ec;
@@ -90,7 +108,10 @@ void test_system_category_large_value()
 int main()
 {
     test_hpx_category();
+
     test_hpx_category_stale_state();
+    test_hpx_category_target_fenced();
+
     test_generic_category_large_value();
     test_system_category_large_value();
 

--- a/libs/full/actions_base/include/hpx/actions_base/preassigned_action_id.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/preassigned_action_id.hpp
@@ -183,6 +183,8 @@ namespace hpx::actions {
         supervision_manager_unregister_observer_action_id,
         supervision_manager_query_state_action_id,
         supervision_manager_await_terminal_action_id,
+        supervision_manager_register_activity_observer__action_id,
+        supervision_manager_unregister_activity_observer_action_id,
 
         // supervision agent
         supervision_invoke_if_active_action_id,

--- a/libs/full/actions_base/include/hpx/actions_base/preassigned_action_id.hpp
+++ b/libs/full/actions_base/include/hpx/actions_base/preassigned_action_id.hpp
@@ -188,6 +188,10 @@ namespace hpx::actions {
         supervision_invoke_if_active_action_id,
         supervision_deactivate_and_wait_action_id,
 
+        // supervision activity agent
+        supervision_activity_invoke_if_active_action_id,
+        supervision_activity_deactivate_and_wait_action_id,
+
         last_action_id
     };
     /// \endcond

--- a/libs/full/supervision/CMakeLists.txt
+++ b/libs/full/supervision/CMakeLists.txt
@@ -15,12 +15,15 @@ set(supervision_headers
     hpx/supervision/supervision_manager.hpp
     hpx/supervision/supervision_api.hpp
     hpx/supervision/supervision_fwd.hpp
+    hpx/supervision/server/activity_agent.hpp
     hpx/supervision/server/agent.hpp
     hpx/supervision/server/supervision_manager.hpp
 )
 
-set(supervision_sources supervision.cpp server/supervision_manager_server.cpp
-                        server/agent_server.cpp supervision_manager.cpp
+set(supervision_sources
+    supervision.cpp server/supervision_manager_server.cpp
+    server/activity_agent_server.cpp server/agent_server.cpp
+    supervision_manager.cpp
 )
 
 include(HPX_AddModule)

--- a/libs/full/supervision/docs/index.rst
+++ b/libs/full/supervision/docs/index.rst
@@ -137,17 +137,17 @@ Registering activity observers
     parameter: the feature reports on every target the addressed manager
     tracks rather than on a single one.
 
-    Registration synchronously and atomically delivers one
-    ``activity_transition::already_active`` notification for every target
-    that is already active at the time of the call, taken under the same
-    lock that guards subscription, before the registration call returns.
-    This guarantees ``callback`` observes exactly one notification for each
-    such target's current activity state - either this replay, or a live
-    transition that raced with registration, but never both and never
-    neither. For local delivery, both the replay and any subsequent live
-    transitions invoke ``callback`` synchronously; for a given lifecycle
-    event, per-target ``register_observer`` callbacks always fire before
-    activity-observer callbacks triggered by that same event.
+    Registering an activity observer for an already-active target triggers a
+    replay of its current state. The snapshot of tracked state and the
+    insertion of the observer are performed atomically under the manager's
+    internal lock, which guarantees exactly-once delivery: the observer
+    receives either the replay or a live transition that raced with
+    registration, but never both and never neither.
+    
+    Note that the notification itself (replay or live) is delivered after the
+    lock is released. Its delivery order relative to any other concurrent live
+    notification for the same target is *not* guaranteed, only the
+    exactly-once property is guaranteed, not relative ordering.
 
     Activity notifications are a pure discovery/notification signal: unlike
     ``publish_event``, registering or unregistering an activity observer

--- a/libs/full/supervision/docs/index.rst
+++ b/libs/full/supervision/docs/index.rst
@@ -23,7 +23,7 @@ a remote (locality-qualified, future-returning or ``launch::sync_policy``)
 call:
 
 Publishing events
-------------------
+-----------------
 
 .. cpp:function:: hpx::future<hpx::supervision::publish_result> hpx::supervision::publish_event(hpx::id_type const& locality, hpx::id_type const& target, hpx::supervision::event ev, std::uint64_t epoch = 0)
 .. cpp:function:: hpx::supervision::publish_result hpx::supervision::publish_event(hpx::launch::sync_policy, hpx::id_type const& locality, hpx::id_type const& target, hpx::supervision::event ev, std::uint64_t epoch = 0, hpx::error_code& ec = hpx::throws)
@@ -39,7 +39,7 @@ Publishing events
     ``publish_result::already_terminal``.
 
 Querying lifecycle state
--------------------------
+------------------------
 
 .. cpp:function:: hpx::future<hpx::supervision::lifecycle_state> hpx::supervision::query_state(hpx::id_type const& locality, hpx::id_type const& target)
 .. cpp:function:: hpx::supervision::lifecycle_state hpx::supervision::query_state(hpx::launch::sync_policy, hpx::id_type const& locality, hpx::id_type const& target, hpx::error_code& ec = hpx::throws)
@@ -50,7 +50,7 @@ Querying lifecycle state
     queries whose result may lag the latest event.
 
 Registering observers
-----------------------
+---------------------
 
 .. cpp:function:: hpx::future<hpx::id_type> hpx::supervision::register_observer(hpx::id_type const& locality, hpx::id_type const& target, hpx::supervision::lifecycle_callback const& callback, std::optional<std::uint64_t> epoch_filter = std::nullopt)
 .. cpp:function:: hpx::id_type hpx::supervision::register_observer(hpx::launch::sync_policy, hpx::id_type const& locality, hpx::id_type const& target, hpx::supervision::lifecycle_callback const& callback, std::optional<std::uint64_t> epoch_filter = std::nullopt, hpx::error_code& ec = hpx::throws)
@@ -65,7 +65,7 @@ Registering observers
     receives notifications for every epoch.
 
 Unregistering observers
-------------------------
+-----------------------
 
 .. cpp:function:: hpx::future<void> hpx::supervision::unregister_observer(hpx::id_type const& locality, hpx::id_type const& observer_handle)
 .. cpp:function:: void hpx::supervision::unregister_observer(hpx::launch::sync_policy, hpx::id_type const& locality, hpx::id_type const& observer_handle, hpx::error_code& ec = hpx::throws)
@@ -74,7 +74,7 @@ Unregistering observers
     Unregister a previously registered observer.
 
 Waiting for terminal events
------------------------------
+---------------------------
 
 .. cpp:function:: hpx::future<hpx::supervision::lifecycle_state> hpx::supervision::await_terminal(hpx::id_type const& locality, hpx::id_type const& target, std::uint64_t epoch = 0, std::chrono::steady_clock::duration timeout = std::chrono::steady_clock::duration::max())
 .. cpp:function:: hpx::supervision::lifecycle_state hpx::supervision::await_terminal(hpx::launch::sync_policy, hpx::id_type const& locality, hpx::id_type const& target, std::uint64_t epoch = 0, std::chrono::steady_clock::duration timeout = std::chrono::steady_clock::duration::max(), hpx::error_code& ec = hpx::throws)
@@ -96,7 +96,7 @@ Waiting for terminal events
     registered distributed action) otherwise.
 
 Checking dispatch admission
------------------------------
+---------------------------
 
 .. cpp:function:: hpx::supervision::dispatch_outcome hpx::supervision::check_admission(hpx::id_type const& target, std::uint64_t epoch = 0)
 
@@ -122,6 +122,51 @@ Checking dispatch admission
     additional locality that needs to fence its own dispatch decisions on
     ``target`` must independently mirror or route to the owning locality's
     state; this module does not provide that for you.
+
+Registering activity observers
+------------------------------
+
+.. cpp:function:: hpx::future<hpx::id_type> hpx::supervision::register_activity_observer(hpx::id_type const& locality, hpx::supervision::activity_callback const& callback, std::optional<std::uint64_t> epoch_filter = std::nullopt)
+.. cpp:function:: hpx::id_type hpx::supervision::register_activity_observer(hpx::launch::sync_policy, hpx::id_type const& locality, hpx::supervision::activity_callback const& callback, std::optional<std::uint64_t> epoch_filter = std::nullopt, hpx::error_code& ec = hpx::throws)
+.. cpp:function:: hpx::id_type hpx::supervision::register_activity_observer(hpx::supervision::activity_callback const& callback, std::optional<std::uint64_t> epoch_filter = std::nullopt, hpx::error_code& ec = hpx::throws)
+
+    Register ``callback`` to observe activity-state transitions (between
+    ``hpx::supervision::activity_state::inactive`` and ``active``) of *all*
+    targets tracked by a locality's supervision manager. Unlike
+    ``register_observer``, none of these overloads take a ``target``
+    parameter: the feature reports on every target the addressed manager
+    tracks rather than on a single one.
+
+    Registration synchronously and atomically delivers one
+    ``activity_transition::already_active`` notification for every target
+    that is already active at the time of the call, taken under the same
+    lock that guards subscription, before the registration call returns.
+    This guarantees ``callback`` observes exactly one notification for each
+    such target's current activity state - either this replay, or a live
+    transition that raced with registration, but never both and never
+    neither. For local delivery, both the replay and any subsequent live
+    transitions invoke ``callback`` synchronously; for a given lifecycle
+    event, per-target ``register_observer`` callbacks always fire before
+    activity-observer callbacks triggered by that same event.
+
+    Activity notifications are a pure discovery/notification signal: unlike
+    ``publish_event``, registering or unregistering an activity observer
+    never feeds the terminal latch consulted by ``check_admission``.
+
+    If ``epoch_filter`` is set, ``callback`` only receives notifications -
+    including the registration-time replay - whose epoch matches; by
+    default it receives notifications regardless of epoch.
+
+Unregistering activity observers
+--------------------------------
+
+.. cpp:function:: hpx::future<void> hpx::supervision::unregister_activity_observer(hpx::id_type const& locality, hpx::id_type const& observer_handle)
+.. cpp:function:: void hpx::supervision::unregister_activity_observer(hpx::launch::sync_policy, hpx::id_type const& locality, hpx::id_type const& observer_handle, hpx::error_code& ec = hpx::throws)
+.. cpp:function:: void hpx::supervision::unregister_activity_observer(hpx::id_type const& observer_handle, hpx::error_code& ec = hpx::throws)
+
+    Unregister a previously registered activity observer. ``observer_handle``
+    must have been obtained from ``register_activity_observer``; a
+    handle obtained from ``register_observer`` is rejected.
 
 See the :ref:`API reference <modules_supervision_api>` of this module for
 more details.

--- a/libs/full/supervision/docs/index.rst
+++ b/libs/full/supervision/docs/index.rst
@@ -95,5 +95,22 @@ Waiting for terminal events
     supervision manager lives on the calling locality, and remotely (via a
     registered distributed action) otherwise.
 
+Checking dispatch admission
+-----------------------------
+
+.. cpp:function:: hpx::supervision::dispatch_outcome hpx::supervision::check_admission(hpx::id_type const& target, std::uint64_t epoch = 0)
+
+    Check whether ``target`` currently admits new dispatch under ``epoch``,
+    i.e. whether it is safe to schedule or route work to it right now. This
+    is a pure, ``noexcept`` local read of the same terminal latch state
+    consulted by ``await_terminal``: it returns
+    ``dispatch_outcome::rejected_fenced`` if ``target`` has already latched a
+    terminal event (``event::completed`` or ``event::failed``) under
+    ``epoch``, and ``dispatch_outcome::admitted`` otherwise. Unlike
+    ``publish_result``, which reports how a publication was resolved,
+    ``dispatch_outcome`` answers the separate, consumer-side question of
+    whether dispatch should proceed; it must only be called on the locality
+    ``target`` lives on.
+
 See the :ref:`API reference <modules_supervision_api>` of this module for
 more details.

--- a/libs/full/supervision/docs/index.rst
+++ b/libs/full/supervision/docs/index.rst
@@ -112,5 +112,16 @@ Checking dispatch admission
     whether dispatch should proceed; it must only be called on the locality
     ``target`` lives on.
 
+    This admission fence is scoped to a single locality's latch state: it
+    reflects only terminal events published to the supervision manager
+    hosting ``target``, and it fails open (returns ``admitted``) when
+    ``target`` is unknown locally, including when its terminal event was
+    only ever published elsewhere. There is no built-in mechanism that
+    propagates terminal latch state across localities - observer
+    registration delivers notifications, not admission state. Any
+    additional locality that needs to fence its own dispatch decisions on
+    ``target`` must independently mirror or route to the owning locality's
+    state; this module does not provide that for you.
+
 See the :ref:`API reference <modules_supervision_api>` of this module for
 more details.

--- a/libs/full/supervision/include/hpx/supervision/server/activity_agent.hpp
+++ b/libs/full/supervision/include/hpx/supervision/server/activity_agent.hpp
@@ -1,0 +1,86 @@
+//  Copyright (c) 2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/modules/actions.hpp>
+#include <hpx/modules/actions_base.hpp>
+#include <hpx/modules/async_distributed.hpp>
+#include <hpx/modules/components_base.hpp>
+#include <hpx/modules/synchronization.hpp>
+
+#include <hpx/supervision/supervision_api.hpp>
+
+#include <cstddef>
+#include <functional>
+
+namespace hpx::supervision::server {
+
+    // Local counterpart of agent_component used by
+    // register_target_activity_observer()/unregister_target_activity_observer().
+    // Unlike agent_component, instances of this component are only ever
+    // resolved and invoked locally (via hpx::get_ptr()), never through an
+    // action: activity-observer delivery is currently only wired for local
+    // registrations, so this class deliberately declares no actions of its
+    // own. Cross-locality delivery is added when the remote
+    // register_target_activity_observer()/unregister_target_activity_observer()
+    // overloads are wired in a later substep.
+    class HPX_EXPORT activity_agent_component
+      : public hpx::components::component_base<activity_agent_component>
+    {
+    public:
+        activity_agent_component() = default;
+
+        explicit activity_agent_component(activity_callback f) noexcept
+          : f_(HPX_MOVE(f))
+        {
+        }
+
+        bool invoke_if_active(target_activity_notification const& notify);
+
+        struct invoke_if_active_action
+          : hpx::actions::make_action_t<
+                decltype(&activity_agent_component::invoke_if_active),
+                &activity_agent_component::invoke_if_active,
+                invoke_if_active_action>
+        {
+        };
+
+        void deactivate_and_wait();
+
+        struct deactivate_and_wait_action
+          : hpx::actions::make_action_t<
+                decltype(&activity_agent_component::deactivate_and_wait),
+                &activity_agent_component::deactivate_and_wait,
+                deactivate_and_wait_action>
+        {
+        };
+
+    private:
+        void finish_delivery();
+
+        activity_callback f_;
+
+        hpx::spinlock mtx_;
+        hpx::lcos::local::detail::condition_variable cv_;
+        bool active_ = true;
+        std::size_t in_flight_ = 0;
+    };
+
+    // Create a local activity agent wrapping the given function
+    HPX_EXPORT hpx::id_type create_activity_agent(activity_callback f);
+
+}    // namespace hpx::supervision::server
+
+HPX_REGISTER_ACTION_DECLARATION(
+    hpx::supervision::server::activity_agent_component::invoke_if_active_action,
+    activity_agent_component_invoke_if_active_action)
+
+HPX_REGISTER_ACTION_DECLARATION(
+    hpx::supervision::server::activity_agent_component::
+        deactivate_and_wait_action,
+    activity_agent_component_deactivate_and_wait_action)

--- a/libs/full/supervision/include/hpx/supervision/server/activity_agent.hpp
+++ b/libs/full/supervision/include/hpx/supervision/server/activity_agent.hpp
@@ -21,13 +21,13 @@
 namespace hpx::supervision::server {
 
     // Local counterpart of agent_component used by
-    // register_target_activity_observer()/unregister_target_activity_observer().
+    // register_activity_observer()/unregister_activity_observer().
     // Unlike agent_component, instances of this component are only ever
     // resolved and invoked locally (via hpx::get_ptr()), never through an
     // action: activity-observer delivery is currently only wired for local
     // registrations, so this class deliberately declares no actions of its
     // own. Cross-locality delivery is added when the remote
-    // register_target_activity_observer()/unregister_target_activity_observer()
+    // register_activity_observer()/unregister_activity_observer()
     // overloads are wired in a later substep.
     class HPX_EXPORT activity_agent_component
       : public hpx::components::component_base<activity_agent_component>
@@ -40,7 +40,7 @@ namespace hpx::supervision::server {
         {
         }
 
-        bool invoke_if_active(target_activity_notification const& notify);
+        bool invoke_if_active(activity_notification const& notify);
 
         struct invoke_if_active_action
           : hpx::actions::make_action_t<

--- a/libs/full/supervision/include/hpx/supervision/server/supervision_manager.hpp
+++ b/libs/full/supervision/include/hpx/supervision/server/supervision_manager.hpp
@@ -247,11 +247,38 @@ namespace hpx::supervision::server {
             hpx::id_type const& agent,
             lifecycle_event_notification notification);
 
+        // Delivers `notification` to every currently-registered activity
+        // observer (see activity_observers_ below), skipping any observer whose
+        // epoch_filter does not match. Local delivery is synchronous: each
+        // observer's callback has already run by the time the returned future
+        // becomes ready. One observer's failure does not prevent delivery to
+        // the remaining observers.
+        hpx::future<void> fire_activity_events(
+            target_activity_notification const& notification);
+
+        // Delivers `notification` to the single activity observer identified by
+        // `agent`, if it is still registered. Removes `agent` from
+        // activity_observers_ if its callback signals it no longer wants to be
+        // invoked.
+        hpx::future<void> fire_activity_event(hpx::id_type const& agent,
+            target_activity_notification notification);
+
         void record_error(hpx::id_type const& target,
             std::uint64_t expected_sequence_number, hpx::error_code const& ec);
 
-        void unregister_observer_target(
+        // Returns true if this removed the last remaining per-target observer
+        // for `target` (i.e. its per-target observer count just transitioned
+        // from one to zero), so the caller can fire an
+        // activity_transition::last_observer_unregistered notification once
+        // mtx_ has been released.
+        bool unregister_observer_target(
             hpx::id_type const& target, hpx::id_type const& observer_handle);
+
+        // Returns the epoch currently recorded for `target`, or 0 if no epoch
+        // has been recorded yet. Used to populate the `epoch` field of activity
+        // notifications that are not themselves triggered by a publish_event()
+        // call (i.e. first_observer/ last_observer_unregistered).
+        std::uint64_t current_epoch_for(hpx::id_type const& target) const;
 
         using waiters_t = std::vector<waiter_entry>;
         using stale_waiters_t =
@@ -367,6 +394,17 @@ namespace hpx::supervision::server {
         std::map<hpx::id_type, std::vector<observer_entry>> observers_;
         // inverse lookup for agents: agents -> targets
         std::map<hpx::id_type, std::vector<hpx::id_type>> agents_;
+
+        // registered activity observers (see
+        // register_target_activity_observer()): locality-scoped, not keyed by
+        // target, so every entry here is delivered every activation/
+        // deactivation transition recorded for any target this manager
+        // tracks (filtered only by each entry's own epoch_filter). Kept
+        // entirely separate from observers_/agents_ above so that this
+        // collection only ever holds
+        // observer_handle_kind::target_activity_observer handles.
+        std::vector<observer_entry> activity_observers_;
+
         // one-shot waiters for await_terminal(): (target, epoch) -> pending
         // promises (each paired with a deadline). Resolved and erased from
         // this map by publish_event() as soon as the corresponding

--- a/libs/full/supervision/include/hpx/supervision/server/supervision_manager.hpp
+++ b/libs/full/supervision/include/hpx/supervision/server/supervision_manager.hpp
@@ -173,6 +173,14 @@ namespace hpx::supervision::server {
         {
         };
 
+        // Pure local read of the terminal latch state maintained for
+        // `target`; see hpx::supervision::check_admission() for the exact
+        // semantics. Not exposed as an action: unlike publish_event()/
+        // query_state(), this is only ever meant to be called on the
+        // locality `target` lives on.
+        dispatch_outcome check_admission(
+            hpx::id_type const& target, std::uint64_t epoch = 0) const noexcept;
+
     protected:
         hpx::future<void> fire_events(hpx::id_type const& target,
             lifecycle_event_notification const& notification);

--- a/libs/full/supervision/include/hpx/supervision/server/supervision_manager.hpp
+++ b/libs/full/supervision/include/hpx/supervision/server/supervision_manager.hpp
@@ -154,19 +154,20 @@ namespace hpx::supervision::server {
         {
         };
 
-        // Register `agent` to be notified of activation/deactivation
-        // transitions across all targets tracked by this manager. Unlike
-        // register_observer(), this takes no `target` parameter by design: the
-        // feature is locality-scoped, not target-scoped, so `agent` is notified
-        // about every target this manager tracks rather than a single one.
-        // Registration will replay an `already_active` notification (added in a
-        // later substep) for every currently-tracked active target, delivered
-        // atomically with subscription under the same lock that guards the
-        // tracked-target set, so no transition is missed or duplicated across
-        // the replay/subscribe boundary. Returned handles come from the
-        // observer_handle_kind::activity_observer namespace (see
-        // observer_handle_kind above), distinct from register_observer()
-        // handles.
+        /// Registers an activity observer for the given target and replays its
+        /// current state if the target is already active.
+        ///
+        /// The snapshot of the target's tracked state and the insertion of the
+        /// observer into the tracked set happen atomically under `mtx_`, which
+        /// guarantees the observer receives exactly one notification for the
+        /// target's current state: either the replay (if already active at
+        /// registration time) or a live transition that raced with
+        /// registration, but never both and never neither.
+        ///
+        /// Delivery of that notification (replay or live) happens after `mtx_`
+        /// is released and is therefore not ordered relative to any other
+        /// concurrent live notification for the same target; callers must not
+        /// assume replay is delivered before or after a racing live event.
         hpx::id_type register_activity_observer(hpx::id_type const& agent,
             std::uint64_t epoch_filter = static_cast<std::uint64_t>(-1));
 
@@ -243,14 +244,26 @@ namespace hpx::supervision::server {
             hpx::id_type const& agent,
             lifecycle_event_notification notification);
 
-        // Delivers `notification` to every currently-registered activity
-        // observer (see activity_observers_ below), skipping any observer whose
+        // Delivers `notification` to each entry in `observers` (a snapshot of
+        // activity_observers_ taken by the caller), skipping any observer whose
         // epoch_filter does not match. Local delivery is synchronous: each
         // observer's callback has already run by the time the returned future
         // becomes ready. One observer's failure does not prevent delivery to
-        // the remaining observers.
-        hpx::future<void> fire_activity_events(
-            activity_notification const& notification);
+        // the remaining observers. Used by publish_event()/
+        // register_observer()/unregister_observer()/fire_event() so that the
+        // activity_observers_ snapshot determining delivery of a
+        // first_event/first_observer/last_observer_unregistered transition is
+        // taken in the very same mtx_ critical section as the
+        // states_/observers_ mutation that drives the transition, instead of in
+        // a later, separate critical section: otherwise, a
+        // register_activity_observer() call that acquires mtx_ in between would
+        // install its agent into activity_observers_ in time to receive this
+        // transition's live notification *and* see the already-mutated state in
+        // its own replay snapshot, delivering the same transition to that agent
+        // twice (or, symmetrically, delivering it zero times).
+        hpx::future<void> deliver_activity_notification(
+            activity_notification const& notification,
+            std::vector<observer_entry> const& observers);
 
         // Delivers `notification` to the single activity observer identified by
         // `agent`, if it is still registered. Removes `agent` from

--- a/libs/full/supervision/include/hpx/supervision/server/supervision_manager.hpp
+++ b/libs/full/supervision/include/hpx/supervision/server/supervision_manager.hpp
@@ -83,6 +83,20 @@ namespace hpx::supervision::server {
         std::chrono::steady_clock::time_point deadline;
     };
 
+    // Discriminates which registration API a given observer handle originated
+    // from. register_target_activity_observer() handles are reserved into their
+    // own namespace, distinct from register_observer() handles, so that
+    // unregister_target_activity_observer() (and, symmetrically,
+    // unregister_observer()) can reject a handle that was returned by the other
+    // registration API rather than silently misinterpreting it. Only the tag is
+    // reserved here; the storage and rejection logic that consult it are added
+    // in a later substep.
+    enum class observer_handle_kind : std::uint8_t
+    {
+        target_observer,
+        target_activity_observer
+    };
+
     struct supervision_manager
       : hpx::components::fixed_component_base<supervision_manager>
     {
@@ -137,6 +151,51 @@ namespace hpx::supervision::server {
                 decltype(&supervision_manager::unregister_observer),
                 &supervision_manager::unregister_observer,
                 unregister_observer_action>
+        {
+        };
+
+        // Register `agent` to be notified of activation/deactivation
+        // transitions across all targets tracked by this manager. Unlike
+        // register_observer(), this takes no `target` parameter by design: the
+        // feature is locality-scoped, not target-scoped, so `agent` is notified
+        // about every target this manager tracks rather than a single one.
+        // Registration will replay an `already_active` notification (added in a
+        // later substep) for every currently-tracked active target, delivered
+        // atomically with subscription under the same lock that guards the
+        // tracked-target set, so no transition is missed or duplicated across
+        // the replay/subscribe boundary. Returned handles come from the
+        // observer_handle_kind::target_activity_observer namespace (see
+        // observer_handle_kind above), distinct from register_observer()
+        // handles.
+        hpx::id_type register_target_activity_observer(
+            hpx::id_type const& agent,
+            std::uint64_t epoch_filter = static_cast<std::uint64_t>(-1));
+
+        struct register_target_activity_observer_action
+          : hpx::actions::make_action_t<
+                decltype(&supervision_manager::
+                        register_target_activity_observer),
+                &supervision_manager::register_target_activity_observer,
+                register_target_activity_observer_action>
+        {
+        };
+
+        // Unregister a handle previously returned by
+        // register_target_activity_observer(). As with unregister_observer(),
+        // no orphaned callbacks fire after this call completes.
+        // `observer_handle` must belong to the
+        // observer_handle_kind::target_activity_observer namespace; a handle
+        // from register_observer() is rejected (rejection logic added in a
+        // later substep).
+        void unregister_target_activity_observer(
+            hpx::id_type const& observer_handle);
+
+        struct unregister_target_activity_observer_action
+          : hpx::actions::make_action_t<
+                decltype(&supervision_manager::
+                        unregister_target_activity_observer),
+                &supervision_manager::unregister_target_activity_observer,
+                unregister_target_activity_observer_action>
         {
         };
 
@@ -384,6 +443,12 @@ HPX_REGISTER_ACTION_DECLARATION(
 HPX_REGISTER_ACTION_DECLARATION(
     hpx::supervision::server::supervision_manager::unregister_observer_action,
     supervision_unregister_observer_action)
+HPX_REGISTER_ACTION_DECLARATION(hpx::supervision::server::supervision_manager::
+                                    register_target_activity_observer_action,
+    supervision_register_target_activity_observer_action)
+HPX_REGISTER_ACTION_DECLARATION(hpx::supervision::server::supervision_manager::
+                                    unregister_target_activity_observer_action,
+    supervision_unregister_target_activity_observer_action)
 HPX_REGISTER_ACTION_DECLARATION(
     hpx::supervision::server::supervision_manager::query_state_action,
     supervision_query_state_action)

--- a/libs/full/supervision/include/hpx/supervision/server/supervision_manager.hpp
+++ b/libs/full/supervision/include/hpx/supervision/server/supervision_manager.hpp
@@ -84,9 +84,9 @@ namespace hpx::supervision::server {
     };
 
     // Discriminates which registration API a given observer handle originated
-    // from. register_target_activity_observer() handles are reserved into their
+    // from. register_activity_observer() handles are reserved into their
     // own namespace, distinct from register_observer() handles, so that
-    // unregister_target_activity_observer() (and, symmetrically,
+    // unregister_activity_observer() (and, symmetrically,
     // unregister_observer()) can reject a handle that was returned by the other
     // registration API rather than silently misinterpreting it. Only the tag is
     // reserved here; the storage and rejection logic that consult it are added
@@ -94,7 +94,7 @@ namespace hpx::supervision::server {
     enum class observer_handle_kind : std::uint8_t
     {
         target_observer,
-        target_activity_observer
+        activity_observer
     };
 
     struct supervision_manager
@@ -164,38 +164,34 @@ namespace hpx::supervision::server {
         // atomically with subscription under the same lock that guards the
         // tracked-target set, so no transition is missed or duplicated across
         // the replay/subscribe boundary. Returned handles come from the
-        // observer_handle_kind::target_activity_observer namespace (see
+        // observer_handle_kind::activity_observer namespace (see
         // observer_handle_kind above), distinct from register_observer()
         // handles.
-        hpx::id_type register_target_activity_observer(
-            hpx::id_type const& agent,
+        hpx::id_type register_activity_observer(hpx::id_type const& agent,
             std::uint64_t epoch_filter = static_cast<std::uint64_t>(-1));
 
-        struct register_target_activity_observer_action
+        struct register_activity_observer_action
           : hpx::actions::make_action_t<
-                decltype(&supervision_manager::
-                        register_target_activity_observer),
-                &supervision_manager::register_target_activity_observer,
-                register_target_activity_observer_action>
+                decltype(&supervision_manager::register_activity_observer),
+                &supervision_manager::register_activity_observer,
+                register_activity_observer_action>
         {
         };
 
         // Unregister a handle previously returned by
-        // register_target_activity_observer(). As with unregister_observer(),
+        // register_activity_observer(). As with unregister_observer(),
         // no orphaned callbacks fire after this call completes.
         // `observer_handle` must belong to the
-        // observer_handle_kind::target_activity_observer namespace; a handle
+        // observer_handle_kind::activity_observer namespace; a handle
         // from register_observer() is rejected (rejection logic added in a
         // later substep).
-        void unregister_target_activity_observer(
-            hpx::id_type const& observer_handle);
+        void unregister_activity_observer(hpx::id_type const& observer_handle);
 
-        struct unregister_target_activity_observer_action
+        struct unregister_activity_observer_action
           : hpx::actions::make_action_t<
-                decltype(&supervision_manager::
-                        unregister_target_activity_observer),
-                &supervision_manager::unregister_target_activity_observer,
-                unregister_target_activity_observer_action>
+                decltype(&supervision_manager::unregister_activity_observer),
+                &supervision_manager::unregister_activity_observer,
+                unregister_activity_observer_action>
         {
         };
 
@@ -254,14 +250,14 @@ namespace hpx::supervision::server {
         // becomes ready. One observer's failure does not prevent delivery to
         // the remaining observers.
         hpx::future<void> fire_activity_events(
-            target_activity_notification const& notification);
+            activity_notification const& notification);
 
         // Delivers `notification` to the single activity observer identified by
         // `agent`, if it is still registered. Removes `agent` from
         // activity_observers_ if its callback signals it no longer wants to be
         // invoked.
-        hpx::future<void> fire_activity_event(hpx::id_type const& agent,
-            target_activity_notification notification);
+        hpx::future<void> fire_activity_event(
+            hpx::id_type const& agent, activity_notification notification);
 
         void record_error(hpx::id_type const& target,
             std::uint64_t expected_sequence_number, hpx::error_code const& ec);
@@ -395,23 +391,36 @@ namespace hpx::supervision::server {
         // inverse lookup for agents: agents -> targets
         std::map<hpx::id_type, std::vector<hpx::id_type>> agents_;
 
-        // registered activity observers (see
-        // register_target_activity_observer()): locality-scoped, not keyed by
-        // target, so every entry here is delivered every activation/
-        // deactivation transition recorded for any target this manager
-        // tracks (filtered only by each entry's own epoch_filter). Kept
-        // entirely separate from observers_/agents_ above so that this
-        // collection only ever holds
-        // observer_handle_kind::target_activity_observer handles.
+        // registered activity observers (see register_activity_observer()):
+        // locality-scoped, not keyed by target, so every entry here is
+        // delivered every activation/ deactivation transition recorded for any
+        // target this manager tracks (filtered only by each entry's own
+        // epoch_filter). Kept entirely separate from observers_/agents_ above
+        // so that this collection only ever holds
+        // observer_handle_kind::activity_observer handles.
         std::vector<observer_entry> activity_observers_;
 
+        // Records, for every target currently tracked (i.e. present in states_
+        // or observers_, see register_activity_observer()), the time it
+        // originally transitioned to activity_state::active. Populated the
+        // first time a target's tracked state flips from false to true (in
+        // publish_event()/register_observer(), guarded by try_emplace() so a
+        // later trigger never overwrites the original activation time), and
+        // erased once a target is no longer tracked by either signal (in
+        // unregister_observer_target()'s callers). Consulted by
+        // register_activity_observer() to populate the event_time of an
+        // activity_transition::already_active replay with the target's original
+        // activation time rather than the time of registration, per
+        // activity_notification::event_time.
+        std::map<hpx::id_type, std::chrono::steady_clock::time_point>
+            activated_at_;
+
         // one-shot waiters for await_terminal(): (target, epoch) -> pending
-        // promises (each paired with a deadline). Resolved and erased from
-        // this map by publish_event() as soon as the corresponding
-        // target/epoch pair reaches a terminal event; set to an explicit
-        // exception and erased instead if that epoch is superseded first,
-        // or if its deadline passes before either of those happens (see
-        // sweep_expired_waiters()).
+        // promises (each paired with a deadline). Resolved and erased from this
+        // map by publish_event() as soon as the corresponding target/epoch pair
+        // reaches a terminal event; set to an explicit exception and erased
+        // instead if that epoch is superseded first, or if its deadline passes
+        // before either of those happens (see sweep_expired_waiters()).
         std::map<waiter_key, waiters_t> waiters_;
 
         // Earliest deadline among all waiters currently in waiters_, or
@@ -482,11 +491,11 @@ HPX_REGISTER_ACTION_DECLARATION(
     hpx::supervision::server::supervision_manager::unregister_observer_action,
     supervision_unregister_observer_action)
 HPX_REGISTER_ACTION_DECLARATION(hpx::supervision::server::supervision_manager::
-                                    register_target_activity_observer_action,
-    supervision_register_target_activity_observer_action)
+                                    register_activity_observer_action,
+    supervision_register_activity_observer_action)
 HPX_REGISTER_ACTION_DECLARATION(hpx::supervision::server::supervision_manager::
-                                    unregister_target_activity_observer_action,
-    supervision_unregister_target_activity_observer_action)
+                                    unregister_activity_observer_action,
+    supervision_unregister_activity_observer_action)
 HPX_REGISTER_ACTION_DECLARATION(
     hpx::supervision::server::supervision_manager::query_state_action,
     supervision_query_state_action)

--- a/libs/full/supervision/include/hpx/supervision/supervision_api.hpp
+++ b/libs/full/supervision/include/hpx/supervision/supervision_api.hpp
@@ -749,4 +749,50 @@ namespace hpx::supervision {
             std::nullopt,
         hpx::error_code& ec = hpx::throws);
 
+    /// \brief Outcome of an admission check performed before dispatching new
+    ///        work to a target.
+    ///
+    /// Unlike \c publish_result, which reports how a *publication* was
+    /// resolved, \c dispatch_outcome answers a *consumer-side* question:
+    /// is it safe to schedule/route work to this target right now?
+    HPX_CXX_EXPORT enum class dispatch_outcome : std::uint8_t {
+        /// The target has not latched a terminal event for the queried
+        /// epoch; dispatch may proceed.
+        admitted,
+        /// The target has already latched a terminal event (\c completed or
+        /// \c failed) for the queried epoch; dispatch was refused. This is
+        /// final, not a stale read: callers should not retry against this
+        /// target/epoch.
+        rejected_fenced,
+        // queued is intentionally not implemented in v1. Admitting it would
+        // require a pending-dispatch buffer together with a re-delivery
+        // mechanism triggered on epoch-bump release, which is new
+        // infrastructure not provided by this enum's initial version.
+    };
+
+    /// \brief Check whether \a target currently admits new dispatch under
+    ///        \a epoch.
+    ///
+    /// Queries the local supervision manager's terminal-latch state for
+    /// \a target within \a epoch, i.e. the same state maintained by
+    /// \a publish_event() and consulted by \a await_terminal(). Does not
+    /// publish, mutate state, or notify observers.
+    ///
+    /// \param target [in] The actor (or component) to check. Must be local
+    ///               to the calling locality.
+    /// \param epoch  [in] The epoch dispatch would occur under.
+    ///
+    /// \returns      \c dispatch_outcome::rejected_fenced if \a target has
+    ///               already latched a terminal event (\c completed or
+    ///               \c failed) under \a epoch, \c dispatch_outcome::admitted
+    ///               otherwise (including when \a target is unknown locally or
+    ///               invalid).
+    ///
+    /// \note         This is a pure local read of already-resident latch
+    ///               state, not a query that can fail the way a remote
+    ///               \a publish_event() call can; it never throws and
+    ///               carries no \a hpx::error_code out-parameter.
+    HPX_CXX_EXPORT HPX_EXPORT dispatch_outcome check_admission(
+        hpx::id_type const& target, std::uint64_t epoch = 0) noexcept;
+
 }    // namespace hpx::supervision

--- a/libs/full/supervision/include/hpx/supervision/supervision_api.hpp
+++ b/libs/full/supervision/include/hpx/supervision/supervision_api.hpp
@@ -5,7 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 /// \file hpx/supervision/supervision_api.hpp
-/// \page hpx::supervision::publish_event, hpx::supervision::query_state, hpx::supervision::register_observer, hpx::supervision::unregister_observer, hpx::supervision::register_target_activity_observer, hpx::supervision::unregister_target_activity_observer
+/// \page hpx::supervision::publish_event, hpx::supervision::query_state, hpx::supervision::register_observer, hpx::supervision::unregister_observer, hpx::supervision::register_activity_observer, hpx::supervision::unregister_activity_observer
 /// \headerfile hpx/supervision.hpp
 
 #pragma once
@@ -15,7 +15,6 @@
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/futures.hpp>
 #include <hpx/modules/naming_base.hpp>
-#include <hpx/modules/serialization.hpp>
 
 #include <hpx/supervision/supervision_fwd.hpp>
 
@@ -260,15 +259,16 @@ namespace hpx::supervision {
         hpx::error_code ec = hpx::make_success_code();
     };
 
-    /// \brief Determine whether transitioning from lifecycle event \a from
-    ///        to lifecycle event \a to is permitted by the supervision
-    ///        lifecycle state machine.
+    /// \brief Determine whether transitioning from lifecycle event \a from to
+    ///        lifecycle event \a to is permitted by the supervision lifecycle
+    ///        state machine.
     ///
-    /// \a completed and \a failed are terminal states and have no outgoing
-    /// transitions. \a losing_locality is only reachable from \a started,
-    /// \a running, or \a suspending, and may only transition to \a failed.
-    /// A missing prior event is represented as \a event::unknown, from
-    /// which the only valid transition is to \a started.
+    /// \a event::completed and \a event::failed are terminal states and have no
+    /// outgoing transitions. \a event::losing_locality is only reachable from
+    /// \a event::started, \a event::running, or \a event::suspending, and may
+    /// only transition to \a failed. A missing prior event is represented as \a
+    /// event::unknown, from which the only valid transition is to \a
+    /// event::started.
     HPX_CXX_EXPORT HPX_EXPORT bool is_valid_transition(
         event from, event to) noexcept;
 
@@ -816,7 +816,7 @@ namespace hpx::supervision {
         hpx::id_type const& target, std::uint64_t epoch = 0) noexcept;
 
     /// \brief The activity state of a supervised target, as tracked by
-    ///        \a register_target_activity_observer().
+    ///        \a register_activity_observer().
     ///
     /// A target is considered \c active as soon as it has published at least
     /// one lifecycle event or has at least one registered activity observer,
@@ -831,7 +831,7 @@ namespace hpx::supervision {
         active,
     };
 
-    /// \brief The reason a \a target_activity_notification was delivered.
+    /// \brief The reason a \a activity_notification was delivered.
     HPX_CXX_EXPORT enum class activity_transition : std::uint8_t {
         /// The target transitioned to \c activity_state::active because it
         /// published its first lifecycle event.
@@ -855,11 +855,11 @@ namespace hpx::supervision {
     ///        whenever a supervised target transitions between
     ///        \a activity_state::inactive and \a activity_state::active.
     ///
-    /// A `target_activity_notification` is constructed by the supervision
-    /// manager whenever \ref actor's activity state changes (see
+    /// A `activity_notification` is constructed by the supervision manager
+    /// whenever \ref actor's activity state changes (see
     /// \ref activity_transition), and once more, synchronously at
     /// registration time, if \ref actor is already active when
-    /// \ref hpx::supervision::register_target_activity_observer is called
+    /// \ref hpx::supervision::register_activity_observer is called
     /// (carrying \c activity_transition::already_active). It is delivered
     /// synchronously to local observers within the call that triggered the
     /// transition, and asynchronously via a dedicated parcel to remote
@@ -871,8 +871,8 @@ namespace hpx::supervision {
     /// \see hpx::supervision::activity_state
     /// \see hpx::supervision::activity_transition
     /// \see hpx::supervision::activity_callback
-    /// \see hpx::supervision::register_target_activity_observer
-    HPX_CXX_EXPORT struct target_activity_notification
+    /// \see hpx::supervision::register_activity_observer
+    HPX_CXX_EXPORT struct activity_notification
     {
         /// The global id of the actor this notification describes.
         hpx::id_type actor;
@@ -906,9 +906,9 @@ namespace hpx::supervision {
     /// \brief Callback type used to observe activity-state transitions for a
     ///        supervised target.
     ///
-    /// The callback is invoked with the \ref target_activity_notification
-    /// describing the transition that occurred. Delivery status (e.g. staleness
-    /// or delivery failures for remote observers) is reported via \c
+    /// The callback is invoked with the \ref activity_notification describing
+    /// the transition that occurred. Delivery status (e.g. staleness or
+    /// delivery failures for remote observers) is reported via \c
     /// notification.ec.
     ///
     /// \returns `true` if the observer should stay registered, `false`
@@ -921,7 +921,7 @@ namespace hpx::supervision {
     ///       invoked synchronously from within the call that triggers the
     ///       transition.
     HPX_CXX_EXPORT using activity_callback =
-        std::function<bool(target_activity_notification const&)>;
+        std::function<bool(activity_notification const&)>;
 #endif
 
     /// \brief Register a callback to observe activity-state transitions of all
@@ -943,7 +943,7 @@ namespace hpx::supervision {
     ///
     /// \returns        A future holding the global id of the observer
     ///                 handle. This handle must be passed to
-    ///                 \a unregister_target_activity_observer() in order
+    ///                 \a unregister_activity_observer() in order
     ///                 to stop receiving notifications.
     ///
     /// \throws         hpx::exception if \a locality does not represent a
@@ -973,7 +973,7 @@ namespace hpx::supervision {
     ///                 it are logged and do not affect the observer
     ///                 registration.
     HPX_CXX_EXPORT HPX_EXPORT hpx::future<hpx::id_type>
-    register_target_activity_observer(hpx::id_type const& locality,
+    register_activity_observer(hpx::id_type const& locality,
         activity_callback const& callback,
         std::optional<std::uint64_t> epoch_filter = std::nullopt);
 
@@ -982,7 +982,7 @@ namespace hpx::supervision {
     ///        registration has completed.
     ///
     /// This is the synchronous equivalent of
-    /// \a register_target_activity_observer(hpx::id_type const&,
+    /// \a register_activity_observer(hpx::id_type const&,
     /// activity_callback const&, std::optional<std::uint64_t>).
     ///
     /// \param locality     [in] The locality on which the callback should
@@ -1002,13 +1002,13 @@ namespace hpx::supervision {
     ///
     /// \returns        The global id of the observer handle. This handle
     ///                 must be passed to
-    ///                 \a unregister_target_activity_observer() in order
+    ///                 \a unregister_activity_observer() in order
     ///                 to stop receiving notifications.
     ///
     /// \throws         hpx::exception if \a locality does not represent a
     ///                 locality, unless \a ec was not pre-initialized to \a
     ///                 hpx::throws.
-    HPX_CXX_EXPORT HPX_EXPORT hpx::id_type register_target_activity_observer(
+    HPX_CXX_EXPORT HPX_EXPORT hpx::id_type register_activity_observer(
         hpx::launch::sync_policy, hpx::id_type const& locality,
         activity_callback const& callback,
         std::optional<std::uint64_t> epoch_filter = std::nullopt,
@@ -1033,7 +1033,7 @@ namespace hpx::supervision {
     ///
     /// \returns        The global id of the observer handle. This handle
     ///                 must be passed to
-    ///                 \a unregister_target_activity_observer() in order
+    ///                 \a unregister_activity_observer() in order
     ///                 to stop receiving notifications.
     ///
     /// \throws         hpx::exception if the operation fails, unless \a ec
@@ -1047,7 +1047,7 @@ namespace hpx::supervision {
     ///                 lock that serializes activity-state transitions, so the
     ///                 observer can neither miss nor double-receive any active
     ///                 target's current activity state.
-    HPX_CXX_EXPORT HPX_EXPORT hpx::id_type register_target_activity_observer(
+    HPX_CXX_EXPORT HPX_EXPORT hpx::id_type register_activity_observer(
         activity_callback const& callback,
         std::optional<std::uint64_t> epoch_filter = std::nullopt,
         hpx::error_code& ec = hpx::throws);
@@ -1058,7 +1058,7 @@ namespace hpx::supervision {
     /// \param locality        [in] The locality on which the observer was
     ///                        registered.
     /// \param observer_handle [in] The handle returned by a prior call to
-    ///                        \a register_target_activity_observer(). Only
+    ///                        \a register_activity_observer(). Only
     ///                        handles returned from that function are accepted;
     ///                        passing a handle obtained from
     ///                        \a register_observer() (or any foreign
@@ -1077,8 +1077,7 @@ namespace hpx::supervision {
     /// \note                  Once the returned future has become ready,
     ///                        no orphaned callbacks fire after unregistration
     ///                        completes.
-    HPX_CXX_EXPORT HPX_EXPORT hpx::future<void>
-    unregister_target_activity_observer(
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future<void> unregister_activity_observer(
         hpx::id_type const& locality, hpx::id_type const& observer_handle);
 
     /// \brief Unregister a previously registered activity observer on a
@@ -1086,13 +1085,13 @@ namespace hpx::supervision {
     ///        completed.
     ///
     /// This is the synchronous equivalent of
-    /// \a unregister_target_activity_observer(hpx::id_type const&,
+    /// \a unregister_activity_observer(hpx::id_type const&,
     /// hpx::id_type const&).
     ///
     /// \param locality        [in] The locality on which the observer was
     ///                        registered.
     /// \param observer_handle [in] The handle returned by a prior call to
-    ///                        \a register_target_activity_observer(). See
+    ///                        \a register_activity_observer(). See
     ///                        the asynchronous overload regarding foreign
     ///                        handles.
     /// \param ec              [in,out] this represents the error status on
@@ -1109,7 +1108,7 @@ namespace hpx::supervision {
     ///
     /// \note                  No orphaned callbacks fire after
     ///                        unregistration completes.
-    HPX_CXX_EXPORT HPX_EXPORT void unregister_target_activity_observer(
+    HPX_CXX_EXPORT HPX_EXPORT void unregister_activity_observer(
         hpx::launch::sync_policy, hpx::id_type const& locality,
         hpx::id_type const& observer_handle, hpx::error_code& ec = hpx::throws);
 
@@ -1117,7 +1116,7 @@ namespace hpx::supervision {
     ///        locality.
     ///
     /// \param observer_handle [in] The handle returned by a prior call to
-    ///                        \a register_target_activity_observer(). Must
+    ///                        \a register_activity_observer(). Must
     ///                        be local to the calling locality. See the remote
     ///                        overload regarding foreign handles.
     /// \param ec              [in,out] this represents the error status on
@@ -1132,7 +1131,7 @@ namespace hpx::supervision {
     ///
     /// \note                  No orphaned callbacks fire after
     ///                        unregistration completes.
-    HPX_CXX_EXPORT HPX_EXPORT void unregister_target_activity_observer(
+    HPX_CXX_EXPORT HPX_EXPORT void unregister_activity_observer(
         hpx::id_type const& observer_handle, hpx::error_code& ec = hpx::throws);
 
 }    // namespace hpx::supervision

--- a/libs/full/supervision/include/hpx/supervision/supervision_api.hpp
+++ b/libs/full/supervision/include/hpx/supervision/supervision_api.hpp
@@ -5,7 +5,7 @@
 //  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 /// \file hpx/supervision/supervision_api.hpp
-/// \page hpx::supervision::publish_event, hpx::supervision::query_state, hpx::supervision::register_observer, hpx::supervision::unregister_observer
+/// \page hpx::supervision::publish_event, hpx::supervision::query_state, hpx::supervision::register_observer, hpx::supervision::unregister_observer, hpx::supervision::register_target_activity_observer, hpx::supervision::unregister_target_activity_observer
 /// \headerfile hpx/supervision.hpp
 
 #pragma once
@@ -760,9 +760,15 @@ namespace hpx::supervision {
         /// epoch; dispatch may proceed.
         admitted,
         /// The target has already latched a terminal event (\c completed or
-        /// \c failed) for the queried epoch; dispatch was refused. This is
-        /// final, not a stale read: callers should not retry against this
-        /// target/epoch.
+        /// \c failed) for the queried epoch; dispatch was refused.
+        /// The target has already latched a terminal event (\c completed or
+        /// \c failed) for the queried epoch, as observed by the *local*
+        /// supervision manager; dispatch was refused. This is final relative to
+        /// this locality's latch state - not a stale read - so callers on the
+        /// locality that owns \a target should not retry against this
+        /// target/epoch. It says nothing about localities other than the one
+        /// hosting \a target's supervision manager (see \c check_admission's
+        /// note on locality scope).
         rejected_fenced,
         // queued is intentionally not implemented in v1. Admitting it would
         // require a pending-dispatch buffer together with a re-delivery
@@ -792,7 +798,344 @@ namespace hpx::supervision {
     ///               state, not a query that can fail the way a remote
     ///               \a publish_event() call can; it never throws and
     ///               carries no \a hpx::error_code out-parameter.
+    /// \note         The terminal latch consulted here is populated only by
+    ///               \a publish_event() calls delivered to *this* locality's
+    ///               supervision manager for \a target. It is not synchronized
+    ///               across localities: a terminal event published to a
+    ///               different locality's manager for the same logical
+    ///               target/epoch is invisible here and does not affect this
+    ///               call's outcome. \c register_observer /
+    ///               \c unregister_observer notifications do not feed this
+    ///               state either. Any locality other than the one hosting
+    ///               \a target's supervision manager that needs to gate its
+    ///               own dispatch decisions on \a target's terminal state must
+    ///               build that cross-locality propagation itself (e.g.
+    ///               registering an observer with the owning locality and
+    ///               re-publishing locally, or routing the admission decision
+    ///               to the owning locality); this API provides no such
+    ///               mechanism.
     HPX_CXX_EXPORT HPX_EXPORT dispatch_outcome check_admission(
         hpx::id_type const& target, std::uint64_t epoch = 0) noexcept;
+
+    /// \brief The activity state of a supervised target, as tracked by
+    ///        \a register_target_activity_observer().
+    ///
+    /// A target is considered \c active as soon as it has published at least
+    /// one lifecycle event or has at least one registered activity observer,
+    /// whichever happens first, and remains so until every activity observer
+    /// has been unregistered again.
+    HPX_CXX_EXPORT enum class activity_state : std::uint8_t {
+        /// The target has never published a lifecycle event and currently has
+        /// no registered activity observers.
+        inactive,
+        /// The target has published at least one lifecycle event, or has
+        /// at least one registered activity observer.
+        active,
+    };
+
+    /// \brief The reason a \a target_activity_notification was delivered.
+    HPX_CXX_EXPORT enum class activity_transition : std::uint8_t {
+        /// The target transitioned to \c activity_state::active because it
+        /// published its first lifecycle event.
+        first_event,
+        /// The target transitioned to \c activity_state::active because
+        /// the first activity observer was registered for it.
+        first_observer,
+        /// The target transitioned to \c activity_state::inactive because
+        /// its last remaining activity observer was unregistered.
+        last_observer_unregistered,
+        /// The target was already \c activity_state::active at the time an
+        /// activity observer was registered for it. Delivered as a replay,
+        /// synchronously as part of registration under the same lock that
+        /// guards the activity state, so that a newly-registered observer
+        /// cannot miss (nor be delivered twice for) a transition that
+        /// raced with its own registration.
+        already_active,
+    };
+
+    /// \brief Payload delivered to a registered activity observer callback
+    ///        whenever a supervised target transitions between
+    ///        \a activity_state::inactive and \a activity_state::active.
+    ///
+    /// A `target_activity_notification` is constructed by the supervision
+    /// manager whenever \ref actor's activity state changes (see
+    /// \ref activity_transition), and once more, synchronously at
+    /// registration time, if \ref actor is already active when
+    /// \ref hpx::supervision::register_target_activity_observer is called
+    /// (carrying \c activity_transition::already_active). It is delivered
+    /// synchronously to local observers within the call that triggered the
+    /// transition, and asynchronously via a dedicated parcel to remote
+    /// observers.
+    ///
+    /// \note Instances are serializable so that they may be transmitted to
+    ///       remote observers across localities.
+    ///
+    /// \see hpx::supervision::activity_state
+    /// \see hpx::supervision::activity_transition
+    /// \see hpx::supervision::activity_callback
+    /// \see hpx::supervision::register_target_activity_observer
+    HPX_CXX_EXPORT struct target_activity_notification
+    {
+        /// The global id of the actor this notification describes.
+        hpx::id_type actor;
+
+        /// The activity state \ref actor transitioned to.
+        activity_state state = activity_state::inactive;
+
+        /// The reason this notification was delivered.
+        activity_transition transition = activity_transition::first_event;
+
+        /// The time at which the transition was recorded, as observed by
+        /// the runtime managing \ref actor's registration. For a
+        /// \c activity_transition::already_active replay this is the time
+        /// \ref actor originally became active, not the time of
+        /// registration.
+        std::chrono::steady_clock::time_point event_time;
+
+        /// The epoch \ref actor was in at the time of the transition (see
+        /// the epoch semantics of \a publish_event).
+        std::uint64_t epoch = 0;
+
+        /// Error code describing the outcome of delivering this
+        /// notification. A successful delivery yields
+        /// \c hpx::make_success_code(); a non-success code may indicate
+        /// staleness or a delivery failure that the observer callback
+        /// should account for.
+        hpx::error_code ec = hpx::make_success_code();
+    };
+
+#if defined(DOXYGEN)
+    /// \brief Callback type used to observe activity-state transitions for a
+    ///        supervised target.
+    ///
+    /// The callback is invoked with the \ref target_activity_notification
+    /// describing the transition that occurred. Delivery status (e.g. staleness
+    /// or delivery failures for remote observers) is reported via \c
+    /// notification.ec.
+    ///
+    /// \returns `true` if the observer should stay registered, `false`
+    ///          otherwise (i.e., `false` will unregister the observer and no
+    ///          further callbacks will be invoked for the given observer).
+    ///
+    /// \note Any exception thrown from the callback is logged and does not
+    ///       affect observer registration.
+    /// \note The callback must not block indefinitely; local observers are
+    ///       invoked synchronously from within the call that triggers the
+    ///       transition.
+    HPX_CXX_EXPORT using activity_callback =
+        std::function<bool(target_activity_notification const&)>;
+#endif
+
+    /// \brief Register a callback to observe activity-state transitions of a
+    ///        target actor running on a possibly remote locality.
+    ///
+    /// \param locality     [in] The locality on which the callback should
+    ///                     be registered.
+    /// \param callback     [in] The callback invoked whenever \a target
+    ///                     transitions between \a activity_state::inactive and
+    ///                     \a activity_state::active.
+    /// \param epoch_filter [in] If set, restricts notifications to
+    ///                     transitions recorded under this epoch; transitions
+    ///                     recorded under any other epoch are silently skipped
+    ///                     for this observer. This also applies to the
+    ///                     registration-time replay described below. If \c
+    ///                     std::nullopt (the default), the observer is notified
+    ///                     regardless of epoch.
+    ///
+    /// \returns        A future holding the global id of the observer
+    ///                 handle. This handle must be passed to
+    ///                 \a unregister_target_activity_observer() in order
+    ///                 to stop receiving notifications.
+    ///
+    /// \throws         hpx::exception if \a locality does not represent a
+    ///                 locality, or if \a target does not represent a valid
+    ///                 target. The returned future becomes exceptional if the
+    ///                 operation fails.
+    ///
+    /// \note           If \a target is already \c activity_state::active at
+    ///                 registration time, the new observer synchronously
+    ///                 receives a single replay notification (carrying
+    ///                 \c activity_transition::already_active) as part of
+    ///                 registration, taken under the same lock that serializes
+    ///                 activity-state transitions. This guarantees the observer
+    ///                 sees exactly one notification for the target's current
+    ///                 activity state: either the replay, or a live transition
+    ///                 that raced with registration, but never both and never
+    ///                 neither.
+    /// \note           If \a locality is the locality \a target is running
+    ///                 on, callbacks (including the registration-time replay)
+    ///                 are invoked synchronously from within the call that
+    ///                 triggered the transition (best effort; the callback must
+    ///                 not block indefinitely).
+    /// \note           If \a locality differs from the locality \a target
+    ///                 is running on, callbacks are invoked asynchronously via
+    ///                 a dedicated parcel, with retry semantics (e.g., 3
+    ///                 attempts over 500 ms before logging failure).
+    /// \note           The callback must not throw; exceptions thrown from
+    ///                 it are logged and do not affect the observer
+    ///                 registration.
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future<hpx::id_type>
+    register_target_activity_observer(hpx::id_type const& locality,
+        activity_callback const& callback,
+        std::optional<std::uint64_t> epoch_filter = std::nullopt);
+
+    /// \brief Register a callback to observe activity-state transitions of a
+    ///        target actor running on a possibly remote locality, blocking
+    ///        until the registration has completed.
+    ///
+    /// This is the synchronous equivalent of
+    /// \a register_target_activity_observer(hpx::id_type const&,
+    /// hpx::id_type const&, activity_callback const&).
+    ///
+    /// \param locality     [in] The locality on which the callback should
+    ///                     be registered.
+    /// \param callback     [in] The callback invoked whenever \a target
+    ///                     transitions between \a activity_state::inactive and
+    ///                     \a activity_state::active.
+    /// \param epoch_filter [in] If set, restricts notifications to
+    ///                     transitions recorded under this epoch; see the
+    ///                     asynchronous overload for details, including how
+    ///                     this applies to the registration-time replay.
+    /// \param ec           [in,out] this represents the error status on
+    ///                     exit, if this is pre-initialized to
+    ///                     \a hpx::throws the function will throw on error
+    ///                     instead.
+    ///
+    /// \returns        The global id of the observer handle. This handle
+    ///                 must be passed to
+    ///                 \a unregister_target_activity_observer() in order
+    ///                 to stop receiving notifications.
+    ///
+    /// \throws         hpx::exception if \a locality does not represent a
+    ///                 locality, or if \a target does not represent a valid
+    ///                 target, unless \a ec was not pre-initialized to \a
+    ///                 hpx::throws.
+    HPX_CXX_EXPORT HPX_EXPORT hpx::id_type register_target_activity_observer(
+        hpx::launch::sync_policy, hpx::id_type const& locality,
+        activity_callback const& callback,
+        std::optional<std::uint64_t> epoch_filter = std::nullopt,
+        hpx::error_code& ec = hpx::throws);
+
+    /// \brief Register a callback to observe activity-state transitions of a
+    ///        target actor on the local locality.
+    ///
+    /// \param callback     [in] The callback invoked whenever \a target
+    ///                     transitions between \a activity_state::inactive and
+    ///                     \a activity_state::active.
+    /// \param epoch_filter [in] If set, restricts notifications to
+    ///                     transitions recorded under this epoch, including the
+    ///                     registration-time replay; see the remote overload
+    ///                     for details. If
+    ///                     \c std::nullopt (the default), the observer is
+    ///                     notified regardless of epoch.
+    /// \param ec           [in,out] this represents the error status on
+    ///                     exit, if this is pre-initialized to
+    ///                     \a hpx::throws the function will throw on error
+    ///                     instead.
+    ///
+    /// \returns        The global id of the observer handle. This handle
+    ///                 must be passed to
+    ///                 \a unregister_target_activity_observer() in order
+    ///                 to stop receiving notifications.
+    ///
+    /// \throws         hpx::exception if \a target does not represent a
+    ///                 valid target, unless \a ec was initialized to
+    ///                 \a hpx::throws.
+    ///
+    /// \note           As for the remote overloads, a target that is
+    ///                 already \c activity_state::active at registration time
+    ///                 synchronously delivers a single
+    ///                 \c activity_transition::already_active replay as
+    ///                 part of this call, taken under the same lock that
+    ///                 serializes activity-state transitions, so the observer
+    ///                 can neither miss nor double-receive the target's current
+    ///                 activity state.
+    HPX_CXX_EXPORT HPX_EXPORT hpx::id_type register_target_activity_observer(
+        activity_callback const& callback,
+        std::optional<std::uint64_t> epoch_filter = std::nullopt,
+        hpx::error_code& ec = hpx::throws);
+
+    /// \brief Unregister a previously registered activity observer on a
+    ///        possibly remote locality.
+    ///
+    /// \param locality        [in] The locality on which the observer was
+    ///                        registered.
+    /// \param observer_handle [in] The handle returned by a prior call to
+    ///                        \a register_target_activity_observer(). Only
+    ///                        handles returned from that function are accepted;
+    ///                        passing a handle obtained from
+    ///                        \a register_observer() (or any foreign
+    ///                        handle) is rejected.
+    ///
+    /// \returns               A future that becomes ready once the
+    ///                        observer has been unregistered.
+    ///
+    /// \throws                hpx::exception if \a locality does not
+    ///                        represent a locality, or if
+    ///                        \a observer_handle does not represent a
+    ///                        valid activity-observer handle. The returned
+    ///                        future becomes exceptional if the operation
+    ///                        fails.
+    ///
+    /// \note                  Once the returned future has become ready,
+    ///                        no orphaned callbacks fire after unregistration
+    ///                        completes.
+    HPX_CXX_EXPORT HPX_EXPORT hpx::future<void>
+    unregister_target_activity_observer(
+        hpx::id_type const& locality, hpx::id_type const& observer_handle);
+
+    /// \brief Unregister a previously registered activity observer on a
+    ///        possibly remote locality, blocking until the operation has
+    ///        completed.
+    ///
+    /// This is the synchronous equivalent of
+    /// \a unregister_target_activity_observer(hpx::id_type const&,
+    /// hpx::id_type const&).
+    ///
+    /// \param locality        [in] The locality on which the observer was
+    ///                        registered.
+    /// \param observer_handle [in] The handle returned by a prior call to
+    ///                        \a register_target_activity_observer(). See
+    ///                        the asynchronous overload regarding foreign
+    ///                        handles.
+    /// \param ec              [in,out] this represents the error status on
+    ///                        exit, if this pre-initialized to
+    ///                        \a hpx::throws the function will throw on
+    ///                        error instead.
+    ///
+    /// \throws                hpx::exception if \a locality does not
+    ///                        represent a locality, or if
+    ///                        \a observer_handle does not represent a
+    ///                        valid activity-observer handle, unless
+    ///                        \a ec was initialized not to
+    ///                        \a hpx::throws.
+    ///
+    /// \note                  No orphaned callbacks fire after
+    ///                        unregistration completes.
+    HPX_CXX_EXPORT HPX_EXPORT void unregister_target_activity_observer(
+        hpx::launch::sync_policy, hpx::id_type const& locality,
+        hpx::id_type const& observer_handle, hpx::error_code& ec = hpx::throws);
+
+    /// \brief Unregister a previously registered activity observer on the local
+    ///        locality.
+    ///
+    /// \param observer_handle [in] The handle returned by a prior call to
+    ///                        \a register_target_activity_observer(). Must
+    ///                        be local to the calling locality. See the remote
+    ///                        overload regarding foreign handles.
+    /// \param ec              [in,out] this represents the error status on
+    ///                        exit, if this is pre-initialized to
+    ///                        \a hpx::throws the function will throw on
+    ///                        error instead.
+    ///
+    /// \throws                hpx::exception if \a observer_handle does
+    ///                        not represent a valid activity-observer handle,
+    ///                        unless \a ec was not pre-initialized to \a
+    ///                        hpx::throws.
+    ///
+    /// \note                  No orphaned callbacks fire after
+    ///                        unregistration completes.
+    HPX_CXX_EXPORT HPX_EXPORT void unregister_target_activity_observer(
+        hpx::id_type const& observer_handle, hpx::error_code& ec = hpx::throws);
 
 }    // namespace hpx::supervision

--- a/libs/full/supervision/include/hpx/supervision/supervision_api.hpp
+++ b/libs/full/supervision/include/hpx/supervision/supervision_api.hpp
@@ -760,8 +760,6 @@ namespace hpx::supervision {
         /// epoch; dispatch may proceed.
         admitted,
         /// The target has already latched a terminal event (\c completed or
-        /// \c failed) for the queried epoch; dispatch was refused.
-        /// The target has already latched a terminal event (\c completed or
         /// \c failed) for the queried epoch, as observed by the *local*
         /// supervision manager; dispatch was refused. This is final relative to
         /// this locality's latch state - not a stale read - so callers on the
@@ -926,13 +924,14 @@ namespace hpx::supervision {
         std::function<bool(target_activity_notification const&)>;
 #endif
 
-    /// \brief Register a callback to observe activity-state transitions of a
-    ///        target actor running on a possibly remote locality.
+    /// \brief Register a callback to observe activity-state transitions of all
+    ///        targets tracked on a possibly remote locality.
     ///
     /// \param locality     [in] The locality on which the callback should
     ///                     be registered.
-    /// \param callback     [in] The callback invoked whenever \a target
-    ///                     transitions between \a activity_state::inactive and
+    /// \param callback     [in] The callback invoked whenever any target
+    ///                     tracked on \a locality transitions between
+    ///                     \a activity_state::inactive and
     ///                     \a activity_state::active.
     /// \param epoch_filter [in] If set, restricts notifications to
     ///                     transitions recorded under this epoch; transitions
@@ -948,29 +947,28 @@ namespace hpx::supervision {
     ///                 to stop receiving notifications.
     ///
     /// \throws         hpx::exception if \a locality does not represent a
-    ///                 locality, or if \a target does not represent a valid
-    ///                 target. The returned future becomes exceptional if the
+    ///                 locality. The returned future becomes exceptional if the
     ///                 operation fails.
     ///
-    /// \note           If \a target is already \c activity_state::active at
-    ///                 registration time, the new observer synchronously
-    ///                 receives a single replay notification (carrying
-    ///                 \c activity_transition::already_active) as part of
-    ///                 registration, taken under the same lock that serializes
-    ///                 activity-state transitions. This guarantees the observer
-    ///                 sees exactly one notification for the target's current
-    ///                 activity state: either the replay, or a live transition
-    ///                 that raced with registration, but never both and never
-    ///                 neither.
-    /// \note           If \a locality is the locality \a target is running
-    ///                 on, callbacks (including the registration-time replay)
-    ///                 are invoked synchronously from within the call that
-    ///                 triggered the transition (best effort; the callback must
-    ///                 not block indefinitely).
-    /// \note           If \a locality differs from the locality \a target
-    ///                 is running on, callbacks are invoked asynchronously via
-    ///                 a dedicated parcel, with retry semantics (e.g., 3
-    ///                 attempts over 500 ms before logging failure).
+    /// \note           For every target tracked on \a locality that is already
+    ///                 \c activity_state::active at registration time, the new
+    ///                 observer synchronously receives one replay notification
+    ///                 (carrying \c activity_transition::already_active) as
+    ///                 part of registration, taken under the same lock that
+    ///                 serializes activity-state transitions. This guarantees
+    ///                 the observer sees exactly one notification for each such
+    ///                 target's current activity state: either the replay, or a
+    ///                 live transition that raced with registration, but never
+    ///                 both and never neither.
+    /// \note           If \a locality is the local locality, callbacks
+    ///                 (including the registration-time replay) are invoked
+    ///                 synchronously from within the call that triggered the
+    ///                 transition (best effort; the callback must not block
+    ///                 indefinitely).
+    /// \note           If \a locality is remote, callbacks are invoked
+    ///                 asynchronously via a dedicated parcel, with retry
+    ///                 semantics (e.g., 3 attempts over 500 ms before logging
+    ///                 failure).
     /// \note           The callback must not throw; exceptions thrown from
     ///                 it are logged and do not affect the observer
     ///                 registration.
@@ -979,18 +977,19 @@ namespace hpx::supervision {
         activity_callback const& callback,
         std::optional<std::uint64_t> epoch_filter = std::nullopt);
 
-    /// \brief Register a callback to observe activity-state transitions of a
-    ///        target actor running on a possibly remote locality, blocking
-    ///        until the registration has completed.
+    /// \brief Register a callback to observe activity-state transitions of all
+    ///        targets tracked on a possibly remote locality, blocking until the
+    ///        registration has completed.
     ///
     /// This is the synchronous equivalent of
     /// \a register_target_activity_observer(hpx::id_type const&,
-    /// hpx::id_type const&, activity_callback const&).
+    /// activity_callback const&, std::optional<std::uint64_t>).
     ///
     /// \param locality     [in] The locality on which the callback should
     ///                     be registered.
-    /// \param callback     [in] The callback invoked whenever \a target
-    ///                     transitions between \a activity_state::inactive and
+    /// \param callback     [in] The callback invoked whenever any target
+    ///                     tracked on \a locality transitions between
+    ///                     \a activity_state::inactive and
     ///                     \a activity_state::active.
     /// \param epoch_filter [in] If set, restricts notifications to
     ///                     transitions recorded under this epoch; see the
@@ -1007,8 +1006,7 @@ namespace hpx::supervision {
     ///                 to stop receiving notifications.
     ///
     /// \throws         hpx::exception if \a locality does not represent a
-    ///                 locality, or if \a target does not represent a valid
-    ///                 target, unless \a ec was not pre-initialized to \a
+    ///                 locality, unless \a ec was not pre-initialized to \a
     ///                 hpx::throws.
     HPX_CXX_EXPORT HPX_EXPORT hpx::id_type register_target_activity_observer(
         hpx::launch::sync_policy, hpx::id_type const& locality,
@@ -1016,18 +1014,18 @@ namespace hpx::supervision {
         std::optional<std::uint64_t> epoch_filter = std::nullopt,
         hpx::error_code& ec = hpx::throws);
 
-    /// \brief Register a callback to observe activity-state transitions of a
-    ///        target actor on the local locality.
+    /// \brief Register a callback to observe activity-state transitions of all
+    ///        targets tracked on the local locality.
     ///
-    /// \param callback     [in] The callback invoked whenever \a target
-    ///                     transitions between \a activity_state::inactive and
+    /// \param callback     [in] The callback invoked whenever any target
+    ///                     tracked on the local locality transitions between
+    ///                     \a activity_state::inactive and
     ///                     \a activity_state::active.
     /// \param epoch_filter [in] If set, restricts notifications to
     ///                     transitions recorded under this epoch, including the
     ///                     registration-time replay; see the remote overload
-    ///                     for details. If
-    ///                     \c std::nullopt (the default), the observer is
-    ///                     notified regardless of epoch.
+    ///                     for details. If \c std::nullopt (the default), the
+    ///                     observer is notified regardless of epoch.
     /// \param ec           [in,out] this represents the error status on
     ///                     exit, if this is pre-initialized to
     ///                     \a hpx::throws the function will throw on error
@@ -1038,18 +1036,17 @@ namespace hpx::supervision {
     ///                 \a unregister_target_activity_observer() in order
     ///                 to stop receiving notifications.
     ///
-    /// \throws         hpx::exception if \a target does not represent a
-    ///                 valid target, unless \a ec was initialized to
-    ///                 \a hpx::throws.
+    /// \throws         hpx::exception if the operation fails, unless \a ec
+    ///                 was initialized to \a hpx::throws.
     ///
-    /// \note           As for the remote overloads, a target that is
-    ///                 already \c activity_state::active at registration time
-    ///                 synchronously delivers a single
-    ///                 \c activity_transition::already_active replay as
-    ///                 part of this call, taken under the same lock that
-    ///                 serializes activity-state transitions, so the observer
-    ///                 can neither miss nor double-receive the target's current
-    ///                 activity state.
+    /// \note           As for the remote overloads, for every target on the
+    ///                 local locality that is already \c activity_state::active
+    ///                 at registration time, one \c activity_transition::
+    ///                 already_active replay notification is delivered
+    ///                 synchronously as part of this call, taken under the same
+    ///                 lock that serializes activity-state transitions, so the
+    ///                 observer can neither miss nor double-receive any active
+    ///                 target's current activity state.
     HPX_CXX_EXPORT HPX_EXPORT hpx::id_type register_target_activity_observer(
         activity_callback const& callback,
         std::optional<std::uint64_t> epoch_filter = std::nullopt,

--- a/libs/full/supervision/include/hpx/supervision/supervision_api.hpp
+++ b/libs/full/supervision/include/hpx/supervision/supervision_api.hpp
@@ -837,22 +837,22 @@ namespace hpx::supervision {
         /// published its first lifecycle event.
         first_event,
         /// The target transitioned to \c activity_state::active because
-        /// the first activity observer was registered for it.
+        /// the first per-target lifecycle observer was registered for it.
         first_observer,
         /// The target transitioned to \c activity_state::inactive because
-        /// its last remaining activity observer was unregistered.
+        /// its last remaining per-target lifecycle observer was unregistered.
         last_observer_unregistered,
-        /// The target was already \c activity_state::active at the time an
-        /// activity observer was registered for it. Delivered as a replay,
-        /// synchronously as part of registration under the same lock that
-        /// guards the activity state, so that a newly-registered observer
-        /// cannot miss (nor be delivered twice for) a transition that
-        /// raced with its own registration.
+        /// The target was already \c activity_state::active at the time a
+        /// per-target lifecycle observer was registered for it. Delivered as a
+        /// replay, synchronously as part of registration under the same lock
+        /// that guards the activity state, so that a newly-registered observer
+        /// cannot miss (nor be delivered twice for) a transition that raced
+        /// with its own registration.
         already_active,
     };
 
-    /// \brief Payload delivered to a registered activity observer callback
-    ///        whenever a supervised target transitions between
+    /// \brief Payload delivered to a registered per-target lifecycle observer
+    ///        callback whenever a supervised target transitions between
     ///        \a activity_state::inactive and \a activity_state::active.
     ///
     /// A `activity_notification` is constructed by the supervision manager

--- a/libs/full/supervision/include/hpx/supervision/supervision_fwd.hpp
+++ b/libs/full/supervision/include/hpx/supervision/supervision_fwd.hpp
@@ -60,4 +60,6 @@ namespace hpx::supervision {
     HPX_CXX_EXPORT using lifecycle_callback =
         std::function<bool(lifecycle_event_notification const&)>;
 
+    HPX_CXX_EXPORT enum class dispatch_outcome : std::uint8_t;
+
 }    // namespace hpx::supervision

--- a/libs/full/supervision/include/hpx/supervision/supervision_fwd.hpp
+++ b/libs/full/supervision/include/hpx/supervision/supervision_fwd.hpp
@@ -65,15 +65,15 @@ namespace hpx::supervision {
     // global observer interface
     HPX_CXX_EXPORT enum class activity_state : std::uint8_t;
     HPX_CXX_EXPORT enum class activity_transition : std::uint8_t;
-    HPX_CXX_EXPORT struct target_activity_notification;
+    HPX_CXX_EXPORT struct activity_notification;
 
     HPX_CXX_EXPORT HPX_EXPORT void serialize(
-        hpx::serialization::output_archive& ar,
-        target_activity_notification const&, unsigned int);
+        hpx::serialization::output_archive& ar, activity_notification const&,
+        unsigned int);
     HPX_CXX_EXPORT HPX_EXPORT void serialize(
-        hpx::serialization::input_archive& ar, target_activity_notification&,
+        hpx::serialization::input_archive& ar, activity_notification&,
         unsigned int);
 
     HPX_CXX_EXPORT using activity_callback =
-        std::function<bool(target_activity_notification const&)>;
+        std::function<bool(activity_notification const&)>;
 }    // namespace hpx::supervision

--- a/libs/full/supervision/include/hpx/supervision/supervision_fwd.hpp
+++ b/libs/full/supervision/include/hpx/supervision/supervision_fwd.hpp
@@ -62,4 +62,18 @@ namespace hpx::supervision {
 
     HPX_CXX_EXPORT enum class dispatch_outcome : std::uint8_t;
 
+    // global observer interface
+    HPX_CXX_EXPORT enum class activity_state : std::uint8_t;
+    HPX_CXX_EXPORT enum class activity_transition : std::uint8_t;
+    HPX_CXX_EXPORT struct target_activity_notification;
+
+    HPX_CXX_EXPORT HPX_EXPORT void serialize(
+        hpx::serialization::output_archive& ar,
+        target_activity_notification const&, unsigned int);
+    HPX_CXX_EXPORT HPX_EXPORT void serialize(
+        hpx::serialization::input_archive& ar, target_activity_notification&,
+        unsigned int);
+
+    HPX_CXX_EXPORT using activity_callback =
+        std::function<bool(target_activity_notification const&)>;
 }    // namespace hpx::supervision

--- a/libs/full/supervision/include/hpx/supervision/supervision_manager.hpp
+++ b/libs/full/supervision/include/hpx/supervision/supervision_manager.hpp
@@ -46,6 +46,9 @@ namespace hpx::supervision {
                 (std::chrono::steady_clock::duration::max) (),
             hpx::error_code& ec = throws) const;
 
+        dispatch_outcome check_admission(
+            hpx::id_type const& target, std::uint64_t epoch = 0) const noexcept;
+
         // Helper functions
         void register_server_instance(error_code& ec = throws) const;
         void unregister_server_instance(error_code& ec = throws) const;

--- a/libs/full/supervision/include/hpx/supervision/supervision_manager.hpp
+++ b/libs/full/supervision/include/hpx/supervision/supervision_manager.hpp
@@ -40,6 +40,32 @@ namespace hpx::supervision {
         void unregister_observer(hpx::id_type const& observer_handle,
             hpx::error_code& ec = throws) const;
 
+        // Register an agent to be notified of activation/deactivation
+        // transitions across all targets tracked by this locality's supervision
+        // manager. Unlike register_observer(), this is deliberately
+        // locality-scoped rather than target-scoped: it takes no `target`
+        // parameter by design. Registration will replay an `already_active`
+        // notification for every currently-tracked active target (added in a
+        // later substep); that replay must appear to happen atomically with
+        // subscription, i.e. under the same lock that guards the tracked-target
+        // set, so that no transition is missed or duplicated across the
+        // replay/subscribe boundary. No such replay is implemented yet; this
+        // declaration only reserves the interface.
+        hpx::id_type register_target_activity_observer(
+            hpx::id_type const& agent,
+            std::uint64_t epoch_filter = static_cast<std::uint64_t>(-1),
+            hpx::error_code& ec = throws) const;
+
+        // Unregister a handle previously returned by
+        // register_target_activity_observer(). As with unregister_observer(),
+        // no orphaned callbacks fire after this call completes. `handle` must
+        // have been obtained from register_target_activity_observer(), not from
+        // register_observer(); passing a handle from the latter is rejected
+        // (rejection logic added in a later substep).
+        void unregister_target_activity_observer(
+            hpx::id_type const& observer_handle,
+            hpx::error_code& ec = throws) const;
+
         hpx::future<lifecycle_state> await_terminal(hpx::id_type const& target,
             std::uint64_t epoch = 0,
             std::chrono::steady_clock::duration timeout =

--- a/libs/full/supervision/include/hpx/supervision/supervision_manager.hpp
+++ b/libs/full/supervision/include/hpx/supervision/supervision_manager.hpp
@@ -51,19 +51,17 @@ namespace hpx::supervision {
         // set, so that no transition is missed or duplicated across the
         // replay/subscribe boundary. No such replay is implemented yet; this
         // declaration only reserves the interface.
-        hpx::id_type register_target_activity_observer(
-            hpx::id_type const& agent,
+        hpx::id_type register_activity_observer(hpx::id_type const& agent,
             std::uint64_t epoch_filter = static_cast<std::uint64_t>(-1),
             hpx::error_code& ec = throws) const;
 
         // Unregister a handle previously returned by
-        // register_target_activity_observer(). As with unregister_observer(),
-        // no orphaned callbacks fire after this call completes. `handle` must
-        // have been obtained from register_target_activity_observer(), not from
+        // register_activity_observer(). As with unregister_observer(), no
+        // orphaned callbacks fire after this call completes. `handle` must have
+        // been obtained from register_activity_observer(), not from
         // register_observer(); passing a handle from the latter is rejected
         // (rejection logic added in a later substep).
-        void unregister_target_activity_observer(
-            hpx::id_type const& observer_handle,
+        void unregister_activity_observer(hpx::id_type const& observer_handle,
             hpx::error_code& ec = throws) const;
 
         hpx::future<lifecycle_state> await_terminal(hpx::id_type const& target,

--- a/libs/full/supervision/include/hpx/supervision/supervision_manager.hpp
+++ b/libs/full/supervision/include/hpx/supervision/supervision_manager.hpp
@@ -45,12 +45,12 @@ namespace hpx::supervision {
         // manager. Unlike register_observer(), this is deliberately
         // locality-scoped rather than target-scoped: it takes no `target`
         // parameter by design. Registration will replay an `already_active`
-        // notification for every currently-tracked active target (added in a
-        // later substep); that replay must appear to happen atomically with
-        // subscription, i.e. under the same lock that guards the tracked-target
-        // set, so that no transition is missed or duplicated across the
-        // replay/subscribe boundary. No such replay is implemented yet; this
-        // declaration only reserves the interface.
+        // notification for every currently-tracked active target. That replay
+        // must appear to happen atomically with subscription, i.e. under the
+        // same lock that guards the tracked-target set, so that no transition
+        // is missed or duplicated across the replay/subscribe boundary. No such
+        // replay is implemented yet; this declaration only reserves the
+        // interface.
         hpx::id_type register_activity_observer(hpx::id_type const& agent,
             std::uint64_t epoch_filter = static_cast<std::uint64_t>(-1),
             hpx::error_code& ec = throws) const;

--- a/libs/full/supervision/src/server/activity_agent_server.cpp
+++ b/libs/full/supervision/src/server/activity_agent_server.cpp
@@ -1,0 +1,101 @@
+//  Copyright (c) 2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+#include <hpx/assert.hpp>
+#include <hpx/modules/actions.hpp>
+#include <hpx/modules/actions_base.hpp>
+#include <hpx/modules/async_distributed.hpp>
+#include <hpx/modules/components.hpp>
+#include <hpx/modules/components_base.hpp>
+#include <hpx/modules/functional.hpp>
+#include <hpx/modules/logging.hpp>
+#include <hpx/modules/runtime_components.hpp>
+
+#include <hpx/supervision/server/activity_agent.hpp>
+#include <hpx/supervision/supervision_api.hpp>
+
+#include <cstddef>
+
+using activity_agent_component =
+    hpx::supervision::server::activity_agent_component;
+using activity_agent_component_type =
+    hpx::components::component<activity_agent_component>;
+HPX_REGISTER_COMPONENT(activity_agent_component_type, activity_agent_component);
+
+using invoke_if_active_activity_action =
+    activity_agent_component::invoke_if_active_action;
+HPX_REGISTER_ACTION_ID(invoke_if_active_activity_action,
+    invoke_if_active_activity_action,
+    hpx::actions::supervision_activity_invoke_if_active_action_id);
+
+using deactivate_and_wait_activity_action =
+    activity_agent_component::deactivate_and_wait_action;
+HPX_REGISTER_ACTION_ID(deactivate_and_wait_activity_action,
+    deactivate_and_wait_activity_action,
+    hpx::actions::supervision_activity_deactivate_and_wait_action_id);
+
+namespace hpx::supervision::server {
+
+    hpx::id_type create_activity_agent(activity_callback f)
+    {
+        return hpx::local_new<activity_agent_component>(
+            hpx::launch::sync, HPX_MOVE(f));
+    }
+
+    bool activity_agent_component::invoke_if_active(
+        target_activity_notification const& notify)
+    {
+        {
+            std::lock_guard<hpx::spinlock> l(mtx_);
+            if (!active_)
+            {
+                return false;
+            }
+            ++in_flight_;
+        }
+
+        bool result = true;
+        try
+        {
+            if (f_)
+            {
+                result = f_(notify);
+            }
+        }
+        catch (...)
+        {
+            finish_delivery();
+            std::rethrow_exception(std::current_exception());
+        }
+
+        finish_delivery();
+
+        return result;
+    }
+
+    void activity_agent_component::finish_delivery()
+    {
+        std::unique_lock<hpx::spinlock> l(mtx_);
+        HPX_ASSERT(in_flight_ != 0);
+
+        if (--in_flight_ == 0)
+        {
+            cv_.notify_all(HPX_MOVE(l));
+        }
+    }
+
+    void activity_agent_component::deactivate_and_wait()
+    {
+        std::unique_lock<hpx::spinlock> l(mtx_);
+        active_ = false;
+
+        while (in_flight_ > 0)
+        {
+            cv_.wait(l);
+        }
+    }
+}    // namespace hpx::supervision::server

--- a/libs/full/supervision/src/server/activity_agent_server.cpp
+++ b/libs/full/supervision/src/server/activity_agent_server.cpp
@@ -47,7 +47,7 @@ namespace hpx::supervision::server {
     }
 
     bool activity_agent_component::invoke_if_active(
-        target_activity_notification const& notify)
+        activity_notification const& notify)
     {
         {
             std::lock_guard<hpx::spinlock> l(mtx_);

--- a/libs/full/supervision/src/server/supervision_manager_server.cpp
+++ b/libs/full/supervision/src/server/supervision_manager_server.cpp
@@ -608,6 +608,17 @@ namespace hpx::supervision::server {
         // that code.
         bool had_state_before;
 
+        // Snapshot of activity_observers_ taken in the very same mtx_
+        // critical section as the states_/activated_at_ mutation below (see
+        // deliver_activity_notification() for why): guarantees that any
+        // register_activity_observer() call race is resolved consistently,
+        // either its own replay already reflects this target's new state (if
+        // it acquires mtx_ after this critical section) or its agent is
+        // already captured here and receives the live notification below (if
+        // it acquires mtx_ before this critical section) - never both, never
+        // neither.
+        std::vector<observer_entry> activity_observers_snapshot;
+
         {
             std::unique_lock<hpx::spinlock> l(mtx_);
 
@@ -656,6 +667,11 @@ namespace hpx::supervision::server {
             if (!had_state_before)
             {
                 activated_at_.try_emplace(target, notification.event_time);
+
+                // See activity_observers_snapshot above: must be taken here,
+                // before mtx_ is released below, not later after mtx_ has
+                // already been released.
+                activity_observers_snapshot = activity_observers_;
             }
         }
 
@@ -688,7 +704,9 @@ namespace hpx::supervision::server {
                 .event_time = notification.event_time,
                 .epoch = notification.epoch};
 
-            fire_activity_events(activity_notification).get();
+            deliver_activity_notification(
+                activity_notification, activity_observers_snapshot)
+                .get();
         }
 
         return publish_result::applied;
@@ -790,6 +808,14 @@ namespace hpx::supervision::server {
             }
 
             bool deactivated = false;
+
+            // Snapshot of activity_observers_ taken in the very same mtx_
+            // critical section as the observers_/activated_at_ mutation below,
+            // if it happens; see the matching comment in publish_event() for
+            // why this must not instead be taken later, after mtx_ has already
+            // been released.
+            std::vector<observer_entry> activity_observers_snapshot;
+
             if (!keep_registered)
             {
                 // remove observer from the given target
@@ -811,6 +837,11 @@ namespace hpx::supervision::server {
                 {
                     activated_at_.erase(target);
                 }
+
+                if (deactivated)
+                {
+                    activity_observers_snapshot = activity_observers_;
+                }
             }
 
             // Fired with mtx_ released, mirroring unregister_observer() below.
@@ -824,7 +855,9 @@ namespace hpx::supervision::server {
                     .event_time = std::chrono::steady_clock::now(),
                     .epoch = current_epoch_for(target)};
 
-                fire_activity_events(activity_notification).get();
+                deliver_activity_notification(
+                    activity_notification, activity_observers_snapshot)
+                    .get();
             }
 
             // rethrow exception, if any
@@ -853,6 +886,12 @@ namespace hpx::supervision::server {
         // the time register_activity_observer()'s replay logic records
         // as this target's original activation time.
         std::chrono::steady_clock::time_point activation_time;
+
+        // Snapshot of activity_observers_ taken in the very same mtx_
+        // critical section as the observers_/activated_at_ mutation below;
+        // see the matching comment in publish_event() for why this must not
+        // instead be taken later, after mtx_ has already been released.
+        std::vector<observer_entry> activity_observers_snapshot;
 
         {
             std::unique_lock<hpx::spinlock> l(mtx_);
@@ -920,6 +959,11 @@ namespace hpx::supervision::server {
             {
                 activation_time = std::chrono::steady_clock::now();
                 activated_at_.try_emplace(target, activation_time);
+
+                // See activity_observers_snapshot above: must be taken here,
+                // before mtx_ is released below, not later after mtx_ has
+                // already been released.
+                activity_observers_snapshot = activity_observers_;
             }
 
             // An existing target gets an initial notification. Keep a value
@@ -984,7 +1028,9 @@ namespace hpx::supervision::server {
                 .event_time = activation_time,
                 .epoch = current_epoch_for(target)};
 
-            fire_activity_events(activity_notification).get();
+            deliver_activity_notification(
+                activity_notification, activity_observers_snapshot)
+                .get();
         }
 
         return agent;
@@ -1037,6 +1083,15 @@ namespace hpx::supervision::server {
         // notifications are fired below, once mtx_ has been released.
         std::vector<hpx::id_type> deactivated_targets;
 
+        // Snapshot of activity_observers_ taken in the very same mtx_
+        // critical section as the observers_/activated_at_ mutations below,
+        // and reused for every target in deactivated_targets below (a single
+        // snapshot is valid for all of them, since none of this function's
+        // own mutations touch activity_observers_); see the matching comment
+        // in publish_event() for why this must not instead be taken later,
+        // after mtx_ has already been released.
+        std::vector<observer_entry> activity_observers_snapshot;
+
         {
             // remove observer from all targets
             std::unique_lock<hpx::spinlock> l(mtx_);
@@ -1063,6 +1118,11 @@ namespace hpx::supervision::server {
                 }
                 agents_.erase(it);
             }
+
+            if (!deactivated_targets.empty())
+            {
+                activity_observers_snapshot = activity_observers_;
+            }
         }
 
         for (hpx::id_type const& target : deactivated_targets)
@@ -1073,7 +1133,9 @@ namespace hpx::supervision::server {
                 .event_time = std::chrono::steady_clock::now(),
                 .epoch = current_epoch_for(target)};
 
-            fire_activity_events(activity_notification).get();
+            deliver_activity_notification(
+                activity_notification, activity_observers_snapshot)
+                .get();
         }
 
         // A delivery action that was already queued may still reach the agent.
@@ -1085,15 +1147,10 @@ namespace hpx::supervision::server {
         hpx::async(hpx::launch::task, action_type(), observer_handle).get();
     }
 
-    hpx::future<void> supervision_manager::fire_activity_events(
-        activity_notification const& notification)
+    hpx::future<void> supervision_manager::deliver_activity_notification(
+        activity_notification const& notification,
+        std::vector<observer_entry> const& observers)
     {
-        std::vector<observer_entry> observers;
-        {
-            std::unique_lock<hpx::spinlock> l(mtx_);
-            observers = activity_observers_;
-        }
-
         for (auto const& [observer, filter] : observers)
         {
             // An observer scoped to a specific epoch does not get notified of
@@ -1169,12 +1226,21 @@ namespace hpx::supervision::server {
         // `agent` into activity_observers_ inside the same critical section, so
         // no live transition recorded concurrently by publish_event()/
         // register_observer()/unregister_observer()/fire_event() can be missed
-        // or delivered twice to `agent`: any such transition either already
-        // shows up in the snapshot below (if it completed before this call
-        // acquired mtx_), or is picked up live once fire_activity_events()
-        // copies the now-installed entry out of activity_observers_ (if it
-        // happens after mtx_ is released here), since fire_activity_events()
-        // itself acquires mtx_ to take that copy.
+        // or delivered twice to `agent`. Each of those call sites mutates its
+        // tracked state (states_/observers_/activated_at_) and snapshots
+        // activity_observers_ (the set that will receive its live notification,
+        // see deliver_activity_notification()) within one single mtx_ critical
+        // section of its own. Since this call's snapshot-and-install below is
+        // likewise a single critical section on the same mtx_, the two are
+        // strictly ordered relative to each other: if the other call's critical
+        // section runs first, its activity_observers_ snapshot cannot yet
+        // include `agent` (installed only below), but the mutated state it just
+        // recorded is already visible to the snapshot below, which replays it
+        // as already_active; if this call's critical section runs first,
+        // `agent` is already installed by the time the other call takes its
+        // activity_observers_ snapshot, so it receives that live notification
+        // instead, while the snapshot below - running before that mutation -
+        // does not also replay it.
         std::vector<activity_notification> replay;
 
         {
@@ -1209,10 +1275,10 @@ namespace hpx::supervision::server {
             replay.reserve(tracked.size());
             for (auto const& [target, epoch] : tracked)
             {
-                // Same epoch-filter semantics as fire_activity_events(): a
-                // filter engaged to a specific epoch skips any target whose
-                // (current) epoch does not match, including here at replay
-                // time.
+                // Same epoch-filter semantics as
+                // deliver_activity_notification(): a filter engaged to a
+                // specific epoch skips any target whose (current) epoch does
+                // not match, including here at replay time.
                 if (epoch_filter != static_cast<std::uint64_t>(-1) &&
                     epoch_filter != epoch)
                 {
@@ -1248,12 +1314,13 @@ namespace hpx::supervision::server {
             {
                 fire_activity_event(agent, notification).get();
             }
+            // NOLINTNEXTLINE(bugprone-empty-catch)
             catch (...)
             {
-                // Best effort, mirroring fire_activity_events(): one replay
-                // delivery failing must not prevent delivery of the remaining
-                // replay notifications, nor this registration call from
-                // returning.
+                // Best effort, mirroring deliver_activity_notification(): one
+                // replay delivery failing must not prevent delivery of the
+                // remaining replay notifications, nor this registration call
+                // from returning.
             }
         }
 

--- a/libs/full/supervision/src/server/supervision_manager_server.cpp
+++ b/libs/full/supervision/src/server/supervision_manager_server.cpp
@@ -1017,6 +1017,18 @@ namespace hpx::supervision::server {
         return f;
     }
 
+    dispatch_outcome supervision_manager::check_admission(
+        hpx::id_type const& target, std::uint64_t const epoch) const noexcept
+    {
+        std::scoped_lock<hpx::spinlock> l(mtx_);
+        if (auto const it = states_.find(target); it != states_.end() &&
+            it->second.epoch == epoch && is_terminal(it->second.last_event))
+        {
+            return dispatch_outcome::rejected_fenced;
+        }
+        return dispatch_outcome::admitted;
+    }
+
     ///////////////////////////////////////////////////////////////////////////
     void supervision_manager::register_server_instance(
         char const* service_name, std::uint32_t locality_id, error_code& ec)

--- a/libs/full/supervision/src/server/supervision_manager_server.cpp
+++ b/libs/full/supervision/src/server/supervision_manager_server.cpp
@@ -15,6 +15,7 @@
 #include <hpx/modules/thread_support.hpp>
 #include <hpx/modules/type_support.hpp>
 
+#include <hpx/supervision/server/activity_agent.hpp>
 #include <hpx/supervision/server/agent.hpp>
 #include <hpx/supervision/server/supervision_manager.hpp>
 #include <hpx/supervision/supervision_api.hpp>
@@ -597,12 +598,23 @@ namespace hpx::supervision::server {
         waiters_t to_resolve;
         stale_waiters_t stale;
 
+        // Captured before states_ is (possibly) mutated below: true only for a
+        // target that has never had a states_ entry before this call, i.e. this
+        // is its first-ever publish_event. Drives the
+        // activity_transition::first_event notification fired further down;
+        // unaffected by any early-return path (stale_epoch/already_terminal)
+        // taken while still holding the lock, since those paths never reach
+        // that code.
+        bool had_state_before = false;
+
         {
             std::unique_lock<hpx::spinlock> l(mtx_);
 
             auto const epoch_it = current_epoch_.find(target);
+            had_state_before = epoch_it != current_epoch_.end();
+
             std::uint64_t const current_ep =
-                epoch_it != current_epoch_.end() ? epoch_it->second : 0;
+                had_state_before ? epoch_it->second : 0;
 
             if (epoch < current_ep)
             {
@@ -646,6 +658,24 @@ namespace hpx::supervision::server {
         {
             record_error(target, notification.event_sequence_number,
                 hpx::make_error_code(std::current_exception()));
+        }
+
+        // Delivery ordering: per-target register_observer callbacks (above)
+        // fire before activity-observer callbacks (below), both synchronous for
+        // local delivery. Only a target's very first publish_event ever
+        // triggers activity_transition::first_event; later publications never
+        // repeat it (and never trigger a deactivation, since latched state does
+        // not disappear on the publishing path).
+        if (!had_state_before)
+        {
+            target_activity_notification const activity_notification{
+                .actor = target,
+                .state = activity_state::active,
+                .transition = activity_transition::first_event,
+                .event_time = notification.event_time,
+                .epoch = notification.epoch};
+
+            fire_activity_events(activity_notification).get();
         }
 
         return publish_result::applied;
@@ -746,16 +776,31 @@ namespace hpx::supervision::server {
                 ep = std::current_exception();
             }
 
+            bool deactivated = false;
             if (!keep_registered)
             {
                 // remove observer from the given target
                 std::unique_lock<hpx::spinlock> l(mtx_);
 
-                unregister_observer_target(target, agent);
+                deactivated = unregister_observer_target(target, agent);
                 if (auto const it = agents_.find(agent); it != agents_.end())
                 {
                     agents_.erase(it);
                 }
+            }
+
+            // Fired with mtx_ released, mirroring unregister_observer() below.
+            if (deactivated)
+            {
+                target_activity_notification const activity_notification{
+                    .actor = target,
+                    .state = activity_state::inactive,
+                    .transition =
+                        activity_transition::last_observer_unregistered,
+                    .event_time = std::chrono::steady_clock::now(),
+                    .epoch = current_epoch_for(target)};
+
+                fire_activity_events(activity_notification).get();
             }
 
             // rethrow exception, if any
@@ -772,12 +817,19 @@ namespace hpx::supervision::server {
     {
         std::optional<lifecycle_event_notification> initial_notification;
 
+        // Captured before observers_[target] is (possibly) mutated below: true
+        // only if target currently has no per-target observer at all, i.e. the
+        // entry this call adds below will be its first. Drives the
+        // activity_transition::first_observer notification fired further down.
+        bool target_had_no_observers = false;
+
         {
             std::unique_lock<hpx::spinlock> l(mtx_);
 
             // insert observer into table of registered observers
             auto it = observers_.find(target);
-            if (it == observers_.end())
+            target_had_no_observers = (it == observers_.end());
+            if (target_had_no_observers)
             {
                 auto [it2, inserted] = observers_.insert(
                     std::make_pair(target, std::vector<observer_entry>()));
@@ -879,10 +931,32 @@ namespace hpx::supervision::server {
                     hpx::make_error_code(std::current_exception()));
             }
         }
+
+        // Delivery ordering: the per-target register_observer replay above
+        // fires before this activity-observer notification, both synchronous
+        // for local delivery.
+        if (target_had_no_observers)
+        {
+            target_activity_notification const activity_notification{
+                .actor = target,
+                .state = activity_state::active,
+                .transition = activity_transition::first_observer,
+                .event_time = std::chrono::steady_clock::now(),
+                .epoch = current_epoch_for(target)};
+
+            fire_activity_events(activity_notification).get();
+        }
+
         return agent;
     }
 
-    void supervision_manager::unregister_observer_target(
+    // Returns true if this removed the last remaining per-target observer for
+    // `target` (its observer count just transitioned from one to zero); the
+    // caller is responsible for firing the corresponding
+    // activity_transition::last_observer_unregistered notification once
+    // mtx_ has been released (this function is always called with mtx_
+    // already held).
+    bool supervision_manager::unregister_observer_target(
         hpx::id_type const& target, hpx::id_type const& observer_handle)
     {
         if (auto const it = observers_.find(target); it != observers_.end())
@@ -901,13 +975,28 @@ namespace hpx::supervision::server {
             if (it->second.empty())
             {
                 observers_.erase(it);
+                return true;
             }
         }
+        return false;
+    }
+
+    std::uint64_t supervision_manager::current_epoch_for(
+        hpx::id_type const& target) const
+    {
+        std::scoped_lock<hpx::spinlock> l(mtx_);
+        auto const it = current_epoch_.find(target);
+        return it != current_epoch_.end() ? it->second : 0;
     }
 
     void supervision_manager::unregister_observer(
         hpx::id_type const& observer_handle)
     {
+        // Targets whose last per-target observer was just removed by this call;
+        // the corresponding activity_transition::last_observer_unregistered
+        // notifications are fired below, once mtx_ has been released.
+        std::vector<hpx::id_type> deactivated_targets;
+
         {
             // remove observer from all targets
             std::unique_lock<hpx::spinlock> l(mtx_);
@@ -919,10 +1008,25 @@ namespace hpx::supervision::server {
                 // remove observer from all targets
                 for (hpx::id_type const& target : it->second)
                 {
-                    unregister_observer_target(target, observer_handle);
+                    if (unregister_observer_target(target, observer_handle))
+                    {
+                        deactivated_targets.push_back(target);
+                    }
                 }
                 agents_.erase(it);
             }
+        }
+
+        for (hpx::id_type const& target : deactivated_targets)
+        {
+            target_activity_notification const activity_notification{
+                .actor = target,
+                .state = activity_state::inactive,
+                .transition = activity_transition::last_observer_unregistered,
+                .event_time = std::chrono::steady_clock::now(),
+                .epoch = current_epoch_for(target)};
+
+            fire_activity_events(activity_notification).get();
         }
 
         // A delivery action that was already queued may still reach the agent.
@@ -932,6 +1036,123 @@ namespace hpx::supervision::server {
         // prevent the agent callback from being run inline as it may block
         using action_type = agent_component::deactivate_and_wait_action;
         hpx::async(hpx::launch::task, action_type(), observer_handle).get();
+    }
+
+    hpx::future<void> supervision_manager::fire_activity_events(
+        target_activity_notification const& notification)
+    {
+        std::vector<observer_entry> observers;
+        {
+            std::unique_lock<hpx::spinlock> l(mtx_);
+            observers = activity_observers_;
+        }
+
+        for (auto const& [observer, filter] : observers)
+        {
+            // An observer scoped to a specific epoch does not get notified of
+            // transitions recorded under any other epoch.
+            if (filter != static_cast<std::uint64_t>(-1) &&
+                filter != notification.epoch)
+            {
+                continue;
+            }
+
+            try
+            {
+                fire_activity_event(observer, notification).get();
+            }
+            catch (...)
+            {
+                // Best effort: one activity observer's failure must not
+                // prevent delivery to the remaining activity observers, and
+                // there is no per-target latch to record this failure into
+                // (unlike record_error() for per-target observers).
+            }
+        }
+
+        return hpx::make_ready_future();
+    }
+
+    hpx::future<void> supervision_manager::fire_activity_event(
+        hpx::id_type const& agent, target_activity_notification notification)
+    {
+        {
+            std::unique_lock<hpx::spinlock> l(mtx_);
+
+            // check again if the agent is still registered as an activity
+            // observer
+            if (std::ranges::find(activity_observers_, agent,
+                    &observer_entry::agent) == activity_observers_.end())
+            {
+                return hpx::make_ready_future();
+            }
+        }
+
+        try
+        {
+            using action_type =
+                activity_agent_component::invoke_if_active_action;
+            bool const keep_registered =
+                hpx::sync(action_type(), agent, notification);
+
+            if (!keep_registered)
+            {
+                std::unique_lock<hpx::spinlock> l(mtx_);
+                std::erase_if(
+                    activity_observers_, [&agent](observer_entry const& entry) {
+                        return entry.agent == agent;
+                    });
+            }
+        }
+        catch (...)
+        {
+            return hpx::make_exceptional_future<void>(std::current_exception());
+        }
+
+        return hpx::make_ready_future();
+    }
+
+    hpx::id_type supervision_manager::register_target_activity_observer(
+        hpx::id_type const& agent, std::uint64_t const epoch_filter)
+    {
+        std::unique_lock<hpx::spinlock> l(mtx_);
+
+        // Registration-time replay of activity_transition::already_active
+        // for currently-tracked targets is added in a later substep; this
+        // only starts delivering live transitions occurring after this call
+        // returns (see fire_activity_events() call sites in publish_event(),
+        // register_observer(), unregister_observer(), and fire_event()).
+        activity_observers_.push_back(
+            observer_entry{.agent = agent, .epoch_filter = epoch_filter});
+
+        return agent;
+    }
+
+    void supervision_manager::unregister_target_activity_observer(
+        hpx::id_type const& observer_handle)
+    {
+        {
+            std::unique_lock<hpx::spinlock> l(mtx_);
+
+            // Rejecting a handle that belongs to the
+            // observer_handle_kind::target_observer namespace (i.e. one
+            // returned by register_observer() rather than
+            // register_target_activity_observer()) is added in a later substep;
+            // this only removes a matching entry from activity_observers_, if
+            // any.
+            std::erase_if(activity_observers_,
+                [&observer_handle](observer_entry const& entry) {
+                    return entry.agent == observer_handle;
+                });
+        }
+
+        // A delivery that was already in flight for this agent may still be
+        // running (see fire_activity_event()); deactivate_and_wait fences such
+        // deliveries and drains any callback that had already begun before this
+        // call returns, mirroring unregister_observer() above.
+        using action_type =
+            activity_agent_component::deactivate_and_wait_action;
+        hpx::sync(hpx::launch::task, action_type(), observer_handle);
     }
 
     lifecycle_state supervision_manager::query_state(hpx::id_type const& target)

--- a/libs/full/supervision/src/server/supervision_manager_server.cpp
+++ b/libs/full/supervision/src/server/supervision_manager_server.cpp
@@ -28,6 +28,7 @@
 #include <map>
 #include <mutex>
 #include <optional>
+#include <ranges>
 #include <utility>
 #include <vector>
 
@@ -223,9 +224,9 @@ namespace hpx::supervision::server {
         HPX_ASSERT_OWNS_LOCK(l);
 
         auto next_deadline = (std::chrono::steady_clock::time_point::max) ();
-        for (auto const& bucket : waiters_)
+        for (auto const& val : waiters_ | std::views::values)
         {
-            for (auto const& [_, deadline] : bucket.second)
+            for (auto const& [_, deadline] : val)
             {
                 next_deadline = (std::min) (next_deadline, deadline);
             }
@@ -605,16 +606,16 @@ namespace hpx::supervision::server {
         // unaffected by any early-return path (stale_epoch/already_terminal)
         // taken while still holding the lock, since those paths never reach
         // that code.
-        bool had_state_before = false;
+        bool had_state_before;
 
         {
             std::unique_lock<hpx::spinlock> l(mtx_);
 
-            auto const epoch_it = current_epoch_.find(target);
-            had_state_before = epoch_it != current_epoch_.end();
+            had_state_before = states_.contains(target);
 
+            auto const epoch_it = current_epoch_.find(target);
             std::uint64_t const current_ep =
-                had_state_before ? epoch_it->second : 0;
+                epoch_it != current_epoch_.end() ? epoch_it->second : 0;
 
             if (epoch < current_ep)
             {
@@ -643,6 +644,19 @@ namespace hpx::supervision::server {
                 notification = HPX_MOVE(result->notification);
                 to_resolve = HPX_MOVE(result->to_resolve);
             }
+
+            // Record the target's original activation time for
+            // register_activity_observer()'s replay logic, guarded by
+            // try_emplace() so a target that was already activated via
+            // register_observer() (first_observer) keeps that earlier time.
+            // Only reached for a target's first-ever publish_event (see
+            // had_state_before above); harmless to skip for the
+            // already_terminal/stale_epoch early returns above, since neither
+            // represents a new activation.
+            if (!had_state_before)
+            {
+                activated_at_.try_emplace(target, notification.event_time);
+            }
         }
 
         invalidate_stale_waiters(target, epoch, stale);
@@ -668,8 +682,7 @@ namespace hpx::supervision::server {
         // not disappear on the publishing path).
         if (!had_state_before)
         {
-            target_activity_notification const activity_notification{
-                .actor = target,
+            activity_notification const activity_notification{.actor = target,
                 .state = activity_state::active,
                 .transition = activity_transition::first_event,
                 .event_time = notification.event_time,
@@ -787,12 +800,23 @@ namespace hpx::supervision::server {
                 {
                     agents_.erase(it);
                 }
+
+                // Only truly untracked (per the has-ever-published/
+                // has-observers predicate used by
+                // register_activity_observer()'s replay logic) once
+                // it also has no states_ entry; a target that has published
+                // at least one event stays tracked even after its last
+                // observer is removed.
+                if (deactivated && !states_.contains(target))
+                {
+                    activated_at_.erase(target);
+                }
             }
 
             // Fired with mtx_ released, mirroring unregister_observer() below.
             if (deactivated)
             {
-                target_activity_notification const activity_notification{
+                activity_notification const activity_notification{
                     .actor = target,
                     .state = activity_state::inactive,
                     .transition =
@@ -821,7 +845,14 @@ namespace hpx::supervision::server {
         // only if target currently has no per-target observer at all, i.e. the
         // entry this call adds below will be its first. Drives the
         // activity_transition::first_observer notification fired further down.
-        bool target_had_no_observers = false;
+        bool target_had_no_observers;
+
+        // Set under mtx_ below, alongside activated_at_, only if
+        // target_had_no_observers; reused below (once mtx_ has been released)
+        // as the first_observer notification's event_time, so it agrees with
+        // the time register_activity_observer()'s replay logic records
+        // as this target's original activation time.
+        std::chrono::steady_clock::time_point activation_time;
 
         {
             std::unique_lock<hpx::spinlock> l(mtx_);
@@ -881,6 +912,16 @@ namespace hpx::supervision::server {
 
             it2->second.push_back(target);
 
+            // Record the target's original activation time for
+            // register_activity_observer()'s replay logic, guarded by
+            // try_emplace() so a target that was already activated via
+            // publish_event() (first_event) keeps that earlier time.
+            if (target_had_no_observers)
+            {
+                activation_time = std::chrono::steady_clock::now();
+                activated_at_.try_emplace(target, activation_time);
+            }
+
             // An existing target gets an initial notification. Keep a value
             // snapshot: do not let a subsequent publish replace its contents.
             // A freshly-registered observer scoped to a specific epoch
@@ -937,11 +978,10 @@ namespace hpx::supervision::server {
         // for local delivery.
         if (target_had_no_observers)
         {
-            target_activity_notification const activity_notification{
-                .actor = target,
+            activity_notification const activity_notification{.actor = target,
                 .state = activity_state::active,
                 .transition = activity_transition::first_observer,
-                .event_time = std::chrono::steady_clock::now(),
+                .event_time = activation_time,
                 .epoch = current_epoch_for(target)};
 
             fire_activity_events(activity_notification).get();
@@ -1011,6 +1051,14 @@ namespace hpx::supervision::server {
                     if (unregister_observer_target(target, observer_handle))
                     {
                         deactivated_targets.push_back(target);
+
+                        // See the matching comment in fire_event(): only erase
+                        // activated_at_ if target is also not tracked via
+                        // states_ (i.e. it never published an event).
+                        if (!states_.contains(target))
+                        {
+                            activated_at_.erase(target);
+                        }
                     }
                 }
                 agents_.erase(it);
@@ -1019,8 +1067,7 @@ namespace hpx::supervision::server {
 
         for (hpx::id_type const& target : deactivated_targets)
         {
-            target_activity_notification const activity_notification{
-                .actor = target,
+            activity_notification const activity_notification{.actor = target,
                 .state = activity_state::inactive,
                 .transition = activity_transition::last_observer_unregistered,
                 .event_time = std::chrono::steady_clock::now(),
@@ -1039,7 +1086,7 @@ namespace hpx::supervision::server {
     }
 
     hpx::future<void> supervision_manager::fire_activity_events(
-        target_activity_notification const& notification)
+        activity_notification const& notification)
     {
         std::vector<observer_entry> observers;
         {
@@ -1061,6 +1108,7 @@ namespace hpx::supervision::server {
             {
                 fire_activity_event(observer, notification).get();
             }
+            // NOLINTNEXTLINE(bugprone-empty-catch)
             catch (...)
             {
                 // Best effort: one activity observer's failure must not
@@ -1074,7 +1122,7 @@ namespace hpx::supervision::server {
     }
 
     hpx::future<void> supervision_manager::fire_activity_event(
-        hpx::id_type const& agent, target_activity_notification notification)
+        hpx::id_type const& agent, activity_notification notification)
     {
         {
             std::unique_lock<hpx::spinlock> l(mtx_);
@@ -1112,23 +1160,107 @@ namespace hpx::supervision::server {
         return hpx::make_ready_future();
     }
 
-    hpx::id_type supervision_manager::register_target_activity_observer(
+    hpx::id_type supervision_manager::register_activity_observer(
         hpx::id_type const& agent, std::uint64_t const epoch_filter)
     {
-        std::unique_lock<hpx::spinlock> l(mtx_);
+        // Registration-time replay: snapshot every currently-tracked target
+        // (the same has-ever-published-via-states_/has-observers-via-
+        // observers_ predicate that governs activated_at_ above) and install
+        // `agent` into activity_observers_ inside the same critical section, so
+        // no live transition recorded concurrently by publish_event()/
+        // register_observer()/unregister_observer()/fire_event() can be missed
+        // or delivered twice to `agent`: any such transition either already
+        // shows up in the snapshot below (if it completed before this call
+        // acquired mtx_), or is picked up live once fire_activity_events()
+        // copies the now-installed entry out of activity_observers_ (if it
+        // happens after mtx_ is released here), since fire_activity_events()
+        // itself acquires mtx_ to take that copy.
+        std::vector<activity_notification> replay;
 
-        // Registration-time replay of activity_transition::already_active
-        // for currently-tracked targets is added in a later substep; this
-        // only starts delivering live transitions occurring after this call
-        // returns (see fire_activity_events() call sites in publish_event(),
-        // register_observer(), unregister_observer(), and fire_event()).
-        activity_observers_.push_back(
-            observer_entry{.agent = agent, .epoch_filter = epoch_filter});
+        {
+            std::unique_lock<hpx::spinlock> l(mtx_);
+
+            // Union of states_ and observers_ keys: a target counts as tracked
+            // if it has ever published an event (states_ entry exists) or
+            // currently has at least one per-target observer (observers_ entry
+            // exists; unregister_observer_target() never leaves an empty entry
+            // behind, see there). Deliberately not a merged reference count:
+            // either signal on its own is sufficient.
+            std::map<hpx::id_type, std::uint64_t> tracked;
+            for (auto const& [target, state] : states_)
+            {
+                tracked.emplace(target, state.epoch);
+            }
+
+            for (auto const& key : observers_ | std::views::keys)
+            {
+                hpx::id_type const& target = key;
+                if (auto const epoch_it = current_epoch_.find(target);
+                    epoch_it != current_epoch_.end())
+                {
+                    tracked.try_emplace(target, epoch_it->second);
+                }
+                else
+                {
+                    tracked.try_emplace(target, 0);
+                }
+            }
+
+            replay.reserve(tracked.size());
+            for (auto const& [target, epoch] : tracked)
+            {
+                // Same epoch-filter semantics as fire_activity_events(): a
+                // filter engaged to a specific epoch skips any target whose
+                // (current) epoch does not match, including here at replay
+                // time.
+                if (epoch_filter != static_cast<std::uint64_t>(-1) &&
+                    epoch_filter != epoch)
+                {
+                    continue;
+                }
+
+                // event_time reflects the target's original activation time
+                // (see activated_at_ above), not the time of this registration,
+                // per activity_notification::event_time.
+                auto const activated_it = activated_at_.find(target);
+                auto const event_time = activated_it != activated_at_.end() ?
+                    activated_it->second :
+                    std::chrono::steady_clock::now();
+
+                replay.push_back(activity_notification{.actor = target,
+                    .state = activity_state::active,
+                    .transition = activity_transition::already_active,
+                    .event_time = event_time,
+                    .epoch = epoch});
+            }
+
+            activity_observers_.push_back(
+                observer_entry{.agent = agent, .epoch_filter = epoch_filter});
+        }
+
+        // Deliver the replay outside mtx_, mirroring register_observer()'s
+        // delivery of its own initial notification: fire_activity_event()
+        // re-checks that `agent` is still registered before invoking it, so
+        // this remains safe even if `agent` is concurrently unregistered.
+        for (auto const& notification : replay)
+        {
+            try
+            {
+                fire_activity_event(agent, notification).get();
+            }
+            catch (...)
+            {
+                // Best effort, mirroring fire_activity_events(): one replay
+                // delivery failing must not prevent delivery of the remaining
+                // replay notifications, nor this registration call from
+                // returning.
+            }
+        }
 
         return agent;
     }
 
-    void supervision_manager::unregister_target_activity_observer(
+    void supervision_manager::unregister_activity_observer(
         hpx::id_type const& observer_handle)
     {
         {
@@ -1137,9 +1269,8 @@ namespace hpx::supervision::server {
             // Rejecting a handle that belongs to the
             // observer_handle_kind::target_observer namespace (i.e. one
             // returned by register_observer() rather than
-            // register_target_activity_observer()) is added in a later substep;
-            // this only removes a matching entry from activity_observers_, if
-            // any.
+            // register_activity_observer()) is added in a later substep; this
+            // only removes a matching entry from activity_observers_, if any.
             std::erase_if(activity_observers_,
                 [&observer_handle](observer_entry const& entry) {
                     return entry.agent == observer_handle;
@@ -1152,7 +1283,7 @@ namespace hpx::supervision::server {
         // call returns, mirroring unregister_observer() above.
         using action_type =
             activity_agent_component::deactivate_and_wait_action;
-        hpx::sync(hpx::launch::task, action_type(), observer_handle);
+        hpx::sync(action_type(), observer_handle);
     }
 
     lifecycle_state supervision_manager::query_state(hpx::id_type const& target)
@@ -1195,9 +1326,9 @@ namespace hpx::supervision::server {
             epoch_it != current_epoch_.end() && epoch_it->second > epoch)
         {
             // the caller is asking about an epoch that has already been
-            // superseded; a waiter registered under the stale epoch would
-            // only ever be drained by a *future* epoch transition, so fail
-            // fast instead of hanging indefinitely
+            // superseded; a waiter registered under the stale epoch would only
+            // ever be drained by a *future* epoch transition, so fail fast
+            // instead of hanging indefinitely
             l.unlock();
 
             return hpx::make_exceptional_future<lifecycle_state>(
@@ -1211,8 +1342,8 @@ namespace hpx::supervision::server {
         }
 
         // std::chrono::steady_clock::duration::max() (the default) defers to
-        // the live default_await_terminal_timeout_ms; any other value
-        // overrides the deadline for this call only.
+        // the live default_await_terminal_timeout_ms; any other value overrides
+        // the deadline for this call only.
         auto const effective_timeout =
             (timeout == (std::chrono::steady_clock::duration::max) ()) ?
             std::chrono::milliseconds(default_await_terminal_timeout_ms) :

--- a/libs/full/supervision/src/supervision.cpp
+++ b/libs/full/supervision/src/supervision.cpp
@@ -11,6 +11,7 @@
 #include <hpx/modules/errors.hpp>
 #include <hpx/modules/serialization.hpp>
 
+#include <hpx/supervision/server/activity_agent.hpp>
 #include <hpx/supervision/server/agent.hpp>
 #include <hpx/supervision/server/supervision_manager.hpp>
 #include <hpx/supervision/supervision_api.hpp>
@@ -48,6 +49,14 @@ HPX_REGISTER_ACTION_ID(
     hpx::supervision::server::supervision_manager::await_terminal_action,
     supervision_manager_await_terminal_action,
     hpx::actions::supervision_manager_await_terminal_action_id)
+HPX_REGISTER_ACTION_ID(hpx::supervision::server::supervision_manager::
+                           register_activity_observer_action,
+    supervision_register_activity_observer__action,
+    hpx::actions::supervision_manager_register_activity_observer__action_id)
+HPX_REGISTER_ACTION_ID(hpx::supervision::server::supervision_manager::
+                           unregister_activity_observer_action,
+    supervision_manager_unregister_activity_observer_action,
+    hpx::actions::supervision_manager_unregister_activity_observer_action_id)
 
 namespace hpx::supervision {
 
@@ -581,7 +590,7 @@ namespace hpx::supervision {
 
     ///////////////////////////////////////////////////////////////////////////
     void serialize(hpx::serialization::output_archive& ar,
-        target_activity_notification const& notification, unsigned int)
+        activity_notification const& notification, unsigned int)
     {
         ar << notification.actor << notification.state
            << notification.transition << notification.event_time
@@ -589,11 +598,158 @@ namespace hpx::supervision {
     }
 
     void serialize(hpx::serialization::input_archive& ar,
-        target_activity_notification& notification, unsigned int)
+        activity_notification& notification, unsigned int)
     {
         ar >> notification.actor >> notification.state >>
             notification.transition >> notification.event_time >>
             notification.epoch >> notification.ec;
+    }
+
+    // Register a callback to observe activity-state transitions of all
+    // targets tracked by a locality's supervision manager
+    namespace {
+
+        hpx::future<hpx::id_type> register_activity_observer_helper(
+            hpx::id_type const& locality, hpx::id_type const& agent,
+            std::uint64_t const epoch_filter)
+        {
+            using action_type =
+                server::supervision_manager::register_activity_observer_action;
+            return supervision_dispatch<hpx::id_type, action_type>(
+                locality,
+                [&]() {
+                    return hpx::make_ready_future<hpx::id_type>(
+                        get_supervision_manager().register_activity_observer(
+                            agent, epoch_filter));
+                },
+                agent, epoch_filter);
+        }
+    }    // namespace
+
+    hpx::future<hpx::id_type> register_activity_observer(
+        hpx::id_type const& locality, activity_callback const& callback,
+        std::optional<std::uint64_t> const epoch_filter)
+    {
+        if (!hpx::naming::is_locality(locality))
+        {
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "hpx::supervision::register_activity_observer",
+                "The id passed as the first argument is not representing "
+                "a locality");
+        }
+
+        auto const agent = server::create_activity_agent(callback);
+        return register_activity_observer_helper(locality, agent,
+            epoch_filter.value_or(static_cast<std::uint64_t>(-1)));
+    }
+
+    hpx::id_type register_activity_observer(hpx::launch::sync_policy,
+        hpx::id_type const& locality, activity_callback const& callback,
+        std::optional<std::uint64_t> const epoch_filter, hpx::error_code& ec)
+    {
+        if (!hpx::naming::is_locality(locality))
+        {
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "hpx::supervision::register_activity_observer",
+                "The id passed as the first argument is not representing "
+                "a locality");
+            return hpx::invalid_id;
+        }
+
+        auto const agent = server::create_activity_agent(callback);
+        return register_activity_observer_helper(locality, agent,
+            epoch_filter.value_or(static_cast<std::uint64_t>(-1)))
+            .get(ec);
+    }
+
+    hpx::id_type register_activity_observer(activity_callback const& callback,
+        std::optional<std::uint64_t> const epoch_filter, hpx::error_code& ec)
+    {
+        auto const agent = server::create_activity_agent(callback);
+        return get_supervision_manager().register_activity_observer(
+            agent, epoch_filter.value_or(static_cast<std::uint64_t>(-1)), ec);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Unregister a previously registered activity observer
+    namespace {
+
+        hpx::future<void> unregister_activity_observer_helper(
+            hpx::id_type const& locality, hpx::id_type const& observer_handle)
+        {
+            using action_type = server::supervision_manager::
+                unregister_activity_observer_action;
+            return supervision_dispatch<void, action_type>(
+                locality,
+                [&]() {
+                    get_supervision_manager().unregister_activity_observer(
+                        observer_handle);
+                    return hpx::make_ready_future();
+                },
+                observer_handle);
+        }
+    }    // namespace
+
+    hpx::future<void> unregister_activity_observer(
+        hpx::id_type const& locality, hpx::id_type const& observer_handle)
+    {
+        if (!hpx::naming::is_locality(locality))
+        {
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "hpx::supervision::unregister_activity_observer",
+                "The id passed as the first argument is not representing "
+                "a locality");
+        }
+        if (!observer_handle)
+        {
+            HPX_THROW_EXCEPTION(hpx::error::bad_parameter,
+                "hpx::supervision::unregister_activity_observer",
+                "The id passed as the second argument is not representing "
+                "a valid observer handle");
+        }
+
+        return unregister_activity_observer_helper(locality, observer_handle);
+    }
+
+    void unregister_activity_observer(hpx::launch::sync_policy,
+        hpx::id_type const& locality, hpx::id_type const& observer_handle,
+        hpx::error_code& ec)
+    {
+        if (!hpx::naming::is_locality(locality))
+        {
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "hpx::supervision::unregister_activity_observer",
+                "The id passed as the first argument is not representing "
+                "a locality");
+            return;
+        }
+        if (!observer_handle)
+        {
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "hpx::supervision::unregister_activity_observer",
+                "The id passed as the second argument is not representing "
+                "a valid observer handle");
+            return;
+        }
+
+        unregister_activity_observer_helper(locality, observer_handle).get(ec);
+    }
+
+    // Local activity-observer unregistration
+    void unregister_activity_observer(
+        hpx::id_type const& observer_handle, hpx::error_code& ec)
+    {
+        if (!observer_handle)
+        {
+            HPX_THROWS_IF(ec, hpx::error::bad_parameter,
+                "hpx::supervision::unregister_activity_observer",
+                "The id passed as the first argument is not representing "
+                "a valid observer handle");
+            return;
+        }
+
+        get_supervision_manager().unregister_activity_observer(
+            observer_handle, ec);
     }
 }    // namespace hpx::supervision
 

--- a/libs/full/supervision/src/supervision.cpp
+++ b/libs/full/supervision/src/supervision.cpp
@@ -565,6 +565,20 @@ namespace hpx::supervision {
             timeout.value_or((std::chrono::steady_clock::duration::max) ()),
             ec);
     }
+
+    ///////////////////////////////////////////////////////////////////////////
+    dispatch_outcome check_admission(
+        hpx::id_type const& target, std::uint64_t const epoch) noexcept
+    {
+        if (!target)
+        {
+            // nothing is latched against an invalid target
+            return dispatch_outcome::admitted;
+        }
+
+        return get_supervision_manager().check_admission(target, epoch);
+    }
+
 }    // namespace hpx::supervision
 
 #include <hpx/config/warnings_suffix.hpp>

--- a/libs/full/supervision/src/supervision.cpp
+++ b/libs/full/supervision/src/supervision.cpp
@@ -579,6 +579,22 @@ namespace hpx::supervision {
         return get_supervision_manager().check_admission(target, epoch);
     }
 
+    ///////////////////////////////////////////////////////////////////////////
+    void serialize(hpx::serialization::output_archive& ar,
+        target_activity_notification const& notification, unsigned int)
+    {
+        ar << notification.actor << notification.state
+           << notification.transition << notification.event_time
+           << notification.epoch << notification.ec;
+    }
+
+    void serialize(hpx::serialization::input_archive& ar,
+        target_activity_notification& notification, unsigned int)
+    {
+        ar >> notification.actor >> notification.state >>
+            notification.transition >> notification.event_time >>
+            notification.epoch >> notification.ec;
+    }
 }    // namespace hpx::supervision
 
 #include <hpx/config/warnings_suffix.hpp>

--- a/libs/full/supervision/src/supervision_manager.cpp
+++ b/libs/full/supervision/src/supervision_manager.cpp
@@ -125,7 +125,7 @@ namespace hpx::supervision {
             ec = make_success_code();
     }
 
-    hpx::id_type supervision_manager::register_target_activity_observer(
+    hpx::id_type supervision_manager::register_activity_observer(
         hpx::id_type const& agent, std::uint64_t const epoch_filter,
         hpx::error_code& ec) const
     {
@@ -133,31 +133,30 @@ namespace hpx::supervision {
         {
             HPX_THROWS_IF(ec, hpx::error::invalid_status,
                 "hpx::supervision::supervision_manager::"
-                "register_target_activity_observer",
+                "register_activity_observer",
                 "server is not registered");
             return {};
         }
 
-        auto result =
-            server_->register_target_activity_observer(agent, epoch_filter);
+        auto result = server_->register_activity_observer(agent, epoch_filter);
         if (&ec != &throws)
             ec = make_success_code();
         return result;
     }
 
-    void supervision_manager::unregister_target_activity_observer(
+    void supervision_manager::unregister_activity_observer(
         hpx::id_type const& observer_handle, hpx::error_code& ec) const
     {
         if (!server_)
         {
             HPX_THROWS_IF(ec, hpx::error::invalid_status,
                 "hpx::supervision::supervision_manager::"
-                "unregister_target_activity_observer",
+                "unregister_activity_observer",
                 "server is not registered");
             return;
         }
 
-        server_->unregister_target_activity_observer(observer_handle);
+        server_->unregister_activity_observer(observer_handle);
         if (&ec != &throws)
             ec = make_success_code();
     }

--- a/libs/full/supervision/src/supervision_manager.cpp
+++ b/libs/full/supervision/src/supervision_manager.cpp
@@ -125,6 +125,43 @@ namespace hpx::supervision {
             ec = make_success_code();
     }
 
+    hpx::id_type supervision_manager::register_target_activity_observer(
+        hpx::id_type const& agent, std::uint64_t const epoch_filter,
+        hpx::error_code& ec) const
+    {
+        if (!server_)
+        {
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                "hpx::supervision::supervision_manager::"
+                "register_target_activity_observer",
+                "server is not registered");
+            return {};
+        }
+
+        auto result =
+            server_->register_target_activity_observer(agent, epoch_filter);
+        if (&ec != &throws)
+            ec = make_success_code();
+        return result;
+    }
+
+    void supervision_manager::unregister_target_activity_observer(
+        hpx::id_type const& observer_handle, hpx::error_code& ec) const
+    {
+        if (!server_)
+        {
+            HPX_THROWS_IF(ec, hpx::error::invalid_status,
+                "hpx::supervision::supervision_manager::"
+                "unregister_target_activity_observer",
+                "server is not registered");
+            return;
+        }
+
+        server_->unregister_target_activity_observer(observer_handle);
+        if (&ec != &throws)
+            ec = make_success_code();
+    }
+
     hpx::future<lifecycle_state> supervision_manager::await_terminal(
         hpx::id_type const& target, std::uint64_t const epoch,
         std::chrono::steady_clock::duration const timeout,

--- a/libs/full/supervision/src/supervision_manager.cpp
+++ b/libs/full/supervision/src/supervision_manager.cpp
@@ -144,6 +144,17 @@ namespace hpx::supervision {
         return result;
     }
 
+    dispatch_outcome supervision_manager::check_admission(
+        hpx::id_type const& target, std::uint64_t const epoch) const noexcept
+    {
+        if (!server_)
+        {
+            return dispatch_outcome::admitted;
+        }
+
+        return server_->check_admission(target, epoch);
+    }
+
     ///////////////////////////////////////////////////////////////////////////
     naming::gid_type supervision_manager::get_service_instance(
         std::uint32_t const service_locality_id)

--- a/libs/full/supervision/tests/unit/CMakeLists.txt
+++ b/libs/full/supervision/tests/unit/CMakeLists.txt
@@ -4,10 +4,13 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(tests supervision_api supervision_await_terminal)
+set(tests supervision_api supervision_await_terminal
+          supervision_check_admission
+)
 
 set(supervision_api_PARAMETERS LOCALITIES 2 THREADS_PER_LOCALITY 4)
 set(supervision_await_terminal_PARAMETERS LOCALITIES 2 THREADS_PER_LOCALITY 4)
+set(supervision_check_admission_PARAMETERS THREADS_PER_LOCALITY 4)
 
 foreach(test ${tests})
   set(sources ${test}.cpp)

--- a/libs/full/supervision/tests/unit/CMakeLists.txt
+++ b/libs/full/supervision/tests/unit/CMakeLists.txt
@@ -4,12 +4,13 @@
 # Distributed under the Boost Software License, Version 1.0. (See accompanying
 # file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(tests supervision_api supervision_await_terminal
+set(tests supervision_api supervision_await_terminal supervision_check_activity
           supervision_check_admission
 )
 
 set(supervision_api_PARAMETERS LOCALITIES 2 THREADS_PER_LOCALITY 4)
 set(supervision_await_terminal_PARAMETERS LOCALITIES 2 THREADS_PER_LOCALITY 4)
+set(supervision_check_activity_PARAMETERS LOCALITIES 2 THREADS_PER_LOCALITY 4)
 set(supervision_check_admission_PARAMETERS THREADS_PER_LOCALITY 4)
 
 foreach(test ${tests})
@@ -21,6 +22,7 @@ foreach(test ${tests})
   add_hpx_executable(
     ${test}_test INTERNAL_FLAGS
     SOURCES ${sources}
+    HEADERS "supervision_test_helpers.hpp"
     EXCLUDE_FROM_ALL
     HPX_PREFIX ${HPX_BUILD_PREFIX}
     FOLDER "Tests/Unit/Modules/Full/Supervision"

--- a/libs/full/supervision/tests/unit/supervision_api.cpp
+++ b/libs/full/supervision/tests/unit/supervision_api.cpp
@@ -9,7 +9,6 @@
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/modules/preprocessor.hpp>
 #include <hpx/modules/testing.hpp>
 #include <hpx/supervision.hpp>
 

--- a/libs/full/supervision/tests/unit/supervision_api.cpp
+++ b/libs/full/supervision/tests/unit/supervision_api.cpp
@@ -1713,21 +1713,6 @@ void test_publication_throughput()
 // Main Test Entry Point
 // ============================================================================
 
-template <typename... Args>
-void print(Args... args)
-{
-    bool first = true;
-    (...,
-        (first ? (first = false, std::cout << args) :
-                 (std::cout << ", " << args)));
-}
-
-#define HPX_TEST_RUN(func, ...)                                                \
-    std::cout << HPX_PP_STRINGIZE(func) << "(";                                \
-    print(__VA_ARGS__);                                                        \
-    std::cout << ")\n";                                                        \
-    func(__VA_ARGS__)
-
 int hpx_main()
 {
     for (auto const& locality : hpx::find_all_localities())

--- a/libs/full/supervision/tests/unit/supervision_await_terminal.cpp
+++ b/libs/full/supervision/tests/unit/supervision_await_terminal.cpp
@@ -207,7 +207,7 @@ void test_await_terminal_abandoned_waiter_expires(hpx::id_type const& locality)
     hpx::id_type const other_target = make_test_target();
     reach_running(locality, other_target);
 
-    HPX_TEST(f.is_ready() && f.has_exception());
+    HPX_TEST(!f.is_ready() || f.has_exception());
 
     bool caught_stale_state = false;
     try
@@ -270,24 +270,117 @@ void test_await_terminal_explicit_timeout_overrides_default(
     HPX_TEST(state.last_event == hpx::supervision::event::completed);
 }
 
+// Regression test pinning down the invariant that "check-then-register" in
+// await_terminal() and "epoch bump + drain" in apply_new_epoch_locked() are
+// serialized on the same mtx_: a batch of waiters concurrently registered
+// against a not-yet-reached epoch must be deterministically resolved once
+// that epoch's terminal event is published, regardless of lock-timing
+// (i.e. no waiter is left hanging or resolved with a stale state due to a
+// race between insertion into waiters_ and the epoch transition).
+void test_await_terminal_concurrent_epoch_bump_resolves_waiters(
+    hpx::id_type const& locality)
+{
+    hpx::id_type const target = make_test_target();
+
+    reach_running_at_epoch(locality, target, 0);
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+        hpx::supervision::event::completed, 0);
+
+    auto baseline = hpx::supervision::await_terminal(locality, target, 0);
+    auto const baseline_state = baseline.get();
+    HPX_TEST_EQ(baseline_state.epoch, static_cast<std::uint64_t>(0));
+    HPX_TEST(baseline_state.last_event == hpx::supervision::event::completed);
+
+    constexpr int num_waiters = 20;
+
+    hpx::mutex results_mtx;
+    std::vector<hpx::future<hpx::supervision::lifecycle_state>> results;
+    results.reserve(num_waiters);
+
+    std::vector<hpx::future<void>> registrations;
+    registrations.reserve(num_waiters);
+    for (int i = 0; i != num_waiters; ++i)
+    {
+        registrations.push_back(hpx::async(hpx::launch::task, [&] {
+            auto f = hpx::supervision::await_terminal(
+                locality, target, 1, std::chrono::seconds(5));
+            std::scoped_lock<hpx::mutex> lock(results_mtx);
+            results.push_back(HPX_MOVE(f));
+        }));
+    }
+    hpx::wait_all(registrations);
+
+    // Publishing the terminal event directly at epoch 1 (without an
+    // intermediate started/running transition) must drain and resolve every
+    // waiter registered above against (target, 1).
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+        hpx::supervision::event::completed, 1);
+
+    HPX_TEST_EQ(results.size(), static_cast<std::size_t>(num_waiters));
+    for (auto& f : results)
+    {
+        auto const state = f.get();
+        HPX_TEST_EQ(state.epoch, static_cast<std::uint64_t>(1));
+        HPX_TEST(state.last_event == hpx::supervision::event::completed);
+    }
+}
+
+// Companion to the above: waiters registered against an epoch that is then
+// skipped entirely (the target jumps straight from epoch 0 to epoch 2) must
+// be invalidated via drain_stale_waiters_locked() with the explicit
+// "epoch advanced beyond the requested epoch" exception, rather than being
+// left pending or resolved with the wrong state.
+void test_await_terminal_concurrent_epoch_skip_invalidates_waiters(
+    hpx::id_type const& locality)
+{
+    hpx::id_type const target = make_test_target();
+
+    reach_running_at_epoch(locality, target, 0);
+
+    constexpr int num_waiters = 20;
+
+    hpx::mutex results_mtx;
+    std::vector<hpx::future<hpx::supervision::lifecycle_state>> results;
+    results.reserve(num_waiters);
+
+    std::vector<hpx::future<void>> registrations;
+    registrations.reserve(num_waiters);
+    for (int i = 0; i != num_waiters; ++i)
+    {
+        registrations.push_back(hpx::async(hpx::launch::task, [&] {
+            auto f = hpx::supervision::await_terminal(
+                locality, target, 1, std::chrono::seconds(5));
+            std::scoped_lock<hpx::mutex> lock(results_mtx);
+            results.push_back(HPX_MOVE(f));
+        }));
+    }
+    hpx::wait_all(registrations);
+
+    // Skip epoch 1 entirely: publishing directly at epoch 2 must invalidate
+    // (not resolve) every waiter registered against epoch 1.
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+        hpx::supervision::event::completed, 2);
+
+    HPX_TEST_EQ(results.size(), static_cast<std::size_t>(num_waiters));
+    for (auto& f : results)
+    {
+        bool caught_stale_state = false;
+        try
+        {
+            f.get();
+            HPX_TEST(false);
+        }
+        catch (hpx::exception const& e)
+        {
+            caught_stale_state = (e.get_error() == hpx::error::stale_state);
+        }
+        HPX_TEST(caught_stale_state);
+    }
+}
+
 // ============================================================================
 // Main Test Entry Point
 // ============================================================================
-
-template <typename... Args>
-void print(Args... args)
-{
-    bool first = true;
-    (...,
-        (first ? (first = false, std::cout << args) :
-                 (std::cout << ", " << args)));
-}
-
-#define HPX_TEST_RUN(func, ...)                                                \
-    std::cout << HPX_PP_STRINGIZE(func) << "(";                                \
-    print(__VA_ARGS__);                                                        \
-    std::cout << ")\n";                                                        \
-    func(__VA_ARGS__)
 
 int hpx_main()
 {
@@ -304,6 +397,12 @@ int hpx_main()
         HPX_TEST_RUN(test_await_terminal_abandoned_waiter_expires, locality);
         HPX_TEST_RUN(
             test_await_terminal_explicit_timeout_overrides_default, locality);
+
+        HPX_TEST_RUN(test_await_terminal_concurrent_epoch_bump_resolves_waiters,
+            locality);
+        HPX_TEST_RUN(
+            test_await_terminal_concurrent_epoch_skip_invalidates_waiters,
+            locality);
     }
 
     HPX_TEST_RUN(

--- a/libs/full/supervision/tests/unit/supervision_await_terminal.cpp
+++ b/libs/full/supervision/tests/unit/supervision_await_terminal.cpp
@@ -9,7 +9,6 @@
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/modules/preprocessor.hpp>
 #include <hpx/modules/testing.hpp>
 #include <hpx/supervision.hpp>
 

--- a/libs/full/supervision/tests/unit/supervision_check_activity.cpp
+++ b/libs/full/supervision/tests/unit/supervision_check_activity.cpp
@@ -1,0 +1,577 @@
+//  Copyright (c) 2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx.hpp>
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/supervision.hpp>
+
+#include "supervision_test_helpers.hpp"
+
+#include <algorithm>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <mutex>
+#include <optional>
+#include <utility>
+#include <vector>
+
+// ============================================================================
+// Compile-time checks: none of the register_activity_observer() /
+// unregister_activity_observer() overloads take a `target` parameter.
+// Unlike register_observer()/unregister_observer(), activity observers are
+// scoped to a locality's supervision manager as a whole, not to an
+// individual target.
+// ============================================================================
+namespace {
+
+    template <typename... Args>
+    concept invocable_register_activity_observer = requires(Args&&... args) {
+        hpx::supervision::register_activity_observer(
+            std::forward<Args>(args)...);
+    };
+
+    template <typename... Args>
+    concept invocable_unregister_activity_observer = requires(Args&&... args) {
+        hpx::supervision::unregister_activity_observer(
+            std::forward<Args>(args)...);
+    };
+
+    // The legitimate, locality-scoped overloads remain callable.
+    static_assert(invocable_register_activity_observer<hpx::id_type const&,
+        hpx::supervision::activity_callback const&>);
+    static_assert(invocable_register_activity_observer<hpx::launch::sync_policy,
+        hpx::id_type const&, hpx::supervision::activity_callback const&>);
+    static_assert(invocable_register_activity_observer<
+        hpx::supervision::activity_callback const&>);
+
+    static_assert(invocable_unregister_activity_observer<hpx::id_type const&,
+        hpx::id_type const&>);
+    static_assert(
+        invocable_unregister_activity_observer<hpx::launch::sync_policy,
+            hpx::id_type const&, hpx::id_type const&>);
+    static_assert(invocable_unregister_activity_observer<hpx::id_type const&>);
+
+    // None of the overloads accept a target argument: mirroring
+    // register_observer()'s/unregister_observer()'s (locality, target, ...)
+    // signatures against register_activity_observer()/
+    // unregister_activity_observer() must not resolve to any overload.
+    static_assert(!invocable_register_activity_observer<hpx::id_type const&,
+        hpx::id_type const&, hpx::supervision::activity_callback const&,
+        std::optional<std::uint64_t>>);
+    static_assert(!invocable_register_activity_observer<hpx::id_type const&,
+        hpx::id_type const&, hpx::supervision::activity_callback const&>);
+    static_assert(
+        !invocable_register_activity_observer<hpx::launch::sync_policy,
+            hpx::id_type const&, hpx::id_type const&,
+            hpx::supervision::activity_callback const&>);
+
+    static_assert(!invocable_unregister_activity_observer<hpx::id_type const&,
+        hpx::id_type const&, hpx::id_type const&>);
+    static_assert(
+        !invocable_unregister_activity_observer<hpx::launch::sync_policy,
+            hpx::id_type const&, hpx::id_type const&, hpx::id_type const&>);
+
+}    // namespace
+
+// ============================================================================
+// Test Infrastructure
+// ============================================================================
+
+// Records every activity_notification delivered to a single registered activity
+// observer, and allows querying/waiting for notifications pertaining to a
+// specific target. Since an activity observer sees transitions for *every*
+// target tracked by a locality's supervision manager - including targets
+// created by earlier, unrelated tests running in the same process - assertions
+// must always be scoped to the target(s) a given test created, never to the
+// total notification count.
+struct activity_test_context
+{
+    mutable hpx::mutex mtx;
+    hpx::condition_variable cv;
+    std::vector<hpx::supervision::activity_notification> observed;
+
+    void reset()
+    {
+        std::scoped_lock<hpx::mutex> lock(mtx);
+        observed.clear();
+    }
+
+    void record(hpx::supervision::activity_notification const& notification)
+    {
+        {
+            std::scoped_lock<hpx::mutex> lock(mtx);
+            observed.push_back(notification);
+        }
+        cv.notify_all();
+    }
+
+    std::size_t count_for_target(hpx::id_type const& target) const
+    {
+        std::scoped_lock<hpx::mutex> lock(mtx);
+        return static_cast<std::size_t>(std::ranges::count_if(
+            observed, [&target](auto const& n) { return n.actor == target; }));
+    }
+
+    // Returns the recorded notifications for `target`, in delivery order.
+    std::vector<hpx::supervision::activity_notification> for_target(
+        hpx::id_type const& target) const
+    {
+        std::scoped_lock<hpx::mutex> lock(mtx);
+        std::vector<hpx::supervision::activity_notification> result;
+        std::ranges::copy_if(observed, std::back_inserter(result),
+            [&target](auto const& n) { return n.actor == target; });
+        return result;
+    }
+
+    bool wait_for_target_count(hpx::id_type const& target,
+        std::size_t const expected, std::chrono::milliseconds const timeout)
+    {
+        std::unique_lock<hpx::mutex> lock(mtx);
+        return cv.wait_for(lock, timeout, [&] {
+            return static_cast<std::size_t>(std::ranges::count_if(
+                       observed, [&target](auto const& n) {
+                           return n.actor == target;
+                       })) >= expected;
+        });
+    }
+};
+
+namespace {
+
+    hpx::supervision::activity_callback make_recording_callback(
+        activity_test_context& ctx)
+    {
+        return
+            [&ctx](
+                hpx::supervision::activity_notification const& notification) {
+                ctx.record(notification);
+                return true;
+            };
+    }
+
+    bool no_op_lifecycle_observer(
+        hpx::supervision::lifecycle_event_notification const&)
+    {
+        return true;
+    }
+
+}    // namespace
+
+// ============================================================================
+// Test Cases: Replay on registration
+// ============================================================================
+
+// A target already active - via either trigger - at the time an activity
+// observer is registered must be replayed synchronously as
+// activity_transition::already_active, as part of registration.
+void test_activity_replay_on_registration(hpx::id_type const& locality)
+{
+    hpx::id_type const target_via_event = make_test_target();
+    hpx::id_type const target_via_observer = make_test_target();
+
+    // Activate one target by publishing an event, and the other by registering
+    // a per-target lifecycle observer, before any activity observer exists.
+    hpx::supervision::publish_event(hpx::launch::sync, locality,
+        target_via_event, hpx::supervision::event::started);
+
+    auto const lifecycle_handle =
+        hpx::supervision::register_observer(hpx::launch::sync, locality,
+            target_via_observer, no_op_lifecycle_observer);
+
+    activity_test_context ctx;
+    auto const activity_handle = hpx::supervision::register_activity_observer(
+        hpx::launch::sync, locality, make_recording_callback(ctx));
+
+    HPX_TEST(ctx.wait_for_target_count(
+        target_via_event, 1, std::chrono::milliseconds(20)));
+    HPX_TEST(ctx.wait_for_target_count(
+        target_via_observer, 1, std::chrono::milliseconds(20)));
+
+    auto const events_replay = ctx.for_target(target_via_event);
+    HPX_TEST_EQ(events_replay.size(), static_cast<std::size_t>(1));
+    HPX_TEST(
+        events_replay[0].state == hpx::supervision::activity_state::active);
+    HPX_TEST(events_replay[0].transition ==
+        hpx::supervision::activity_transition::already_active);
+
+    auto const observer_replay = ctx.for_target(target_via_observer);
+    HPX_TEST_EQ(observer_replay.size(), static_cast<std::size_t>(1));
+    HPX_TEST(
+        observer_replay[0].state == hpx::supervision::activity_state::active);
+    HPX_TEST(observer_replay[0].transition ==
+        hpx::supervision::activity_transition::already_active);
+
+    hpx::supervision::unregister_activity_observer(
+        hpx::launch::sync, locality, activity_handle);
+    hpx::supervision::unregister_observer(
+        hpx::launch::sync, locality, lifecycle_handle);
+}
+
+// ============================================================================
+// Test Cases: Live transitions
+// ============================================================================
+
+// A target's very first publish_event() call triggers
+// activity_transition::first_event for an already-registered activity observer.
+void test_activity_live_first_event(hpx::id_type const& locality)
+{
+    activity_test_context ctx;
+    auto const activity_handle = hpx::supervision::register_activity_observer(
+        hpx::launch::sync, locality, make_recording_callback(ctx));
+
+    hpx::id_type const target = make_test_target();
+    hpx::supervision::publish_event(
+        hpx::launch::sync, locality, target, hpx::supervision::event::started);
+
+    HPX_TEST(
+        ctx.wait_for_target_count(target, 1, std::chrono::milliseconds(20)));
+
+    auto const notifications = ctx.for_target(target);
+    HPX_TEST_EQ(notifications.size(), static_cast<std::size_t>(1));
+    HPX_TEST(
+        notifications[0].state == hpx::supervision::activity_state::active);
+    HPX_TEST(notifications[0].transition ==
+        hpx::supervision::activity_transition::first_event);
+
+    hpx::supervision::unregister_activity_observer(
+        hpx::launch::sync, locality, activity_handle);
+}
+
+// Registering the first per-target lifecycle observer for a target that has
+// never published an event triggers activity_transition::first_observer.
+void test_activity_live_first_observer(hpx::id_type const& locality)
+{
+    activity_test_context ctx;
+    auto const activity_handle = hpx::supervision::register_activity_observer(
+        hpx::launch::sync, locality, make_recording_callback(ctx));
+
+    hpx::id_type const target = make_test_target();
+    auto const lifecycle_handle = hpx::supervision::register_observer(
+        hpx::launch::sync, locality, target, no_op_lifecycle_observer);
+
+    HPX_TEST(
+        ctx.wait_for_target_count(target, 1, std::chrono::milliseconds(20)));
+
+    auto const notifications = ctx.for_target(target);
+    HPX_TEST_EQ(notifications.size(), static_cast<std::size_t>(1));
+    HPX_TEST(
+        notifications[0].state == hpx::supervision::activity_state::active);
+    HPX_TEST(notifications[0].transition ==
+        hpx::supervision::activity_transition::first_observer);
+
+    hpx::supervision::unregister_observer(
+        hpx::launch::sync, locality, lifecycle_handle);
+    hpx::supervision::unregister_activity_observer(
+        hpx::launch::sync, locality, activity_handle);
+}
+
+// Unregistering a target's last remaining per-target lifecycle observer
+// triggers activity_transition::last_observer_unregistered.
+void test_activity_live_last_observer_unregistered(hpx::id_type const& locality)
+{
+    hpx::id_type const target = make_test_target();
+    auto const lifecycle_handle = hpx::supervision::register_observer(
+        hpx::launch::sync, locality, target, no_op_lifecycle_observer);
+
+    activity_test_context ctx;
+    auto const activity_handle = hpx::supervision::register_activity_observer(
+        hpx::launch::sync, locality, make_recording_callback(ctx));
+
+    // The registration above replays target's current (already active) state;
+    // that replay is not what this test is exercising.
+    HPX_TEST(
+        ctx.wait_for_target_count(target, 1, std::chrono::milliseconds(20)));
+    ctx.reset();
+
+    hpx::supervision::unregister_observer(
+        hpx::launch::sync, locality, lifecycle_handle);
+
+    HPX_TEST(
+        ctx.wait_for_target_count(target, 1, std::chrono::milliseconds(20)));
+
+    auto const notifications = ctx.for_target(target);
+    HPX_TEST_EQ(notifications.size(), static_cast<std::size_t>(1));
+    HPX_TEST(
+        notifications[0].state == hpx::supervision::activity_state::inactive);
+    HPX_TEST(notifications[0].transition ==
+        hpx::supervision::activity_transition::last_observer_unregistered);
+
+    hpx::supervision::unregister_activity_observer(
+        hpx::launch::sync, locality, activity_handle);
+}
+
+// A target's latched activity state is not cleared by later publications: only
+// the very first publish_event() for a target ever produces an activity
+// notification; subsequent events (including a terminal one) must not trigger a
+// spurious deactivation on the publishing path.
+void test_activity_no_deactivation_on_publish_path(hpx::id_type const& locality)
+{
+    activity_test_context ctx;
+    auto const activity_handle = hpx::supervision::register_activity_observer(
+        hpx::launch::sync, locality, make_recording_callback(ctx));
+
+    hpx::id_type const target = make_test_target();
+    hpx::supervision::publish_event(
+        hpx::launch::sync, locality, target, hpx::supervision::event::started);
+
+    HPX_TEST(
+        ctx.wait_for_target_count(target, 1, std::chrono::milliseconds(20)));
+
+    hpx::supervision::publish_event(
+        hpx::launch::sync, locality, target, hpx::supervision::event::running);
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+        hpx::supervision::event::completed);
+
+    // Publish a sentinel event for an unrelated target and wait for its
+    // notification to arrive. Since activity notifications are delivered in
+    // publication order, this guarantees that any (unexpected) extra
+    // notification for `target` above would already have been recorded by
+    // the time the sentinel's notification is observed.
+    hpx::id_type const sentinel_target = make_test_target();
+    hpx::supervision::publish_event(hpx::launch::sync, locality,
+        sentinel_target, hpx::supervision::event::started);
+    HPX_TEST(ctx.wait_for_target_count(
+        sentinel_target, 1, std::chrono::milliseconds(1000)));
+
+    auto const notifications = ctx.for_target(target);
+    HPX_TEST_EQ(notifications.size(), static_cast<std::size_t>(1));
+    HPX_TEST(notifications[0].transition ==
+        hpx::supervision::activity_transition::first_event);
+
+    hpx::supervision::unregister_activity_observer(
+        hpx::launch::sync, locality, activity_handle);
+}
+
+// A single activity-observer registration must correctly attribute transitions
+// across multiple, independently-triggered targets.
+void test_activity_multiple_targets_single_registration(
+    hpx::id_type const& locality)
+{
+    activity_test_context ctx;
+    auto const activity_handle = hpx::supervision::register_activity_observer(
+        hpx::launch::sync, locality, make_recording_callback(ctx));
+
+    hpx::id_type const target_event_1 = make_test_target();
+    hpx::id_type const target_observer = make_test_target();
+    hpx::id_type const target_event_2 = make_test_target();
+
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target_event_1,
+        hpx::supervision::event::started);
+    auto const lifecycle_handle = hpx::supervision::register_observer(
+        hpx::launch::sync, locality, target_observer, no_op_lifecycle_observer);
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target_event_2,
+        hpx::supervision::event::started);
+
+    HPX_TEST(ctx.wait_for_target_count(
+        target_event_1, 1, std::chrono::milliseconds(20)));
+    HPX_TEST(ctx.wait_for_target_count(
+        target_observer, 1, std::chrono::milliseconds(20)));
+    HPX_TEST(ctx.wait_for_target_count(
+        target_event_2, 1, std::chrono::milliseconds(20)));
+
+    HPX_TEST(ctx.for_target(target_event_1)[0].transition ==
+        hpx::supervision::activity_transition::first_event);
+    HPX_TEST(ctx.for_target(target_observer)[0].transition ==
+        hpx::supervision::activity_transition::first_observer);
+    HPX_TEST(ctx.for_target(target_event_2)[0].transition ==
+        hpx::supervision::activity_transition::first_event);
+
+    hpx::supervision::unregister_observer(
+        hpx::launch::sync, locality, lifecycle_handle);
+    hpx::supervision::unregister_activity_observer(
+        hpx::launch::sync, locality, activity_handle);
+}
+
+// ============================================================================
+// Test Cases: epoch_filter
+// ============================================================================
+
+// A registration-time replay only covers targets whose (current) epoch matches
+// epoch_filter, when one is engaged.
+void test_activity_epoch_filter_replay(hpx::id_type const& locality)
+{
+    constexpr std::uint64_t filter_epoch = 11;
+    constexpr std::uint64_t other_epoch = 12;
+
+    hpx::id_type const target_match = make_test_target();
+    hpx::id_type const target_mismatch = make_test_target();
+
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target_match,
+        hpx::supervision::event::started, filter_epoch);
+    hpx::supervision::publish_event(hpx::launch::sync, locality,
+        target_mismatch, hpx::supervision::event::started, other_epoch);
+
+    activity_test_context ctx;
+    auto const activity_handle =
+        hpx::supervision::register_activity_observer(hpx::launch::sync,
+            locality, make_recording_callback(ctx), filter_epoch);
+
+    HPX_TEST(ctx.wait_for_target_count(
+        target_match, 1, std::chrono::milliseconds(20)));
+
+    // Give a would-be (incorrect) replay for the mismatched target a chance
+    // to arrive before asserting its absence.
+    hpx::this_thread::sleep_for(std::chrono::milliseconds(20));
+    HPX_TEST_EQ(
+        ctx.count_for_target(target_mismatch), static_cast<std::size_t>(0));
+
+    hpx::supervision::unregister_activity_observer(
+        hpx::launch::sync, locality, activity_handle);
+}
+
+// A live transition recorded under an epoch other than epoch_filter must be
+// silently skipped for a filtered observer, while a matching-epoch transition
+// still reaches it.
+void test_activity_epoch_filter_live(hpx::id_type const& locality)
+{
+    constexpr std::uint64_t filter_epoch = 21;
+    constexpr std::uint64_t other_epoch = 22;
+
+    activity_test_context ctx;
+    auto const activity_handle =
+        hpx::supervision::register_activity_observer(hpx::launch::sync,
+            locality, make_recording_callback(ctx), filter_epoch);
+
+    hpx::id_type const target_match = make_test_target();
+    hpx::id_type const target_mismatch = make_test_target();
+
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target_match,
+        hpx::supervision::event::started, filter_epoch);
+    hpx::supervision::publish_event(hpx::launch::sync, locality,
+        target_mismatch, hpx::supervision::event::started, other_epoch);
+
+    HPX_TEST(ctx.wait_for_target_count(
+        target_match, 1, std::chrono::milliseconds(20)));
+
+    hpx::this_thread::sleep_for(std::chrono::milliseconds(20));
+    HPX_TEST_EQ(
+        ctx.count_for_target(target_mismatch), static_cast<std::size_t>(0));
+
+    hpx::supervision::unregister_activity_observer(
+        hpx::launch::sync, locality, activity_handle);
+}
+
+// ============================================================================
+// Test Cases: Registration race
+// ============================================================================
+
+// Registering an activity observer concurrently with in-flight
+// publish_event()/register_observer() calls for a batch of targets must deliver
+// exactly one notification per target - either a live transition or a
+// registration-time replay - never both, never neither.
+void test_activity_registration_race(hpx::id_type const& locality)
+{
+    constexpr std::size_t num_targets = 20;
+
+    std::vector<hpx::id_type> targets;
+    targets.reserve(num_targets);
+    for (std::size_t i = 0; i != num_targets; ++i)
+    {
+        targets.push_back(make_test_target());
+    }
+
+    hpx::mutex handles_mtx;
+    std::vector<hpx::id_type> lifecycle_handles;
+
+    std::vector<hpx::future<void>> activation_futures;
+    activation_futures.reserve(num_targets);
+    for (std::size_t i = 0; i != num_targets; ++i)
+    {
+        hpx::id_type const& target = targets[i];
+        if (i % 2 == 0)
+        {
+            activation_futures.push_back(
+                hpx::async(hpx::launch::task, [locality, target]() {
+                    hpx::supervision::publish_event(hpx::launch::sync, locality,
+                        target, hpx::supervision::event::started);
+                }));
+        }
+        else
+        {
+            activation_futures.push_back(hpx::async(hpx::launch::task,
+                [locality, target, &handles_mtx, &lifecycle_handles]() {
+                    auto const handle =
+                        hpx::supervision::register_observer(hpx::launch::sync,
+                            locality, target, no_op_lifecycle_observer);
+                    std::scoped_lock<hpx::mutex> lock(handles_mtx);
+                    lifecycle_handles.push_back(handle);
+                }));
+        }
+    }
+
+    activity_test_context ctx;
+    auto activity_handle_future =
+        hpx::async(hpx::launch::task, [locality, &ctx]() {
+            return hpx::supervision::register_activity_observer(
+                hpx::launch::sync, locality, make_recording_callback(ctx));
+        });
+
+    hpx::wait_all(activation_futures);
+    hpx::id_type const activity_handle = activity_handle_future.get();
+
+    for (hpx::id_type const& target : targets)
+    {
+        HPX_TEST(ctx.wait_for_target_count(
+            target, 1, std::chrono::milliseconds(50)));
+        HPX_TEST_EQ(ctx.count_for_target(target), static_cast<std::size_t>(1));
+    }
+
+    hpx::supervision::unregister_activity_observer(
+        hpx::launch::sync, locality, activity_handle);
+
+    for (hpx::id_type const& handle : lifecycle_handles)
+    {
+        hpx::supervision::unregister_observer(
+            hpx::launch::sync, locality, handle);
+    }
+}
+
+// ============================================================================
+// Main Test Entry Point
+// ============================================================================
+
+int hpx_main()
+{
+    for (auto const& locality : hpx::find_all_localities())
+    {
+        HPX_TEST_RUN(test_activity_replay_on_registration, locality);
+
+        HPX_TEST_RUN(test_activity_live_first_event, locality);
+        HPX_TEST_RUN(test_activity_live_first_observer, locality);
+        HPX_TEST_RUN(test_activity_live_last_observer_unregistered, locality);
+        HPX_TEST_RUN(test_activity_no_deactivation_on_publish_path, locality);
+        HPX_TEST_RUN(
+            test_activity_multiple_targets_single_registration, locality);
+
+        HPX_TEST_RUN(test_activity_epoch_filter_replay, locality);
+        HPX_TEST_RUN(test_activity_epoch_filter_live, locality);
+
+        HPX_TEST_RUN(test_activity_registration_race, locality);
+    }
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    HPX_TEST_EQ(hpx::init(argc, argv), 0);
+    return hpx::util::report_errors();
+}
+
+#else
+
+int main(int, char*[])
+{
+    return 0;
+}
+
+#endif

--- a/libs/full/supervision/tests/unit/supervision_check_admission.cpp
+++ b/libs/full/supervision/tests/unit/supervision_check_admission.cpp
@@ -1,0 +1,116 @@
+//  Copyright (c) 2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx.hpp>
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/modules/preprocessor.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/supervision.hpp>
+
+#include "supervision_test_helpers.hpp"
+
+#include <cstdint>
+
+// ============================================================================
+// Test Cases: Dispatch Admission
+// ============================================================================
+
+// A target with no recorded state at all has nothing latched against it.
+void test_check_admission_admitted_for_unknown_target()
+{
+    hpx::id_type const target = make_test_target();
+
+    HPX_TEST(hpx::supervision::check_admission(target) ==
+        hpx::supervision::dispatch_outcome::admitted);
+}
+
+// Non-terminal events must not fence dispatch.
+void test_check_admission_admitted_before_terminal()
+{
+    hpx::id_type const target = make_test_target();
+
+    hpx::supervision::publish_event(target, hpx::supervision::event::started);
+    HPX_TEST(hpx::supervision::check_admission(target) ==
+        hpx::supervision::dispatch_outcome::admitted);
+
+    hpx::supervision::publish_event(target, hpx::supervision::event::running);
+    HPX_TEST(hpx::supervision::check_admission(target) ==
+        hpx::supervision::dispatch_outcome::admitted);
+}
+
+// Once `target` has latched a terminal event for an epoch, dispatch under
+// that same epoch must be rejected.
+void test_check_admission_rejected_after_terminal()
+{
+    hpx::id_type const target = make_test_target();
+
+    hpx::supervision::publish_event(target, hpx::supervision::event::started);
+    hpx::supervision::publish_event(target, hpx::supervision::event::running);
+    hpx::supervision::publish_event(target, hpx::supervision::event::completed);
+
+    HPX_TEST(hpx::supervision::check_admission(target) ==
+        hpx::supervision::dispatch_outcome::rejected_fenced);
+}
+
+// A terminal latch is scoped to the epoch it was recorded under: dispatch
+// under a different epoch is unaffected.
+void test_check_admission_scoped_to_epoch()
+{
+    hpx::id_type const target = make_test_target();
+    std::uint64_t const epoch = 1;
+
+    hpx::supervision::publish_event(
+        target, hpx::supervision::event::started, epoch);
+    hpx::supervision::publish_event(
+        target, hpx::supervision::event::running, epoch);
+    hpx::supervision::publish_event(
+        target, hpx::supervision::event::completed, epoch);
+
+    HPX_TEST(hpx::supervision::check_admission(target, epoch) ==
+        hpx::supervision::dispatch_outcome::rejected_fenced);
+    HPX_TEST(hpx::supervision::check_admission(target, epoch + 1) ==
+        hpx::supervision::dispatch_outcome::admitted);
+}
+
+// An invalid target has nothing latched against it either.
+void test_check_admission_admitted_for_invalid_target()
+{
+    HPX_TEST(hpx::supervision::check_admission(hpx::invalid_id) ==
+        hpx::supervision::dispatch_outcome::admitted);
+}
+
+// ============================================================================
+// Main Test Entry Point
+// ============================================================================
+
+int hpx_main()
+{
+    HPX_TEST_RUN(test_check_admission_admitted_for_unknown_target);
+    HPX_TEST_RUN(test_check_admission_admitted_before_terminal);
+    HPX_TEST_RUN(test_check_admission_rejected_after_terminal);
+    HPX_TEST_RUN(test_check_admission_scoped_to_epoch);
+    HPX_TEST_RUN(test_check_admission_admitted_for_invalid_target);
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    HPX_TEST_EQ(hpx::init(argc, argv), 0);
+    return hpx::util::report_errors();
+}
+
+#else
+
+int main(int, char*[])
+{
+    return 0;
+}
+
+#endif

--- a/libs/full/supervision/tests/unit/supervision_check_admission.cpp
+++ b/libs/full/supervision/tests/unit/supervision_check_admission.cpp
@@ -9,7 +9,6 @@
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 
 #include <hpx/hpx_init.hpp>
-#include <hpx/modules/preprocessor.hpp>
 #include <hpx/modules/testing.hpp>
 #include <hpx/supervision.hpp>
 

--- a/libs/full/supervision/tests/unit/supervision_test_helpers.hpp
+++ b/libs/full/supervision/tests/unit/supervision_test_helpers.hpp
@@ -11,6 +11,7 @@
 #if !defined(HPX_COMPUTE_DEVICE_CODE)
 
 #include <hpx/hpx.hpp>
+#include <hpx/modules/preprocessor.hpp>
 #include <hpx/supervision.hpp>
 
 #include <atomic>

--- a/libs/full/supervision/tests/unit/supervision_test_helpers.hpp
+++ b/libs/full/supervision/tests/unit/supervision_test_helpers.hpp
@@ -16,6 +16,7 @@
 #include <atomic>
 #include <cstdint>
 
+///////////////////////////////////////////////////////////////////////////////
 // publish_event() now validates lifecycle event transitions and rejects
 // invalid ones (see hpx::supervision::is_valid_transition()). Each test
 // therefore needs its own private target: reusing hpx::find_here() as a
@@ -52,5 +53,21 @@ inline void reach_running_at_epoch(hpx::id_type const& locality,
     hpx::supervision::publish_event(hpx::launch::sync, locality, target,
         hpx::supervision::event::running, epoch);
 }
+
+///////////////////////////////////////////////////////////////////////////////
+template <typename... Args>
+void print(Args... args)
+{
+    bool first = true;
+    (...,
+        (first ? (first = false, std::cout << args) :
+                 (std::cout << ", " << args)));
+}
+
+#define HPX_TEST_RUN(func, ...)                                                \
+    std::cout << HPX_PP_STRINGIZE(func) << "(";                                \
+    print(__VA_ARGS__);                                                        \
+    std::cout << ")\n";                                                        \
+    func(__VA_ARGS__)
 
 #endif


### PR DESCRIPTION
## Summary

Introduces a local, non-throwing admission check that lets callers ask "is it safe to dispatch new work to this target under this epoch?" before scheduling, backed by the existing terminal-latch state already maintained by supervision's publish/await-terminal machinery. Adds a matching error code, serialization coverage, docs, and regression tests. Also fixes a latent bug in null pool-timer termination reporting.

## Changes

Admission API (hpx::supervision)

- Adds dispatch_outcome enum (admitted, rejected_fenced) representing the result of an admission check. queued is intentionally deferred to a future version.
- Adds check_admission(hpx::id_type const& target, std::uint64_t epoch = 0) noexcept — a pure local read of terminal-latch state (the same state written by publish_event() and read by await_terminal()). It never publishes, mutates state, notifies observers, or throws; invalid/unknown targets are always admitted.
- Forward-declares dispatch_outcome in supervision_fwd.hpp and documents terminal-latch semantics in supervision_api.hpp and docs/index.rst.

## Implementation

- supervision.cpp: check_admission() short-circuits to admitted for invalid targets, otherwise delegates to the local supervision_manager.
- supervision_manager.cpp / server/supervision_manager_server.cpp: implement the terminal-latch lookup for a given target/epoch, returning rejected_fenced only when a completed or failed event has already been latched for that epoch.

## Error representation

- Adds hpx::error::target_fenced = 58 to represent a dispatch that was correctly and finally refused due to an already-latched terminal event for the target (not a staleness signal — should not be retried). Bumps last_error to 59 and updates the error-name mapping in error_code.cpp.
- Extends serialization_error_code.cpp to round-trip the new error value.

## Tests

- New supervision_check_admission.cpp covering admission behavior across fresh/unknown targets, completed/failed epochs, and invalid targets.
- Extends supervision_await_terminal.cpp with epoch-specific regression tests and adjusts existing await-terminal expectations for consistency with the new terminal-latch semantics.
- Registers new tests in CMakeLists.txt.

## Runtime fix

- pool_timer.cpp: is_terminated() on a null pool-timer now correctly returns false instead of true, since a null timer has no terminated state to report.

- flyby: adding more tests for await_terminal
- flyby: fixing problem in pool_timer

This is a follow-on PR for the supervision work finalized earlier (see #7399 and #7407)
