### PR TITLE
Add size-based pairwise dispatch to all_to_all

### DIFF
--- a/libs/full/collectives/CMakeLists.txt
+++ b/libs/full/collectives/CMakeLists.txt
@@ -28,6 +28,7 @@ set(collectives_headers
     hpx/collectives/detail/hierarchical_helpers.hpp
     hpx/collectives/detail/hierarchical_scan_helpers.hpp
     hpx/collectives/detail/latch.hpp
+    hpx/collectives/detail/pairwise_all_to_all_helpers.hpp
     hpx/collectives/exclusive_scan.hpp
     hpx/collectives/fold.hpp
     hpx/collectives/gather.hpp
@@ -89,6 +90,7 @@ add_hpx_module(
     "hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp"
     "hpx/collectives/detail/hierarchical_helpers.hpp"
     "hpx/collectives/detail/hierarchical_scan_helpers.hpp"
+    "hpx/collectives/detail/pairwise_all_to_all_helpers.hpp"
   COMPAT_HEADERS ${collectives_compat_headers}
   DEPENDENCIES hpx_core
   MODULE_DEPENDENCIES

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -36,16 +36,15 @@ namespace hpx { namespace collectives {
     /// \param root_site    The site that is responsible for creating the
     ///                     all_to_all support object. This value is optional
     ///                     and defaults to '0' (zero).
-    /// \param threshold    The per-pair payload size, in bytes, at or above
-    ///                     which the rows are exchanged directly between the
-    ///                     participating sites instead of being routed through
-    ///                     one communicator site; see \a pairwise_threshold_arg
-    ///                     for the default and for what a value of zero
-    ///                     selects. The direct exchange additionally requires
-    ///                     at least three participating sites and an explicit
-    ///                     generation number, and a call that supplies neither
-    ///                     is routed whatever this value is. Which path runs
-    ///                     affects performance only, never the result.
+    /// \param threshold    The fixed row-size threshold, in bytes, at or above
+    ///                     which rows are exchanged directly between sites
+    ///                     instead of being routed through one communicator
+    ///                     site. Automatic selection uses sizeof(T) only for a
+    ///                     trivially copyable T; other row types stay routed
+    ///                     unless every site passes zero. See
+    ///                     \a pairwise_threshold_arg for the default and the
+    ///                     remaining direct-exchange requirements. Which path
+    ///                     runs affects performance only, never the result.
     ///
     /// \returns    This function returns a future holding a vector with all
     ///             values send by all participating sites. It will become
@@ -142,16 +141,15 @@ namespace hpx { namespace collectives {
     /// \param root_site    The site that is responsible for creating the
     ///                     all_to_all support object. This value is optional
     ///                     and defaults to '0' (zero).
-    /// \param threshold    The per-pair payload size, in bytes, at or above
-    ///                     which the rows are exchanged directly between the
-    ///                     participating sites instead of being routed through
-    ///                     one communicator site; see \a pairwise_threshold_arg
-    ///                     for the default and for what a value of zero
-    ///                     selects. The direct exchange additionally requires
-    ///                     at least three participating sites and an explicit
-    ///                     generation number, and a call that supplies neither
-    ///                     is routed whatever this value is. Which path runs
-    ///                     affects performance only, never the result.
+    /// \param threshold    The fixed row-size threshold, in bytes, at or above
+    ///                     which rows are exchanged directly between sites
+    ///                     instead of being routed through one communicator
+    ///                     site. Automatic selection uses sizeof(T) only for a
+    ///                     trivially copyable T; other row types stay routed
+    ///                     unless every site passes zero. See
+    ///                     \a pairwise_threshold_arg for the default and the
+    ///                     remaining direct-exchange requirements. Which path
+    ///                     runs affects performance only, never the result.
     ///
     /// \returns    This function returns a vector with all values send by all
     ///             participating sites. This function executes synchronously and

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -664,7 +664,11 @@ namespace hpx::collectives {
                 this_site = this_site_arg(agas::get_locality_id());
             }
 
-            if (!generation.is_default() &&
+            // Leave malformed communicator arguments to the routed path's
+            // existing validation instead of changing their behavior here.
+            if (basename != nullptr && basename[0] != '\0' &&
+                this_site < num_sites && root_site < num_sites &&
+                !generation.is_default() &&
                 exchange_pairwise(static_cast<std::size_t>(num_sites),
                     pairwise_type_bytes<T>(), threshold))
             {
@@ -681,8 +685,13 @@ namespace hpx::collectives {
                 // The site count belongs in the name because two groups of
                 // different size are two different communicators, and the
                 // cache creates one only on the first call that names it.
-                std::string channel_basename = std::string(basename) +
-                    "pairwise/" +
+                std::string channel_basename(basename);
+                HPX_ASSERT(!channel_basename.empty());
+                if (channel_basename.back() != '/')
+                {
+                    channel_basename += '/';
+                }
+                channel_basename += "pairwise/" +
                     std::to_string(static_cast<std::size_t>(num_sites)) + "/";
 
                 std::size_t const num_sites_value = num_sites;

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -687,13 +687,27 @@ namespace hpx::collectives {
                     "pairwise/" +
                     std::to_string(static_cast<std::size_t>(num_sites)) + "/";
 
-                return pairwise_all_to_all(
-                    get_cached_channel_communicator(
-                        HPX_MOVE(channel_basename), num_sites, this_site)
-                        .get(),
-                    HPX_MOVE(local_result), static_cast<std::size_t>(num_sites),
-                    static_cast<std::size_t>(this_site),
-                    tag_arg(static_cast<std::size_t>(generation)));
+                std::size_t const num_sites_value = num_sites;
+                std::size_t const this_site_value = this_site;
+                tag_arg const tag(static_cast<std::size_t>(generation));
+
+                // The communicator is chained onto rather than waited for.
+                // This function backs an overload that hands the caller a
+                // future, so it must not spend the caller's thread on the
+                // first call's AGAS registration before returning one. The
+                // communicator type is spelled out because the unqualified
+                // name resolves to the detail class in this namespace.
+                return get_cached_channel_communicator(
+                    HPX_MOVE(channel_basename), num_sites, this_site)
+                    .then(hpx::launch::sync,
+                        [local_result = HPX_MOVE(local_result), num_sites_value,
+                            this_site_value, tag](hpx::shared_future<
+                            hpx::collectives::channel_communicator>&&
+                                f) mutable {
+                            return pairwise_all_to_all(f.get(),
+                                HPX_MOVE(local_result), num_sites_value,
+                                this_site_value, tag);
+                        });
             }
 
             return hpx::collectives::all_to_all(

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -217,6 +217,7 @@ namespace hpx { namespace collectives {
 #include <hpx/collectives/detail/flattened_data.hpp>
 #include <hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp>
 #include <hpx/collectives/detail/hierarchical_helpers.hpp>
+#include <hpx/collectives/detail/pairwise_all_to_all_helpers.hpp>
 #include <hpx/modules/async_base.hpp>
 #include <hpx/modules/async_distributed.hpp>
 #include <hpx/modules/components_base.hpp>
@@ -225,6 +226,7 @@ namespace hpx { namespace collectives {
 #include <hpx/modules/type_support.hpp>
 
 #include <cstddef>
+#include <string>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -598,17 +600,72 @@ namespace hpx::collectives {
             HPX_MOVE(fid), HPX_MOVE(local_result), this_site, generation);
     }
 
+    namespace detail {
+
+        // all_to_all_by_name: resolves a basename call onto one of the two
+        // exchange paths.
+        //
+        // The routed path is the default and always available. The direct
+        // path additionally needs two things the routed path does not: a
+        // channel communicator, which only a basename can produce, and an
+        // explicit generation, which is what gives every site the same
+        // exchange tag. A default generation therefore stays routed. Which
+        // path runs is a performance choice rather than a semantic one, so an
+        // otherwise valid call is served rather than rejected.
+        template <typename T>
+        hpx::future<std::vector<T>> all_to_all_by_name(char const* basename,
+            std::vector<T>&& local_result, num_sites_arg num_sites,
+            this_site_arg this_site, generation_arg const generation,
+            root_site_arg const root_site,
+            pairwise_threshold_arg const threshold)
+        {
+            if (num_sites.is_default())
+            {
+                num_sites =
+                    num_sites_arg(agas::get_num_localities(hpx::launch::sync));
+            }
+            if (this_site.is_default())
+            {
+                this_site = this_site_arg(agas::get_locality_id());
+            }
+
+            if (!generation.is_default() &&
+                exchange_pairwise(static_cast<std::size_t>(num_sites),
+                    pairwise_type_bytes<T>(), threshold))
+            {
+                // The channel communicator carries a name of its own so it
+                // cannot collide with the collective communicator registered
+                // under this basename.
+                std::string const channel_basename =
+                    std::string(basename) + "pairwise/";
+
+                return pairwise_all_to_all(
+                    hpx::collectives::create_channel_communicator(
+                        hpx::launch::sync, channel_basename.c_str(), num_sites,
+                        this_site),
+                    HPX_MOVE(local_result), static_cast<std::size_t>(num_sites),
+                    static_cast<std::size_t>(this_site),
+                    tag_arg(static_cast<std::size_t>(generation)));
+            }
+
+            return hpx::collectives::all_to_all(
+                hpx::collectives::create_communicator(
+                    basename, num_sites, this_site, generation, root_site),
+                HPX_MOVE(local_result), this_site);
+        }
+    }    // namespace detail
+
     HPX_CXX_EXPORT template <typename T>
     hpx::future<std::vector<T>> all_to_all(char const* basename,
         std::vector<T>&& local_result,
         num_sites_arg const num_sites = num_sites_arg(),
         this_site_arg const this_site = this_site_arg(),
         generation_arg const generation = generation_arg(),
-        root_site_arg const root_site = root_site_arg())
+        root_site_arg const root_site = root_site_arg(),
+        pairwise_threshold_arg const threshold = pairwise_threshold_arg())
     {
-        return all_to_all(create_communicator(basename, num_sites, this_site,
-                              generation, root_site),
-            HPX_MOVE(local_result), this_site);
+        return detail::all_to_all_by_name(basename, HPX_MOVE(local_result),
+            num_sites, this_site, generation, root_site, threshold);
     }
 
     // Forward declaration of the hierarchical overload (defined below) so the
@@ -653,11 +710,11 @@ namespace hpx::collectives {
         num_sites_arg const num_sites = num_sites_arg(),
         this_site_arg const this_site = this_site_arg(),
         generation_arg const generation = generation_arg(),
-        root_site_arg const root_site = root_site_arg())
+        root_site_arg const root_site = root_site_arg(),
+        pairwise_threshold_arg const threshold = pairwise_threshold_arg())
     {
-        return all_to_all(create_communicator(basename, num_sites, this_site,
-                              generation, root_site),
-            HPX_MOVE(local_result), this_site)
+        return detail::all_to_all_by_name(basename, HPX_MOVE(local_result),
+            num_sites, this_site, generation, root_site, threshold)
             .get();
     }
     ///////////////////////////////////////////////////////////////////////////

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -641,6 +641,20 @@ namespace hpx::collectives {
             root_site_arg const root_site,
             pairwise_threshold_arg const threshold)
         {
+            // Validation cannot depend on which path serves the call: the
+            // routed path rejects a zero generation inside detail::all_to_all,
+            // while the direct path would accept it as an exchange tag, since
+            // only a default generation reads as "unspecified" there. Reject it
+            // before the path is chosen, so a performance knob cannot move the
+            // boundary of what the operation accepts.
+            if (generation == 0)
+            {
+                return hpx::make_exceptional_future<std::vector<T>>(
+                    HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                        "hpx::collectives::all_to_all",
+                        "the generation number shouldn't be zero"));
+            }
+
             if (num_sites.is_default())
             {
                 num_sites =

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -635,9 +635,19 @@ namespace hpx::collectives {
             {
                 // The channel communicator carries a name of its own so it
                 // cannot collide with the collective communicator registered
-                // under this basename.
-                std::string const channel_basename =
-                    std::string(basename) + "pairwise/";
+                // under this basename. The generation is part of that name
+                // because a communicator is built per call: registering the
+                // same name for a later generation would be refused while the
+                // earlier one is still registered.
+                //
+                // Building one per call is the conservative choice, not the
+                // cheap one. Reusing a single channel communicator across
+                // generations is what the exchange tag was threaded through
+                // for, and it is the version worth measuring, but it needs a
+                // cache with a lifetime rule of its own.
+                std::string const channel_basename = std::string(basename) +
+                    "pairwise/" +
+                    std::to_string(static_cast<std::size_t>(generation)) + "/";
 
                 return pairwise_all_to_all(
                     hpx::collectives::create_channel_communicator(

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -36,6 +36,16 @@ namespace hpx { namespace collectives {
     /// \param root_site    The site that is responsible for creating the
     ///                     all_to_all support object. This value is optional
     ///                     and defaults to '0' (zero).
+    /// \param threshold    The per-pair payload size, in bytes, at or above
+    ///                     which the rows are exchanged directly between the
+    ///                     participating sites instead of being routed through
+    ///                     one communicator site; see \a pairwise_threshold_arg
+    ///                     for the default and for what a value of zero
+    ///                     selects. The direct exchange additionally requires
+    ///                     at least three participating sites and an explicit
+    ///                     generation number, and a call that supplies neither
+    ///                     is routed whatever this value is. Which path runs
+    ///                     affects performance only, never the result.
     ///
     /// \returns    This function returns a future holding a vector with all
     ///             values send by all participating sites. It will become
@@ -47,7 +57,8 @@ namespace hpx { namespace collectives {
         num_sites_arg num_sites = num_sites_arg(),
         this_site_arg this_site = this_site_arg(),
         generation_arg generation = generation_arg(),
-        root_site_arg root_site = root_site_arg());
+        root_site_arg root_site = root_site_arg(),
+        pairwise_threshold_arg threshold = pairwise_threshold_arg());
 
     /// AllToAll a set of values from different call sites
     ///
@@ -131,6 +142,16 @@ namespace hpx { namespace collectives {
     /// \param root_site    The site that is responsible for creating the
     ///                     all_to_all support object. This value is optional
     ///                     and defaults to '0' (zero).
+    /// \param threshold    The per-pair payload size, in bytes, at or above
+    ///                     which the rows are exchanged directly between the
+    ///                     participating sites instead of being routed through
+    ///                     one communicator site; see \a pairwise_threshold_arg
+    ///                     for the default and for what a value of zero
+    ///                     selects. The direct exchange additionally requires
+    ///                     at least three participating sites and an explicit
+    ///                     generation number, and a call that supplies neither
+    ///                     is routed whatever this value is. Which path runs
+    ///                     affects performance only, never the result.
     ///
     /// \returns    This function returns a vector with all values send by all
     ///             participating sites. This function executes synchronously and
@@ -142,7 +163,8 @@ namespace hpx { namespace collectives {
         num_sites_arg num_sites = num_sites_arg(),
         this_site_arg this_site = this_site_arg(),
         generation_arg generation = generation_arg(),
-        root_site_arg root_site = root_site_arg());
+        root_site_arg root_site = root_site_arg(),
+        pairwise_threshold_arg threshold = pairwise_threshold_arg());
 
     /// AllToAll a set of values from different call sites
     ///

--- a/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
+++ b/libs/full/collectives/include/hpx/collectives/all_to_all.hpp
@@ -235,6 +235,7 @@ namespace hpx { namespace collectives {
 
 #include <hpx/assert.hpp>
 #include <hpx/collectives/argument_types.hpp>
+#include <hpx/collectives/channel_communicator.hpp>
 #include <hpx/collectives/create_communicator.hpp>
 #include <hpx/collectives/detail/flattened_data.hpp>
 #include <hpx/collectives/detail/hierarchical_all_to_all_helpers.hpp>
@@ -671,24 +672,25 @@ namespace hpx::collectives {
             {
                 // The channel communicator carries a name of its own so it
                 // cannot collide with the collective communicator registered
-                // under this basename. The generation is part of that name
-                // because a communicator is built per call: registering the
-                // same name for a later generation would be refused while the
-                // earlier one is still registered.
+                // under this basename. That name spans a group of sites rather
+                // than a single call: one communicator serves every
+                // generation, and the exchange tag is what keeps the
+                // generations apart. Registering a name per generation instead
+                // would put an AGAS registration and a full peer lookup back
+                // into every call, which is the cost this path exists to
+                // remove.
                 //
-                // Building one per call is the conservative choice, not the
-                // cheap one. Reusing a single channel communicator across
-                // generations is what the exchange tag was threaded through
-                // for, and it is the version worth measuring, but it needs a
-                // cache with a lifetime rule of its own.
-                std::string const channel_basename = std::string(basename) +
+                // The site count belongs in the name because two groups of
+                // different size are two different communicators, and the
+                // cache creates one only on the first call that names it.
+                std::string channel_basename = std::string(basename) +
                     "pairwise/" +
-                    std::to_string(static_cast<std::size_t>(generation)) + "/";
+                    std::to_string(static_cast<std::size_t>(num_sites)) + "/";
 
                 return pairwise_all_to_all(
-                    hpx::collectives::create_channel_communicator(
-                        hpx::launch::sync, channel_basename.c_str(), num_sites,
-                        this_site),
+                    get_cached_channel_communicator(
+                        HPX_MOVE(channel_basename), num_sites, this_site)
+                        .get(),
                     HPX_MOVE(local_result), static_cast<std::size_t>(num_sites),
                     static_cast<std::size_t>(this_site),
                     tag_arg(static_cast<std::size_t>(generation)));

--- a/libs/full/collectives/include/hpx/collectives/argument_types.hpp
+++ b/libs/full/collectives/include/hpx/collectives/argument_types.hpp
@@ -72,6 +72,7 @@ namespace hpx::collectives {
         struct tag_tag;
         struct arity_tag;
         struct flat_fallback_threshold_tag;
+        struct pairwise_threshold_tag;
     }    // namespace detail
 
     /// The number of participating sites (default: all localities)
@@ -117,4 +118,17 @@ namespace hpx::collectives {
     /// Pass 0 to disable the fallback and always build a tree.
     HPX_CXX_EXPORT using flat_fallback_threshold_arg =
         detail::argument_type<detail::flat_fallback_threshold_tag, 16>;
+
+    /// The per-pair payload size, in bytes, at or above which all_to_all
+    /// exchanges rows directly between the participating sites instead of
+    /// routing every row through a single communicator site. Direct exchange
+    /// costs num_sites - 1 messages per site rather than two, so it only pays
+    /// once a row is large enough for the routing detour to dominate the
+    /// message count. Pass 0 to always exchange directly.
+    ///
+    /// The default is provisional: measurements on 20 localities per node put
+    /// the crossover between 256 and 1024 four-byte elements per pair, and the
+    /// focused sweep that would pin it down has not been run yet.
+    HPX_CXX_EXPORT using pairwise_threshold_arg =
+        detail::argument_type<detail::pairwise_threshold_tag, 4096>;
 }    // namespace hpx::collectives

--- a/libs/full/collectives/include/hpx/collectives/argument_types.hpp
+++ b/libs/full/collectives/include/hpx/collectives/argument_types.hpp
@@ -119,22 +119,24 @@ namespace hpx::collectives {
     HPX_CXX_EXPORT using flat_fallback_threshold_arg =
         detail::argument_type<detail::flat_fallback_threshold_tag, 16>;
 
-    /// The per-pair payload size, in bytes, at or above which all_to_all
+    /// The fixed row-size threshold, in bytes, at or above which all_to_all
     /// exchanges rows directly between the participating sites instead of
-    /// routing every row through a single communicator site. Direct exchange
-    /// costs num_sites - 1 messages per site rather than two, so it only pays
-    /// once a row is large enough for the routing detour to dominate the
-    /// message count. Pass 0 to ask for the direct exchange whenever it is
-    /// available, which is not unconditional: it also needs at least three
-    /// participating sites, below which there is no routing detour left to
-    /// remove, and an explicit generation number, which is what gives every
-    /// site the same exchange tag. A call supplying neither is routed whatever
-    /// this value is. Which path runs affects performance only, never the
-    /// result.
+    /// routing every row through a single communicator site. Automatic
+    /// selection uses sizeof(T) for a trivially copyable row type T. Other row
+    /// types stay routed because inspecting local dynamic data could make sites
+    /// select different exchange paths. Every participating site must use the
+    /// same threshold.
     ///
-    /// The default is provisional: measurements on 20 localities per node put
-    /// the crossover between 256 and 1024 four-byte elements per pair, and the
-    /// focused sweep that would pin it down has not been run yet.
+    /// Pass 0 at every site to request direct exchange for a dynamically sized
+    /// row type, or to force it for a fixed-size type. Direct exchange still
+    /// requires at least three participating sites and an explicit generation
+    /// number. A call that does not meet those requirements stays routed.
+    /// Which path runs affects performance only, never the result.
+    ///
+    /// The 4096-byte default is the smallest tested payload for which direct
+    /// exchange won in every layout of a 16-node sweep across 16 to 128
+    /// localities. The crossover depends on the transport and topology, so
+    /// callers may override it.
     HPX_CXX_EXPORT using pairwise_threshold_arg =
         detail::argument_type<detail::pairwise_threshold_tag, 4096>;
 }    // namespace hpx::collectives

--- a/libs/full/collectives/include/hpx/collectives/argument_types.hpp
+++ b/libs/full/collectives/include/hpx/collectives/argument_types.hpp
@@ -124,7 +124,13 @@ namespace hpx::collectives {
     /// routing every row through a single communicator site. Direct exchange
     /// costs num_sites - 1 messages per site rather than two, so it only pays
     /// once a row is large enough for the routing detour to dominate the
-    /// message count. Pass 0 to always exchange directly.
+    /// message count. Pass 0 to ask for the direct exchange whenever it is
+    /// available, which is not unconditional: it also needs at least three
+    /// participating sites, below which there is no routing detour left to
+    /// remove, and an explicit generation number, which is what gives every
+    /// site the same exchange tag. A call supplying neither is routed whatever
+    /// this value is. Which path runs affects performance only, never the
+    /// result.
     ///
     /// The default is provisional: measurements on 20 localities per node put
     /// the crossover between 256 and 1024 four-byte elements per pair, and the

--- a/libs/full/collectives/include/hpx/collectives/channel_communicator.hpp
+++ b/libs/full/collectives/include/hpx/collectives/channel_communicator.hpp
@@ -135,6 +135,7 @@ namespace hpx { namespace collectives {
 
 #include <cstddef>
 #include <memory>
+#include <string>
 #include <utility>
 
 namespace hpx::collectives {
@@ -273,6 +274,36 @@ namespace hpx::collectives {
 
         HPX_EXPORT void create_world_channel_communicator();
         HPX_EXPORT void reset_world_channel_communicator();
+
+        ///////////////////////////////////////////////////////////////////////
+        // Returns the channel communicator registered under the given name,
+        // creating it on first use and handing out the same one afterwards.
+        //
+        // A caller that repeats an exchange over one fixed set of sites, and
+        // separates the individual exchanges by tag rather than by name, would
+        // otherwise pay a fresh AGAS registration plus a full peer lookup on
+        // every repetition -- which is the cost such a caller went to the
+        // channel communicator to avoid in the first place.
+        //
+        // The name must therefore identify the group of sites and not one
+        // operation on it: every call naming a given communicator has to agree
+        // on num_sites, because only the first call creates it. The future is
+        // shared because the communicator is, and returning it unwaited keeps
+        // an asynchronous caller asynchronous.
+        //
+        // Entries live until reset_cached_channel_communicators drops them
+        // during runtime shutdown, which is what releases the registered names
+        // while AGAS is still up.
+        //
+        // The communicator type has to be qualified: inside this namespace the
+        // unqualified name resolves to the detail implementation class, not to
+        // the public handle callers hold.
+        HPX_EXPORT hpx::shared_future<collectives::channel_communicator>
+        get_cached_channel_communicator(std::string name,
+            num_sites_arg num_sites = num_sites_arg(),
+            this_site_arg this_site = this_site_arg());
+
+        HPX_EXPORT void reset_cached_channel_communicators();
     }    // namespace detail
 }    // namespace hpx::collectives
 

--- a/libs/full/collectives/include/hpx/collectives/detail/pairwise_all_to_all_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/pairwise_all_to_all_helpers.hpp
@@ -1,0 +1,141 @@
+//  Copyright (c) 2026 Anshuman Agrawal
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+/// \file detail/pairwise_all_to_all_helpers.hpp
+/// Direct site-to-site exchange for the all_to_all collective. The default
+/// all_to_all routes every contribution through one communicator site, which
+/// concentrates the whole exchange on a single locality. This variant sends
+/// each row straight to the site it belongs to, trading two messages per site
+/// for num_sites - 1 of them. That trade only pays for large rows, so the
+/// caller decides which path to take.
+
+#pragma once
+
+#include <hpx/config.hpp>
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+
+#include <hpx/collectives/argument_types.hpp>
+#include <hpx/collectives/channel_communicator.hpp>
+#include <hpx/errors/error.hpp>
+#include <hpx/errors/exception.hpp>
+#include <hpx/futures/future.hpp>
+#include <hpx/modules/async_combinators.hpp>
+#include <hpx/type_support/unused.hpp>
+
+#include <cstddef>
+#include <utility>
+#include <vector>
+
+namespace hpx::collectives::detail {
+
+    ///////////////////////////////////////////////////////////////////////////
+    // pairwise_all_to_all
+    //
+    // Exchanges one row per participating site over a channel communicator,
+    // without a root site relaying the data.
+    //
+    // local_result must hold exactly num_sites rows, where row d is destined
+    // for site d. The returned vector holds one row per source site, so entry
+    // s is what site s contributed for this site. That is the same contract
+    // the communicator-based all_to_all offers, which lets either path serve
+    // the same call.
+    //
+    // Sends are staggered: site h starts at peer h + 1 rather than at peer 0,
+    // so the sites do not all target the same peer at the same time. The
+    // receives are staggered in the opposite direction for the same reason.
+    //
+    // The tag separates concurrent exchanges on one channel communicator, so
+    // the caller must pass a distinct tag per generation.
+    ///////////////////////////////////////////////////////////////////////////
+    HPX_CXX_EXPORT template <typename T>
+    hpx::future<std::vector<T>> pairwise_all_to_all(channel_communicator comm,
+        std::vector<T>&& local_result, std::size_t const num_sites,
+        std::size_t const this_site, tag_arg const tag)
+    {
+        if (num_sites == 0)
+        {
+            return hpx::make_exceptional_future<std::vector<T>>(
+                HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                    "hpx::collectives::detail::pairwise_all_to_all",
+                    "the number of participating sites must not be zero"));
+        }
+
+        if (this_site >= num_sites)
+        {
+            return hpx::make_exceptional_future<std::vector<T>>(
+                HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                    "hpx::collectives::detail::pairwise_all_to_all",
+                    "the local site must be smaller than the number of "
+                    "participating sites"));
+        }
+
+        if (local_result.size() != num_sites)
+        {
+            return hpx::make_exceptional_future<std::vector<T>>(
+                HPX_GET_EXCEPTION(hpx::error::bad_parameter,
+                    "hpx::collectives::detail::pairwise_all_to_all",
+                    "each participating site must contribute exactly "
+                    "num_sites elements"));
+        }
+
+        // A single site exchanges with itself only.
+        if (num_sites == 1)
+        {
+            return hpx::make_ready_future(HPX_MOVE(local_result));
+        }
+
+        std::vector<hpx::future<void>> sends;
+        sends.reserve(num_sites - 1);
+
+        std::vector<hpx::future<T>> receives;
+        receives.reserve(num_sites - 1);
+
+        for (std::size_t k = 1; k != num_sites; ++k)
+        {
+            std::size_t const destination = (this_site + k) % num_sites;
+            sends.push_back(set(comm, that_site_arg(destination),
+                HPX_MOVE(local_result[destination]), tag));
+
+            std::size_t const source = (this_site + num_sites - k) % num_sites;
+            receives.push_back(get<T>(comm, that_site_arg(source), tag));
+        }
+
+        // The diagonal never travels; it is this site's own contribution.
+        T diagonal = HPX_MOVE(local_result[this_site]);
+
+        return hpx::when_all(HPX_MOVE(sends), HPX_MOVE(receives))
+            .then(hpx::launch::sync,
+                [comm = HPX_MOVE(comm), diagonal = HPX_MOVE(diagonal),
+                    num_sites, this_site](auto&& f) mutable {
+                    HPX_UNUSED(comm);
+
+                    auto [sent, received] = HPX_MOVE(f).get();
+
+                    // Report a failed send rather than a truncated result.
+                    for (auto& send : sent)
+                    {
+                        send.get();
+                    }
+
+                    std::vector<T> result(num_sites);
+                    result[this_site] = HPX_MOVE(diagonal);
+
+                    // received[i] came from the peer i + 1 hops behind this
+                    // site, matching the receive order posted above.
+                    for (std::size_t k = 1; k != num_sites; ++k)
+                    {
+                        std::size_t const source =
+                            (this_site + num_sites - k) % num_sites;
+                        result[source] = received[k - 1].get();
+                    }
+
+                    return result;
+                });
+    }
+}    // namespace hpx::collectives::detail
+
+#endif    // !HPX_COMPUTE_DEVICE_CODE

--- a/libs/full/collectives/include/hpx/collectives/detail/pairwise_all_to_all_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/pairwise_all_to_all_helpers.hpp
@@ -20,6 +20,7 @@
 
 #include <hpx/collectives/argument_types.hpp>
 #include <hpx/collectives/channel_communicator.hpp>
+#include <hpx/collectives/detail/hierarchical_helpers.hpp>
 #include <hpx/errors/error.hpp>
 #include <hpx/errors/exception.hpp>
 #include <hpx/futures/future.hpp>
@@ -162,7 +163,7 @@ namespace hpx::collectives::detail {
         {
             std::size_t const destination = (this_site + k) % num_sites;
             sends.push_back(set(comm, that_site_arg(destination),
-                HPX_MOVE(local_result[destination]), tag));
+                handle_bool<T>(HPX_MOVE(local_result[destination])), tag));
 
             std::size_t const source = (this_site + num_sites - k) % num_sites;
             receives.push_back(get<T>(comm, that_site_arg(source), tag));
@@ -185,16 +186,21 @@ namespace hpx::collectives::detail {
                         send.get();
                     }
 
-                    std::vector<T> result(num_sites);
-                    result[this_site] = HPX_MOVE(diagonal);
-
-                    // received[i] came from the peer i + 1 hops behind this
-                    // site, matching the receive order posted above.
-                    for (std::size_t k = 1; k != num_sites; ++k)
+                    std::vector<T> result;
+                    result.reserve(num_sites);
+                    for (std::size_t source = 0; source != num_sites; ++source)
                     {
-                        std::size_t const source =
-                            (this_site + num_sites - k) % num_sites;
-                        result[source] = received[k - 1].get();
+                        if (source == this_site)
+                        {
+                            result.push_back(HPX_MOVE(diagonal));
+                            continue;
+                        }
+
+                        // received[k - 1] came from the peer k hops behind
+                        // this site, matching the receive order posted above.
+                        std::size_t const k =
+                            (this_site + num_sites - source) % num_sites;
+                        result.push_back(received[k - 1].get());
                     }
 
                     return result;

--- a/libs/full/collectives/include/hpx/collectives/detail/pairwise_all_to_all_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/pairwise_all_to_all_helpers.hpp
@@ -24,7 +24,6 @@
 #include <hpx/errors/exception.hpp>
 #include <hpx/futures/future.hpp>
 #include <hpx/modules/async_combinators.hpp>
-#include <hpx/type_support/unused.hpp>
 
 #include <algorithm>
 #include <cstddef>

--- a/libs/full/collectives/include/hpx/collectives/detail/pairwise_all_to_all_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/pairwise_all_to_all_helpers.hpp
@@ -33,6 +33,14 @@
 
 namespace hpx::collectives::detail {
 
+    // The entities carrying HPX_CXX_EXPORT below are exactly the ones the
+    // pairwise_all_to_all and pairwise_all_to_all_dispatch unit tests name
+    // directly. With C++20 modules enabled those tests reach this header
+    // through `import HPX.Full;` (via the generated hpx/modules/collectives.hpp
+    // umbrella), so anything an importer names must be module-exported. The
+    // pairwise_row_bytes specializations are only ever reached from within the
+    // module purview, where reachability is enough, and stay unexported.
+
     ///////////////////////////////////////////////////////////////////////////
     // pairwise_payload_bytes
     //
@@ -85,7 +93,7 @@ namespace hpx::collectives::detail {
         }
     };
 
-    template <typename T>
+    HPX_CXX_EXPORT template <typename T>
     std::size_t pairwise_payload_bytes(std::vector<T> const& rows) noexcept
     {
         return pairwise_row_bytes<T>::call(rows);
@@ -109,7 +117,7 @@ namespace hpx::collectives::detail {
     // select the direct path deliberately, by passing a threshold of 0 at
     // every site.
     ///////////////////////////////////////////////////////////////////////////
-    template <typename T>
+    HPX_CXX_EXPORT template <typename T>
     constexpr std::size_t pairwise_type_bytes() noexcept
     {
         if constexpr (std::is_trivially_copyable_v<T>)
@@ -134,7 +142,7 @@ namespace hpx::collectives::detail {
     // identically, and the same threshold at every site; see
     // pairwise_type_bytes for why.
     ///////////////////////////////////////////////////////////////////////////
-    inline bool exchange_pairwise(std::size_t const num_sites,
+    HPX_CXX_EXPORT inline bool exchange_pairwise(std::size_t const num_sites,
         std::size_t const bytes_per_pair,
         pairwise_threshold_arg const threshold) noexcept
     {

--- a/libs/full/collectives/include/hpx/collectives/detail/pairwise_all_to_all_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/pairwise_all_to_all_helpers.hpp
@@ -93,12 +93,47 @@ namespace hpx::collectives::detail {
     }
 
     ///////////////////////////////////////////////////////////////////////////
+    // pairwise_type_bytes
+    //
+    // The same estimate, but derived from the element type alone.
+    //
+    // Every site has to choose the same exchange path. If one site went
+    // direct while another waited on the routed path, the exchange would
+    // simply never complete, so the choice may only rest on something all
+    // sites are guaranteed to compute identically. A type is such a thing; the
+    // contributed data is not, because nothing in the all_to_all contract
+    // forces two sites to contribute rows of equal length.
+    //
+    // That is why an automatic decision uses this function and not
+    // pairwise_payload_bytes, which measures local data and can therefore
+    // differ between sites. A caller who knows its rows are uniform can still
+    // select the direct path deliberately, by passing a threshold of 0 at
+    // every site.
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    constexpr std::size_t pairwise_type_bytes() noexcept
+    {
+        if constexpr (std::is_trivially_copyable_v<T>)
+        {
+            return sizeof(T);
+        }
+        else
+        {
+            return 0;
+        }
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
     // exchange_pairwise
     //
     // Decides between the direct and the routed exchange. A payload whose
     // size cannot be established never selects the direct path on its own,
     // and neither does an exchange with fewer than three sites: below that
     // there is no routing detour left to remove.
+    //
+    // The caller must pass a bytes_per_pair that every site computes
+    // identically, and the same threshold at every site; see
+    // pairwise_type_bytes for why.
     ///////////////////////////////////////////////////////////////////////////
     inline bool exchange_pairwise(std::size_t const num_sites,
         std::size_t const bytes_per_pair,

--- a/libs/full/collectives/include/hpx/collectives/detail/pairwise_all_to_all_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/pairwise_all_to_all_helpers.hpp
@@ -26,11 +26,97 @@
 #include <hpx/modules/async_combinators.hpp>
 #include <hpx/type_support/unused.hpp>
 
+#include <algorithm>
 #include <cstddef>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
 namespace hpx::collectives::detail {
+
+    ///////////////////////////////////////////////////////////////////////////
+    // pairwise_payload_bytes
+    //
+    // Estimates how many bytes one site sends to one peer, which is what the
+    // choice between the two exchange paths turns on.
+    //
+    // A row is one element of the contribution, so a trivially copyable
+    // element answers the question by itself. The payload this path exists
+    // for is a block per peer, though, so a vector of trivially copyable
+    // elements is measured by its contents; the largest row is used, because
+    // under-reporting would keep a large exchange on the routed path. Anything
+    // else reports 0, meaning "unknown": the caller then keeps the routed
+    // path, which is correct for every payload rather than fast for some.
+    ///////////////////////////////////////////////////////////////////////////
+    template <typename T>
+    struct pairwise_row_bytes
+    {
+        static constexpr std::size_t call(std::vector<T> const&) noexcept
+        {
+            if constexpr (std::is_trivially_copyable_v<T>)
+            {
+                return sizeof(T);
+            }
+            else
+            {
+                return 0;
+            }
+        }
+    };
+
+    template <typename U, typename Allocator>
+    struct pairwise_row_bytes<std::vector<U, Allocator>>
+    {
+        static std::size_t call(
+            std::vector<std::vector<U, Allocator>> const& rows) noexcept
+        {
+            if constexpr (std::is_trivially_copyable_v<U>)
+            {
+                std::size_t longest = 0;
+                for (auto const& row : rows)
+                {
+                    longest = (std::max) (longest, row.size());
+                }
+                return longest * sizeof(U);
+            }
+            else
+            {
+                return 0;
+            }
+        }
+    };
+
+    template <typename T>
+    std::size_t pairwise_payload_bytes(std::vector<T> const& rows) noexcept
+    {
+        return pairwise_row_bytes<T>::call(rows);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // exchange_pairwise
+    //
+    // Decides between the direct and the routed exchange. A payload whose
+    // size cannot be established never selects the direct path on its own,
+    // and neither does an exchange with fewer than three sites: below that
+    // there is no routing detour left to remove.
+    ///////////////////////////////////////////////////////////////////////////
+    inline bool exchange_pairwise(std::size_t const num_sites,
+        std::size_t const bytes_per_pair,
+        pairwise_threshold_arg const threshold) noexcept
+    {
+        if (num_sites < 3)
+        {
+            return false;
+        }
+
+        if (threshold == 0)
+        {
+            return true;
+        }
+
+        return bytes_per_pair != 0 &&
+            bytes_per_pair >= static_cast<std::size_t>(threshold);
+    }
 
     ///////////////////////////////////////////////////////////////////////////
     // pairwise_all_to_all
@@ -51,8 +137,12 @@ namespace hpx::collectives::detail {
     // The tag separates concurrent exchanges on one channel communicator, so
     // the caller must pass a distinct tag per generation.
     ///////////////////////////////////////////////////////////////////////////
+    // The communicator type has to be spelled out: inside this namespace the
+    // unqualified name resolves to the detail implementation class, not to the
+    // public handle callers hold.
     HPX_CXX_EXPORT template <typename T>
-    hpx::future<std::vector<T>> pairwise_all_to_all(channel_communicator comm,
+    hpx::future<std::vector<T>> pairwise_all_to_all(
+        hpx::collectives::channel_communicator comm,
         std::vector<T>&& local_result, std::size_t const num_sites,
         std::size_t const this_site, tag_arg const tag)
     {
@@ -109,10 +199,10 @@ namespace hpx::collectives::detail {
 
         return hpx::when_all(HPX_MOVE(sends), HPX_MOVE(receives))
             .then(hpx::launch::sync,
+                // the communicator is captured to keep it alive until every
+                // send and receive on it has completed
                 [comm = HPX_MOVE(comm), diagonal = HPX_MOVE(diagonal),
                     num_sites, this_site](auto&& f) mutable {
-                    HPX_UNUSED(comm);
-
                     auto [sent, received] = HPX_MOVE(f).get();
 
                     // Report a failed send rather than a truncated result.

--- a/libs/full/collectives/include/hpx/collectives/detail/pairwise_all_to_all_helpers.hpp
+++ b/libs/full/collectives/include/hpx/collectives/detail/pairwise_all_to_all_helpers.hpp
@@ -25,79 +25,12 @@
 #include <hpx/futures/future.hpp>
 #include <hpx/modules/async_combinators.hpp>
 
-#include <algorithm>
 #include <cstddef>
 #include <type_traits>
 #include <utility>
 #include <vector>
 
 namespace hpx::collectives::detail {
-
-    // The entities carrying HPX_CXX_EXPORT below are exactly the ones the
-    // pairwise_all_to_all and pairwise_all_to_all_dispatch unit tests name
-    // directly. With C++20 modules enabled those tests reach this header
-    // through `import HPX.Full;` (via the generated hpx/modules/collectives.hpp
-    // umbrella), so anything an importer names must be module-exported. The
-    // pairwise_row_bytes specializations are only ever reached from within the
-    // module purview, where reachability is enough, and stay unexported.
-
-    ///////////////////////////////////////////////////////////////////////////
-    // pairwise_payload_bytes
-    //
-    // Estimates how many bytes one site sends to one peer, which is what the
-    // choice between the two exchange paths turns on.
-    //
-    // A row is one element of the contribution, so a trivially copyable
-    // element answers the question by itself. The payload this path exists
-    // for is a block per peer, though, so a vector of trivially copyable
-    // elements is measured by its contents; the largest row is used, because
-    // under-reporting would keep a large exchange on the routed path. Anything
-    // else reports 0, meaning "unknown": the caller then keeps the routed
-    // path, which is correct for every payload rather than fast for some.
-    ///////////////////////////////////////////////////////////////////////////
-    template <typename T>
-    struct pairwise_row_bytes
-    {
-        static constexpr std::size_t call(std::vector<T> const&) noexcept
-        {
-            if constexpr (std::is_trivially_copyable_v<T>)
-            {
-                return sizeof(T);
-            }
-            else
-            {
-                return 0;
-            }
-        }
-    };
-
-    template <typename U, typename Allocator>
-    struct pairwise_row_bytes<std::vector<U, Allocator>>
-    {
-        static std::size_t call(
-            std::vector<std::vector<U, Allocator>> const& rows) noexcept
-        {
-            if constexpr (std::is_trivially_copyable_v<U>)
-            {
-                std::size_t longest = 0;
-                for (auto const& row : rows)
-                {
-                    longest = (std::max) (longest, row.size());
-                }
-                return longest * sizeof(U);
-            }
-            else
-            {
-                return 0;
-            }
-        }
-    };
-
-    HPX_CXX_EXPORT template <typename T>
-    std::size_t pairwise_payload_bytes(std::vector<T> const& rows) noexcept
-    {
-        return pairwise_row_bytes<T>::call(rows);
-    }
 
     ///////////////////////////////////////////////////////////////////////////
     // pairwise_type_bytes
@@ -111,11 +44,10 @@ namespace hpx::collectives::detail {
     // contributed data is not, because nothing in the all_to_all contract
     // forces two sites to contribute rows of equal length.
     //
-    // That is why an automatic decision uses this function and not
-    // pairwise_payload_bytes, which measures local data and can therefore
-    // differ between sites. A caller who knows its rows are uniform can still
-    // select the direct path deliberately, by passing a threshold of 0 at
-    // every site.
+    // That is why an automatic decision uses this function and never inspects
+    // the contributed rows. A caller who knows its rows are uniform can still
+    // select the direct path deliberately by passing a threshold of 0 at every
+    // site.
     ///////////////////////////////////////////////////////////////////////////
     HPX_CXX_EXPORT template <typename T>
     constexpr std::size_t pairwise_type_bytes() noexcept

--- a/libs/full/collectives/src/channel_communicator.cpp
+++ b/libs/full/collectives/src/channel_communicator.cpp
@@ -206,10 +206,10 @@ namespace hpx::collectives {
             if (auto const it = cached_channel_communicators.find(name);
                 it != cached_channel_communicators.end())
             {
-                // A creation that failed is handed back as it stands rather
-                // than retried: the only way it fails is a name that was
-                // already registered, and repeating the registration cannot
-                // change that.
+                // Hand an exceptional creation back unchanged. Retrying after
+                // another site may already have registered its endpoint could
+                // split the sites across different communicators; recovery
+                // therefore needs a new basename.
                 return it->second;
             }
 

--- a/libs/full/collectives/src/channel_communicator.cpp
+++ b/libs/full/collectives/src/channel_communicator.cpp
@@ -20,8 +20,10 @@
 #include <hpx/collectives/channel_communicator.hpp>
 
 #include <cstddef>
+#include <map>
 #include <memory>
 #include <mutex>
+#include <string>
 #include <utility>
 
 #include <hpx/config/warnings_prefix.hpp>
@@ -180,6 +182,67 @@ namespace hpx::collectives {
             {
                 world_channel_communicator.free();
             }
+        }
+    }    // namespace detail
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Channel communicators shared by name
+    namespace {
+
+        std::map<std::string, hpx::shared_future<channel_communicator>>
+            cached_channel_communicators;
+        hpx::mutex cached_channel_communicators_mtx;
+    }    // namespace
+
+    namespace detail {
+
+        hpx::shared_future<collectives::channel_communicator>
+        get_cached_channel_communicator(std::string name,
+            num_sites_arg const num_sites, this_site_arg const this_site)
+        {
+            std::unique_lock<hpx::mutex> l(cached_channel_communicators_mtx);
+            [[maybe_unused]] util::ignore_while_checking il(&l);
+
+            if (auto const it = cached_channel_communicators.find(name);
+                it != cached_channel_communicators.end())
+            {
+                // A creation that failed is handed back as it stands rather
+                // than retried: the only way it fails is a name that was
+                // already registered, and repeating the registration cannot
+                // change that.
+                return it->second;
+            }
+
+            auto const it =
+                cached_channel_communicators
+                    .emplace(HPX_MOVE(name),
+                        hpx::shared_future<collectives::channel_communicator>())
+                    .first;
+
+            try
+            {
+                // The key backs the name, not the argument: the asynchronous
+                // factory reads the string back in a continuation of its own,
+                // by which time an argument owned by the caller may be gone.
+                it->second = collectives::create_channel_communicator(
+                    it->first.c_str(), num_sites, this_site)
+                                 .share();
+            }
+            catch (...)
+            {
+                cached_channel_communicators.erase(it);
+                throw;
+            }
+
+            return it->second;
+        }
+
+        void reset_cached_channel_communicators()
+        {
+            std::unique_lock<hpx::mutex> l(cached_channel_communicators_mtx);
+            [[maybe_unused]] util::ignore_while_checking il(&l);
+
+            cached_channel_communicators.clear();
         }
     }    // namespace detail
 }    // namespace hpx::collectives

--- a/libs/full/collectives/tests/performance/benchmark_collectives.cpp
+++ b/libs/full/collectives/tests/performance/benchmark_collectives.cpp
@@ -42,6 +42,12 @@ constexpr char const* inclusive_scan_direct_basename =
 constexpr char const* exclusive_scan_direct_basename =
     "/test/exclusive_scan_direct/";
 constexpr char const* barrier_bench_basename = "/test/barrier_bench/";
+
+// Measurement scaffolding: which all_to_all exchange path the one-shot
+// benchmark asks for. The dispatch table below fixes the one-shot signature
+// for every operation, so this is threaded as a file-scope option rather than
+// as an extra parameter on all ten of them. -1 leaves the library default.
+int pairwise_threshold_option = -1;
 constexpr char const* exclusive_scan_basename = "/test/exclusive_scan_direct/";
 constexpr char const* inclusive_scan_basename = "/test/inclusive_scan_direct/";
 
@@ -1627,7 +1633,11 @@ void test_one_shot_use_all_to_all(int lpn, std::size_t iterations,
         hpx::chrono::high_resolution_timer const timer;
         recv_data = all_to_all(all_to_all_direct_basename, std::move(iter_data),
             num_sites_arg(num_localities), this_site_arg(this_locality),
-            generation_arg(i + 1))
+            generation_arg(i + 1), root_site_arg(0),
+            pairwise_threshold_option < 0 ?
+                pairwise_threshold_arg() :
+                pairwise_threshold_arg(
+                    static_cast<std::size_t>(pairwise_threshold_option)))
                         .get();
         // Reduce max elapsed time to root
         double max_elapsed = timer.elapsed();
@@ -1647,8 +1657,11 @@ void test_one_shot_use_all_to_all(int lpn, std::size_t iterations,
 
     if (this_locality == 0)
     {
-        write_to_file(operation, "single_use", -1, num_localities, lpn,
-            test_size, warmup_iterations, iterations, std::move(result));
+        std::string const mod_name = pairwise_threshold_option < 0 ?
+            "single_use" :
+            "single_use_p" + std::to_string(pairwise_threshold_option);
+        write_to_file(operation, mod_name, -1, num_localities, lpn, test_size,
+            warmup_iterations, iterations, std::move(result));
     }
 }
 
@@ -2118,6 +2131,7 @@ int hpx_main(hpx::program_options::variables_map& vm)
     int const iterations = vm["iterations"].as<int>();
     int const fallback_threshold = vm["fallback_threshold"].as<int>();
     int const warmup_iterations = vm["warmup_iterations"].as<int>();
+    pairwise_threshold_option = vm["pairwise_threshold"].as<int>();
 
     if (iterations <= 0 || warmup_iterations < 0 || test_size <= 0 || lpn <= 0)
     {
@@ -2220,7 +2234,12 @@ int main(int argc, char* argv[])
             "default (16). Set to 0 to force tree construction. Only meaningful "
             "with hierarchical mode.")
         ("warmup_iterations", value<int>()->default_value(3),
-            "Number of warmup iterations before the timed loop (default 3)");
+            "Number of warmup iterations before the timed loop (default 3)")
+        ("pairwise_threshold", value<int>()->default_value(-1),
+            "Per-pair payload size in bytes at or above which the one-shot "
+            "all_to_all exchanges rows directly between sites. -1 uses the "
+            "library default. Set to 0 to force the direct exchange. Only "
+            "meaningful with --operation=all_to_all and --arity=-1.");
     // clang-format on
 
     std::vector<std::string> const cfg = {"hpx.run_hpx_main!=1"};

--- a/libs/full/collectives/tests/performance/benchmark_collectives.cpp
+++ b/libs/full/collectives/tests/performance/benchmark_collectives.cpp
@@ -48,6 +48,29 @@ constexpr char const* barrier_bench_basename = "/test/barrier_bench/";
 // for every operation, so this is threaded as a file-scope option rather than
 // as an extra parameter on all ten of them. -1 leaves the library default.
 int pairwise_threshold_option = -1;
+
+pairwise_threshold_arg benchmark_pairwise_threshold(
+    std::size_t const block_size) noexcept
+{
+    if (pairwise_threshold_option == -1)
+    {
+        return pairwise_threshold_arg();
+    }
+
+    std::size_t const threshold =
+        static_cast<std::size_t>(pairwise_threshold_option);
+    std::size_t const threshold_elements =
+        (threshold + sizeof(int) - 1) / sizeof(int);
+
+    // The benchmark gives every site the same row size, so it can make the
+    // globally consistent choice that the general vector-row API cannot infer.
+    // Zero forces pairwise; any non-zero value keeps an unmeasurable vector row
+    // on the routed path.
+    bool const use_pairwise =
+        threshold == 0 || block_size >= threshold_elements;
+    return pairwise_threshold_arg(use_pairwise ? 0 : 1);
+}
+
 constexpr char const* exclusive_scan_basename = "/test/exclusive_scan_direct/";
 constexpr char const* inclusive_scan_basename = "/test/inclusive_scan_direct/";
 
@@ -1634,10 +1657,7 @@ void test_one_shot_use_all_to_all(int lpn, std::size_t iterations,
         recv_data = all_to_all(all_to_all_direct_basename, std::move(iter_data),
             num_sites_arg(num_localities), this_site_arg(this_locality),
             generation_arg(i + 1), root_site_arg(0),
-            pairwise_threshold_option < 0 ?
-                pairwise_threshold_arg() :
-                pairwise_threshold_arg(
-                    static_cast<std::size_t>(pairwise_threshold_option)))
+            benchmark_pairwise_threshold(block_size))
                         .get();
         // Reduce max elapsed time to root
         double max_elapsed = timer.elapsed();
@@ -1657,7 +1677,7 @@ void test_one_shot_use_all_to_all(int lpn, std::size_t iterations,
 
     if (this_locality == 0)
     {
-        std::string const mod_name = pairwise_threshold_option < 0 ?
+        std::string const mod_name = pairwise_threshold_option == -1 ?
             "single_use" :
             "single_use_p" + std::to_string(pairwise_threshold_option);
         write_to_file(operation, mod_name, -1, num_localities, lpn, test_size,
@@ -2133,10 +2153,12 @@ int hpx_main(hpx::program_options::variables_map& vm)
     int const warmup_iterations = vm["warmup_iterations"].as<int>();
     pairwise_threshold_option = vm["pairwise_threshold"].as<int>();
 
-    if (iterations <= 0 || warmup_iterations < 0 || test_size <= 0 || lpn <= 0)
+    if (iterations <= 0 || warmup_iterations < 0 || test_size <= 0 ||
+        lpn <= 0 || pairwise_threshold_option < -1)
     {
         std::cout << "error: iterations and test_size and lpn must be > 0; "
-                     "warmup_iterations must be >= 0\n";
+                     "warmup_iterations must be >= 0; pairwise_threshold "
+                     "must be >= -1\n";
         return hpx::finalize();
     }
 

--- a/libs/full/collectives/tests/unit/CMakeLists.txt
+++ b/libs/full/collectives/tests/unit/CMakeLists.txt
@@ -24,6 +24,7 @@ set(tests
     fold
     global_spmd_block
     hierarchical_helpers
+    pairwise_all_to_all
     reduce_direct
     remote_latch
     subtree_gather_scatter

--- a/libs/full/collectives/tests/unit/CMakeLists.txt
+++ b/libs/full/collectives/tests/unit/CMakeLists.txt
@@ -49,6 +49,7 @@ if(HPX_WITH_NETWORKING)
       inclusive_scan_
       inclusive_scan_hierarchical
       inclusive_scan_sync
+      pairwise_all_to_all_dispatch
       reduce
       reduce_hierarchical
       reduce_sync
@@ -67,6 +68,10 @@ if(HPX_WITH_NETWORKING)
   # The flat-vs-tree comparison needs a real tree. Five localities with arity
   # two also exercises an uneven subtree with an intermediate payload hop.
   set(hierarchical_flat_fallback_PARAMETERS LOCALITIES 5)
+
+  # Below three sites the direct exchange collapses into the routed one, so the
+  # dispatch has nothing left to choose between.
+  set(pairwise_all_to_all_dispatch_PARAMETERS LOCALITIES 3)
 endif()
 foreach(test ${tests})
   set(sources ${test}.cpp)

--- a/libs/full/collectives/tests/unit/pairwise_all_to_all.cpp
+++ b/libs/full/collectives/tests/unit/pairwise_all_to_all.cpp
@@ -237,8 +237,68 @@ void test_rejects_bad_arguments()
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// What the size estimate reports is what the dispatch decides on, so both
+// the trivially copyable row and the block row have to be measured correctly,
+// and an unmeasurable row has to report that rather than guess.
+struct opaque_row
+{
+    std::vector<int> data;
+
+    template <typename Archive>
+    void serialize(Archive& ar, unsigned)
+    {
+        // clang-format off
+        ar & data;
+        // clang-format on
+    }
+};
+
+void test_payload_size_estimate()
+{
+    std::vector<std::size_t> const scalars(4);
+    HPX_TEST_EQ(detail::pairwise_payload_bytes(scalars), sizeof(std::size_t));
+
+    std::vector<std::vector<int>> blocks(4);
+    blocks[0].resize(10);
+    blocks[1].resize(64);
+    blocks[2].resize(32);
+    blocks[3].resize(7);
+
+    // the largest row decides, so a short row cannot hide a large exchange
+    HPX_TEST_EQ(detail::pairwise_payload_bytes(blocks), 64 * sizeof(int));
+
+    // a row whose size cannot be established reports zero
+    std::vector<opaque_row> const opaque(4);
+    HPX_TEST_EQ(detail::pairwise_payload_bytes(opaque), std::size_t(0));
+}
+
+void test_dispatch_decision()
+{
+    constexpr auto threshold = pairwise_threshold_arg(4096);
+
+    // below three sites there is no routing detour to remove
+    HPX_TEST(!detail::exchange_pairwise(1, 1 << 20, threshold));
+    HPX_TEST(!detail::exchange_pairwise(2, 1 << 20, threshold));
+
+    // small rows stay on the routed path, large rows go direct
+    HPX_TEST(!detail::exchange_pairwise(8, 4095, threshold));
+    HPX_TEST(detail::exchange_pairwise(8, 4096, threshold));
+    HPX_TEST(detail::exchange_pairwise(8, 1 << 20, threshold));
+
+    // an unmeasurable payload never selects the direct path on size alone
+    HPX_TEST(!detail::exchange_pairwise(8, 0, threshold));
+
+    // a zero threshold forces the direct path, unmeasurable payload included
+    HPX_TEST(detail::exchange_pairwise(8, 0, pairwise_threshold_arg(0)));
+    HPX_TEST(detail::exchange_pairwise(8, 1, pairwise_threshold_arg(0)));
+}
+
+///////////////////////////////////////////////////////////////////////////////
 int hpx_main()
 {
+    test_payload_size_estimate();
+    test_dispatch_decision();
+
     // A single site exchanges with itself and never touches the network.
     test_scalar_exchange("scalar-1", 1);
 

--- a/libs/full/collectives/tests/unit/pairwise_all_to_all.cpp
+++ b/libs/full/collectives/tests/unit/pairwise_all_to_all.cpp
@@ -272,6 +272,28 @@ void test_payload_size_estimate()
     HPX_TEST_EQ(detail::pairwise_payload_bytes(opaque), std::size_t(0));
 }
 
+// An automatic decision may only rest on what every site computes the same
+// way, which is the element type. Measuring contributed rows cannot serve:
+// two sites are free to contribute rows of different length, and if that
+// split the exchange path between them the operation would never complete.
+void test_type_size_estimate()
+{
+    static_assert(
+        detail::pairwise_type_bytes<std::size_t>() == sizeof(std::size_t));
+    static_assert(detail::pairwise_type_bytes<std::vector<int>>() == 0);
+    static_assert(detail::pairwise_type_bytes<opaque_row>() == 0);
+
+    // the local measurement really does disagree between sites for the same
+    // type, which is exactly why it must not drive the automatic decision
+    std::vector<std::vector<int>> one_site(3);
+    one_site[0].resize(4096);
+
+    std::vector<std::vector<int>> const other_site(3);
+
+    HPX_TEST(detail::pairwise_payload_bytes(one_site) !=
+        detail::pairwise_payload_bytes(other_site));
+}
+
 void test_dispatch_decision()
 {
     constexpr auto threshold = pairwise_threshold_arg(4096);
@@ -297,6 +319,7 @@ void test_dispatch_decision()
 int hpx_main()
 {
     test_payload_size_estimate();
+    test_type_size_estimate();
     test_dispatch_decision();
 
     // A single site exchanges with itself and never touches the network.

--- a/libs/full/collectives/tests/unit/pairwise_all_to_all.cpp
+++ b/libs/full/collectives/tests/unit/pairwise_all_to_all.cpp
@@ -19,6 +19,7 @@
 #include <hpx/modules/testing.hpp>
 
 #include <cstddef>
+#include <new>
 #include <string>
 #include <utility>
 #include <vector>
@@ -101,6 +102,45 @@ void test_scalar_exchange(char const* const phase, std::size_t const num_sites)
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// vector<bool> rows are proxy references until they are materialized. The
+// direct path must send bool values, not the implementation-specific proxy.
+void run_bool_site(channel_communicator comm, std::size_t const num_sites,
+    std::size_t const this_site)
+{
+    std::vector<bool> local_result;
+    local_result.reserve(num_sites);
+    for (std::size_t destination = 0; destination != num_sites; ++destination)
+    {
+        local_result.push_back((this_site + destination) % 2 != 0);
+    }
+
+    std::vector<bool> const result = detail::pairwise_all_to_all(HPX_MOVE(comm),
+        HPX_MOVE(local_result), num_sites, this_site, tag_arg(1))
+                                         .get();
+
+    HPX_TEST_EQ(result.size(), num_sites);
+    for (std::size_t source = 0; source != num_sites; ++source)
+    {
+        HPX_TEST_EQ(result[source], (source + this_site) % 2 != 0);
+    }
+}
+
+void test_bool_exchange(std::size_t const num_sites)
+{
+    auto comms = create_communicators("bool", num_sites);
+
+    std::vector<hpx::future<void>> sites;
+    sites.reserve(num_sites);
+    for (std::size_t site = 0; site != num_sites; ++site)
+    {
+        sites.push_back(
+            hpx::async(run_bool_site, HPX_MOVE(comms[site]), num_sites, site));
+    }
+
+    hpx::wait_all(sites);
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // The payload this path exists for is a block per peer, not a scalar.
 void run_block_site(channel_communicator comm, std::size_t const num_sites,
     std::size_t const this_site, std::size_t const block_size)
@@ -141,6 +181,84 @@ void test_block_exchange(char const* const phase, std::size_t const num_sites)
     {
         sites.push_back(hpx::async(run_block_site, HPX_MOVE(comms[site]),
             num_sites, site, block_size));
+    }
+
+    hpx::wait_all(sites);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// The existing all_to_all accepts rows that can be constructed in place but
+// cannot be default-constructed or assigned. The direct path must preserve
+// that contract.
+struct nonassignable_row
+{
+    nonassignable_row() = delete;
+    nonassignable_row(nonassignable_row const&) = default;
+    nonassignable_row& operator=(nonassignable_row const&) = delete;
+    nonassignable_row(nonassignable_row&&) = default;
+    nonassignable_row& operator=(nonassignable_row&&) = delete;
+
+    explicit nonassignable_row(std::size_t const value)
+      : value(value)
+    {
+    }
+
+    template <typename Archive>
+    void serialize(Archive&, unsigned int const)
+    {
+    }
+
+    template <typename Archive>
+    friend void save_construct_data(
+        Archive& ar, nonassignable_row const* const row, unsigned int const)
+    {
+        ar & row->value;
+    }
+
+    template <typename Archive>
+    friend void load_construct_data(
+        Archive& ar, nonassignable_row* const row, unsigned int const)
+    {
+        std::size_t value = 0;
+        ar & value;
+        ::new (row) nonassignable_row(value);
+    }
+
+    std::size_t value;
+};
+
+void run_nonassignable_site(channel_communicator comm,
+    std::size_t const num_sites, std::size_t const this_site)
+{
+    std::vector<nonassignable_row> local_result;
+    local_result.reserve(num_sites);
+    for (std::size_t destination = 0; destination != num_sites; ++destination)
+    {
+        local_result.emplace_back(exchanged_value(this_site, destination));
+    }
+
+    std::vector<nonassignable_row> const result =
+        detail::pairwise_all_to_all(HPX_MOVE(comm), HPX_MOVE(local_result),
+            num_sites, this_site, tag_arg(1))
+            .get();
+
+    HPX_TEST_EQ(result.size(), num_sites);
+    for (std::size_t source = 0; source != num_sites; ++source)
+    {
+        HPX_TEST_EQ(result[source].value, exchanged_value(source, this_site));
+    }
+}
+
+void test_nonassignable_exchange(std::size_t const num_sites)
+{
+    auto comms = create_communicators("nonassignable", num_sites);
+
+    std::vector<hpx::future<void>> sites;
+    sites.reserve(num_sites);
+    for (std::size_t site = 0; site != num_sites; ++site)
+    {
+        sites.push_back(hpx::async(
+            run_nonassignable_site, HPX_MOVE(comms[site]), num_sites, site));
     }
 
     hpx::wait_all(sites);
@@ -296,9 +414,11 @@ int hpx_main()
     test_scalar_exchange("scalar-3", 3);
     test_scalar_exchange("scalar-5", 5);
     test_scalar_exchange("scalar-8", 8);
+    test_bool_exchange(5);
 
     test_block_exchange("block-4", 4);
     test_block_exchange("block-7", 7);
+    test_nonassignable_exchange(4);
 
     test_tag_separation(4);
 

--- a/libs/full/collectives/tests/unit/pairwise_all_to_all.cpp
+++ b/libs/full/collectives/tests/unit/pairwise_all_to_all.cpp
@@ -236,10 +236,6 @@ void test_rejects_bad_arguments()
     HPX_TEST(caught_bad_site);
 }
 
-///////////////////////////////////////////////////////////////////////////////
-// What the size estimate reports is what the dispatch decides on, so both
-// the trivially copyable row and the block row have to be measured correctly,
-// and an unmeasurable row has to report that rather than guess.
 struct opaque_row
 {
     std::vector<int> data;
@@ -253,25 +249,6 @@ struct opaque_row
     }
 };
 
-void test_payload_size_estimate()
-{
-    std::vector<std::size_t> const scalars(4);
-    HPX_TEST_EQ(detail::pairwise_payload_bytes(scalars), sizeof(std::size_t));
-
-    std::vector<std::vector<int>> blocks(4);
-    blocks[0].resize(10);
-    blocks[1].resize(64);
-    blocks[2].resize(32);
-    blocks[3].resize(7);
-
-    // the largest row decides, so a short row cannot hide a large exchange
-    HPX_TEST_EQ(detail::pairwise_payload_bytes(blocks), 64 * sizeof(int));
-
-    // a row whose size cannot be established reports zero
-    std::vector<opaque_row> const opaque(4);
-    HPX_TEST_EQ(detail::pairwise_payload_bytes(opaque), std::size_t(0));
-}
-
 // An automatic decision may only rest on what every site computes the same
 // way, which is the element type. Measuring contributed rows cannot serve:
 // two sites are free to contribute rows of different length, and if that
@@ -282,16 +259,6 @@ void test_type_size_estimate()
         detail::pairwise_type_bytes<std::size_t>() == sizeof(std::size_t));
     static_assert(detail::pairwise_type_bytes<std::vector<int>>() == 0);
     static_assert(detail::pairwise_type_bytes<opaque_row>() == 0);
-
-    // the local measurement really does disagree between sites for the same
-    // type, which is exactly why it must not drive the automatic decision
-    std::vector<std::vector<int>> one_site(3);
-    one_site[0].resize(4096);
-
-    std::vector<std::vector<int>> const other_site(3);
-
-    HPX_TEST(detail::pairwise_payload_bytes(one_site) !=
-        detail::pairwise_payload_bytes(other_site));
 }
 
 void test_dispatch_decision()

--- a/libs/full/collectives/tests/unit/pairwise_all_to_all.cpp
+++ b/libs/full/collectives/tests/unit/pairwise_all_to_all.cpp
@@ -318,7 +318,6 @@ void test_dispatch_decision()
 ///////////////////////////////////////////////////////////////////////////////
 int hpx_main()
 {
-    test_payload_size_estimate();
     test_type_size_estimate();
     test_dispatch_decision();
 

--- a/libs/full/collectives/tests/unit/pairwise_all_to_all.cpp
+++ b/libs/full/collectives/tests/unit/pairwise_all_to_all.cpp
@@ -1,0 +1,266 @@
+//  Copyright (c) 2026 Anshuman Agrawal
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// The pairwise all_to_all exchange delivers every row straight to the site it
+// belongs to instead of routing it through one communicator site. These tests
+// pin down the result layout it has to produce, which is the same layout the
+// communicator-based all_to_all produces, plus the tag separation that lets
+// one channel communicator carry several exchanges.
+
+#include <hpx/config.hpp>
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/modules/collectives.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <cstddef>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace hpx::collectives;
+
+///////////////////////////////////////////////////////////////////////////////
+// The value site source contributes for site destination. Encoding both ends
+// in the value is what makes a misrouted row visible.
+constexpr std::size_t exchanged_value(
+    std::size_t const source, std::size_t const destination) noexcept
+{
+    return source * 1000 + destination;
+}
+
+std::vector<channel_communicator> create_communicators(
+    char const* const phase, std::size_t const num_sites)
+{
+    std::string const basename =
+        std::string("/test/pairwise_all_to_all/") + phase + "/";
+
+    std::vector<hpx::future<channel_communicator>> comm_futures;
+    comm_futures.reserve(num_sites);
+
+    for (std::size_t site = 0; site != num_sites; ++site)
+    {
+        comm_futures.push_back(create_channel_communicator(
+            basename.c_str(), num_sites_arg(num_sites), this_site_arg(site)));
+    }
+
+    hpx::wait_all(comm_futures);
+
+    std::vector<channel_communicator> comms;
+    comms.reserve(num_sites);
+    for (auto& comm_future : comm_futures)
+    {
+        comms.push_back(comm_future.get());
+    }
+    return comms;
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Every site contributes one scalar row per peer and must receive exactly the
+// row each peer addressed to it.
+void run_scalar_site(channel_communicator comm, std::size_t const num_sites,
+    std::size_t const this_site, std::size_t const tag)
+{
+    std::vector<std::size_t> local_result;
+    local_result.reserve(num_sites);
+    for (std::size_t destination = 0; destination != num_sites; ++destination)
+    {
+        local_result.push_back(exchanged_value(this_site, destination));
+    }
+
+    std::vector<std::size_t> const result =
+        detail::pairwise_all_to_all(HPX_MOVE(comm), HPX_MOVE(local_result),
+            num_sites, this_site, tag_arg(tag))
+            .get();
+
+    HPX_TEST_EQ(result.size(), num_sites);
+    for (std::size_t source = 0; source != num_sites; ++source)
+    {
+        HPX_TEST_EQ(result[source], exchanged_value(source, this_site));
+    }
+}
+
+void test_scalar_exchange(char const* const phase, std::size_t const num_sites)
+{
+    auto comms = create_communicators(phase, num_sites);
+
+    std::vector<hpx::future<void>> sites;
+    sites.reserve(num_sites);
+    for (std::size_t site = 0; site != num_sites; ++site)
+    {
+        sites.push_back(hpx::async(run_scalar_site, HPX_MOVE(comms[site]),
+            num_sites, site, std::size_t(1)));
+    }
+
+    hpx::wait_all(sites);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// The payload this path exists for is a block per peer, not a scalar.
+void run_block_site(channel_communicator comm, std::size_t const num_sites,
+    std::size_t const this_site, std::size_t const block_size)
+{
+    std::vector<std::vector<std::size_t>> local_result;
+    local_result.reserve(num_sites);
+    for (std::size_t destination = 0; destination != num_sites; ++destination)
+    {
+        local_result.emplace_back(
+            block_size, exchanged_value(this_site, destination));
+    }
+
+    std::vector<std::vector<std::size_t>> const result =
+        detail::pairwise_all_to_all(HPX_MOVE(comm), HPX_MOVE(local_result),
+            num_sites, this_site, tag_arg(1))
+            .get();
+
+    HPX_TEST_EQ(result.size(), num_sites);
+    for (std::size_t source = 0; source != num_sites; ++source)
+    {
+        HPX_TEST_EQ(result[source].size(), block_size);
+        for (std::size_t const value : result[source])
+        {
+            HPX_TEST_EQ(value, exchanged_value(source, this_site));
+        }
+    }
+}
+
+void test_block_exchange(char const* const phase, std::size_t const num_sites)
+{
+    constexpr std::size_t block_size = 128;
+
+    auto comms = create_communicators(phase, num_sites);
+
+    std::vector<hpx::future<void>> sites;
+    sites.reserve(num_sites);
+    for (std::size_t site = 0; site != num_sites; ++site)
+    {
+        sites.push_back(hpx::async(run_block_site, HPX_MOVE(comms[site]),
+            num_sites, site, block_size));
+    }
+
+    hpx::wait_all(sites);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Two exchanges share one communicator and must not mix, which is what the
+// tag is for. Both run concurrently so an ordering assumption would show.
+void run_two_tags(channel_communicator comm, std::size_t const num_sites,
+    std::size_t const this_site)
+{
+    std::vector<hpx::future<void>> exchanges;
+    exchanges.reserve(2);
+
+    for (std::size_t tag = 1; tag != 3; ++tag)
+    {
+        std::vector<std::size_t> local_result;
+        local_result.reserve(num_sites);
+        for (std::size_t destination = 0; destination != num_sites;
+            ++destination)
+        {
+            local_result.push_back(
+                tag * exchanged_value(this_site, destination));
+        }
+
+        exchanges.push_back(detail::pairwise_all_to_all(
+            comm, HPX_MOVE(local_result), num_sites, this_site, tag_arg(tag))
+                .then(hpx::launch::sync, [num_sites, this_site, tag](auto&& f) {
+                    std::vector<std::size_t> const result = f.get();
+
+                    HPX_TEST_EQ(result.size(), num_sites);
+                    for (std::size_t source = 0; source != num_sites; ++source)
+                    {
+                        HPX_TEST_EQ(result[source],
+                            tag * exchanged_value(source, this_site));
+                    }
+                }));
+    }
+
+    hpx::wait_all(exchanges);
+}
+
+void test_tag_separation(std::size_t const num_sites)
+{
+    auto comms = create_communicators("tags", num_sites);
+
+    std::vector<hpx::future<void>> sites;
+    sites.reserve(num_sites);
+    for (std::size_t site = 0; site != num_sites; ++site)
+    {
+        sites.push_back(
+            hpx::async(run_two_tags, HPX_MOVE(comms[site]), num_sites, site));
+    }
+
+    hpx::wait_all(sites);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// A malformed call has to fail through the future rather than exchange a
+// truncated row set.
+void test_rejects_bad_arguments()
+{
+    constexpr std::size_t num_sites = 2;
+
+    auto comms = create_communicators("validation", num_sites);
+
+    bool caught_wrong_size = false;
+    try
+    {
+        std::vector<std::size_t> too_few(num_sites - 1);
+        detail::pairwise_all_to_all(
+            comms[0], HPX_MOVE(too_few), num_sites, 0, tag_arg(1))
+            .get();
+    }
+    catch (hpx::exception const& e)
+    {
+        caught_wrong_size = e.get_error() == hpx::error::bad_parameter;
+    }
+    HPX_TEST(caught_wrong_size);
+
+    bool caught_bad_site = false;
+    try
+    {
+        std::vector<std::size_t> rows(num_sites);
+        detail::pairwise_all_to_all(
+            comms[0], HPX_MOVE(rows), num_sites, num_sites, tag_arg(1))
+            .get();
+    }
+    catch (hpx::exception const& e)
+    {
+        caught_bad_site = e.get_error() == hpx::error::bad_parameter;
+    }
+    HPX_TEST(caught_bad_site);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main()
+{
+    // A single site exchanges with itself and never touches the network.
+    test_scalar_exchange("scalar-1", 1);
+
+    // Odd and non-power-of-two counts exercise the send/receive stagger.
+    test_scalar_exchange("scalar-2", 2);
+    test_scalar_exchange("scalar-3", 3);
+    test_scalar_exchange("scalar-5", 5);
+    test_scalar_exchange("scalar-8", 8);
+
+    test_block_exchange("block-4", 4);
+    test_block_exchange("block-7", 7);
+
+    test_tag_separation(4);
+
+    test_rejects_bad_arguments();
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    HPX_TEST_EQ(hpx::init(argc, argv), 0);
+    return hpx::util::report_errors();
+}
+#endif

--- a/libs/full/collectives/tests/unit/pairwise_all_to_all_dispatch.cpp
+++ b/libs/full/collectives/tests/unit/pairwise_all_to_all_dispatch.cpp
@@ -1,0 +1,180 @@
+//  Copyright (c) 2026 Anshuman Agrawal
+//
+//  SPDX-License-Identifier: BSL-1.0
+//  Distributed under the Boost Software License, Version 1.0. (See accompanying
+//  file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+// all_to_all can route every row through one communicator site or send each
+// row straight to the site it belongs to. Which path runs is a performance
+// choice, so the two must be indistinguishable from the outside. These tests
+// drive the public basename API across real localities and require both paths
+// to produce the same result.
+
+#include <hpx/config.hpp>
+
+#if !defined(HPX_COMPUTE_DEVICE_CODE)
+#include <hpx/hpx.hpp>
+#include <hpx/hpx_init.hpp>
+#include <hpx/modules/collectives.hpp>
+#include <hpx/modules/testing.hpp>
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <utility>
+#include <vector>
+
+using namespace hpx::collectives;
+
+///////////////////////////////////////////////////////////////////////////////
+// The value site source contributes for site destination. Encoding both ends
+// makes a misrouted row visible instead of merely wrong.
+constexpr std::uint32_t exchanged_value(
+    std::uint32_t const source, std::uint32_t const destination) noexcept
+{
+    return source * 1000 + destination;
+}
+
+std::vector<std::uint32_t> contribution(
+    std::uint32_t const this_locality, std::uint32_t const num_localities)
+{
+    std::vector<std::uint32_t> values;
+    values.reserve(num_localities);
+    for (std::uint32_t destination = 0; destination != num_localities;
+        ++destination)
+    {
+        values.push_back(exchanged_value(this_locality, destination));
+    }
+    return values;
+}
+
+void check_result(std::vector<std::uint32_t> const& result,
+    std::uint32_t const this_locality, std::uint32_t const num_localities)
+{
+    HPX_TEST_EQ(result.size(), std::size_t(num_localities));
+    for (std::uint32_t source = 0; source != num_localities; ++source)
+    {
+        HPX_TEST_EQ(result[source], exchanged_value(source, this_locality));
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// A threshold of 0 selects the direct exchange, the default threshold leaves
+// a four-byte row on the routed one. Both have to agree, element for element.
+void test_both_paths_agree(
+    std::uint32_t const this_locality, std::uint32_t const num_localities)
+{
+    std::vector<std::uint32_t> const routed =
+        all_to_all("/test/pairwise_dispatch/routed/",
+            contribution(this_locality, num_localities),
+            num_sites_arg(num_localities), this_site_arg(this_locality),
+            generation_arg(1))
+            .get();
+
+    check_result(routed, this_locality, num_localities);
+
+    std::vector<std::uint32_t> const direct =
+        all_to_all("/test/pairwise_dispatch/direct/",
+            contribution(this_locality, num_localities),
+            num_sites_arg(num_localities), this_site_arg(this_locality),
+            generation_arg(1), root_site_arg(), pairwise_threshold_arg(0))
+            .get();
+
+    check_result(direct, this_locality, num_localities);
+    HPX_TEST(routed == direct);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// Successive generations on one basename must stay separate on the direct
+// path too, which is what the exchange tag is for.
+void test_direct_path_generations(
+    std::uint32_t const this_locality, std::uint32_t const num_localities)
+{
+    for (std::uint32_t generation = 1; generation != 4; ++generation)
+    {
+        std::vector<std::uint32_t> values;
+        values.reserve(num_localities);
+        for (std::uint32_t destination = 0; destination != num_localities;
+            ++destination)
+        {
+            values.push_back(
+                generation * exchanged_value(this_locality, destination));
+        }
+
+        std::vector<std::uint32_t> const result =
+            all_to_all("/test/pairwise_dispatch/generations/", HPX_MOVE(values),
+                num_sites_arg(num_localities), this_site_arg(this_locality),
+                generation_arg(generation), root_site_arg(),
+                pairwise_threshold_arg(0))
+                .get();
+
+        HPX_TEST_EQ(result.size(), std::size_t(num_localities));
+        for (std::uint32_t source = 0; source != num_localities; ++source)
+        {
+            HPX_TEST_EQ(result[source],
+                generation * exchanged_value(source, this_locality));
+        }
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// The sync overload carries the same knob and must reach the same place.
+void test_sync_overload(
+    std::uint32_t const this_locality, std::uint32_t const num_localities)
+{
+    std::vector<std::uint32_t> const result =
+        all_to_all(hpx::launch::sync, "/test/pairwise_dispatch/sync/",
+            contribution(this_locality, num_localities),
+            num_sites_arg(num_localities), this_site_arg(this_locality),
+            generation_arg(1), root_site_arg(), pairwise_threshold_arg(0));
+
+    check_result(result, this_locality, num_localities);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+// A default generation gives the sites no tag they all derive the same way,
+// so the call stays on the routed path rather than failing. It still has to
+// deliver the right answer, which is the part that matters to a caller.
+void test_default_generation_still_works(
+    std::uint32_t const this_locality, std::uint32_t const num_localities)
+{
+    std::vector<std::uint32_t> const result =
+        all_to_all("/test/pairwise_dispatch/default_generation/",
+            contribution(this_locality, num_localities),
+            num_sites_arg(num_localities), this_site_arg(this_locality),
+            generation_arg(), root_site_arg(), pairwise_threshold_arg(0))
+            .get();
+
+    check_result(result, this_locality, num_localities);
+}
+
+///////////////////////////////////////////////////////////////////////////////
+int hpx_main()
+{
+    std::uint32_t const this_locality = hpx::get_locality_id();
+    std::uint32_t const num_localities =
+        hpx::get_num_localities(hpx::launch::sync);
+
+    // the direct path only differs from the routed one above two sites
+    HPX_TEST_LTE(std::uint32_t(3), num_localities);
+
+    test_both_paths_agree(this_locality, num_localities);
+    test_direct_path_generations(this_locality, num_localities);
+    test_sync_overload(this_locality, num_localities);
+    test_default_generation_still_works(this_locality, num_localities);
+
+    return hpx::finalize();
+}
+
+int main(int argc, char* argv[])
+{
+    // every locality has to reach the collective, not just the console
+    std::vector<std::string> const cfg = {"hpx.run_hpx_main!=1"};
+
+    hpx::init_params init_args;
+    init_args.cfg = cfg;
+
+    HPX_TEST_EQ(hpx::init(argc, argv, init_args), 0);
+    return hpx::util::report_errors();
+}
+#endif

--- a/libs/full/collectives/tests/unit/pairwise_all_to_all_dispatch.cpp
+++ b/libs/full/collectives/tests/unit/pairwise_all_to_all_dispatch.cpp
@@ -221,6 +221,29 @@ void test_default_generation_still_works(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// Selecting the direct path must not bypass validation performed by the
+// established routed implementation.
+void test_direct_path_preserves_root_validation(
+    std::uint32_t const this_locality, std::uint32_t const num_localities)
+{
+    bool caught_bad_root = false;
+    try
+    {
+        all_to_all("/test/pairwise_dispatch/invalid_root/",
+            contribution(this_locality, num_localities),
+            num_sites_arg(num_localities), this_site_arg(this_locality),
+            generation_arg(1), root_site_arg(num_localities),
+            pairwise_threshold_arg(0))
+            .get();
+    }
+    catch (hpx::exception const& e)
+    {
+        caught_bad_root = e.get_error() == hpx::error::bad_parameter;
+    }
+    HPX_TEST(caught_bad_root);
+}
+
+///////////////////////////////////////////////////////////////////////////////
 int hpx_main()
 {
     std::uint32_t const this_locality = hpx::get_locality_id();
@@ -236,6 +259,7 @@ int hpx_main()
     test_default_threshold_decides(num_localities);
     test_auto_selects_direct_for_large_rows(this_locality, num_localities);
     test_default_generation_still_works(this_locality, num_localities);
+    test_direct_path_preserves_root_validation(this_locality, num_localities);
 
     return hpx::finalize();
 }

--- a/libs/full/collectives/tests/unit/pairwise_all_to_all_dispatch.cpp
+++ b/libs/full/collectives/tests/unit/pairwise_all_to_all_dispatch.cpp
@@ -18,6 +18,7 @@
 #include <hpx/modules/collectives.hpp>
 #include <hpx/modules/testing.hpp>
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <string>
@@ -25,6 +26,18 @@
 #include <vector>
 
 using namespace hpx::collectives;
+
+///////////////////////////////////////////////////////////////////////////////
+// A row whose type alone reaches the default threshold, which is all an
+// automatic decision is allowed to look at: the contributed data may differ
+// from site to site, and sites that disagreed on the path would wait on each
+// other forever.
+using big_row = std::array<std::uint64_t, 512>;
+
+static_assert(detail::pairwise_type_bytes<big_row>() >=
+    static_cast<std::size_t>(pairwise_threshold_arg()));
+static_assert(detail::pairwise_type_bytes<std::uint32_t>() <
+    static_cast<std::size_t>(pairwise_threshold_arg()));
 
 ///////////////////////////////////////////////////////////////////////////////
 // The value site source contributes for site destination. Encoding both ends
@@ -61,6 +74,8 @@ void check_result(std::vector<std::uint32_t> const& result,
 ///////////////////////////////////////////////////////////////////////////////
 // A threshold of 0 selects the direct exchange, the default threshold leaves
 // a four-byte row on the routed one. Both have to agree, element for element.
+// The first call is therefore also the end-to-end case for a small row being
+// left alone by an automatic decision.
 void test_both_paths_agree(
     std::uint32_t const this_locality, std::uint32_t const num_localities)
 {
@@ -132,6 +147,63 @@ void test_sync_overload(
 }
 
 ///////////////////////////////////////////////////////////////////////////////
+// The tests above force a path. These two leave the choice to the default
+// threshold, which is how a caller who never touches the knob reaches either
+// path.
+//
+// A completed exchange says nothing about which path ran -- that is the point
+// of the dispatch -- so the decision itself is pinned down separately, for the
+// two row types used here and at the site count these tests run at.
+void test_default_threshold_decides(std::uint32_t const num_localities)
+{
+    HPX_TEST(!detail::exchange_pairwise(num_localities,
+        detail::pairwise_type_bytes<std::uint32_t>(),
+        pairwise_threshold_arg()));
+
+    HPX_TEST(detail::exchange_pairwise(num_localities,
+        detail::pairwise_type_bytes<big_row>(), pairwise_threshold_arg()));
+}
+
+// A row large enough for the default threshold to send it directly, driven
+// through the public API with no threshold argument at all. Only the first
+// element is checked against; the rest is filled so that a row arriving from
+// the wrong peer cannot pass by accident.
+big_row big_value(
+    std::uint32_t const source, std::uint32_t const destination) noexcept
+{
+    big_row row{};
+    for (std::size_t i = 0; i != row.size(); ++i)
+    {
+        row[i] = exchanged_value(source, destination) + i;
+    }
+    return row;
+}
+
+void test_auto_selects_direct_for_large_rows(
+    std::uint32_t const this_locality, std::uint32_t const num_localities)
+{
+    std::vector<big_row> values;
+    values.reserve(num_localities);
+    for (std::uint32_t destination = 0; destination != num_localities;
+        ++destination)
+    {
+        values.push_back(big_value(this_locality, destination));
+    }
+
+    std::vector<big_row> const result =
+        all_to_all("/test/pairwise_dispatch/auto_direct/", HPX_MOVE(values),
+            num_sites_arg(num_localities), this_site_arg(this_locality),
+            generation_arg(1))
+            .get();
+
+    HPX_TEST_EQ(result.size(), std::size_t(num_localities));
+    for (std::uint32_t source = 0; source != num_localities; ++source)
+    {
+        HPX_TEST(result[source] == big_value(source, this_locality));
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////
 // A default generation gives the sites no tag they all derive the same way,
 // so the call stays on the routed path rather than failing. It still has to
 // deliver the right answer, which is the part that matters to a caller.
@@ -161,6 +233,8 @@ int hpx_main()
     test_both_paths_agree(this_locality, num_localities);
     test_direct_path_generations(this_locality, num_localities);
     test_sync_overload(this_locality, num_localities);
+    test_default_threshold_decides(num_localities);
+    test_auto_selects_direct_for_large_rows(this_locality, num_localities);
     test_default_generation_still_works(this_locality, num_localities);
 
     return hpx::finalize();

--- a/libs/full/init_runtime/src/pre_main.cpp
+++ b/libs/full/init_runtime/src/pre_main.cpp
@@ -256,6 +256,7 @@ namespace hpx::detail {
         hpx::collectives::detail::reset_global_communicator();
         hpx::collectives::detail::reset_local_communicator();
         hpx::collectives::detail::reset_world_channel_communicator();
+        hpx::collectives::detail::reset_cached_channel_communicators();
 
         // simply destroy global barrier
         hpx::distributed::barrier::get_global_barrier().detach();


### PR DESCRIPTION
## Proposed Changes

- Add a direct pairwise path to the basename-based asynchronous and synchronous `all_to_all` overloads.
- Add `pairwise_threshold_arg`, with a default of 4096 bytes, to select between routed and pairwise exchange.
- Cache the channel communicator across generations, using the generation number as the exchange tag.
- Add unit and distributed dispatch tests, and support `--pairwise_threshold` in `benchmark_collectives`.

## Any background context you want to provide?

The basename-based implementation currently routes every contribution through one communicator site. This limits the number of messages sent by each site, but concentrates the exchange on one locality. The pairwise path sends each destination row directly to its peer. This removes the relay when the payload is large enough to offset the additional messages.

Pairwise exchange requires at least three sites and an explicit positive generation. Calls using the default generation remain on the routed path. Automatic dispatch uses `sizeof(T)` for trivially copyable, fixed-size row types. Dynamically sized rows remain routed because local size checks could cause different sites to select different algorithms. Callers that know the rows are uniform can pass `pairwise_threshold_arg(0)` at every site to request pairwise exchange.

The channel communicator is cached by normalized basename and site count. Reusing it across generations avoids repeated AGAS registration and peer discovery, while generation tags keep exchanges separate. The implementation preserves the existing argument validation and supports `vector<bool>` rows and rows that cannot be default-constructed or assigned.

The 16-node Rostam/Buran campaign covered 16, 32, 64, and 128 localities, with payloads from 4 B through 64 KiB per destination. All 960 executions completed without retries or failures. A 4 KiB threshold was the smallest sampled threshold for which every selected pairwise result beat the fastest non-pairwise HPX result in the same campaign.

Full measurements: [16-node pairwise `all_to_all` results](https://github.com/TheHPXProject/hpx/discussions/7323#discussioncomment-17871871)

### Verification

- Built the pairwise tests and `benchmark_collectives`.
- Passed the asynchronous, synchronous, and hierarchical `all_to_all` tests.
- Passed the pairwise helper and three-locality dispatch tests.
- Checked positive-threshold dispatch at the 1024-byte boundary with 255 and 256 `int` elements.
- Passed `clang-format --dry-run --Werror` and `git diff --check`.

## Checklist

Not all points below apply to all pull requests.

- [x] I have added a new feature and have added tests to go along with it.
- [ ] I have fixed a bug and have added a regression test.
- [ ] I have added a test using random numbers; I have made sure it uses a seed, and that random numbers generated are valid inputs for the tests.
