### PR TITLE
Advertise the parcelport port that was actually bound

### DIFF
--- a/libs/full/agas/tests/regressions/CMakeLists.txt
+++ b/libs/full/agas/tests/regressions/CMakeLists.txt
@@ -34,6 +34,27 @@ if(HPX_WITH_NETWORKING AND HPX_WITH_PARCELPORT_TCP)
       --hpx:ini=hpx.parcel.tcp.priority=1000
       --hpx:ini=hpx.parcel.bootstrap=tcp
   )
+
+  set(tests ${tests} os_assigned_parcelport_port_7406)
+
+  # add executable needed for the os_assigned_parcelport_port_7406 test
+  add_hpx_executable(
+    os_assigned_parcelport_port_7406_child INTERNAL_FLAGS
+    SOURCES os_assigned_parcelport_port_7406_child.cpp
+    EXCLUDE_FROM_ALL
+    HPX_PREFIX ${HPX_BUILD_PREFIX}
+    FOLDER "Tests/Regressions/Modules/Full/AGAS"
+  )
+
+  set(os_assigned_parcelport_port_7406_FLAGS DEPENDENCIES process_component)
+  set(os_assigned_parcelport_port_7406_PARAMETERS
+      RUN_SERIAL
+      --launch=$<TARGET_FILE:os_assigned_parcelport_port_7406_child>
+      --hpx:expect-connecting-localities
+      # Force use of the TCP parcelport
+      --hpx:ini=hpx.parcel.tcp.priority=1000
+      --hpx:ini=hpx.parcel.bootstrap=tcp
+  )
 endif()
 
 set(id_type_ref_counting_1032_PARAMETERS THREADS_PER_LOCALITY 1)
@@ -66,5 +87,9 @@ if(HPX_WITH_NETWORKING AND HPX_WITH_PARCELPORT_TCP)
   add_hpx_pseudo_dependencies(
     tests.regressions.modules.agas.departed_locality_7384
     departed_locality_7384_child
+  )
+  add_hpx_pseudo_dependencies(
+    tests.regressions.modules.agas.os_assigned_parcelport_port_7406
+    os_assigned_parcelport_port_7406_child
   )
 endif()

--- a/libs/full/agas/tests/regressions/os_assigned_parcelport_port_7406.cpp
+++ b/libs/full/agas/tests/regressions/os_assigned_parcelport_port_7406.cpp
@@ -30,6 +30,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <iterator>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -147,13 +148,24 @@ int hpx_main(hpx::program_options::variables_map& vm)
     }
     HPX_TEST(launched != hpx::invalid_id);
 
-    // AGAS has to hold an endpoint for it at all.
+    // AGAS has to hold the endpoint the locality actually bound, not the one
+    // it was configured with. Advertising the configured port would register
+    // this locality on port zero.
     {
         hpx::error_code ec;
         auto const& endpoints = hpx::naming::get_agas_client().resolve_locality(
             launched.get_gid(), ec);
         HPX_TEST(!ec);
         HPX_TEST(!endpoints.empty());
+
+        for (auto const& ep : endpoints)
+        {
+            std::ostringstream os;
+            os << ep.second;
+
+            // the locality prints as "address:port"
+            HPX_TEST(!os.str().ends_with(":0"));
+        }
     }
 
     // Releasing the latch is what proves the locality is reachable: the

--- a/libs/full/agas/tests/regressions/os_assigned_parcelport_port_7406.cpp
+++ b/libs/full/agas/tests/regressions/os_assigned_parcelport_port_7406.cpp
@@ -1,0 +1,188 @@
+//  Copyright (c) 2026 Anshuman Agrawal
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// A locality that is given parcelport port 0 asks the operating system to
+// choose one for it. This test launches such a locality and requires it to
+// become reachable, which it can only be if the port it actually bound is
+// what reaches AGAS.
+//
+// Before the fix for #7406 the parcelport published the port from its
+// configuration rather than the port its acceptor bound. With port 0 that
+// published a locality listening on an ephemeral port while advertising port
+// zero, so the launched locality connected outwards but nothing could reach
+// it: this test hung until it was killed rather than failing.
+
+#include <hpx/config.hpp>
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/lcos.hpp>
+#include <hpx/include/process.hpp>
+#include <hpx/modules/filesystem.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <hpx/agas/addressing_service.hpp>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <iterator>
+#include <string>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+inline int get_arraylen(char** arr)
+{
+    int count = 0;
+    if (nullptr != arr)
+    {
+        while (nullptr != arr[count])
+            ++count;    // simply count the strings
+    }
+    return count;
+}
+
+std::vector<std::string> get_environment()
+{
+    std::vector<std::string> env;
+#if defined(HPX_WINDOWS)
+    int len = get_arraylen(_environ);
+    std::copy(&_environ[0], &_environ[len], std::back_inserter(env));
+#elif defined(linux) || defined(__linux) || defined(__linux__) ||              \
+    defined(__AIX__) || defined(__APPLE__) || defined(__FreeBSD__)
+    int len = get_arraylen(environ);
+    std::copy(&environ[0], &environ[len], std::back_inserter(env));
+#else
+#error "Don't know, how to access the execution environment on this platform"
+#endif
+    return env;
+}
+
+// Replace any inherited entry for the given name. The environment is handed to
+// execve verbatim and getenv returns the first match, so appending alone would
+// leave an inherited entry shadowing the value set here.
+void set_env_var(std::vector<std::string>& env, std::string const& name,
+    std::string const& value)
+{
+    std::string const prefix = name + "=";
+
+    env.erase(std::remove_if(env.begin(), env.end(),
+                  [&prefix](std::string const& entry) {
+                      return entry.starts_with(prefix);
+                  }),
+        env.end());
+
+    env.push_back(prefix + value);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main(hpx::program_options::variables_map& vm)
+{
+    namespace process = hpx::components::process;
+    namespace fs = hpx::filesystem;
+
+    fs::path base_dir = hpx::util::find_prefix();
+    base_dir /= "bin";
+
+    fs::path exe = base_dir /
+        "os_assigned_parcelport_port_7406_child" HPX_EXECUTABLE_EXTENSION;
+
+    if (vm.count("launch"))
+        exe = vm["launch"].as<std::string>();
+
+    std::vector<std::string> args;
+    args.push_back(hpx::filesystem::to_string(exe));
+    args.push_back("--hpx:ignore-batch-env");
+    args.push_back("--hpx:threads=1");
+    // Force use of the TCP parcelport, which is the one that binds a port.
+    args.push_back("--hpx:ini=hpx.parcel.tcp.priority=1000");
+    args.push_back("--hpx:ini=hpx.parcel.bootstrap=tcp");
+
+    std::vector<std::string> env = get_environment();
+
+    std::string const address =
+        hpx::get_config_entry("hpx.agas.address", HPX_INITIAL_IP_ADDRESS);
+
+    set_env_var(env, "HPX_AGAS_SERVER_ADDRESS", address);
+    set_env_var(env, "HPX_AGAS_SERVER_PORT",
+        hpx::get_config_entry(
+            "hpx.agas.port", std::to_string(HPX_INITIAL_IP_PORT)));
+
+    // This is the point of the test: hand the launched locality port 0 and
+    // let the operating system pick. Nothing here knows which port that will
+    // be, so the only way the locality below becomes reachable is if the port
+    // it bound is the port it registered.
+    set_env_var(env, "HPX_PARCEL_SERVER_ADDRESS", address);
+    set_env_var(env, "HPX_PARCEL_SERVER_PORT", "0");
+
+    set_env_var(env, "HPX_ON_STARTUP_WAIT_ON_LATCH",
+        "os_assigned_parcelport_port_7406");
+
+    hpx::distributed::latch sync(2);
+    sync.register_as("os_assigned_parcelport_port_7406_sync");
+
+    process::child c = process::execute(hpx::find_here(),
+        process::run_exe(hpx::filesystem::to_string(exe)),
+        process::set_args(args), process::set_env(env),
+        process::start_in_dir(hpx::filesystem::to_string(base_dir)),
+        process::throw_on_error(),
+        process::wait_on_latch("os_assigned_parcelport_port_7406"));
+
+    c.wait();
+    HPX_TEST(c);
+
+    // the launched locality has joined
+    hpx::id_type const here = hpx::find_here();
+    std::vector<hpx::id_type> const localities = hpx::find_all_localities();
+    HPX_TEST_EQ(localities.size(), std::size_t(2));
+
+    hpx::id_type launched;
+    for (hpx::id_type const& id : localities)
+    {
+        if (id != here)
+            launched = id;
+    }
+    HPX_TEST(launched != hpx::invalid_id);
+
+    // AGAS has to hold an endpoint for it at all.
+    {
+        hpx::error_code ec;
+        auto const& endpoints = hpx::naming::get_agas_client().resolve_locality(
+            launched.get_gid(), ec);
+        HPX_TEST(!ec);
+        HPX_TEST(!endpoints.empty());
+    }
+
+    // Releasing the latch is what proves the locality is reachable: the
+    // launched locality is blocked in arrive_and_wait, and only a parcel from
+    // here can free it. That parcel has to arrive at the port the operating
+    // system chose, which can only happen if that is the port the locality
+    // registered. A locality that published its configured port instead is
+    // never woken and this test hangs.
+    sync.arrive_and_wait();
+
+    int const exit_code = c.wait_for_exit(hpx::launch::sync);
+    HPX_TEST_EQ(exit_code, 0);
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    using namespace hpx::program_options;
+    options_description desc_commandline(
+        "usage: " HPX_APPLICATION_STRING " [options]");
+
+    desc_commandline.add_options()("launch", value<std::string>(),
+        "the process to launch as an additional locality");
+
+    hpx::init_params init_args;
+    init_args.desc_cmdline = desc_commandline;
+
+    HPX_TEST_EQ(hpx::init(argc, argv, init_args), 0);
+    return hpx::util::report_errors();
+}
+#endif

--- a/libs/full/agas/tests/regressions/os_assigned_parcelport_port_7406_child.cpp
+++ b/libs/full/agas/tests/regressions/os_assigned_parcelport_port_7406_child.cpp
@@ -1,0 +1,49 @@
+//  Copyright (c) 2026 Anshuman Agrawal
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// Helper for os_assigned_parcelport_port_7406. This locality is launched with
+// parcelport port 0, connects to the running application, and waits until the
+// test driver has finished talking to it.
+
+#include <hpx/config.hpp>
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/include/lcos.hpp>
+
+#include <string>
+#include <vector>
+
+int hpx_main()
+{
+    // wait until the test driver is done with this locality
+    hpx::distributed::latch sync;
+    sync.connect_to("os_assigned_parcelport_port_7406_sync");
+    sync.arrive_and_wait();
+
+    hpx::disconnect();
+    return 0;
+}
+
+int main(int argc, char* argv[])
+{
+    std::vector<std::string> const cfg = {
+        // Make sure hpx_main above will be executed even if this is not the
+        // console locality.
+        "hpx.run_hpx_main!=1",
+
+        // Make sure networking will not be disabled.
+        "hpx.expect_connecting_localities!=1"};
+
+    // Note: this uses runtime_mode::connect to instruct this locality to
+    // connect to the existing HPX application
+    hpx::init_params init_args;
+    init_args.mode = hpx::runtime_mode::connect;
+    init_args.cfg = cfg;
+
+    return hpx::init(argc, argv, init_args);
+}
+#endif

--- a/libs/full/parcelport_tcp/src/connection_handler_tcp.cpp
+++ b/libs/full/parcelport_tcp/src/connection_handler_tcp.cpp
@@ -129,6 +129,16 @@ namespace hpx::parcelset::policies::tcp {
                     here_ = parcelset::locality(locality(
                         here_.get<locality>().address(), bound.port()));
                 }
+                else if (local_ec)
+                {
+                    // Keeping the configured port is the safe course, but if
+                    // that port was 0 this locality is now unreachable and the
+                    // reason would otherwise be invisible.
+                    LPT_(warning).format(
+                        "tcp::parcelport::run: bound {} but could not read the "
+                        "endpoint back, keeping the configured one: {}",
+                        ep, local_ec.message());
+                }
 
                 acceptor_->async_accept(receiver_conn->socket(),
                     hpx::bind(&connection_handler::handle_accept, this,

--- a/libs/full/parcelport_tcp/src/connection_handler_tcp.cpp
+++ b/libs/full/parcelport_tcp/src/connection_handler_tcp.cpp
@@ -109,26 +109,18 @@ namespace hpx::parcelset::policies::tcp {
                 acceptor_->bind(ep);
                 acceptor_->listen();
 
-                // Advertise the port the acceptor actually bound rather than
-                // the one that was requested. The two differ when the
-                // configuration asks for port 0, which hands the choice to the
-                // operating system; without this nothing would ever learn
-                // which port it picked and no peer could connect.
+                // Advertise the port that was bound, not the one that was
+                // asked for. They differ when the configuration says port 0,
+                // which hands the choice to the operating system; without this
+                // nothing learns which port it picked and no peer can connect.
                 //
-                // Only the port is taken from the acceptor. The address stays
-                // as configured, because the bound address may be a wildcard
-                // that is not reachable from anywhere else.
-                //
-                // A single acceptor is shared by every iteration of this loop,
-                // so at most one bind succeeds and there is exactly one port
-                // to report; later iterations fail in open() and are collected
-                // as errors below.
-                //
-                // This runs before the first async_accept so that no handler
-                // can observe a half-updated locality, and it asks for the
-                // endpoint without throwing: the socket is bound either way,
-                // and a failure to read it back is not a reason to treat this
-                // endpoint as unusable.
+                // Only the port is taken. The bound address may be a wildcard
+                // that is reachable from nowhere, so the configured one stays.
+                // One acceptor serves the whole loop, so at most one bind
+                // succeeds and there is exactly one port to report. Reading it
+                // back is done before the first async_accept, and without
+                // throwing: a bound socket that cannot be queried is still
+                // usable.
                 std::error_code local_ec;
                 if (tcp::endpoint const bound =
                         acceptor_->local_endpoint(local_ec);

--- a/libs/full/parcelport_tcp/src/connection_handler_tcp.cpp
+++ b/libs/full/parcelport_tcp/src/connection_handler_tcp.cpp
@@ -111,6 +111,28 @@ namespace hpx::parcelset::policies::tcp {
                 acceptor_->async_accept(receiver_conn->socket(),
                     hpx::bind(&connection_handler::handle_accept, this,
                         placeholders::_1, receiver_conn));
+
+                // Advertise the port the acceptor actually bound rather than
+                // the one that was requested. The two differ when the
+                // configuration asks for port 0, which hands the choice to the
+                // operating system; without this nothing would ever learn
+                // which port it picked and no peer could connect.
+                //
+                // Only the port is taken from the acceptor. The address stays
+                // as configured, because the bound address may be a wildcard
+                // that is not reachable from anywhere else.
+                //
+                // A single acceptor is shared by every iteration of this loop,
+                // so at most one bind succeeds and there is exactly one port
+                // to report; later iterations fail in open() and are collected
+                // as errors below.
+                if (std::uint16_t const bound_port =
+                        acceptor_->local_endpoint().port();
+                    bound_port != here_.get<locality>().port())
+                {
+                    here_ = parcelset::locality(
+                        locality(here_.get<locality>().address(), bound_port));
+                }
             }
             catch (std::system_error const&)
             {

--- a/libs/full/parcelport_tcp/src/connection_handler_tcp.cpp
+++ b/libs/full/parcelport_tcp/src/connection_handler_tcp.cpp
@@ -108,9 +108,6 @@ namespace hpx::parcelset::policies::tcp {
                 acceptor_->set_option(tcp::acceptor::reuse_address(true));
                 acceptor_->bind(ep);
                 acceptor_->listen();
-                acceptor_->async_accept(receiver_conn->socket(),
-                    hpx::bind(&connection_handler::handle_accept, this,
-                        placeholders::_1, receiver_conn));
 
                 // Advertise the port the acceptor actually bound rather than
                 // the one that was requested. The two differ when the
@@ -126,13 +123,24 @@ namespace hpx::parcelset::policies::tcp {
                 // so at most one bind succeeds and there is exactly one port
                 // to report; later iterations fail in open() and are collected
                 // as errors below.
-                if (std::uint16_t const bound_port =
-                        acceptor_->local_endpoint().port();
-                    bound_port != here_.get<locality>().port())
+                //
+                // This runs before the first async_accept so that no handler
+                // can observe a half-updated locality, and it asks for the
+                // endpoint without throwing: the socket is bound either way,
+                // and a failure to read it back is not a reason to treat this
+                // endpoint as unusable.
+                std::error_code local_ec;
+                if (tcp::endpoint const bound =
+                        acceptor_->local_endpoint(local_ec);
+                    !local_ec && bound.port() != here_.get<locality>().port())
                 {
-                    here_ = parcelset::locality(
-                        locality(here_.get<locality>().address(), bound_port));
+                    here_ = parcelset::locality(locality(
+                        here_.get<locality>().address(), bound.port()));
                 }
+
+                acceptor_->async_accept(receiver_conn->socket(),
+                    hpx::bind(&connection_handler::handle_accept, this,
+                        placeholders::_1, receiver_conn));
             }
             catch (std::system_error const&)
             {

--- a/libs/full/parcelset/include/hpx/parcelset/parcelhandler.hpp
+++ b/libs/full/parcelset/include/hpx/parcelset/parcelhandler.hpp
@@ -231,6 +231,15 @@ namespace hpx::parcelset {
             return endpoints_;
         }
 
+        /// \brief re-read the local endpoint of every enabled parcelport
+        ///
+        /// The endpoints are recorded when a parcelport is attached, which
+        /// happens before it binds. A parcelport that is told to let the
+        /// operating system choose its port only learns the real one at bind
+        /// time, so the recorded endpoint has to be refreshed afterwards and
+        /// before it is published to AGAS.
+        void update_endpoints();
+
         void enable_alternative_parcelports()
         {
             use_alternative_parcelports_.store(true);

--- a/libs/full/parcelset/src/parcelhandler.cpp
+++ b/libs/full/parcelset/src/parcelhandler.cpp
@@ -329,6 +329,18 @@ namespace hpx::parcelset {
             endpoints_[pp->type()] = pp->here();
     }
 
+    void parcelhandler::update_endpoints()
+    {
+        for (pports_type::value_type const& pp : pports_)
+        {
+            if (pp.first > 0 && pp.second)
+            {
+                HPX_ASSERT(pp.second->type() == pp.second->here().type());
+                endpoints_[pp.second->type()] = pp.second->here();
+            }
+        }
+    }
+
     ///////////////////////////////////////////////////////////////////////////
     /// \brief Make sure the specified locality is not held by any
     /// connection caches anymore

--- a/libs/full/runtime_distributed/src/runtime_distributed.cpp
+++ b/libs/full/runtime_distributed/src/runtime_distributed.cpp
@@ -269,6 +269,23 @@ namespace hpx {
                     std::terminate();
                 });
 
+            // Every other locality finds the AGAS root by reading its address
+            // out of its own configuration, so the root is the one locality
+            // whose endpoint cannot be chosen at bind time: no peer would be
+            // able to discover the choice. Say so, rather than let the run
+            // continue with an address that has already been published and no
+            // longer describes this locality.
+            if (pp && pp->here() != pp->agas_locality(rtcfg_))
+            {
+                HPX_THROW_EXCEPTION(hpx::error::network_error,
+                    "runtime_distributed::initialize_agas",
+                    "the AGAS root bound {} but the configuration advertises "
+                    "it as {}; the root locality cannot let its endpoint be "
+                    "assigned at bind time because every other locality reads "
+                    "that endpoint from its own configuration",
+                    pp->here(), pp->agas_locality(rtcfg_));
+            }
+
             agas::get_big_boot_barrier().wait_bootstrap();
         }
         else
@@ -287,6 +304,14 @@ namespace hpx {
                         hpx::get_error_what(e));
                     std::terminate();
                 });
+
+            // The parcelport has bound by now, so its endpoint is final. It
+            // was recorded when the parcelport was attached, which is before
+            // the bind, so refresh it here: wait_hosted below is what hands
+            // these endpoints to AGAS, and a locality that let the operating
+            // system choose its port would otherwise register the port it
+            // asked for rather than the one it got.
+            parcel_handler_.update_endpoints();
 
             agas::get_big_boot_barrier().wait_hosted(
                 pp ? pp->get_locality_name() : "<console>",

--- a/libs/full/runtime_distributed/src/runtime_distributed.cpp
+++ b/libs/full/runtime_distributed/src/runtime_distributed.cpp
@@ -254,6 +254,11 @@ namespace hpx {
 
             init_id_pool_range();
 
+            // The endpoints have just been published, so remember what was
+            // said about this locality. Binding must not contradict it.
+            parcelset::locality const published =
+                pp ? pp->here() : parcelset::locality();
+
             hpx::detail::try_catch_exception_ptr(
                 [&]() {
                     if (pp)
@@ -269,21 +274,24 @@ namespace hpx {
                     std::terminate();
                 });
 
-            // Every other locality finds the AGAS root by reading its address
-            // out of its own configuration, so the root is the one locality
-            // whose endpoint cannot be chosen at bind time: no peer would be
-            // able to discover the choice. Say so, rather than let the run
-            // continue with an address that has already been published and no
-            // longer describes this locality.
-            if (pp && pp->here() != pp->agas_locality(rtcfg_))
+            // Binding may settle an endpoint that was left open in the
+            // configuration, which every other locality is free to do. The
+            // root is the exception: its endpoint has already been published
+            // above, and the peers that will look for it read that endpoint
+            // from their own configuration rather than from AGAS, so a root
+            // that moved is a root nobody can reach. Only a change is
+            // rejected here; an endpoint that disagreed with the
+            // configuration from the start is a separate, pre-existing
+            // condition and is left alone.
+            if (pp && pp->here() != published)
             {
                 HPX_THROW_EXCEPTION(hpx::error::network_error,
                     "runtime_distributed::initialize_agas",
-                    "the AGAS root bound {} but the configuration advertises "
-                    "it as {}; the root locality cannot let its endpoint be "
-                    "assigned at bind time because every other locality reads "
-                    "that endpoint from its own configuration",
-                    pp->here(), pp->agas_locality(rtcfg_));
+                    "the AGAS root locality published {} and then bound {}; "
+                    "the root cannot have its endpoint assigned at bind time "
+                    "because every other locality reads that endpoint from "
+                    "its own configuration",
+                    published, pp->here());
             }
 
             agas::get_big_boot_barrier().wait_bootstrap();


### PR DESCRIPTION
Fixes #7406.

## Purpose

`hpx.parcel.port=0` did not work. The locality listened on a port the operating system picked, but told AGAS it was on port 0, so nothing could reach it. Nothing ever read `acceptor_->local_endpoint()`.

## Changes

`connection_handler::do_run()` reads the bound port and updates `here_`. Only the port. The configured address stays, since the bound one may be a wildcard.

`parcelhandler::update_endpoints()` re-reads each parcelport. `runtime_distributed::initialize_agas()` calls it after the hosted bind, before `wait_hosted()` sends the endpoints to AGAS.

## Two things the issue expected, which do not happen

Each endpoint binding its own port. `acceptor_` is one acceptor reused across the loop, so later iterations throw `already_open`. Only one port is ever bound.

AGAS bootstrap needing a reorder. `wait_hosted()` reads the endpoints live, after the bind.

## Limits

The AGAS root cannot use port 0, because peers read its address from their own config. This was a debug only assert that passed and left an unreachable cluster. It now throws, and only when the endpoint changed.

Only the bootstrap parcelport is settled before publication. Secondary ones run later, after the endpoints reach AGAS. Already true, not addressed here.

## Test Plan

New test `os_assigned_parcelport_port_7406` launches a locality with `HPX_PARCEL_SERVER_PORT=0`. Releasing the latch is itself a parcel to that locality, so the test finishes only if the bound port is the registered port.

```
with the fix     8/8 pass
without the fix  3/3 hang until killed
```

AGAS now resolves it at a real port, for example `127.0.0.1:54485`.

Also run: agas regressions 7/7, collectives 46/46. A 193 test distributed TCP sweep fails about 121 on this macOS box with or without the change (121 against 120), so that is the machine, not this PR.

## Follow-up

This makes the port probe in `departed_locality_7384.cpp` unnecessary. Once #7412 lands it can go.

## Checklist

- [x] I have fixed a bug and have added a regression test.
