### PR TITLE
Fix the build with HPX_WITH_THREAD_QUEUE_WAITTIME=ON

### DIFF
--- a/.github/workflows/linux_debug.yml
+++ b/.github/workflows/linux_debug.yml
@@ -37,6 +37,7 @@ jobs:
               -DHPX_WITH_VERIFY_LOCKS=ON \
               -DHPX_WITH_VERIFY_LOCKS_BACKTRACE=ON \
               -DHPX_WITH_CHECK_MODULE_DEPENDENCIES=On \
+              -DHPX_WITH_THREAD_QUEUE_WAITTIME=ON \
               -DHPX_WITH_TESTS_COMMAND_LINE=--hpx:queuing=local-priority-fifo-double
     - name: Build
       shell: bash

--- a/libs/core/schedulers/include/hpx/schedulers/thread_queue.hpp
+++ b/libs/core/schedulers/include/hpx/schedulers/thread_queue.hpp
@@ -224,7 +224,7 @@ namespace hpx::threads::policies {
                 {
                     addfrom->new_tasks_wait_ +=
                         hpx::chrono::high_resolution_clock::now() -
-                        task.waittime;
+                        task.wait_time;
                     ++addfrom->new_tasks_wait_count_;
                 }
 #endif
@@ -856,9 +856,9 @@ namespace hpx::threads::policies {
                 {
                     std::uint64_t now =
                         hpx::chrono::high_resolution_clock::now();
-                    src->work_items_wait_ += now - trd->waittime;
+                    src->work_items_wait_ += now - trd->wait_time;
                     ++src->work_items_wait_count_;
-                    trd->waittime = now;
+                    trd->wait_time = now;
                 }
 #endif
 
@@ -879,9 +879,9 @@ namespace hpx::threads::policies {
                 {
                     std::int64_t now =
                         hpx::chrono::high_resolution_clock::now();
-                    src->new_tasks_wait_ += now - task.waittime;
+                    src->new_tasks_wait_ += now - task.wait_time;
                     ++src->new_tasks_wait_count_;
-                    task.waittime = now;
+                    task.wait_time = now;
                 }
 #endif
 
@@ -932,7 +932,7 @@ namespace hpx::threads::policies {
                 {
                     work_items_wait_ +=
                         hpx::chrono::high_resolution_clock::now() -
-                        task_desc->waittime;
+                        task_desc->wait_time;
                     ++work_items_wait_count_;
                 }
 
@@ -985,7 +985,7 @@ namespace hpx::threads::policies {
                 {
                     work_items_wait_ +=
                         hpx::chrono::high_resolution_clock::now() -
-                        task_desc->waittime;
+                        task_desc->wait_time;
                     ++work_items_wait_count_;
                 }
 


### PR DESCRIPTION
Fixes #7389.

## Problem
`thread_queue.hpp` declares `wait_time` but seven places still use `waittime`, so building with `HPX_WITH_THREAD_QUEUE_WAITTIME=ON` fails. Two things hid it. The option is off by default, so the block is normally never compiled. And the uses sit in a class template, so they are only checked once a scheduler instantiates it. The declarations were renamed in 917d80900d and the uses were not; 45bdb82ef2 later edited one of the same lines.

## Change
Renames the seven uses to match the declarations. Nothing else. Normalizing the identifier on both sides makes the file identical before and after.

## Test plan
Configured with `-DHPX_WITH_THREAD_QUEUE_WAITTIME=ON`:
```
before   fails, "no member named 'waittime'"
after    hpx_core builds and links clean
```
The errors appear for two instantiations, `lockfree_fifo` and `lockfree_fifo_double`. No test is added, because this only reproduces under a build option CI does not currently configure. Adding that configuration to CI would be a reasonable follow-up, since nothing would have caught this otherwise. This is a compile fix. Whether the wait time counters report correct values after being unbuildable is untested and not addressed here.

## Checklist
- [x] I have fixed a bug.
