### PR TITLE
Don't disabled first core placement if --hpx:bind=none

### DIFF
--- a/libs/core/command_line_handling_local/src/command_line_handling_local.cpp
+++ b/libs/core/command_line_handling_local/src/command_line_handling_local.cpp
@@ -555,7 +555,10 @@ namespace hpx::local::detail {
             affinity_bind_ = "";
 #else
             ini_config.emplace_back("hpx.bind!=" + affinity_bind_);
-            ini_config.emplace_back("hpx.bind-provided!=1");
+            if (affinity_bind_ != "none")
+            {
+                ini_config.emplace_back("hpx.bind-provided!=1");
+            }
 #endif
         }
 #if !defined(__APPLE__)


### PR DESCRIPTION
Fixes #7411

This prevents disabling first core placement if `--hpx:bind=none` was provided on the command line.

@iemAnshuman please check if this resolves the issue you reported.