### PR TITLE
Adding support for fenced dispatch to supervision component

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -9,6 +9,8 @@
 exclude_paths:
   - "tools/**"
   - ".github/**"
+  - "tests/**"
+  - "**/tests/**"
 
 tools:
   duplication:

--- a/components/supervision_dispatch/CMakeLists.txt
+++ b/components/supervision_dispatch/CMakeLists.txt
@@ -18,9 +18,11 @@ set(supervision_dispatch_headers
     hpx/supervision_dispatch/server/sentinel.hpp
     hpx/supervision_dispatch/discovery.hpp
     hpx/supervision_dispatch/dispatch_api.hpp
+    hpx/supervision_dispatch/dispatch_work.hpp
     hpx/supervision_dispatch/registry.hpp
     hpx/supervision_dispatch/sentinel.hpp
     hpx/supervision_dispatch/export_definitions.hpp
+    hpx/supervision_dispatch.hpp
 )
 
 set(supervision_dispatch_sources

--- a/components/supervision_dispatch/include/hpx/supervision_dispatch.hpp
+++ b/components/supervision_dispatch/include/hpx/supervision_dispatch.hpp
@@ -1,0 +1,19 @@
+//  Copyright (c) 2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#if defined(HPX_HAVE_SUPERVISION)
+#include <hpx/modules/supervision.hpp>
+
+#include <hpx/supervision_dispatch/discovery.hpp>
+#include <hpx/supervision_dispatch/dispatch_api.hpp>
+#include <hpx/supervision_dispatch/dispatch_work.hpp>
+#include <hpx/supervision_dispatch/registry.hpp>
+#include <hpx/supervision_dispatch/sentinel.hpp>
+#endif

--- a/components/supervision_dispatch/include/hpx/supervision_dispatch/dispatch_work.hpp
+++ b/components/supervision_dispatch/include/hpx/supervision_dispatch/dispatch_work.hpp
@@ -1,0 +1,225 @@
+//  Copyright (c) 2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file dispatch_work.hpp
+/// \page hpx::supervision::dispatch_work
+/// \headerfile hpx/supervision_dispatch.hpp
+///
+/// \brief Fenced action dispatch for the supervision subsystem.
+///
+/// This header provides the machinery to dispatch an HPX action to a target
+/// component while enforcing supervision "fencing" semantics: once a target has
+/// latched a terminal event for a given epoch, no further actions for that
+/// epoch may execute against it. Dispatch performs a cheap, non-authoritative
+/// admission check on the caller's locality and an authoritative re-check on
+/// the target's own locality (via hpx::colocated), immediately before invoking
+/// the wrapped action, closing the race between admission and invocation.
+
+#pragma once
+
+#include <hpx/config.hpp>
+#include <hpx/modules/async_distributed.hpp>
+#include <hpx/modules/errors.hpp>
+#include <hpx/modules/naming_base.hpp>
+#include <hpx/modules/runtime_distributed.hpp>
+#include <hpx/modules/supervision.hpp>
+
+#include <cstdint>
+
+#include <hpx/config/warnings_prefix.hpp>
+
+/// \namespace hpx::supervision
+///
+/// Types and functions implementing HPX's supervision and fenced dispatch
+/// facilities.
+namespace hpx::supervision {
+
+    /// \brief Remote dispatch point that performs the authoritative admission
+    ///        re-check and invokes the wrapped action.
+    ///
+    /// This is the function body that actually runs as the action on the
+    /// *destination* locality (the target's own locality, reached via
+    /// hpx::colocated in dispatch_work()). It is invoked by fenced_action once
+    /// the action has been dispatched.
+    ///
+    /// The admission check performed here runs on the same locality/thread that
+    /// owns the target's supervision_manager state, so there is no suspension
+    /// point between this check and the actual invocation below. This is what
+    /// closes the client-side/dispatch race: even if the client's own
+    /// (non-authoritative) check_admission() in dispatch_work() returned
+    /// `admitted`, the target may have latched a terminal event for this epoch
+    /// in the meantime, and this re-check will catch it.
+    ///
+    /// \tparam Action  The wrapped HPX action type to invoke on admission.
+    /// \tparam IdType  Type of the target identifier forwarded to \p act (this
+    ///                 type is always `hpx::id_type`).
+    /// \tparam Epoch   Type of the fencing epoch value (this type is always
+    ///                 `std::uint64_t`).
+    /// \tparam Ts      Types of the additional arguments forwarded to \p act.
+    ///
+    /// \param act    The action instance to invoke once admission succeeds.
+    /// \param target Identifier of the component instance being dispatched
+    ///               to; forwarded to \p act (the epoch is fencing metadata
+    ///               only and is not part of \p act's argument list).
+    /// \param epoch  The fencing epoch to check admission for.
+    /// \param ts     Additional arguments forwarded to \p act.
+    ///
+    /// \return The result of invoking \p act, obtained via hpx::sync (run
+    ///         directly/locally, without an extra parcel hop, since this
+    ///         function already executes on the target's locality).
+    ///
+    /// \throws hpx::exception with hpx::error::target_fenced if the target has
+    ///         latched a terminal event for \p epoch since the client's own
+    ///         admission check, in which case the wrapped action is not
+    ///         invoked.
+    template <typename Action, typename IdType, typename Epoch, typename... Ts>
+    decltype(auto) invoke_fenced_action(
+        Action act, IdType target, Epoch const epoch, Ts... ts)
+    {
+        // Authoritative re-check: runs on the same locality/thread that owns
+        // the target's supervision_manager state, so there is no suspension
+        // point between this check and the actual invocation below -- this is
+        // what closes the client-side/dispatch race.
+        dispatch_outcome const outcome =
+            hpx::supervision::check_admission(target, epoch);
+
+        if (outcome == dispatch_outcome::rejected_fenced)
+        {
+            // Target latched a terminal event for this epoch after the client's
+            // own (non-authoritative) check_admission() returned admitted.
+            // Surface this as an exceptional future so callers can distinguish
+            // "fenced" dispatch failures from other errors.
+
+            HPX_THROW_EXCEPTION(hpx::error::target_fenced,
+                "hpx::supervision::invoke_fenced_action",
+                "target has latched a terminal event for this epoch "
+                "since the client-side admission check; dispatch was "
+                "fenced and the wrapped action was not invoked");
+        }
+
+        // Admitted: forward straight into the wrapped Action. Note only
+        // `target` (not `epoch`) is passed on -- epoch is fencing metadata
+        // consumed entirely by this wrapper, not part of Action's own
+        // argument list. hpx::sync runs the action body directly/locally
+        // (no extra parcel hop) since we're already on target's locality.
+        return hpx::sync(act, HPX_MOVE(target), HPX_MOVE(ts)...);
+    }
+
+    /// \brief HPX action wrapper for invoke_fenced_action().
+    ///
+    /// Registers invoke_fenced_action<Action, IdType, Epoch, Ts...> as an HPX
+    /// action so it can be dispatched with hpx::async/hpx::colocated (see
+    /// dispatch_work()).
+    ///
+    /// \tparam Action  The wrapped HPX action type.
+    /// \tparam IdType  Type of the target identifier.
+    /// \tparam Epoch   Type of the fencing epoch value.
+    /// \tparam Ts      Types of the additional action arguments.
+    template <typename Action, typename IdType, typename Epoch, typename... Ts>
+    struct fenced_action
+      : hpx::actions::make_action_t<
+            decltype(&invoke_fenced_action<Action, IdType, Epoch, Ts...>),
+            &invoke_fenced_action<Action, IdType, Epoch, Ts...>,
+            fenced_action<Action, IdType, Epoch, Ts...>>
+    {
+    };
+
+    /// \brief Dispatch an action to \p target under supervision fencing, by
+    ///        action type template argument.
+    ///
+    /// This is the local dispatch point invoked by callers; it runs on the
+    /// *caller's* locality. It first performs a cheap, non-authoritative
+    /// admission check to avoid a wasted round trip when the caller's local
+    /// view already shows the target fenced. This early-out does NOT by itself
+    /// close the race -- the authoritative re-check happens later, inside
+    /// invoke_fenced_action() on the target's own locality.
+    ///
+    /// On admission, the action is wrapped in fenced_action and dispatched via
+    /// hpx::async to run *on the target's own locality* (through
+    /// hpx::colocated), so that the re-check performed in
+    /// invoke_fenced_action() is authoritative and executes on the same thread
+    /// as the wrapped action invocation.
+    ///
+    /// \tparam Action The HPX action type to dispatch.
+    /// \tparam Ts     Types of the additional arguments forwarded to \p Action.
+    ///
+    /// \param target Identifier of the target component instance.
+    /// \param epoch  The fencing epoch to check admission for and to
+    ///               validate authoritatively on the target's locality.
+    /// \param ts     Additional arguments forwarded to the action.
+    ///
+    /// \return A future holding the result of the dispatched action. If the
+    ///         local admission check fails, an already-exceptional future is
+    ///         returned immediately without an actual dispatch.
+    ///
+    /// \note If either the local or the remote admission check fails, the
+    ///       returned future is set to an exceptional state carrying
+    ///       `hpx::error::target_fenced` (same error code/message shape as the
+    ///       server-side fence in invoke_fenced_action(), giving callers a
+    ///       single exception type to handle regardless of which side detected
+    ///       the fence), and the wrapped action is not invoked.
+    template <typename Action, typename... Ts>
+    decltype(auto) dispatch_work(
+        hpx::id_type const& target, std::uint64_t const epoch, Ts&&... ts)
+    {
+        // Cheap, non-authoritative early-out: avoids a wasted round trip when
+        // the caller's local view already shows the target fenced. This does
+        // NOT by itself close the race -- the authoritative re-check happens
+        // later, inside invoke_fenced_action on the target's own locality.
+        dispatch_outcome const outcome =
+            hpx::supervision::check_admission(target, epoch);
+        if (outcome == dispatch_outcome::rejected_fenced)
+        {
+            // Same error code/message shape as the server-side fence, so
+            // callers get one exception type to handle regardless of which side
+            // detected the fence.
+            return hpx::make_exceptional_future<typename Action::result_type>(
+                HPX_GET_EXCEPTION(hpx::error::target_fenced,
+                    "hpx::supervision::detail::dispatch",
+                    "target has already latched a terminal event for this "
+                    "epoch; dispatch was fenced and the wrapped action was "
+                    "not invoked"));
+        }
+
+        using fenced_action =
+            fenced_action<Action, hpx::id_type, std::uint64_t, Ts...>;
+
+        // Dispatch fenced_action to run *on target's own locality*
+        // (hpx::colocated), so invoke_fenced_action's re-check above is
+        // authoritative and same-thread with the wrapped Action call.
+        return hpx::async(fenced_action(), hpx::colocated(target), Action(),
+            target, epoch, HPX_FORWARD(Ts, ts)...);
+    }
+
+    /// \brief Dispatch an action to \p target under supervision fencing, by
+    ///        action instance argument.
+    ///
+    /// Convenience overload of dispatch_work() constrained to HPX action types
+    /// (via `hpx::traits::is_action_v<Action>`) that accepts an action instance
+    /// rather than requiring the caller to specify \p Action explicitly as a
+    /// template argument. Forwards directly to the primary dispatch_work()
+    /// overload.
+    ///
+    /// \tparam Action The HPX action type to dispatch (deduced from the
+    ///                \p Action instance argument).
+    /// \tparam Ts     Types of the additional arguments forwarded to \p Action.
+    ///
+    /// \param target Identifier of the target component instance.
+    /// \param epoch  The fencing epoch to check admission for.
+    /// \param ts     Additional arguments forwarded to the action.
+    ///
+    /// \return See:
+    ///         dispatch_work(hpx::id_type const&, std::uint64_t const, Ts&&...)
+    template <typename Action, typename... Ts>
+        requires(hpx::traits::is_action_v<Action>)
+    decltype(auto) dispatch_work(Action, hpx::id_type const& target,
+        std::uint64_t const epoch, Ts&&... ts)
+    {
+        return dispatch_work<Action>(target, epoch, HPX_FORWARD(Ts, ts)...);
+    }
+}    // namespace hpx::supervision
+
+#include <hpx/config/warnings_suffix.hpp>

--- a/components/supervision_dispatch/include/hpx/supervision_dispatch/registry.hpp
+++ b/components/supervision_dispatch/include/hpx/supervision_dispatch/registry.hpp
@@ -23,6 +23,10 @@
 namespace hpx::supervision {
 
     ///////////////////////////////////////////////////////////////////////////
+    /// A registry is a lightweight, self-supervising handle for pairing with
+    /// peer sentinels. It mirrors a peer's lifecycle state locally via join(),
+    /// and can itself be discovered by name in AGAS like other
+    /// supervision_dispatch components.
     class HPX_SUPERVISION_DISPATCH_EXPORT registry
       : public hpx::components::client_base<registry, server::registry>
     {
@@ -37,22 +41,43 @@ namespace hpx::supervision {
         /// new server-side component.
         registry() = default;
 
-        /// \brief Constructs a registry by creating a new server-side
-        ///        component on the given target locality.
-        /// \param target_locality The locality on which the underlying
-        ///        registry component will be created.
+        /// Constructs a registry by creating a new server-side component on the
+        /// given target locality.
+        ///
+        /// \param target_locality The locality on which the underlying registry
+        ///        component will be created.
         explicit registry(hpx::id_type const& target_locality);
 
+        /// Connect to a peer's registry component.
+        ///
+        /// \param symbolic_name The symbol name of the peer's registry
+        ///        component.
         explicit registry(std::string const& symbolic_name);
 
         /* implicit */ registry(hpx::future<hpx::id_type>&& f);
 
-        // Join a peer sentinel: create (or reuse) a local shadow target
-        // that mirrors the peer's lifecycle state, and register this
-        // registry as an observer of the peer's lifecycle/activity events.
-        // Returns the id of the local shadow target.
+        /// Join a peer sentinel: create (or reuse) a local shadow target that
+        /// mirrors the peer's lifecycle state, and register this registry as an
+        /// observer of the peer's lifecycle/activity events.
+        ///
+        /// \param peer_sentinel The peer sentinel to join.
+        /// \param peer_locality The locality on which the peer sentinel
+        ///        resides.
+        ///
+        /// \return A future that becomes ready with the id of the local shadow
+        ///         target.
         hpx::future<hpx::id_type> join(sentinel const& peer_sentinel,
             hpx::id_type const& peer_locality) const;
+
+        /// \copydoc join(sentinel const&, hpx::id_type const&) const
+        ///
+        /// \param peer_sentinel The peer sentinel to join.
+        /// \param peer_locality The locality on which the peer sentinel
+        ///        resides.
+        /// \param ec Used to hold the error code that results from the
+        ///           operation instead of throwing an exception on failure.
+        ///
+        /// \return The id of the local shadow target.
         hpx::id_type join(hpx::launch::sync_policy,
             sentinel const& peer_sentinel, hpx::id_type const& peer_locality,
             hpx::error_code& ec = hpx::throws) const;

--- a/components/supervision_dispatch/include/hpx/supervision_dispatch/sentinel.hpp
+++ b/components/supervision_dispatch/include/hpx/supervision_dispatch/sentinel.hpp
@@ -23,11 +23,11 @@
 namespace hpx::supervision {
 
     ///////////////////////////////////////////////////////////////////////////
-    // A sentinel is a lightweight, self-supervising handle: constructing it
-    // creates a component on the given target locality, and calling start()
-    // publishes the `started` lifecycle event for that component to the
-    // supervision manager running on the same locality. No registry lookup or
-    // discovery step is required.
+    /// A sentinel is a lightweight, self-supervising handle: constructing it
+    /// creates a component on the given target locality, and calling start()
+    /// publishes the `started` lifecycle event for that component to the
+    /// supervision manager running on the same locality. No registry lookup
+    /// or discovery step is required.
     class HPX_SUPERVISION_DISPATCH_EXPORT sentinel
       : public hpx::components::client_base<sentinel, server::sentinel>
     {
@@ -42,20 +42,36 @@ namespace hpx::supervision {
         /// new server-side component.
         sentinel() = default;
 
-        /// \brief Constructs a sentinel by creating a new server-side component
-        ///        on the given target locality.
+        /// Constructs a sentinel by creating a new server-side component on the
+        /// given target locality.
         /// \param target_locality The locality on which the underlying sentinel
         ///        component will be created.
         explicit sentinel(hpx::id_type const& target_locality);
 
+        /// Connect to a peer's sentinel component.
+        ///
+        /// \param symbolic_name The symbol name of the peer's sentinel
+        ///        component.
         explicit sentinel(std::string const& symbolic_name);
 
         /* implicit */ sentinel(hpx::future<hpx::id_type>&& f);
 
-        // Publish the `started` lifecycle event (at the given epoch) for
-        // this sentinel to the supervision manager running on its target
-        // locality.
+        /// Publish the `started` lifecycle event (at the given epoch) for this
+        /// sentinel to the supervision manager running on its target locality.
+        ///
+        /// \param epoch The epoch value to associate with this lifecycle event.
+        ///
+        /// \return A future that becomes ready with the result of publishing
+        ///         the event.
         hpx::future<publish_result> start(std::uint64_t epoch = 0) const;
+
+        /// \copydoc start(std::uint64_t) const
+        ///
+        /// \param epoch The epoch value to associate with this lifecycle event.
+        /// \param ec Used to hold the error code that results from the
+        ///           operation instead of throwing an exception on failure.
+        ///
+        /// \return The result of publishing the event.
         publish_result start(hpx::launch::sync_policy, std::uint64_t epoch = 0,
             hpx::error_code& ec = hpx::throws) const;
 

--- a/components/supervision_dispatch/tests/unit/CMakeLists.txt
+++ b/components/supervision_dispatch/tests/unit/CMakeLists.txt
@@ -10,6 +10,7 @@ set(tests
     discover_peers
     dispatch_api
     fan_out_join
+    fenced_dispatch
     registry_join
     sentinel_start
 )
@@ -22,6 +23,8 @@ set(discover_peers_FLAGS COMPILE_FLAGS -DHPX_HAVE_RUN_MAIN_EVERYWHERE)
 
 set(fan_out_join_PARAMETERS LOCALITIES 2)
 set(fan_out_join_FLAGS COMPILE_FLAGS -DHPX_HAVE_RUN_MAIN_EVERYWHERE)
+
+set(fenced_dispatch_PARAMETERS LOCALITIES 2)
 
 foreach(test ${tests})
   set(sources ${test}.cpp)

--- a/components/supervision_dispatch/tests/unit/fenced_dispatch.cpp
+++ b/components/supervision_dispatch/tests/unit/fenced_dispatch.cpp
@@ -1,0 +1,263 @@
+//  Copyright (c) 2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/hpx.hpp>
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+
+#include <hpx/hpx_init.hpp>
+#include <hpx/modules/actions.hpp>
+#include <hpx/modules/futures.hpp>
+#include <hpx/modules/supervision.hpp>
+#include <hpx/modules/testing.hpp>
+#include <hpx/supervision_dispatch/dispatch_work.hpp>
+
+#include <atomic>
+#include <cstdint>
+
+// Fixture: a plain action whose invocation count is observable, used as the
+// Action wrapped by fenced_action<Action>.
+
+std::atomic<int> invocation_count{0};
+
+int count_invocation()
+{
+    return invocation_count.fetch_add(1, std::memory_order_relaxed) + 1;
+}
+HPX_PLAIN_ACTION(count_invocation, count_invocation_action);
+
+int get_invocation_count()
+{
+    return invocation_count.load(std::memory_order_acquire);
+}
+HPX_PLAIN_ACTION(get_invocation_count, get_invocation_count_action);
+
+void reset_invocation_count()
+{
+    invocation_count.store(0, std::memory_order_release);
+}
+HPX_PLAIN_ACTION(reset_invocation_count, reset_invocation_count_action);
+
+// ============================================================================
+// Test Cases: Fenced Dispatch
+// ============================================================================
+
+namespace {
+
+    // Reach `running` via a legal path: started -> running.
+    void reach_running_at_epoch(hpx::id_type const& locality,
+        hpx::id_type const& target, std::uint64_t const epoch)
+    {
+        hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+            hpx::supervision::event::started, epoch);
+        hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+            hpx::supervision::event::running, epoch);
+    }
+}    // namespace
+
+// No fence anywhere: dispatch_work() resolves normally, wrapped action runs
+// exactly once.
+void test_dispatch_success(hpx::id_type const& locality)
+{
+    hpx::sync(reset_invocation_count_action(), locality);
+
+    constexpr std::uint64_t epoch = 0;
+
+    hpx::future<int> f = hpx::supervision::dispatch_work(
+        count_invocation_action(), locality, epoch);
+
+    HPX_TEST(f.get() == 1);
+    HPX_TEST_EQ(hpx::sync(get_invocation_count_action(), locality), 1);
+
+    hpx::supervision::remove_target(locality);
+}
+
+// Client-side early-out: target already latched a terminal event before
+// dispatch_work() is called. Wrapped action must never dispatch.
+void test_dispatch_client_side_fence()
+{
+    hpx::id_type const locality = hpx::find_here();
+    hpx::sync(reset_invocation_count_action(), locality);
+
+    hpx::id_type const target = hpx::find_here();
+    constexpr std::uint64_t epoch = 0;
+
+    reach_running_at_epoch(locality, target, epoch);
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+        hpx::supervision::event::completed, epoch);
+
+    hpx::future<int> f = hpx::supervision::dispatch_work(
+        count_invocation_action(), target, epoch);
+
+    bool caught = false;
+    try
+    {
+        f.get();
+    }
+    catch (hpx::exception const& e)
+    {
+        caught = true;
+        HPX_TEST(hpx::get_error(e) == hpx::error::target_fenced);
+    }
+    HPX_TEST(caught);
+    HPX_TEST_EQ(hpx::sync(get_invocation_count_action(), locality), 0);
+
+    hpx::supervision::remove_target(locality, target);
+}
+
+// Server-side race: client-side check_admission() returns admitted, but the
+// target latches a terminal event before the authoritative re-check inside
+// invoke_fenced_action runs. Driven deterministically by publishing between
+// the two checks, then calling invoke_fenced_action() directly.
+void test_dispatch_server_side_race()
+{
+    invocation_count = 0;
+
+    hpx::id_type const& target = hpx::find_here();
+    constexpr std::uint64_t epoch = 0;
+
+    HPX_TEST(hpx::supervision::check_admission(target, epoch) ==
+        hpx::supervision::dispatch_outcome::admitted);
+
+    reach_running_at_epoch(hpx::find_here(), target, epoch);
+    hpx::supervision::publish_event(hpx::launch::sync, hpx::find_here(), target,
+        hpx::supervision::event::completed, epoch);
+
+    bool caught = false;
+    try
+    {
+        hpx::supervision::invoke_fenced_action(
+            count_invocation_action(), target, epoch);
+    }
+    catch (hpx::exception const& e)
+    {
+        caught = true;
+        HPX_TEST(hpx::get_error(e) == hpx::error::target_fenced);
+    }
+    HPX_TEST(caught);
+    HPX_TEST_EQ(invocation_count.load(), 0);
+
+    hpx::supervision::remove_target(target);
+}
+
+// Terminal latch is scoped to the epoch it was recorded under: dispatch
+// under a different epoch is admitted -- guards against an overly-broad
+// re-check that ignores epoch.
+void test_dispatch_epoch_mismatch_not_fenced()
+{
+    hpx::id_type const locality = hpx::find_here();
+    hpx::sync(reset_invocation_count_action(), locality);
+
+    hpx::id_type const target = hpx::find_here();
+    constexpr std::uint64_t fenced_epoch = 1;
+    constexpr std::uint64_t other_epoch = 2;
+
+    reach_running_at_epoch(locality, target, fenced_epoch);
+    hpx::supervision::publish_event(hpx::launch::sync, locality, target,
+        hpx::supervision::event::completed, fenced_epoch);
+
+    hpx::future<int> f =
+        hpx::supervision::dispatch_work<count_invocation_action>(
+            target, other_epoch);
+
+    HPX_TEST(f.get() == 1);
+    HPX_TEST_EQ(hpx::sync(get_invocation_count_action(), locality), 1);
+
+    hpx::supervision::remove_target(locality, target);
+}
+
+// Both fenced paths (client-side, server-side) must report the same error code
+// so callers only need a single catch clause. Assert on
+// hpx::error::target_fenced only, never on message text.
+void test_fenced_error_code_consistent_across_paths(
+    hpx::id_type const& remote_locality)
+{
+    HPX_TEST_NEQ(hpx::find_here(), remote_locality);
+
+    hpx::sync(reset_invocation_count_action(), remote_locality);
+
+    hpx::id_type const client_side_target = hpx::find_here();
+    hpx::id_type const& server_side_target = remote_locality;
+    constexpr std::uint64_t epoch = 0;
+
+    reach_running_at_epoch(hpx::find_here(), client_side_target, epoch);
+    hpx::supervision::publish_event(hpx::launch::sync, hpx::find_here(),
+        client_side_target, hpx::supervision::event::completed, epoch);
+
+    hpx::error client_side_error{};
+    try
+    {
+        hpx::supervision::dispatch_work<count_invocation_action>(
+            client_side_target, epoch)
+            .get();
+    }
+    catch (hpx::exception const& e)
+    {
+        client_side_error = hpx::get_error(e);
+    }
+
+    HPX_TEST(hpx::supervision::check_admission(server_side_target, epoch) ==
+        hpx::supervision::dispatch_outcome::admitted);
+
+    reach_running_at_epoch(hpx::find_here(), server_side_target, epoch);
+    hpx::supervision::publish_event(hpx::launch::sync, hpx::find_here(),
+        server_side_target, hpx::supervision::event::completed, epoch);
+
+    hpx::error server_side_error{};
+    try
+    {
+        hpx::supervision::invoke_fenced_action(
+            count_invocation_action(), server_side_target, epoch);
+    }
+    catch (hpx::exception const& e)
+    {
+        server_side_error = hpx::get_error(e);
+    }
+
+    HPX_TEST(client_side_error == hpx::error::target_fenced);
+    HPX_TEST(server_side_error == hpx::error::target_fenced);
+    HPX_TEST_EQ(hpx::sync(get_invocation_count_action(), remote_locality), 0);
+
+    hpx::supervision::remove_target(hpx::find_here(), client_side_target);
+    hpx::supervision::remove_target(hpx::find_here(), server_side_target);
+}
+
+// ============================================================================
+// Main Test Entry Point
+// ============================================================================
+
+int hpx_main()
+{
+    for (auto const& locality : hpx::find_all_localities())
+    {
+        test_dispatch_success(locality);
+    }
+
+    test_dispatch_client_side_fence();
+    test_dispatch_server_side_race();
+    test_dispatch_epoch_mismatch_not_fenced();
+
+    for (auto const& locality : hpx::find_remote_localities())
+    {
+        test_fenced_error_code_consistent_across_paths(locality);
+    }
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    HPX_TEST_EQ(hpx::init(argc, argv), 0);
+    return hpx::util::report_errors();
+}
+
+#else
+
+int main(int, char*[])
+{
+    return 0;
+}
+
+#endif

--- a/libs/full/distribution_policies/include/hpx/distribution_policies/colocating_distribution_policy.hpp
+++ b/libs/full/distribution_policies/include/hpx/distribution_policies/colocating_distribution_policy.hpp
@@ -61,6 +61,30 @@ namespace hpx::components {
             return colocating_distribution_policy(client.get_id());
         }
 
+    private:
+        // Returns the direct-dispatch target id when colocation resolution can
+        // be short-circuited (empty policy, id_ already a locality address, or
+        // a non-migratable component); returns an empty id_type() otherwise, in
+        // which case the *_colocated_* family must be used with id_ directly.
+        [[nodiscard]] hpx::id_type resolve_direct_target() const
+        {
+            if (!id_)
+            {
+                return naming::get_id_from_locality_id(agas::get_locality_id());
+            }
+            if (naming::is_locality(id_))
+            {
+                return id_;
+            }
+            if (!naming::detail::is_migratable(id_.get_gid()))
+            {
+                return naming::get_id_from_locality_id(
+                    naming::get_locality_id_from_id(id_));
+            }
+            return hpx::id_type();    // signal: use colocated dispatch
+        }
+
+    public:
         /// Create one object on the locality of the object this distribution
         /// policy instance is associated with
         ///
@@ -76,18 +100,10 @@ namespace hpx::components {
         template <typename Component, typename... Ts>
         hpx::future<hpx::id_type> create(Ts&&... vs) const
         {
-            if (!id_)
+            if (hpx::id_type id = resolve_direct_target(); id)
             {
                 return create_async<Component>(
-                    naming::get_id_from_locality_id(agas::get_locality_id()),
-                    HPX_FORWARD(Ts, vs)...);
-            }
-            if (!naming::detail::is_migratable(id_.get_gid()))
-            {
-                return create_async<Component>(
-                    naming::get_id_from_locality_id(
-                        naming::get_locality_id_from_id(id_)),
-                    HPX_FORWARD(Ts, vs)...);
+                    HPX_MOVE(id), HPX_FORWARD(Ts, vs)...);
             }
             return create_colocated_async<Component>(
                 id_, HPX_FORWARD(Ts, vs)...);
@@ -115,26 +131,10 @@ namespace hpx::components {
         hpx::future<std::vector<bulk_locality_result>> bulk_create(
             std::size_t count, Ts&&... vs) const
         {
-            hpx::id_type id;
+            hpx::id_type id = resolve_direct_target();
             hpx::future<std::vector<hpx::id_type>> f;
-            if (!id_)
+            if (id)
             {
-                id = naming::get_id_from_locality_id(agas::get_locality_id());
-                if constexpr (WithCount)
-                {
-                    f = bulk_create_async<WithCount, Component>(
-                        id, count, 0, HPX_FORWARD(Ts, vs)...);
-                }
-                else
-                {
-                    f = bulk_create_async<WithCount, Component>(
-                        id, count, HPX_FORWARD(Ts, vs)...);
-                }
-            }
-            else if (!naming::detail::is_migratable(id_.get_gid()))
-            {
-                id = naming::get_id_from_locality_id(
-                    naming::get_locality_id_from_id(id_));
                 if constexpr (WithCount)
                 {
                     f = bulk_create_async<WithCount, Component>(
@@ -185,18 +185,10 @@ namespace hpx::components {
         typename async_result<Action>::type async(
             launch policy, Ts&&... vs) const
         {
-            if (!id_)
+            if (hpx::id_type id = resolve_direct_target(); id)
             {
-                return hpx::detail::async_impl<Action>(policy,
-                    naming::get_id_from_locality_id(agas::get_locality_id()),
-                    HPX_FORWARD(Ts, vs)...);
-            }
-            if (!naming::detail::is_migratable(id_.get_gid()))
-            {
-                return hpx::detail::async_impl<Action>(policy,
-                    naming::get_id_from_locality_id(
-                        naming::get_locality_id_from_id(id_)),
-                    HPX_FORWARD(Ts, vs)...);
+                return hpx::detail::async_impl<Action>(
+                    policy, HPX_MOVE(id), HPX_FORWARD(Ts, vs)...);
             }
             return hpx::detail::async_colocated<Action>(
                 id_, HPX_FORWARD(Ts, vs)...);
@@ -209,17 +201,9 @@ namespace hpx::components {
         typename async_result<Action>::type async_cb(
             launch policy, Callback&& cb, Ts&&... vs) const
         {
-            if (!id_)
+            if (hpx::id_type id = resolve_direct_target(); id)
             {
-                return hpx::detail::async_cb_impl<Action>(policy,
-                    naming::get_id_from_locality_id(agas::get_locality_id()),
-                    HPX_FORWARD(Callback, cb), HPX_FORWARD(Ts, vs)...);
-            }
-            if (!naming::detail::is_migratable(id_.get_gid()))
-            {
-                return hpx::detail::async_cb_impl<Action>(policy,
-                    naming::get_id_from_locality_id(
-                        naming::get_locality_id_from_id(id_)),
+                return hpx::detail::async_cb_impl<Action>(policy, HPX_MOVE(id),
                     HPX_FORWARD(Callback, cb), HPX_FORWARD(Ts, vs)...);
             }
             return hpx::detail::async_colocated_cb<Action>(
@@ -232,20 +216,11 @@ namespace hpx::components {
         template <typename Action, typename Continuation, typename... Ts>
         bool apply(Continuation&& c, launch policy, Ts&&... vs) const
         {
-            if (!id_)
+            if (hpx::id_type id = resolve_direct_target())
             {
                 return hpx::detail::post_impl<Action>(
-                    HPX_FORWARD(Continuation, c),
-                    naming::get_id_from_locality_id(agas::get_locality_id()),
-                    policy, HPX_FORWARD(Ts, vs)...);
-            }
-            if (!naming::detail::is_migratable(id_.get_gid()))
-            {
-                return hpx::detail::post_impl<Action>(
-                    HPX_FORWARD(Continuation, c),
-                    naming::get_id_from_locality_id(
-                        naming::get_locality_id_from_id(id_)),
-                    policy, HPX_FORWARD(Ts, vs)...);
+                    HPX_FORWARD(Continuation, c), HPX_MOVE(id), policy,
+                    HPX_FORWARD(Ts, vs)...);
             }
             return hpx::detail::post_colocated<Action>(
                 HPX_FORWARD(Continuation, c), id_, HPX_FORWARD(Ts, vs)...);
@@ -254,18 +229,10 @@ namespace hpx::components {
         template <typename Action, typename... Ts>
         bool apply(launch policy, Ts&&... vs) const
         {
-            if (!id_)
+            if (hpx::id_type id = resolve_direct_target(); id)
             {
                 return hpx::detail::post_impl<Action>(
-                    naming::get_id_from_locality_id(agas::get_locality_id()),
-                    policy, HPX_FORWARD(Ts, vs)...);
-            }
-            if (!naming::detail::is_migratable(id_.get_gid()))
-            {
-                return hpx::detail::post_impl<Action>(
-                    naming::get_id_from_locality_id(
-                        naming::get_locality_id_from_id(id_)),
-                    policy, HPX_FORWARD(Ts, vs)...);
+                    HPX_MOVE(id), policy, HPX_FORWARD(Ts, vs)...);
             }
             return hpx::detail::post_colocated<Action>(
                 id_, HPX_FORWARD(Ts, vs)...);
@@ -279,20 +246,11 @@ namespace hpx::components {
         bool apply_cb(
             Continuation&& c, launch policy, Callback&& cb, Ts&&... vs) const
         {
-            if (!id_)
+            if (hpx::id_type id = resolve_direct_target(); id)
             {
                 return hpx::detail::post_cb_impl<Action>(
-                    HPX_FORWARD(Continuation, c),
-                    naming::get_id_from_locality_id(agas::get_locality_id()),
-                    policy, HPX_FORWARD(Callback, cb), HPX_FORWARD(Ts, vs)...);
-            }
-            if (!naming::detail::is_migratable(id_.get_gid()))
-            {
-                return hpx::detail::post_cb_impl<Action>(
-                    HPX_FORWARD(Continuation, c),
-                    naming::get_id_from_locality_id(
-                        naming::get_locality_id_from_id(id_)),
-                    policy, HPX_FORWARD(Callback, cb), HPX_FORWARD(Ts, vs)...);
+                    HPX_FORWARD(Continuation, c), HPX_MOVE(id), policy,
+                    HPX_FORWARD(Callback, cb), HPX_FORWARD(Ts, vs)...);
             }
             return hpx::detail::post_colocated_cb<Action>(
                 HPX_FORWARD(Continuation, c), id_, HPX_FORWARD(Callback, cb),
@@ -302,18 +260,10 @@ namespace hpx::components {
         template <typename Action, typename Callback, typename... Ts>
         bool apply_cb(launch policy, Callback&& cb, Ts&&... vs) const
         {
-            if (!id_)
+            if (hpx::id_type id = resolve_direct_target(); id)
             {
-                return hpx::detail::post_cb_impl<Action>(
-                    naming::get_id_from_locality_id(agas::get_locality_id()),
-                    policy, HPX_FORWARD(Callback, cb), HPX_FORWARD(Ts, vs)...);
-            }
-            if (!naming::detail::is_migratable(id_.get_gid()))
-            {
-                return hpx::detail::post_cb_impl<Action>(
-                    naming::get_id_from_locality_id(
-                        naming::get_locality_id_from_id(id_)),
-                    policy, HPX_FORWARD(Callback, cb), HPX_FORWARD(Ts, vs)...);
+                return hpx::detail::post_cb_impl<Action>(HPX_MOVE(id), policy,
+                    HPX_FORWARD(Callback, cb), HPX_FORWARD(Ts, vs)...);
             }
             return hpx::detail::post_colocated_cb<Action>(
                 id_, HPX_FORWARD(Callback, cb), HPX_FORWARD(Ts, vs)...);

--- a/libs/full/distribution_policies/tests/unit/CMakeLists.txt
+++ b/libs/full/distribution_policies/tests/unit/CMakeLists.txt
@@ -5,10 +5,10 @@
 #  Distributed under the Boost Software License, Version 1.0. (See accompanying
 #  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
-set(tests new_binpacking)
+set(tests colocating_policy new_binpacking)
 
 set(new_binpacking_PARAMETERS LOCALITIES 2)
-set(new_colocated_PARAMETERS LOCALITIES 2)
+set(colocating_policy_PARAMETERS LOCALITIES 2)
 
 foreach(test ${tests})
   set(sources ${test}.cpp)

--- a/libs/full/distribution_policies/tests/unit/colocating_policy.cpp
+++ b/libs/full/distribution_policies/tests/unit/colocating_policy.cpp
@@ -1,0 +1,126 @@
+//  Copyright (c) 2026 Hartmut Kaiser
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <hpx/config.hpp>
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+#include <hpx/hpx_main.hpp>
+#include <hpx/include/actions.hpp>
+#include <hpx/include/components.hpp>
+#include <hpx/include/runtime.hpp>
+
+#include <hpx/modules/distribution_policies.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <cstddef>
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////
+struct test_server : hpx::components::component_base<test_server>
+{
+    hpx::id_type call() const
+    {
+        return hpx::find_here();
+    }
+
+    HPX_DEFINE_COMPONENT_ACTION(test_server, call)
+};
+
+using server_type = hpx::components::component<test_server>;
+HPX_REGISTER_COMPONENT(server_type, test_server)
+
+using call_action = test_server::call_action;
+HPX_REGISTER_ACTION(call_action)
+
+hpx::id_type get_locality()
+{
+    return hpx::find_here();
+}
+
+HPX_PLAIN_ACTION(get_locality, get_locality_action)
+
+///////////////////////////////////////////////////////////////////////////////
+// direct-locality routing: create() and async() should target the given
+// locality id directly (no colocation hop)
+void test_direct_locality_routing()
+{
+    std::vector<hpx::id_type> const localities = hpx::find_all_localities();
+    hpx::id_type const& target_locality = localities.back();
+
+    auto const policy = hpx::components::colocated(target_locality);
+
+    hpx::id_type obj_id = policy.create<test_server>().get();
+    HPX_TEST_EQ(hpx::async<call_action>(obj_id).get(), target_locality);
+
+    auto const obj_policy = hpx::components::colocated(obj_id);
+
+    HPX_TEST_EQ(obj_policy.async<get_locality_action>(hpx::launch::async).get(),
+        target_locality);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// bulk_create regression test for the locality-id continuation bug: when id_ is
+// itself a locality id, the reported bulk_locality_result.first must be that
+// same locality id, not a default-constructed id_type
+void test_bulk_create_reports_locality_id()
+{
+    std::vector<hpx::id_type> const localities = hpx::find_all_localities();
+    hpx::id_type const& target_locality = localities.back();
+
+    auto const policy = hpx::components::colocated(target_locality);
+
+    auto const results = policy.bulk_create<false, test_server>(3).get();
+
+    HPX_TEST_EQ(results.size(), static_cast<std::size_t>(1));
+    HPX_TEST(static_cast<bool>(results[0].first));
+    if (!results.empty())
+    {
+        HPX_TEST_EQ(results[0].first, target_locality);
+        HPX_TEST_EQ(results[0].second.size(), static_cast<std::size_t>(3));
+
+        for (hpx::id_type const& id : results[0].second)
+        {
+            HPX_TEST_EQ(hpx::async<call_action>(id).get(), target_locality);
+        }
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// empty policy (default-constructed) falls back to the local locality
+void test_empty_policy_uses_local_locality()
+{
+    hpx::components::colocating_distribution_policy const policy;
+
+    hpx::id_type obj_id = policy.create<test_server>().get();
+    HPX_TEST_EQ(hpx::async<call_action>(obj_id).get(), hpx::find_here());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// colocation with a non-migratable component's id still resolves to that
+// component's owning locality directly (not through create_colocated)
+void test_colocated_with_object_id()
+{
+    hpx::id_type anchor = hpx::new_<test_server>(hpx::find_here()).get();
+    hpx::id_type const anchor_locality = hpx::async<call_action>(anchor).get();
+
+    auto const policy = hpx::components::colocated(anchor);
+
+    hpx::id_type obj_id = policy.create<test_server>().get();
+    HPX_TEST_EQ(hpx::async<call_action>(obj_id).get(), anchor_locality);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int main()
+{
+    test_empty_policy_uses_local_locality();
+    test_direct_locality_routing();
+    test_bulk_create_reports_locality_id();
+    test_colocated_with_object_id();
+
+    return hpx::util::report_errors();
+}
+
+#endif


### PR DESCRIPTION
## Summary

This PR introduces two independent feature sets:

### Fenced Dispatch (components/supervision_dispatch)

Adds a new supervision-aware "fenced dispatch" mechanism for actions:
- Dispatch API (supervision_dispatch.hpp, dispatch_work.hpp): performs admission checks on both the client and target sides before running an action, wraps the action invocation, and surfaces target-side fencing errors distinctly from other failures. Also exposes the installed umbrella header and adds the component's CMakeLists.txt wiring.
- Unit tests (fenced_dispatch.cpp + test CMakeLists.txt): cover successful dispatch, client-side and server-side fencing rejection, epoch isolation (stale vs. current epoch), consistent error reporting across localities, and invocation-count verification.
- Supervision documentation (registry.hpp, sentinel.hpp): adds doc comments describing peer supervision, locality/symbolic-name construction, lifecycle observation, and start/join semantics — no behavioral changes.

### Direct Locality Routing (libs/full/distribution_policies)

Centralizes locality-target resolution for the colocating distribution policy:
- Locality resolution (colocating_distribution_policy.hpp): introduces a single resolver used consistently across creation and dispatch paths to determine the target locality — covering explicit locality IDs, non-migratable objects, migratable objects, and default/fallback targets.
- Unit tests (colocating_policy.cpp + test CMakeLists.txt): validate direct locality routing, bulk-creation locality selection, default-policy fallback behavior, and colocation with existing objects.

## Notes
- The two cohorts (fenced dispatch and locality routing) are independent and can be reviewed separately.
- No changes appear to alter existing distribution-policy or supervision behavior outside of the centralized resolution path and new dispatch component.

More work towards resolving #7390

- flyby: adding direct support for localities to hpx::colocated(id) (short-cutting AGAS resolution)

